### PR TITLE
skill: #1637 — Preserve QA verification tests as regression tests

### DIFF
--- a/references/sub-skills/pm-specific/task-intake.md
+++ b/references/sub-skills/pm-specific/task-intake.md
@@ -318,7 +318,7 @@ Write results to .squidsquad/[ROLE]/planning/FEAT-[ROLE_UPPER]-XXX-QA-RESULTS.md
 ```
 
 PM reviews QA-RESULTS.md and makes the final decision:
-- **All pass** → Status → `Shipped`. Delete planning files (`.squidsquad/[ROLE]/planning/FEAT-XXX-*`). Append Discussion entry.
+- **All pass** → Status → `Shipped`. Delete planning files (`.squidsquad/[ROLE]/planning/FEAT-XXX-*`) EXCEPT test files that have been promoted to `tests/`. Append Discussion entry.
 - **Any fail** → Status → `In Progress`. Append Discussion with which test cases failed and what was observed.
 
 The PM decides — the subagent only reports results.

--- a/references/sub-skills/pm-specific/testing-and-verification.md
+++ b/references/sub-skills/pm-specific/testing-and-verification.md
@@ -75,7 +75,13 @@ For each result:
 1. Test against the acceptance criteria.
 2. **Zero-gap gate**: If ANY gap, ambiguity, missing documentation, failed check, or unresolved finding is discovered — update back to `In Progress` and append a Discussion entry listing every specific finding. Do NOT mark Pending Ship with "gaps noted for follow-up." ALL findings must be resolved before shipping.
 3. **Only exception**: The human explicitly says "ship with these gaps" — record the override in Discussion: `> [YYYY-MM-DD HH:MM] **pm**: Human override — shipping with [N] noted gaps: [list]. Status → Pending Ship.`
-4. If all criteria pass with zero gaps: update to `Pending Ship`, append Discussion entry: `> [YYYY-MM-DD HH:MM] **pm**: Verified — zero gaps. Status → Pending Ship.`
+4. If all criteria pass with zero gaps:
+   **Promote test files to tests/** (before transitioning):
+   If any test files exist in `.squidsquad/[ROLE]/planning/` matching `*-tests.py` or `*-QA-RESULTS*.md`:
+   - Copy test `.py` files to `tests/` with naming convention: `tests/test_feat_[NUMBER]_[short_name].py`
+   - Verify promoted tests still pass: `python -m pytest tests/test_feat_[NUMBER]_*.py`
+   - These tests persist as regression tests — NOT deleted during planning cleanup
+   Update to `Pending Ship`, append Discussion entry: `> [YYYY-MM-DD HH:MM] **pm**: Verified — zero gaps. Status → Pending Ship.`
 5. **delivery:skip check**: If the task is internal-only (agent template changes, config changes, internal tooling, process improvements) with no user-facing delivery work needed, add `delivery: skip` to the Discussion entry when marking Pending Ship: `> [YYYY-MM-DD HH:MM] **pm**: Verified — zero gaps. delivery: skip (internal-only, no user-facing changes). Status → Pending Ship.` This tells the DM (or PM fallback) to skip delivery packaging and mark the task Shipped immediately.
 6. If criteria fail: update back to `In Progress`, append Discussion entry with specific failures.
 

--- a/references/sub-skills/qa-specific/verification.md
+++ b/references/sub-skills/qa-specific/verification.md
@@ -152,6 +152,13 @@ python references/scripts/git_ops.py branch-switch main
    ```
 5. If all criteria pass with zero gaps:
 
+   **Promote test files to tests/** (before transitioning):
+   If any test files exist in `.squidsquad/[ROLE]/planning/` matching `*-tests.py` or `*-QA-RESULTS*.md`:
+   - Copy test `.py` files to `tests/` with naming convention: `tests/test_feat_[NUMBER]_[short_name].py`
+   - If comprehension test files exist, also copy to `tests/`
+   - Verify the promoted tests still pass: `python -m pytest tests/test_feat_[NUMBER]_*.py`
+   - These tests persist as regression tests — they are NOT deleted during planning cleanup
+
    Check PR Flow: `python references/scripts/config.py get pr-flow`
 
    **If PR Flow `yes`** and a PR exists for this issue:


### PR DESCRIPTION
Closes #1637

## #1637

- QA verification sub-skill: added test promotion step (copy tests to tests/ before marking pending-ship)
- PM testing-and-verification sub-skill: added same promotion step
- PM task-intake: planning cleanup excludes promoted test files
- Naming convention: tests/test_feat_[NUMBER]_[short_name].py

Status: Pending Test