### PR TITLE
skill: #1493 — Route 3 tracker functions through forge_adapter

### DIFF
--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -568,9 +568,22 @@ def create_task(title, body, role, priority, reporter=None):
 
     # Strip existing prefix to avoid double TASK: TASK: or legacy FEAT: FEAT:
     clean_title = title.removeprefix("TASK:").removeprefix("TASK :").removeprefix("FEAT:").removeprefix("FEAT :").strip()
+    full_title = f"TASK: {clean_title}"
+    label_list = labels.split(",")
+
+    adapter = _get_forge_adapter()
+    if adapter:
+        result = adapter.create_issue(full_title, body, labels=label_list)
+        if not result:
+            print("ERROR: Failed to create task via forge adapter", file=sys.stderr)
+            return -1
+        print(json.dumps(result))
+        return result.get("number", -1)
+
+    # Default: gh CLI
     result = _run_list([
         "gh", "issue", "create",
-        "--title", f"TASK: {clean_title}",
+        "--title", full_title,
         "--body", body,
         "--label", labels,
     ])

--- a/tests/test_forge_adapter.py
+++ b/tests/test_forge_adapter.py
@@ -143,6 +143,62 @@ class TestForgejoAdapter:
         assert adapter.provider == "forgejo"
 
 
+class TestTrackerForgeRouting:
+    """Tests that tracker.py functions route through forge_adapter for non-GitHub."""
+
+    def _mock_adapter(self):
+        adapter = MagicMock()
+        adapter.list_issues.return_value = [
+            {"number": 1, "title": "test issue"}
+        ]
+        adapter.create_issue.return_value = {"number": 42, "url": "http://test/42"}
+        return adapter
+
+    def test_list_by_labels_uses_adapter(self):
+        import tracker
+        adapter = self._mock_adapter()
+        with patch.object(tracker, "_get_forge_adapter", return_value=adapter):
+            result = tracker.list_by_labels("type:issue,role:skill")
+        adapter.list_issues.assert_called_once_with(
+            labels=["type:issue", "role:skill"], state="open", limit=50
+        )
+        assert len(result) == 1
+
+    def test_list_all_open_uses_adapter(self):
+        import tracker
+        adapter = self._mock_adapter()
+        with patch.object(tracker, "_get_forge_adapter", return_value=adapter):
+            result = tracker.list_all_open()
+        adapter.list_issues.assert_called_once_with(
+            labels=None, state="open", limit=50
+        )
+        assert len(result) == 1
+
+    def test_create_task_uses_adapter(self):
+        import tracker
+        adapter = self._mock_adapter()
+        with patch.object(tracker, "_get_forge_adapter", return_value=adapter):
+            number = tracker.create_task(
+                "test task", "body", "skill", "medium"
+            )
+        adapter.create_issue.assert_called_once()
+        assert number == 42
+        # Verify title has TASK: prefix
+        call_args = adapter.create_issue.call_args
+        assert call_args[0][0].startswith("TASK:")
+
+    def test_list_by_labels_falls_back_to_gh(self):
+        import tracker
+        with patch.object(tracker, "_get_forge_adapter", return_value=None), \
+             patch.object(tracker, "_run_list") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout='[{"number": 1}]'
+            )
+            result = tracker.list_by_labels("type:issue")
+        mock_run.assert_called_once()
+        assert len(result) == 1
+
+
 class TestBaseAdapter:
     def test_edit_labels_calls_both(self):
         adapter = forge_adapter.ForgeAdapter({


### PR DESCRIPTION
Closes #1493

## #1493

- Routed list_by_labels, list_all_open, create_task through forge_adapter for non-GitHub backends
- Same pattern as existing list_issues and create_issue
- Added 4 regression tests (adapter routing + gh CLI fallback)

Status: Pending Test