### PR TITLE
skill: #1077 — Add comprehension testing to QA verification

### DIFF
--- a/.squidsquad/pm/CLAUDE.md
+++ b/.squidsquad/pm/CLAUDE.md
@@ -1179,6 +1179,7 @@ Read .squidsquad/[ROLE]/planning/FEAT-[ROLE_UPPER]-XXX-RESEARCH.md and .squidsqu
 4. Upgrade verification tests (existing installs get the task correctly via upgrade, no breakage for non-upgraded installs)
 5. Smoke tests (quick checks)
 6. Regression risks
+7. Comprehension questions (if the task touches LLM-consumed instructions). Questions a fresh agent should answer correctly by reading only the modified files. Skip for script-only changes.
 
 Write output to .squidsquad/[ROLE]/planning/FEAT-[ROLE_UPPER]-XXX-TEST-PLAN.md
 ```
@@ -1211,6 +1212,11 @@ PM reviews the subagent's draft, adjusts as needed, and saves the final version.
 
 ## Regression Risks
 - [Risk]: [what to watch for]
+
+## Comprehension Questions (if task touches LLM-consumed instructions)
+### CQ-1: [question a fresh agent should answer from the modified files]
+- **Files**: [which files to read]
+- **Expected**: [correct answer, derivable only from the files]
 ```
 
 **Open in editor**: After TEST-PLAN.md is created, offer to open it (see "Open Artifacts in Editor" below).

--- a/.squidsquad/pm/working-state.md
+++ b/.squidsquad/pm/working-state.md
@@ -1,25 +1,7 @@
 # Working State
 
-- **Task**: #1228 — PM pipeline sentinel
+- **Task**: #1278 — Vault entity extraction + connection mining
 - **Status**: in-progress
-- **Phase**: none
-
-## Active Pipeline
-
-- #475 — Token efficiency audit (in-progress, PR#1157 — awaiting auto-merge)
-- #329 — Consistent per-cycle reporting (in-progress, PR#1203 — awaiting auto-merge)
-- #1204 — PR Flow conflict detection (pending-test, awaiting QA)
-- #1211 — Prefix references with type context (pending)
-- #1217 — Boot script session name bug (pending-test)
-- #1111 — Heartbeat-based agent liveness (pending)
-- #474 — PM/QA test coverage verification (approved, awaiting skill pickup)
-- #473 — Dev SOUL.md test coverage requirement (approved, awaiting skill pickup)
-- #1022 — health_check.py Unicode crash (open, severity low)
-
-## Open PRs
-
-- PR#1203 — Consistent per-cycle reporting (rebased)
-- PR#1157 — Token efficiency audit (rebased)
-- PR#1016 — Exclude .claude/ from feature branch commits (awaiting human merge)
+- **Phase**: researching #1278
 
 ## Quiet cycle counter: 0

--- a/.squidsquad/qa/CLAUDE.md
+++ b/.squidsquad/qa/CLAUDE.md
@@ -389,6 +389,16 @@ python references/scripts/git_ops.py branch-switch main
 
    QA reviews QA-RESULTS.md and makes the final decision.
 
+1b. **Comprehension testing** (if TEST-PLAN.md has a `## Comprehension Questions` section):
+
+   This applies when the task touches LLM-consumed instructions (CLAUDE.md, sub-skills, SOUL.md). If TEST-PLAN.md has no `## Comprehension Questions` section, skip this step.
+
+   Spawn a comprehension agent (via the Agent tool) with a neutral, file-scoped prompt: "Read the following files and answer ONLY from what you find in them. Files: [list modified files]. Answer each question below, quoting file content."
+
+   **Adaptive spawning**: If 4+ sub-skills affected, spawn one agent per sub-skill group. Otherwise, single spawn.
+
+   Record results in QA-RESULTS.md under `## Comprehension Tests` with per-CQ PASS/FAIL entries. A comprehension failure is a legitimate finding.
+
 2. **If no TEST-PLAN.md exists**, test against the acceptance criteria manually.
 
 3. **Zero-gap gate**: If ANY gap, ambiguity, missing documentation, failed check, or unresolved finding is discovered:

--- a/.squidsquad/skill/CLAUDE.md
+++ b/.squidsquad/skill/CLAUDE.md
@@ -710,17 +710,6 @@ Split commits into code (feature branch) and state (main):
    - If human requested changes via review: fix the issues and push to the branch
    - After pushing fixes, re-request review if appropriate
 
-5. **Merge your PR when task reaches pending-ship**: Each cycle, check for your tasks at `pending-ship` with open PRs:
-   ```bash
-   python references/scripts/tracker.py list-tasks skill --status pending-ship
-   ```
-   For each pending-ship task with an open PR (and `Auto Merge: yes` in config, `type:task` not `type:issue`, no `merge:manual` label):
-   ```bash
-   gh pr list --search "squidsquad/skill/[NUMBER]" --state open --json number,headRefName,mergeable --limit 1
-   python references/scripts/git_ops.py pr-merge [PR_NUMBER]
-   ```
-   On merge conflict: rebase onto main and retry. On success: comment on the issue.
-
 **If `no`** (default — direct-to-main workflow):
 
 ```bash

--- a/references/sub-skills/pm-specific/task-intake.md
+++ b/references/sub-skills/pm-specific/task-intake.md
@@ -223,6 +223,7 @@ Read .squidsquad/[ROLE]/planning/FEAT-[ROLE_UPPER]-XXX-RESEARCH.md and .squidsqu
 4. Upgrade verification tests (existing installs get the task correctly via upgrade, no breakage for non-upgraded installs)
 5. Smoke tests (quick checks)
 6. Regression risks
+7. Comprehension questions (if the task touches LLM-consumed instructions). Questions a fresh agent should answer correctly by reading only the modified files. Skip for script-only changes.
 
 Write output to .squidsquad/[ROLE]/planning/FEAT-[ROLE_UPPER]-XXX-TEST-PLAN.md
 ```
@@ -255,6 +256,11 @@ PM reviews the subagent's draft, adjusts as needed, and saves the final version.
 
 ## Regression Risks
 - [Risk]: [what to watch for]
+
+## Comprehension Questions (if task touches LLM-consumed instructions)
+### CQ-1: [question a fresh agent should answer from the modified files]
+- **Files**: [which files to read]
+- **Expected**: [correct answer, derivable only from the files]
 ```
 
 **Open in editor**: After TEST-PLAN.md is created, offer to open it (see "Open Artifacts in Editor" below).

--- a/references/sub-skills/qa-specific/verification.md
+++ b/references/sub-skills/qa-specific/verification.md
@@ -106,6 +106,16 @@ python references/scripts/git_ops.py branch-switch main
 
    QA reviews QA-RESULTS.md and makes the final decision.
 
+1b. **Comprehension testing** (if TEST-PLAN.md has a `## Comprehension Questions` section):
+
+   This applies when the task touches LLM-consumed instructions (CLAUDE.md, sub-skills, SOUL.md). If TEST-PLAN.md has no `## Comprehension Questions` section, skip this step.
+
+   Spawn a comprehension agent (via the Agent tool) with a neutral, file-scoped prompt: "Read the following files and answer ONLY from what you find in them. Files: [list modified files]. Answer each question below, quoting file content."
+
+   **Adaptive spawning**: If 4+ sub-skills affected, spawn one agent per sub-skill group. Otherwise, single spawn.
+
+   Record results in QA-RESULTS.md under `## Comprehension Tests` with per-CQ PASS/FAIL entries. A comprehension failure is a legitimate finding.
+
 2. **If no TEST-PLAN.md exists**, test against the acceptance criteria manually.
 
 3. **Zero-gap gate**: If ANY gap, ambiguity, missing documentation, failed check, or unresolved finding is discovered:


### PR DESCRIPTION
Closes #1077

## Summary

- QA verification gains Step 1b: comprehension testing for template changes
- PM test plan template gains comprehension questions section
- Neutral prompt, adaptive spawning, results in QA-RESULTS.md

Status: Pending Test