### PR TITLE
skill: #1550 — Replace agent self-health with watchdog supervisor

### DIFF
--- a/.squidsquad/dm/iterations/iter-2.md
+++ b/.squidsquad/dm/iterations/iter-2.md
@@ -1,0 +1,5 @@
+# Iteration 2
+
+- **Date**: 2026-04-19 11:02
+- **Type**: quiet
+- **Note**: No pending-ship items. Bugs unchanged: #1396 pending-test, #302/#303 pending PM.

--- a/.squidsquad/dm/iterations/iter-22.md
+++ b/.squidsquad/dm/iterations/iter-22.md
@@ -1,5 +1,0 @@
-# Iteration 22
-
-- **Date**: 2026-04-19 01:02
-- **Type**: quiet
-- **Note**: No pending-ship items. #1396 still pending-test. Shipped count 0/10.

--- a/.squidsquad/dm/iterations/iter-23.md
+++ b/.squidsquad/dm/iterations/iter-23.md
@@ -1,5 +1,0 @@
-# Iteration 23
-
-- **Date**: 2026-04-19 01:32
-- **Type**: quiet
-- **Note**: No pending-ship items. #1396 still pending-test. Shipped count 0/10.

--- a/.squidsquad/pm/iterations/iter-346.md
+++ b/.squidsquad/pm/iterations/iter-346.md
@@ -1,0 +1,10 @@
+# Iteration 346
+
+- **Date**: 2026-04-19 11:02
+- **Type**: active
+- **Work Summary**:
+  - #1550 at pending-test (skill fast-tracked watchdog)
+  - #474 #473 #1518 in-progress by skill
+  - all agents healthy after reboot
+  - config.md cleaned (boot removed from Dev Agents)
+- **Notes**: Pending human decision: remove Aliases section from config.md

--- a/.squidsquad/qa/iterations/iter-12.md
+++ b/.squidsquad/qa/iterations/iter-12.md
@@ -1,5 +1,8 @@
 # Iteration 12
 
-- **Date**: 2026-04-19 03:33
-- **Type**: quiet
-- **Note**: No pending-test items. PM restarting. All agents healthy.
+- **Date**: 2026-04-19 11:35
+- **Type**: active
+- **Work Summary**:
+  - Re-verified #473 PASS (dev SOUL.md test coverage)
+  - #474 PASS (PM/QA verification test coverage). Both → Pending Ship. Ship counter 3→5.
+- **Notes**: #473/#474 QA rework fixed installed file regression. #1518 closed externally.

--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -500,7 +500,7 @@ def main():
             output = deploy_role(role)
             lines = output.read_text(encoding="utf-8").count("\n")
             print(f"  {role}: {lines} lines -> {output.relative_to(REPO_ROOT)}")
-        # Generate .local-config for health check and auto-boot
+        # Generate .local-config for health check and watchdog
         lc = generate_local_config(roles)
         print(f"  .local-config: {len(roles)} agents -> {lc.relative_to(REPO_ROOT)}")
 

--- a/references/scripts/config.py
+++ b/references/scripts/config.py
@@ -49,7 +49,6 @@ FIELD_MAP = {
     "interval": ("Iteration Interval", "Minutes"),
     "context-threshold": ("Context Pressure", "Threshold"),
     "pr-flow": ("PR Flow", "Enabled"),
-    "auto-boot": ("Auto Boot Agents", "Enabled"),
     "improvement-scanning": ("Improvement Scanning", "Enabled"),
     "ship-threshold": ("Auto Versioning", "Ship Threshold"),
     "shipped-since-bump": ("Auto Versioning", "Shipped Since Last Bump"),

--- a/references/scripts/wizard.py
+++ b/references/scripts/wizard.py
@@ -815,7 +815,7 @@ def scaffold_install(spec, target_root, overwrite_existing=False):
             "working_state": str(ws_path),
         })
 
-    # 3. Generate .local-config for health check and auto-boot
+    # 3. Generate .local-config for health check and watchdog
     try:
         from compose import generate_local_config
     except ImportError:

--- a/references/sub-skills/qa-specific/verification.md
+++ b/references/sub-skills/qa-specific/verification.md
@@ -215,21 +215,8 @@ For each PR:
 
 If `PR Flow: no`, skip this step.
 
-### Step 6 — Agent Health Check
+### Step 6 — Agent Health Check (Watchdog-Managed)
 
-Print: `[🦑 HH:MM:SS] Checking agent health...`
+Agent health monitoring is handled by the external **watchdog** (`references/scripts/watchdog.py`). QA no longer runs health checks manually.
 
-Check each agent's health by reading their `current-state` file via cross-clone paths from `.squidsquad/.local-config`. Each agent writes to its `current-state` file at the end of every cycle (including quiet cycles), so the file's mtime indicates when the agent last completed a cycle.
-
-Read `.squidsquad/.local-config` to get each agent's clone path. For each dev agent listed in `config.md`, plus PM, plus DM and designer (if their directories exist):
-
-1. Look up the agent's clone path from `.local-config` (format: `- **role**: /absolute/path`).
-2. Read `<path>/.squidsquad/<role>/current-state` and check the file's mtime.
-3. Read the `Iteration Interval > Minutes` value from `config.md` (default 30). An agent is stalled if the `current-state` mtime is older than 2× the iteration interval.
-
-- If `current-state` exists and mtime is recent (within 2× interval): agent is healthy (🦑).
-- If `current-state` exists but mtime is stale (older than 2× interval): agent is **stalled** (👻). Log a warning in `qa/qa-log.md` and append a Discussion note:
-  ```
-  > [YYYY-MM-DD HH:MM] **qa**: Agent [role] appears stalled — no cycle activity for [elapsed] minutes. Please check.
-  ```
-- If `.local-config` is missing, path is unreachable, or `current-state` doesn't exist: agent status is unknown (❓) — note in QA log.
+This step is a no-op — skip it entirely.

--- a/references/templates/start-role.ps1
+++ b/references/templates/start-role.ps1
@@ -52,10 +52,8 @@ $env:SQUIDSQUAD_ROLE = "{{ROLE}}"
 $RoleDir = Join-Path $repoRoot ".squidsquad/{{ROLE}}"
 $PidFile = Join-Path $RoleDir ".pid"
 $StopFile = Join-Path $RoleDir ".stop"
-$RestartSentinel = Join-Path $RoleDir ".restart"
 $RestartLog = Join-Path $RoleDir "restart-log.txt"
 $StateFile = Join-Path $RoleDir "current-state"
-$PressureFile = Join-Path $RoleDir "context-pressure"
 $HealthFile = Join-Path $RoleDir ".health"
 
 if (-not (Test-Path $RoleDir)) { New-Item -ItemType Directory -Path $RoleDir -Force | Out-Null }
@@ -114,19 +112,17 @@ $PID | Set-Content $PidFile -NoNewline
 
 # --- Cleanup on exit: remove PID file, write .health dead ---
 try {
-    # --- Auto-restart wrapper ---
+    # --- Auto-restart wrapper (crash recovery only — lifecycle managed by watchdog) ---
     $MaxRestarts = 50
     $RestartCount = 0
     $CooldownBase = 2
     $CooldownMax = 300
     $MinRuntimeSeconds = 120
-    $SelfRestartLimit = 3  # max self-restarts per hour
 
     while ($true) {
-        # Reset status bar and context pressure for a fresh session
+        # Reset status bar for a fresh session
         Remove-Item $StateFile -ErrorAction SilentlyContinue
         "idle|Initializing..." | Set-Content $StateFile -NoNewline
-        Remove-Item $PressureFile -ErrorAction SilentlyContinue
 
         Write-Health "alive"
 
@@ -135,72 +131,11 @@ try {
         $sysPrompt = "SQUIDSQUAD_ROLE={{ROLE}}"
         $initMsg = "start the loop"
 
-        # Read context threshold from config (default 70)
-        $CtxThreshold = 70
-        try {
-            $t = (python references/scripts/config.py get context-threshold 2>$null).Trim()
-            if ($t -match '^\d+$') { $CtxThreshold = [int]$t }
-        } catch {}
-
-        # Start Claude as a background process so we can poll for .restart and context pressure
-        # Use cmd /c to launch — claude is a .cmd shim on Windows, Start-Process can't exec .cmd directly
+        # Start Claude as a foreground process (no background watcher needed — watchdog handles lifecycle)
         $claudeProc = Start-Process -FilePath "cmd.exe" -ArgumentList "/c", "claude", "--dangerously-skip-permissions", "--name", "`"$AgentName`"", "--append-system-prompt", "$sysPrompt", "$initMsg" -NoNewWindow -PassThru
-
-        # Background poller: watch for .restart sentinel AND context pressure
-        # Context pressure flow:
-        #   1. Agent writes pressure % to context-pressure file (Step 1b, early in cycle)
-        #   2. Watcher detects pressure >= threshold
-        #   3. Watcher waits for agent to finish cycle (idle| in current-state, max 10 min)
-        #   4. Watcher kills process → boot script restarts with fresh context
-        $watcherJob = Start-Job -ScriptBlock {
-            param($sentinel, $pid, $pressureFile, $stateFile, $threshold)
-            $MaxWaitCycle = 600  # 10 minutes max wait for cycle to finish
-            while (-not (Get-Process -Id $pid -ErrorAction SilentlyContinue).HasExited) {
-                # Check .restart sentinel (agent requested restart)
-                if (Test-Path $sentinel) {
-                    Write-Output "[SquidSquad] Restart sentinel detected — stopping Claude (PID $pid)..."
-                    try { & taskkill /T /F /PID $pid 2>$null } catch {}
-                    break
-                }
-                # Check context pressure
-                if (Test-Path $pressureFile) {
-                    $raw = (Get-Content $pressureFile -ErrorAction SilentlyContinue | Select-Object -First 1)
-                    if ($raw -match '^\d+$') {
-                        $pressure = [int]$raw
-                        if ($pressure -ge $threshold) {
-                            Write-Output "[SquidSquad] Context pressure ${pressure}% >= ${threshold}% — waiting for cycle to finish..."
-                            # Wait for agent to finish its current cycle (idle| in current-state)
-                            $waited = 0
-                            while ($waited -lt $MaxWaitCycle) {
-                                if ((Get-Process -Id $pid -ErrorAction SilentlyContinue).HasExited) { break }
-                                if (Test-Path $stateFile) {
-                                    $state = (Get-Content $stateFile -ErrorAction SilentlyContinue | Select-Object -First 1)
-                                    if ($state -match '^idle\|') {
-                                        Write-Output "[SquidSquad] Cycle complete — restarting for fresh context..."
-                                        break
-                                    }
-                                }
-                                Start-Sleep -Seconds 10
-                                $waited += 10
-                            }
-                            if ($waited -ge $MaxWaitCycle) {
-                                Write-Output "[SquidSquad] Timed out waiting for cycle — forcing restart..."
-                            }
-                            try { & taskkill /T /F /PID $pid 2>$null } catch {}
-                            break
-                        }
-                    }
-                }
-                Start-Sleep -Seconds 5
-            }
-        } -ArgumentList $RestartSentinel, $claudeProc.Id, $PressureFile, $StateFile, $CtxThreshold
 
         $claudeProc.WaitForExit()
         $exitCode = $claudeProc.ExitCode
-
-        # Clean up watcher
-        Stop-Job $watcherJob -ErrorAction SilentlyContinue
-        Remove-Job $watcherJob -ErrorAction SilentlyContinue
 
         $runtime = [int]((Get-Date) - $startTime).TotalSeconds
 
@@ -211,60 +146,6 @@ try {
             "stopped|Agent stopped by user" | Set-Content $StateFile -NoNewline
             Write-Health "dead"
             break
-        }
-
-        # Check for self-restart sentinel (agent requested restart)
-        if (Test-Path $RestartSentinel) {
-            $reason = (Get-Content $RestartSentinel -ErrorAction SilentlyContinue | Select-Object -First 1)
-            if (-not $reason) { $reason = "unknown" }
-            Remove-Item $RestartSentinel -ErrorAction SilentlyContinue
-
-            # --- Self-restart rate limit: 3 per hour (hard enforcement) ---
-            $selfRestartCount = 0
-            $oneHourAgo = (Get-Date).AddHours(-1)
-            if (Test-Path $RestartLog) {
-                $lines = Get-Content $RestartLog -ErrorAction SilentlyContinue
-                foreach ($line in $lines) {
-                    if ($line -match "self-restart" -and $line -match "^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})") {
-                        try {
-                            $entryTime = [datetime]::ParseExact($Matches[1], "yyyy-MM-dd HH:mm:ss", $null)
-                            if ($entryTime -gt $oneHourAgo) { $selfRestartCount++ }
-                        } catch {}
-                    }
-                }
-            }
-
-            if ($selfRestartCount -ge $SelfRestartLimit) {
-                $ts = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-                "$ts | exit=$exitCode | self-restart-BLOCKED | reason=$reason | rate-limit ($SelfRestartLimit/hr exceeded) | runtime=${runtime}s" | Add-Content $RestartLog
-                Write-Host "[SquidSquad] Self-restart rate limit ($SelfRestartLimit/hr) exceeded — ignoring .restart sentinel."
-                # Continue running — do NOT restart, fall through to normal crash handling
-            } else {
-                $ts = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-                "$ts | exit=$exitCode | self-restart | reason=$reason | runtime=${runtime}s" | Add-Content $RestartLog
-                Write-Host "[SquidSquad] Self-restart requested: $reason. Restarting immediately..."
-                Write-Health "restarting"
-                "restarting|Self-restart: $reason" | Set-Content $StateFile -NoNewline
-                $RestartCount = 0
-                Start-Sleep -Seconds 2
-                continue
-            }
-        }
-
-        # Check if this was a context pressure restart
-        if (Test-Path $PressureFile) {
-            $raw = (Get-Content $PressureFile -ErrorAction SilentlyContinue | Select-Object -First 1)
-            if ($raw -match '^\d+$' -and [int]$raw -ge $CtxThreshold) {
-                $ts = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-                "$ts | exit=$exitCode | context-pressure | pressure=${raw}% | runtime=${runtime}s" | Add-Content $RestartLog
-                Write-Host "[SquidSquad] Context pressure restart (${raw}%). Restarting with fresh context..."
-                Write-Health "restarting"
-                "restarting|Context pressure ${raw}% — fresh start" | Set-Content $StateFile -NoNewline
-                Remove-Item $PressureFile -ErrorAction SilentlyContinue
-                $RestartCount = 0
-                Start-Sleep -Seconds 2
-                continue
-            }
         }
 
         # Append restart log entry

--- a/references/templates/start-role.sh
+++ b/references/templates/start-role.sh
@@ -46,10 +46,8 @@ export SQUIDSQUAD_ROLE="{{ROLE}}"
 ROLE_DIR=".squidsquad/{{ROLE}}"
 PID_FILE="$ROLE_DIR/.pid"
 STOP_FILE="$ROLE_DIR/.stop"
-RESTART_SENTINEL="$ROLE_DIR/.restart"
 RESTART_LOG="$ROLE_DIR/restart-log.txt"
 STATE_FILE="$ROLE_DIR/current-state"
-PRESSURE_FILE="$ROLE_DIR/context-pressure"
 HEALTH_FILE="$ROLE_DIR/.health"
 
 mkdir -p "$ROLE_DIR"
@@ -96,7 +94,7 @@ if [ -f "$PID_FILE" ]; then
 fi
 echo $$ > "$PID_FILE"
 
-# --- Cleanup trap: remove PID file on any exit, kill child on signal, write .health dead ---
+# --- Cleanup trap: remove PID file on any exit, write .health dead ---
 CHILD_PID=""
 cleanup() {
   [ -n "$CHILD_PID" ] && kill "$CHILD_PID" 2>/dev/null || true
@@ -133,84 +131,28 @@ on_sigint() {
 trap on_sigint INT
 trap 'echo "[SquidSquad] SIGTERM — stopping."; exit 0' TERM
 
-# --- Auto-restart wrapper ---
+# --- Auto-restart wrapper (crash recovery only — lifecycle managed by watchdog) ---
 MAX_RESTARTS=50
 RESTART_COUNT=0
 COOLDOWN_BASE=2
 COOLDOWN_MAX=300
 MIN_RUNTIME_SECONDS=120
-SELF_RESTART_LIMIT=3  # max self-restarts per hour
 
 while true; do
-  # Reset status bar and context pressure for a fresh session
+  # Reset status bar for a fresh session
   rm -f "$STATE_FILE"
   echo "idle|Initializing..." > "$STATE_FILE"
-  rm -f "$PRESSURE_FILE"
 
   write_health "alive"
 
   START_TIME=$(date +%s)
 
-  # Read context threshold from config (default 70)
-  CTX_THRESHOLD=$(python references/scripts/config.py get context-threshold 2>/dev/null || echo "70")
-  CTX_THRESHOLD=${CTX_THRESHOLD//[^0-9]/}
-  [ -z "$CTX_THRESHOLD" ] && CTX_THRESHOLD=70
-
   claude --dangerously-skip-permissions --name "$AGENT_NAME" --append-system-prompt "SQUIDSQUAD_ROLE={{ROLE}}" "start the loop" &
   CHILD_PID=$!
-
-  # Background poller: watch for .restart sentinel AND context pressure
-  # Context pressure flow:
-  #   1. Agent writes pressure % to context-pressure file (Step 1b, early in cycle)
-  #   2. Watcher detects pressure >= threshold
-  #   3. Watcher waits for agent to finish cycle (idle| in current-state, max 10 min)
-  #   4. Watcher kills process → boot script restarts with fresh context
-  (
-    MAX_WAIT_CYCLE=600  # 10 minutes max wait for cycle to finish
-    while kill -0 "$CHILD_PID" 2>/dev/null; do
-      # Check .restart sentinel (agent requested restart)
-      if [ -f "$RESTART_SENTINEL" ]; then
-        echo "[SquidSquad] Restart sentinel detected — killing Claude (PID $CHILD_PID)..."
-        kill -INT "$CHILD_PID" 2>/dev/null
-        break
-      fi
-      # Check context pressure
-      if [ -f "$PRESSURE_FILE" ]; then
-        RAW=$(cat "$PRESSURE_FILE" 2>/dev/null | head -1 | tr -d '[:space:]')
-        if [[ "$RAW" =~ ^[0-9]+$ ]] && [ "$RAW" -ge "$CTX_THRESHOLD" ]; then
-          echo "[SquidSquad] Context pressure ${RAW}% >= ${CTX_THRESHOLD}% — waiting for cycle to finish..."
-          WAITED=0
-          while [ "$WAITED" -lt "$MAX_WAIT_CYCLE" ]; do
-            kill -0 "$CHILD_PID" 2>/dev/null || break
-            if [ -f "$STATE_FILE" ]; then
-              STATE=$(head -1 "$STATE_FILE" 2>/dev/null)
-              if [[ "$STATE" == idle\|* ]]; then
-                echo "[SquidSquad] Cycle complete — restarting for fresh context..."
-                break
-              fi
-            fi
-            sleep 10
-            WAITED=$((WAITED + 10))
-          done
-          if [ "$WAITED" -ge "$MAX_WAIT_CYCLE" ]; then
-            echo "[SquidSquad] Timed out waiting for cycle — forcing restart..."
-          fi
-          kill -INT "$CHILD_PID" 2>/dev/null
-          break
-        fi
-      fi
-      sleep 5
-    done
-  ) &
-  WATCHER_PID=$!
 
   wait "$CHILD_PID"
   EXIT_CODE=$?
   CHILD_PID=""
-
-  # Clean up watcher
-  kill "$WATCHER_PID" 2>/dev/null
-  wait "$WATCHER_PID" 2>/dev/null
 
   END_TIME=$(date +%s)
   RUNTIME=$((END_TIME - START_TIME))
@@ -222,61 +164,6 @@ while true; do
     echo "stopped|Agent stopped by user" > "$STATE_FILE"
     write_health "dead"
     break
-  fi
-
-  # Check for self-restart sentinel (agent requested restart)
-  if [ -f "$RESTART_SENTINEL" ]; then
-    REASON=$(cat "$RESTART_SENTINEL" 2>/dev/null || echo "unknown")
-    rm -f "$RESTART_SENTINEL"
-
-    # --- Self-restart rate limit: 3 per hour (hard enforcement) ---
-    ONE_HOUR_AGO=$(date -d '1 hour ago' +%s 2>/dev/null || date -v-1H +%s 2>/dev/null || echo 0)
-    SELF_RESTART_COUNT=0
-    if [ -f "$RESTART_LOG" ]; then
-      while IFS= read -r line; do
-        if echo "$line" | grep -q "self-restart" && ! echo "$line" | grep -q "self-restart-BLOCKED"; then
-          ENTRY_TS=$(echo "$line" | grep -o '^[0-9-]* [0-9:]*')
-          if [ -n "$ENTRY_TS" ]; then
-            ENTRY_EPOCH=$(date -d "$ENTRY_TS" +%s 2>/dev/null || date -j -f "%Y-%m-%d %H:%M:%S" "$ENTRY_TS" +%s 2>/dev/null || echo 0)
-            if [ "$ENTRY_EPOCH" -gt "$ONE_HOUR_AGO" ] 2>/dev/null; then
-              SELF_RESTART_COUNT=$((SELF_RESTART_COUNT + 1))
-            fi
-          fi
-        fi
-      done < "$RESTART_LOG"
-    fi
-
-    if [ "$SELF_RESTART_COUNT" -ge "$SELF_RESTART_LIMIT" ]; then
-      TS=$(date '+%Y-%m-%d %H:%M:%S')
-      echo "$TS | exit=$EXIT_CODE | self-restart-BLOCKED | reason=$REASON | rate-limit ($SELF_RESTART_LIMIT/hr exceeded) | runtime=${RUNTIME}s" >> "$RESTART_LOG"
-      echo "[SquidSquad] Self-restart rate limit ($SELF_RESTART_LIMIT/hr) exceeded — ignoring .restart sentinel."
-      # Fall through to normal crash handling
-    else
-      TS=$(date '+%Y-%m-%d %H:%M:%S')
-      echo "$TS | exit=$EXIT_CODE | self-restart | reason=$REASON | runtime=${RUNTIME}s" >> "$RESTART_LOG"
-      echo "[SquidSquad] Self-restart requested: $REASON. Restarting immediately..."
-      write_health "restarting"
-      echo "restarting|Self-restart: $REASON" > "$STATE_FILE"
-      RESTART_COUNT=0
-      sleep 2
-      continue
-    fi
-  fi
-
-  # Check if this was a context pressure restart
-  if [ -f "$PRESSURE_FILE" ]; then
-    RAW=$(cat "$PRESSURE_FILE" 2>/dev/null | head -1 | tr -d '[:space:]')
-    if [[ "$RAW" =~ ^[0-9]+$ ]] && [ "$RAW" -ge "$CTX_THRESHOLD" ]; then
-      TS=$(date '+%Y-%m-%d %H:%M:%S')
-      echo "$TS | exit=$EXIT_CODE | context-pressure | pressure=${RAW}% | runtime=${RUNTIME}s" >> "$RESTART_LOG"
-      echo "[SquidSquad] Context pressure restart (${RAW}%). Restarting with fresh context..."
-      write_health "restarting"
-      echo "restarting|Context pressure ${RAW}% — fresh start" > "$STATE_FILE"
-      rm -f "$PRESSURE_FILE"
-      RESTART_COUNT=0
-      sleep 2
-      continue
-    fi
   fi
 
   # Append restart log entry: timestamp | exit_code | restart_count | runtime

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -1,0 +1,364 @@
+"""Tests for references/scripts/watchdog.py — standalone agent lifecycle supervisor."""
+
+import json
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import watchdog
+import health_check
+
+
+class TestReadContextThreshold:
+    def test_reads_from_config(self, tmp_path):
+        config = tmp_path / "config.md"
+        config.write_text("## Context Pressure\n\n- **Threshold**: 80\n")
+        with patch.object(watchdog, "CONFIG_MD", config):
+            assert watchdog._read_context_threshold() == 80
+
+    def test_missing_config_returns_default(self, tmp_path):
+        with patch.object(watchdog, "CONFIG_MD", tmp_path / "missing"):
+            assert watchdog._read_context_threshold() == 70
+
+
+class TestReadIntervalMinutes:
+    def test_reads_from_config(self, tmp_path):
+        config = tmp_path / "config.md"
+        config.write_text("## Iteration Interval\n\n- **Minutes**: 45\n")
+        with patch.object(watchdog, "CONFIG_MD", config):
+            assert watchdog._read_interval_minutes() == 45
+
+    def test_missing_config_returns_default(self, tmp_path):
+        with patch.object(watchdog, "CONFIG_MD", tmp_path / "missing"):
+            assert watchdog._read_interval_minutes() == 30
+
+
+class TestGetAllRoles:
+    def test_includes_pm_always(self, tmp_path):
+        config = tmp_path / "config.md"
+        config.write_text("## Agents\n\n- **Dev Agents**: skill\n")
+        with patch.object(watchdog, "CONFIG_MD", config):
+            roles = watchdog._get_all_roles()
+        assert "pm" in roles
+
+    def test_includes_dev_agents(self, tmp_path):
+        config = tmp_path / "config.md"
+        config.write_text("## Agents\n\n- **Dev Agents**: skill, boot\n")
+        with patch.object(watchdog, "CONFIG_MD", config):
+            roles = watchdog._get_all_roles()
+        assert "skill" in roles
+        assert "boot" in roles
+
+    def test_includes_dm_when_present(self, tmp_path):
+        config = tmp_path / "config.md"
+        config.write_text(
+            "## Agents\n\n- **Dev Agents**: skill\n- **DM**: present\n"
+        )
+        with patch.object(watchdog, "CONFIG_MD", config):
+            roles = watchdog._get_all_roles()
+        assert "dm" in roles
+
+    def test_includes_qa_when_present(self, tmp_path):
+        config = tmp_path / "config.md"
+        config.write_text(
+            "## Agents\n\n- **Dev Agents**: skill\n- **QA**: always present\n"
+        )
+        with patch.object(watchdog, "CONFIG_MD", config):
+            roles = watchdog._get_all_roles()
+        assert "qa" in roles
+
+    def test_missing_config_returns_pm_only(self, tmp_path):
+        with patch.object(watchdog, "CONFIG_MD", tmp_path / "missing"):
+            roles = watchdog._get_all_roles()
+        assert roles == ["pm"]
+
+
+class TestReadContextPressure:
+    def test_reads_pressure_value(self, tmp_path):
+        squid = tmp_path / ".squidsquad" / "skill"
+        squid.mkdir(parents=True)
+        (squid / "context-pressure").write_text("42")
+        assert watchdog._read_context_pressure("skill", tmp_path) == 42
+
+    def test_returns_none_when_missing(self, tmp_path):
+        assert watchdog._read_context_pressure("skill", tmp_path) is None
+
+    def test_returns_none_on_invalid_content(self, tmp_path):
+        squid = tmp_path / ".squidsquad" / "skill"
+        squid.mkdir(parents=True)
+        (squid / "context-pressure").write_text("not-a-number")
+        assert watchdog._read_context_pressure("skill", tmp_path) is None
+
+
+class TestReadCurrentState:
+    def test_reads_idle_state(self, tmp_path):
+        squid = tmp_path / ".squidsquad" / "skill"
+        squid.mkdir(parents=True)
+        (squid / "current-state").write_text("idle|")
+        phase, desc = watchdog._read_current_state("skill", tmp_path)
+        assert phase == "idle"
+        assert desc == ""
+
+    def test_reads_active_state(self, tmp_path):
+        squid = tmp_path / ".squidsquad" / "skill"
+        squid.mkdir(parents=True)
+        (squid / "current-state").write_text("implementing|dev-agent — #42")
+        phase, desc = watchdog._read_current_state("skill", tmp_path)
+        assert phase == "implementing"
+        assert desc == "dev-agent — #42"
+
+    def test_returns_empty_when_missing(self, tmp_path):
+        phase, desc = watchdog._read_current_state("skill", tmp_path)
+        assert phase == ""
+        assert desc == ""
+
+
+class TestIsCycleComplete:
+    def test_idle_means_complete(self, tmp_path):
+        squid = tmp_path / ".squidsquad" / "skill"
+        squid.mkdir(parents=True)
+        (squid / "current-state").write_text("idle|")
+        assert watchdog._is_cycle_complete("skill", tmp_path) is True
+
+    def test_implementing_means_not_complete(self, tmp_path):
+        squid = tmp_path / ".squidsquad" / "skill"
+        squid.mkdir(parents=True)
+        (squid / "current-state").write_text("implementing|#42")
+        assert watchdog._is_cycle_complete("skill", tmp_path) is False
+
+
+class TestCheckAndAct:
+    """Integration tests for the main watchdog logic."""
+
+    def _setup_agent(self, tmp_path, role, health_status="alive",
+                     pressure=None, state="idle|", pid=12345):
+        """Set up a fake agent directory for testing."""
+        squid = tmp_path / ".squidsquad" / role
+        squid.mkdir(parents=True, exist_ok=True)
+        if health_status:
+            (squid / ".health").write_text(health_status)
+        if pressure is not None:
+            (squid / "context-pressure").write_text(str(pressure))
+        if state:
+            (squid / "current-state").write_text(state)
+        if pid:
+            (squid / ".pid").write_text(str(pid))
+        # Create CLAUDE.md
+        (squid / "CLAUDE.md").write_text("# Test agent")
+
+    @patch.object(watchdog.boot_remote, "_parse_local_config")
+    @patch.object(watchdog.health_check, "check_agent_health")
+    def test_healthy_agent_no_action(self, mock_health, mock_config, tmp_path):
+        mock_config.return_value = {"skill": tmp_path}
+        mock_health.return_value = {
+            "role": "skill",
+            "health": "healthy",
+            "reason": "all good",
+        }
+        self._setup_agent(tmp_path, "skill", pressure=10)
+
+        with patch.object(watchdog, "REPO_ROOT", tmp_path), \
+             patch.object(watchdog, "CONFIG_MD", tmp_path / "config.md"):
+            (tmp_path / "config.md").write_text(
+                "## Agents\n- **Dev Agents**: skill\n"
+                "## Context Pressure\n- **Threshold**: 70\n"
+                "## Iteration Interval\n- **Minutes**: 30\n"
+            )
+            actions = watchdog.check_and_act(roles=["skill"])
+
+        assert len(actions) == 1
+        assert actions[0]["action"] == "healthy"
+
+    @patch.object(watchdog.boot_remote, "_parse_local_config")
+    @patch.object(watchdog.health_check, "check_agent_health")
+    @patch.object(watchdog.boot_remote, "boot_agent")
+    def test_dead_agent_gets_booted(self, mock_boot, mock_health, mock_config, tmp_path):
+        mock_config.return_value = {"skill": tmp_path}
+        mock_health.return_value = {
+            "role": "skill",
+            "health": "stalled",
+            "reason": ".health=dead",
+        }
+        mock_boot.return_value = {
+            "role": "skill",
+            "action": "spawn",
+            "success": True,
+            "message": "spawned",
+        }
+
+        with patch.object(watchdog, "REPO_ROOT", tmp_path), \
+             patch.object(watchdog, "CONFIG_MD", tmp_path / "config.md"), \
+             patch.object(watchdog, "WATCHDOG_LOG", tmp_path / "log.txt"):
+            (tmp_path / "config.md").write_text(
+                "## Agents\n- **Dev Agents**: skill\n"
+            )
+            actions = watchdog.check_and_act(roles=["skill"])
+
+        assert len(actions) == 1
+        assert actions[0]["action"] == "boot"
+        mock_boot.assert_called_once_with("skill")
+
+    @patch.object(watchdog.boot_remote, "_parse_local_config")
+    @patch.object(watchdog.health_check, "check_agent_health")
+    def test_stopped_agent_skipped(self, mock_health, mock_config, tmp_path):
+        mock_config.return_value = {"skill": tmp_path}
+        mock_health.return_value = {
+            "role": "skill",
+            "health": "stopped",
+            "reason": ".stop sentinel",
+        }
+
+        with patch.object(watchdog, "REPO_ROOT", tmp_path), \
+             patch.object(watchdog, "CONFIG_MD", tmp_path / "config.md"):
+            (tmp_path / "config.md").write_text(
+                "## Agents\n- **Dev Agents**: skill\n"
+            )
+            actions = watchdog.check_and_act(roles=["skill"])
+
+        assert len(actions) == 1
+        assert actions[0]["action"] == "skip"
+
+    @patch.object(watchdog, "_kill_agent")
+    @patch.object(watchdog.boot_remote, "_parse_local_config")
+    @patch.object(watchdog.health_check, "check_agent_health")
+    def test_high_pressure_idle_agent_restarted(
+        self, mock_health, mock_config, mock_kill, tmp_path
+    ):
+        mock_config.return_value = {"skill": tmp_path}
+        mock_health.return_value = {
+            "role": "skill",
+            "health": "healthy",
+            "reason": "all good",
+        }
+        mock_kill.return_value = True
+
+        self._setup_agent(tmp_path, "skill", pressure=85, state="idle|", pid=99999)
+
+        with patch.object(watchdog, "REPO_ROOT", tmp_path), \
+             patch.object(watchdog, "CONFIG_MD", tmp_path / "config.md"), \
+             patch.object(watchdog, "WATCHDOG_LOG", tmp_path / "log.txt"):
+            (tmp_path / "config.md").write_text(
+                "## Agents\n- **Dev Agents**: skill\n"
+                "## Context Pressure\n- **Threshold**: 70\n"
+                "## Iteration Interval\n- **Minutes**: 30\n"
+            )
+            actions = watchdog.check_and_act(roles=["skill"])
+
+        assert len(actions) == 1
+        assert actions[0]["action"] == "restart"
+        assert "context pressure" in actions[0]["detail"]
+        mock_kill.assert_called_once_with(99999)
+
+    @patch.object(watchdog.boot_remote, "_parse_local_config")
+    @patch.object(watchdog.health_check, "check_agent_health")
+    def test_high_pressure_busy_agent_pending(
+        self, mock_health, mock_config, tmp_path
+    ):
+        mock_config.return_value = {"skill": tmp_path}
+        mock_health.return_value = {
+            "role": "skill",
+            "health": "healthy",
+            "reason": "all good",
+        }
+
+        self._setup_agent(
+            tmp_path, "skill", pressure=85, state="implementing|#42", pid=99999
+        )
+
+        with patch.object(watchdog, "REPO_ROOT", tmp_path), \
+             patch.object(watchdog, "CONFIG_MD", tmp_path / "config.md"):
+            (tmp_path / "config.md").write_text(
+                "## Agents\n- **Dev Agents**: skill\n"
+                "## Context Pressure\n- **Threshold**: 70\n"
+                "## Iteration Interval\n- **Minutes**: 30\n"
+            )
+            actions = watchdog.check_and_act(roles=["skill"])
+
+        assert len(actions) == 1
+        assert actions[0]["action"] == "pending-restart"
+        assert "waiting for cycle" in actions[0]["detail"]
+
+
+class TestRunOnce:
+    @patch.object(watchdog, "check_and_act")
+    def test_returns_actions_and_flag(self, mock_check):
+        mock_check.return_value = [
+            {"role": "skill", "action": "healthy", "detail": "ok"},
+        ]
+        actions, any_intervention = watchdog.run_once()
+        assert len(actions) == 1
+        assert any_intervention is False
+
+    @patch.object(watchdog, "check_and_act")
+    def test_intervention_flag_when_boot(self, mock_check):
+        mock_check.return_value = [
+            {"role": "skill", "action": "boot", "detail": "spawned"},
+        ]
+        actions, any_intervention = watchdog.run_once()
+        assert any_intervention is True
+
+    @patch.object(watchdog, "check_and_act")
+    def test_intervention_flag_when_restart(self, mock_check):
+        mock_check.return_value = [
+            {"role": "skill", "action": "restart", "detail": "pressure"},
+        ]
+        actions, any_intervention = watchdog.run_once()
+        assert any_intervention is True
+
+
+class TestLog:
+    def test_log_writes_to_file(self, tmp_path):
+        log_file = tmp_path / "watchdog-log.txt"
+        with patch.object(watchdog, "WATCHDOG_LOG", log_file):
+            watchdog._log("test message")
+        content = log_file.read_text(encoding="utf-8")
+        assert "test message" in content
+        assert "INFO" in content
+
+    def test_trim_log_keeps_max_lines(self, tmp_path):
+        log_file = tmp_path / "watchdog-log.txt"
+        lines = [f"line {i}\n" for i in range(600)]
+        log_file.write_text("".join(lines), encoding="utf-8")
+        with patch.object(watchdog, "WATCHDOG_LOG", log_file), \
+             patch.object(watchdog, "MAX_LOG_LINES", 100):
+            watchdog._trim_log()
+        remaining = log_file.read_text(encoding="utf-8").splitlines()
+        assert len(remaining) == 100
+
+
+class TestMainCLI:
+    @patch.object(watchdog, "run_once")
+    def test_once_flag(self, mock_run):
+        mock_run.return_value = (
+            [{"role": "skill", "action": "healthy", "detail": "ok"}],
+            False,
+        )
+        with patch.object(watchdog, "SQUIDSQUAD_DIR", Path(".")):
+            with patch("sys.argv", ["watchdog.py", "--once"]):
+                result = watchdog.main()
+        assert result == 0
+
+    @patch.object(watchdog, "run_once")
+    def test_json_flag(self, mock_run, capsys):
+        mock_run.return_value = (
+            [{"role": "skill", "action": "boot", "detail": "spawned"}],
+            True,
+        )
+        with patch.object(watchdog, "SQUIDSQUAD_DIR", Path(".")):
+            with patch("sys.argv", ["watchdog.py", "--json"]):
+                result = watchdog.main()
+        assert result == 1
+        output = json.loads(capsys.readouterr().out)
+        assert output["any_intervention"] is True
+
+    def test_missing_squidsquad_dir(self, tmp_path):
+        with patch.object(watchdog, "SQUIDSQUAD_DIR", tmp_path / "nope"):
+            with patch("sys.argv", ["watchdog.py", "--once"]):
+                result = watchdog.main()
+        assert result == 2

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -143,6 +143,12 @@ class TestCheckAndAct:
         """Set up a fake agent directory for testing."""
         squid = tmp_path / ".squidsquad" / role
         squid.mkdir(parents=True, exist_ok=True)
+        # Create CLAUDE.md first with an older mtime so template change
+        # detection doesn't trigger (template_mtime < session_start)
+        (squid / "CLAUDE.md").write_text("# Test agent")
+        import os
+        old_time = time.time() - 3600  # 1 hour ago
+        os.utime(squid / "CLAUDE.md", (old_time, old_time))
         if health_status:
             (squid / ".health").write_text(health_status)
         if pressure is not None:
@@ -151,8 +157,6 @@ class TestCheckAndAct:
             (squid / "current-state").write_text(state)
         if pid:
             (squid / ".pid").write_text(str(pid))
-        # Create CLAUDE.md
-        (squid / "CLAUDE.md").write_text("# Test agent")
 
     @patch.object(watchdog.boot_remote, "_parse_local_config")
     @patch.object(watchdog.health_check, "check_agent_health")

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -108,10 +108,12 @@ class TestReadCurrentState:
     def test_reads_active_state(self, tmp_path):
         squid = tmp_path / ".squidsquad" / "skill"
         squid.mkdir(parents=True)
-        (squid / "current-state").write_text("implementing|dev-agent — #42")
+        (squid / "current-state").write_text(
+            "implementing|dev-agent - #42", encoding="utf-8"
+        )
         phase, desc = watchdog._read_current_state("skill", tmp_path)
         assert phase == "implementing"
-        assert desc == "dev-agent — #42"
+        assert desc == "dev-agent - #42"
 
     def test_returns_empty_when_missing(self, tmp_path):
         phase, desc = watchdog._read_current_state("skill", tmp_path)


### PR DESCRIPTION
Closes #1550

## #1550

- Created `references/scripts/watchdog.py` — standalone supervisor that monitors all agent health every ~30s, boots dead/stalled agents, handles context pressure restarts, and template change restarts
- Simplified boot script templates — removed watcher background process, self-restart sentinel, context pressure restart logic; kept crash recovery + exponential backoff
- Updated sub-skills: self-restart.md, context-pressure.md, boot-remote-agents.md, health-check.md now reference watchdog
- Updated QA verification.md health check step
- Removed Auto Boot Agents config section and config.py key
- Added 20 unit tests for watchdog.py

Status: Pending Test