### PR TITLE
skill: #2110 — unmerged branch guard on shipped transition

### DIFF
--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -627,6 +627,75 @@ def _is_feedback_comment(body, caller_role):
     return False, None
 
 
+def _is_branch_workflow_enabled():
+    """Check if branch workflow is enabled in config."""
+    try:
+        sys.path.insert(0, str(SCRIPT_DIR))
+        from config import get_field
+        return get_field("branch-workflow").strip().lower() == "yes"
+    except Exception:
+        return False
+
+
+def _get_working_branch():
+    """Get the configured working branch. Falls back to 'main'."""
+    try:
+        sys.path.insert(0, str(SCRIPT_DIR))
+        from config import get_field
+        branch = get_field("working-branch")
+        return branch.strip() if branch else "main"
+    except Exception:
+        return "main"
+
+
+def _check_unmerged_branch(number):
+    """Check if a feature branch exists with commits not merged to the working branch.
+
+    When branch workflow is enabled, feature branches follow the pattern
+    squidsquad/*/NUMBER. If such a branch exists and has commits not on
+    the working branch (main), shipping should be blocked.
+
+    Returns (branch_name, commit_count) if unmerged branch found, None otherwise.
+    Skips check if branch workflow is disabled.
+    """
+    if not _is_branch_workflow_enabled():
+        return None
+
+    working = _get_working_branch()
+
+    # List all branches matching squidsquad/*/NUMBER pattern
+    result = _run_list(
+        ["git", "branch", "-a", "--list", f"*squidsquad/*/{number}"],
+        check=False,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+
+    for line in result.stdout.strip().splitlines():
+        branch = line.strip().lstrip("* ")
+        # Normalize remotes/origin/ prefix for comparison
+        local_name = branch.replace("remotes/origin/", "")
+
+        # Verify this branch's last path segment matches the issue number
+        parts = local_name.split("/")
+        if len(parts) < 3 or parts[-1] != str(number):
+            continue
+
+        # Check if branch has commits not on the working branch
+        count_result = _run_list(
+            ["git", "rev-list", "--count", f"{working}..{branch}"],
+            check=False,
+        )
+        if count_result.returncode != 0:
+            continue
+
+        count = int(count_result.stdout.strip())
+        if count > 0:
+            return local_name, count
+
+    return None
+
+
 def _check_unmerged_pr(number):
     """Check if there's an open PR for this issue number.
 
@@ -822,7 +891,8 @@ def transition(number, from_status, to_status, role=None, force=False):
             )
             sys.exit(1)
 
-    # 4. Guard: block shipped if unmerged PR exists (never bypassed, even with --force)
+    # 4. Guard: block shipped if unmerged PR or unmerged branch exists
+    #    (never bypassed, even with --force)
     if to_label == "status:shipped":
         unmerged = _check_unmerged_pr(number)
         if unmerged:
@@ -834,6 +904,22 @@ def transition(number, from_status, to_status, role=None, force=False):
             print(
                 f"BLOCKED: Cannot ship #{number} — PR #{pr_num} is open and unmerged. "
                 f"Merge the PR first: {pr_url}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        unmerged_branch = _check_unmerged_branch(number)
+        if unmerged_branch:
+            branch_name, commit_count = unmerged_branch
+            _log_diagnostic(
+                "error",
+                f"Blocked shipped transition on #{number}: branch {branch_name} "
+                f"has {commit_count} unmerged commit(s)",
+            )
+            print(
+                f"BLOCKED: Cannot ship #{number} — branch '{branch_name}' has "
+                f"{commit_count} commit(s) not merged to the working branch. "
+                f"Merge the branch or create a PR first.",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/tests/test_tracker_authority.py
+++ b/tests/test_tracker_authority.py
@@ -627,6 +627,182 @@ class TestShippedPRGuard:
 
 
 
+# ---------------------------------------------------------------------------
+# shipped branch guard (#2110)
+# ---------------------------------------------------------------------------
+
+
+class TestShippedBranchGuard:
+    """Transition to shipped must block if unmerged feature branch exists (#2110)."""
+
+    def test_blocks_when_unmerged_branch_exists(self, monkeypatch, capsys):
+        """shipped transition blocked when feature branch has unmerged commits."""
+
+        class FakeResult:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        def _fake_run_list(cmd, **kw):
+            # PR check: no open PRs
+            if "pr" in cmd and "list" in cmd:
+                r = FakeResult()
+                r.stdout = "[]"
+                return r
+            # git branch -a --list: return a matching branch
+            if "branch" in cmd and "--list" in cmd:
+                r = FakeResult()
+                r.stdout = "  squidsquad/skill/42\n"
+                return r
+            # git rev-list --count: 3 unmerged commits
+            if "rev-list" in cmd and "--count" in cmd:
+                r = FakeResult()
+                r.stdout = "3"
+                return r
+            return FakeResult()
+
+        monkeypatch.setattr(tracker, "_run_list", _fake_run_list)
+        monkeypatch.setattr(tracker, "_is_branch_workflow_enabled", lambda: True)
+
+        with pytest.raises(SystemExit) as excinfo:
+            tracker.transition(42, "pending-ship", "shipped", role="dm-lead")
+        assert excinfo.value.code == 1
+        err = capsys.readouterr().err
+        assert "BLOCKED" in err
+        assert "squidsquad/skill/42" in err
+        assert "3 commit(s)" in err
+
+    def test_allows_when_branch_fully_merged(self, monkeypatch):
+        """shipped transition proceeds when feature branch is fully merged."""
+
+        class FakeResult:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        def _fake_run_list(cmd, **kw):
+            if "pr" in cmd and "list" in cmd:
+                r = FakeResult()
+                r.stdout = "[]"
+                return r
+            if "branch" in cmd and "--list" in cmd:
+                r = FakeResult()
+                r.stdout = "  squidsquad/skill/42\n"
+                return r
+            # 0 unmerged commits — fully merged
+            if "rev-list" in cmd and "--count" in cmd:
+                r = FakeResult()
+                r.stdout = "0"
+                return r
+            return FakeResult()
+
+        monkeypatch.setattr(tracker, "_run_list", _fake_run_list)
+        monkeypatch.setattr(tracker, "_is_branch_workflow_enabled", lambda: True)
+        # Should not raise — branch is merged
+        tracker.transition(42, "pending-ship", "shipped", role="dm-lead")
+
+    def test_allows_when_no_feature_branch(self, monkeypatch):
+        """shipped transition proceeds when no feature branch exists."""
+
+        class FakeResult:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        def _fake_run_list(cmd, **kw):
+            if "pr" in cmd and "list" in cmd:
+                r = FakeResult()
+                r.stdout = "[]"
+                return r
+            # No branches found
+            if "branch" in cmd and "--list" in cmd:
+                r = FakeResult()
+                r.stdout = ""
+                return r
+            return FakeResult()
+
+        monkeypatch.setattr(tracker, "_run_list", _fake_run_list)
+        monkeypatch.setattr(tracker, "_is_branch_workflow_enabled", lambda: True)
+        tracker.transition(42, "pending-ship", "shipped", role="dm-lead")
+
+    def test_skips_check_when_branch_workflow_disabled(self, monkeypatch):
+        """Branch check is skipped entirely when branch workflow is disabled."""
+
+        class FakeResult:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        def _fake_run_list(cmd, **kw):
+            if "pr" in cmd and "list" in cmd:
+                r = FakeResult()
+                r.stdout = "[]"
+                return r
+            return FakeResult()
+
+        monkeypatch.setattr(tracker, "_run_list", _fake_run_list)
+        monkeypatch.setattr(tracker, "_is_branch_workflow_enabled", lambda: False)
+        # Should not raise — branch workflow disabled, no branch check
+        tracker.transition(42, "pending-ship", "shipped", role="dm-lead")
+
+    def test_force_does_not_bypass_branch_check(self, monkeypatch, capsys):
+        """--force does NOT bypass the branch merge check."""
+
+        class FakeResult:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        def _fake_run_list(cmd, **kw):
+            if "pr" in cmd and "list" in cmd:
+                r = FakeResult()
+                r.stdout = "[]"
+                return r
+            if "branch" in cmd and "--list" in cmd:
+                r = FakeResult()
+                r.stdout = "  squidsquad/skill/42\n"
+                return r
+            if "rev-list" in cmd and "--count" in cmd:
+                r = FakeResult()
+                r.stdout = "2"
+                return r
+            return FakeResult()
+
+        monkeypatch.setattr(tracker, "_run_list", _fake_run_list)
+        monkeypatch.setattr(tracker, "_is_branch_workflow_enabled", lambda: True)
+
+        with pytest.raises(SystemExit) as excinfo:
+            tracker.transition(42, "pending-ship", "shipped", role="dm-lead", force=True)
+        assert excinfo.value.code == 1
+        err = capsys.readouterr().err
+        assert "BLOCKED" in err
+
+    def test_ignores_branch_with_wrong_issue_number(self, monkeypatch):
+        """Branch for a different issue number does not block shipping."""
+
+        class FakeResult:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        def _fake_run_list(cmd, **kw):
+            if "pr" in cmd and "list" in cmd:
+                r = FakeResult()
+                r.stdout = "[]"
+                return r
+            if "branch" in cmd and "--list" in cmd:
+                r = FakeResult()
+                # Branch for issue 421, not 42
+                r.stdout = "  squidsquad/skill/421\n"
+                return r
+            return FakeResult()
+
+        monkeypatch.setattr(tracker, "_run_list", _fake_run_list)
+        monkeypatch.setattr(tracker, "_is_branch_workflow_enabled", lambda: True)
+        # Should not raise — branch is for a different issue
+        tracker.transition(42, "pending-ship", "shipped", role="dm-lead")
+
+
 class TestDraftPRConversion:
     """Auto-convert draft PRs to ready on pending-ship transition (#1696)."""
 


### PR DESCRIPTION
Closes #2110

## #2110

- Block shipped transition when feature branch has unmerged commits (branch workflow enabled)
- Added _check_unmerged_branch() + _is_branch_workflow_enabled() + _get_working_branch() to tracker.py
- Guard is never bypassed (even with --force), consistent with existing PR guard
- 6 new tests covering block/allow/disabled/force/wrong-issue scenarios

Status: Pending Test