### PR TITLE
skill: #1292 — fix inc_counter double-print

### DIFF
--- a/references/scripts/cycle.py
+++ b/references/scripts/cycle.py
@@ -71,15 +71,19 @@ def _get_working_state_path(role):
     return SQUIDSQUAD_DIR / role / "working-state.md"
 
 
-def get_counter(role):
-    """Read quiet cycle counter from working-state.md."""
+def _get_counter_value(role):
+    """Read quiet cycle counter value without printing."""
     ws_path = _get_working_state_path(role)
     if not ws_path.exists():
-        print("0")
         return 0
     text = ws_path.read_text(encoding="utf-8")
     match = re.search(r'Quiet Cycle Counter\*\*:\s*(\d+)', text)
-    count = int(match.group(1)) if match else 0
+    return int(match.group(1)) if match else 0
+
+
+def get_counter(role):
+    """Read quiet cycle counter from working-state.md."""
+    count = _get_counter_value(role)
     print(str(count))
     return count
 
@@ -101,8 +105,7 @@ def set_counter(role, value):
 
 def inc_counter(role):
     """Increment quiet cycle counter."""
-    count = get_counter(role)
-    # get_counter already printed, suppress duplicate
+    count = _get_counter_value(role)
     new_count = count + 1
     set_counter(role, new_count)
     print(str(new_count))

--- a/tests/test_cycle.py
+++ b/tests/test_cycle.py
@@ -92,6 +92,14 @@ class TestCounters:
             result = cycle.inc_counter("skill")
         assert result == 3
 
+    def test_inc_counter_prints_only_new_value(self, tmp_path, capsys):
+        """inc_counter should print exactly one line: the new value (not old+new)."""
+        self._setup_working_state(tmp_path, "skill", counter=5)
+        with patch.object(cycle, "SQUIDSQUAD_DIR", tmp_path):
+            cycle.inc_counter("skill")
+        output = capsys.readouterr().out.strip()
+        assert output == "6"
+
     def test_reset_counter(self, tmp_path, capsys):
         self._setup_working_state(tmp_path, "skill", counter=5)
         with patch.object(cycle, "SQUIDSQUAD_DIR", tmp_path):


### PR DESCRIPTION
## #1292

Fix cycle.py inc_counter() printing both old and new counter values to stdout. Extracted _get_counter_value() internal function. Added test.

Status: Pending Test