### PR TITLE
skill: #1345 — fix watcher job relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ You have a codebase and Claude Code. You can fix one bug at a time. But what if 
 - **Shared memory vault** — agents learn your preferences, decisions, and patterns over time via an Obsidian-compatible knowledge base
 - **Self-improvement scanning** — agents proactively find code quality issues, test gaps, and doc drift during quiet cycles, with SQLite-backed scan targeting that learns from past results to focus on high-value areas
 - **Live status bar** — emoji-rich status line showing what each agent is doing, backlog counts, context pressure, and cycle countdown
-- **Agent health monitoring** — boot scripts write `.health` files that track each agent's lifecycle (booting → alive → restarting → dead). PM reads these files for reliable health detection — no more false positives from stale file timestamps
+- **Agent health monitoring** — agent liveness is determined by PID process checks, not file-based state. Boot scripts and health checks verify the actual OS process is running — if the process is dead, the agent is dead, regardless of what `.health` says. `.health` files carry metadata (lifecycle phase, error details) but never gate boot or liveness decisions
 - **Pre-flight checks** — boot scripts verify prerequisites (gh auth, correct branch) before launching agents. Failures are written to `.health` with a reason, preventing crash loops
 - **Auto-restart wrapper** — agents automatically restart with a fresh context when context pressure rises or loops expire, with rate limiting (3 restarts/hour) to prevent restart storms. All agents resume from saved state with no manual reboot needed
 - **Auto-merge** — when QA verifies a task, PM automatically squash-merges the PR so you don't have to. Bug fixes and items tagged `merge:manual` still require your review. Controlled via `Auto Merge` in `config.md`
+- **Multi-model subagents** — route token-heavy tasks (research, discussion prep, test plans, improvement scanning) to external models like GPT 5.2 via API, keeping Claude for the main loop and comprehension testing. Configure per-task model routing in `config.md` under `Model Routing`. Falls back to Claude automatically if the external model is unavailable
 - **Auto versioning** — ships are counted and minor versions auto-bump when thresholds are met
 
 ---

--- a/SKILL.md
+++ b/SKILL.md
@@ -173,6 +173,8 @@ All agents maintain a **working state file** (`.squidsquad/[role]/working-state.
 
 **Auto versioning**: PM tracks a `Shipped Since Last Bump` counter in `config.md`. Each time an item is marked `Shipped` (features) or `Closed` (bugs), the counter increments. When the counter reaches `Ship Threshold` (default 10) AND zero open bugs exist across all trackers, PM automatically bumps the minor version (e.g. `0.5.1` → `0.6.0`), updates `config.md` and `SKILL.md` frontmatter, adds a CHANGELOG section, creates a git tag, and pushes. Version bumps bypass PR flow.
 
+**Multi-model subagents**: Token-heavy tasks (research, discussion prep, test plan drafting, improvement scanning) can be routed to external models via API instead of spawning Claude subagents. Configure which model handles each task type in the `Model Routing` section of `config.md` (e.g. `Research Model: gpt-5.2`, `Comprehension Model: claude`). The router (`references/scripts/model_router.py`) provides a model-agnostic interface with automatic fallback to Claude if the external model fails. Comprehension testing is always Claude-only for same-model fidelity. API keys are managed via environment variables (e.g. `OPENAI_API_KEY`).
+
 ### [Role] Lead Ralph Loop
 
 Each dev agent follows this loop, substituting its own role name and tracker paths:
@@ -423,7 +425,7 @@ When the user says `/squidsquad-status` (or "squad status", "show me the squad",
 
 1. Read `.squidsquad/config.md` to get the list of dev agents and the loop interval.
 2. For each agent (dev agents + PM + DM if `.squidsquad/dm/` exists):
-   - Check health: read `.squidsquad/[role]/.health` if it exists (values: `alive`, `booting`, `restarting`, `dead`, `error|reason`). Fall back to `git log --oneline --since="[2×interval] minutes ago" --grep="^[agent]:"` if no `.health` file — if commits found, show as `active`; if prior commits exist but none recent, show as `stalled`; else `unknown`.
+   - Check health: read `.squidsquad/[role]/.health` if it exists (values: `alive`, `booting`, `restarting`, `dead`, `error|reason`). Note: `.health` files are PID-verified — if the process is dead but `.health` says `alive`, health checks auto-correct it to `dead`. Fall back to `git log --oneline --since="[2×interval] minutes ago" --grep="^[agent]:"` if no `.health` file — if commits found, show as `active`; if prior commits exist but none recent, show as `stalled`; else `unknown`.
    - Show last commit time: `git log --oneline --grep="^[agent]:" -1 --format="%ar"`
 3. For each dev agent, query GitHub Issues via `python references/scripts/tracker.py`:
    - `python references/scripts/tracker.py list-issues [role]` — count and list open issues

--- a/references/templates/start-role.ps1
+++ b/references/templates/start-role.ps1
@@ -49,14 +49,14 @@ try { python references/scripts/config.py sync-agents 2>$null } catch {}
 $env:SQUIDSQUAD_ROLE = "{{ROLE}}"
 
 # --- PID lock: prevent double-start ---
-$RoleDir = ".squidsquad/{{ROLE}}"
-$PidFile = "$RoleDir/.pid"
-$StopFile = "$RoleDir/.stop"
-$RestartSentinel = "$RoleDir/.restart"
-$RestartLog = "$RoleDir/restart-log.txt"
-$StateFile = "$RoleDir/current-state"
-$PressureFile = "$RoleDir/context-pressure"
-$HealthFile = "$RoleDir/.health"
+$RoleDir = Join-Path $repoRoot ".squidsquad/{{ROLE}}"
+$PidFile = Join-Path $RoleDir ".pid"
+$StopFile = Join-Path $RoleDir ".stop"
+$RestartSentinel = Join-Path $RoleDir ".restart"
+$RestartLog = Join-Path $RoleDir "restart-log.txt"
+$StateFile = Join-Path $RoleDir "current-state"
+$PressureFile = Join-Path $RoleDir "context-pressure"
+$HealthFile = Join-Path $RoleDir ".health"
 
 if (-not (Test-Path $RoleDir)) { New-Item -ItemType Directory -Path $RoleDir -Force | Out-Null }
 


### PR DESCRIPTION
## #1345

Boot wrapper watcher Start-Job used relative paths — .restart sentinel never detected because Start-Job runs in $HOME, not repo root. Changed to absolute paths via Join-Path $repoRoot. Deployed to all 5 role boot scripts.

Status: Pending Test