### PR TITLE
skill: #1495 — Route pr_merge through forge_adapter

### DIFF
--- a/.squidsquad/dm/iterations/iter-27.md
+++ b/.squidsquad/dm/iterations/iter-27.md
@@ -1,5 +1,0 @@
-# Iteration 27
-
-- **Date**: 2026-04-19 03:32
-- **Type**: quiet
-- **Note**: No pending-ship items. #1396 still pending-test. Shipped count 1/10. Context ~65%.

--- a/.squidsquad/dm/iterations/iter-5.md
+++ b/.squidsquad/dm/iterations/iter-5.md
@@ -1,0 +1,5 @@
+# Iteration 5
+
+- **Date**: 2026-04-19 12:31
+- **Type**: quiet
+- **Note**: No pending-ship items. Bugs unchanged.

--- a/.squidsquad/pm/iterations/iter-349.md
+++ b/.squidsquad/pm/iterations/iter-349.md
@@ -1,0 +1,11 @@
+# Iteration 349
+
+- **Date**: 2026-04-19 12:32
+- **Type**: active
+- **Work Summary**:
+  - #474 #473 shipped
+  - #1496 has PR #1613
+  - #1495 at pending-test
+  - skill agent burning through approved queue
+  - all agents healthy
+- **Notes**: #1396 (DM, pending-test) stalled 360m — already nudged 3x, skipping. #1550 watchdog still pending-test.

--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -215,11 +215,37 @@ def pr_create(title, body):
 
 
 def pr_merge(pr_number, strategy="squash"):
-    """Merge a PR via gh CLI. Returns (success, message).
+    """Merge a PR. Uses forge adapter for non-GitHub backends,
+    gh CLI for GitHub. Returns (success, message).
 
     Checks PR state first — if already merged, returns success.
     On merge conflict or unexpected failure, returns failure with details.
     """
+    try:
+        from forge_adapter import get_adapter, _read_forge_config
+        config = _read_forge_config()
+        if config["provider"] not in ("github", ""):
+            adapter = get_adapter(config)
+            # Check state first via adapter
+            pr_data = adapter.view_pr(pr_number)
+            if pr_data:
+                state = pr_data.get("state", "")
+                if state == "MERGED":
+                    print(f"PR #{pr_number} already merged")
+                    return True, "already merged"
+                if state == "CLOSED":
+                    print(f"PR #{pr_number} closed without merge", file=sys.stderr)
+                    return False, "PR closed without merge"
+            success, msg = adapter.merge_pr(pr_number, strategy)
+            if success:
+                print(f"PR #{pr_number} merged ({strategy})")
+            else:
+                print(f"ERROR: PR #{pr_number} merge failed: {msg}", file=sys.stderr)
+            return success, msg
+    except ImportError:
+        pass
+
+    # Default: gh CLI
     # Check PR state first
     state_result = _run_list(
         ["gh", "pr", "view", str(pr_number), "--json", "state"],
@@ -242,7 +268,7 @@ def pr_merge(pr_number, strategy="squash"):
     result = _run_list(merge_args, check=False)
     if result.returncode == 0:
         print(f"PR #{pr_number} merged ({strategy})")
-        # Extract linked issue number from branch name and transition to pending-ship
+        # Extract linked issue number from branch name
         branch_result = _run_list(
             ["gh", "pr", "view", str(pr_number), "--json", "headRefName"],
             check=False,

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -233,10 +233,11 @@ class TestPrCreate:
 class TestPrMerge:
     @patch("git_ops._run_list")
     def test_successful_squash_merge(self, mock_run):
-        # First call: check state → OPEN, second call: merge → success
+        # First call: check state → OPEN, second: merge → success, third: branch name lookup
         mock_run.side_effect = [
             _mock_result(stdout='{"state": "OPEN"}'),
             _mock_result(stdout=""),
+            _mock_result(stdout='{"headRefName": "squidsquad/skill/42"}'),
         ]
         success, msg = git_ops.pr_merge(42)
         assert success is True
@@ -287,6 +288,7 @@ class TestPrMerge:
         mock_run.side_effect = [
             _mock_result(stdout='{"state": "OPEN"}'),
             _mock_result(stdout=""),
+            _mock_result(stdout='{"headRefName": "feature"}'),
         ]
         git_ops.pr_merge(42, strategy="rebase")
         merge_call = mock_run.call_args_list[1]
@@ -294,14 +296,41 @@ class TestPrMerge:
 
     @patch("git_ops._run_list")
     def test_state_check_fails_still_attempts_merge(self, mock_run):
-        # State check fails (non-zero), merge succeeds
+        # State check fails (non-zero), merge succeeds, branch lookup
         mock_run.side_effect = [
             _mock_result(returncode=1, stderr="not found"),
             _mock_result(stdout=""),
+            _mock_result(stdout='{"headRefName": "feature"}'),
         ]
         success, msg = git_ops.pr_merge(42)
         assert success is True
         assert msg == "merged"
+
+
+    @patch("git_ops._run_list")
+    def test_forge_adapter_routing(self, mock_run):
+        """When forge provider is non-GitHub, pr_merge uses the adapter."""
+        mock_adapter = MagicMock()
+        mock_adapter.view_pr.return_value = {"state": "OPEN"}
+        mock_adapter.merge_pr.return_value = (True, "merged")
+
+        mock_config = {"provider": "forgejo", "endpoint": "http://localhost:3000"}
+
+        with patch.dict("sys.modules", {
+            "forge_adapter": MagicMock(
+                get_adapter=MagicMock(return_value=mock_adapter),
+                _read_forge_config=MagicMock(return_value=mock_config),
+            ),
+        }):
+            # Need to re-import to pick up the mock
+            success, msg = git_ops.pr_merge(42)
+
+        assert success is True
+        assert msg == "merged"
+        mock_adapter.view_pr.assert_called_once_with(42)
+        mock_adapter.merge_pr.assert_called_once_with(42, "squash")
+        # gh CLI should NOT be called when adapter handles it
+        mock_run.assert_not_called()
 
 
 class TestGetAlias:


### PR DESCRIPTION
Closes #1495

## #1495

- pr_merge now checks forge_adapter for non-GitHub providers before falling back to gh CLI
- Same pattern as pr_create: try adapter first, gh CLI as fallback
- Added regression test for adapter routing
- Updated 3 existing tests for post-merge branch lookup call

Status: Pending Test