### PR TITLE
skill: #2070 — cycle runner scripts (transport/behavior separation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 .squidsquad/.backlog-cache
 .squidsquad/.backlog-cache.tmp
 .squidsquad/diagnostics/*.jsonl
+.squidsquad/*/cycle-input.json
+.squidsquad/*/cycle-output.json
 
 .claude/commands/squidsquad-*
 .claude/settings.local.json

--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""SquidSquad cycle_post — post-cycle mechanical operations.
+
+Runs after the agent's creative phase. Reads cycle-output.json and handles
+all git commits, pushes, status transitions, iteration logging, and cleanup.
+
+Usage:
+    python references/scripts/cycle_post.py <role>
+
+Exit codes:
+    0 — success
+    1 — fatal error (invalid output, cannot continue)
+"""
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# Ensure UTF-8 output on Windows
+if sys.stdout.encoding != "utf-8":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if sys.stderr.encoding != "utf-8":
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+SQUID_DIR = REPO_ROOT / ".squidsquad"
+
+# Required top-level fields in cycle-output.json
+REQUIRED_FIELDS = {"role", "cycle_number", "cycle_type"}
+VALID_CYCLE_TYPES = {"active", "quiet", "suppressed"}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(cmd, check=False):
+    """Run a command from repo root."""
+    return subprocess.run(
+        cmd, capture_output=True, text=True,
+        encoding="utf-8", errors="replace",
+        check=check, cwd=str(REPO_ROOT),
+    )
+
+
+def _run_script(script, *args, check=False):
+    """Run a Python script in references/scripts/."""
+    return _run([sys.executable, str(SCRIPT_DIR / script)] + list(args), check=check)
+
+
+def _timestamp_short():
+    """Get HH:MM:SS timestamp."""
+    return datetime.now().strftime("%H:%M:%S")
+
+
+def _write_status_bar(role, phase, description):
+    """Write status bar state atomically."""
+    state_file = SQUID_DIR / role / "current-state"
+    tmp_file = state_file.with_suffix(".tmp")
+    content = f"{phase}|{description}"
+    try:
+        tmp_file.write_text(content, encoding="utf-8")
+        tmp_file.replace(state_file)
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_output(data):
+    """Validate cycle-output.json structure. Returns list of errors."""
+    errors = []
+
+    if not isinstance(data, dict):
+        return ["cycle-output.json must be a JSON object"]
+
+    for field in REQUIRED_FIELDS:
+        if field not in data:
+            errors.append(f"Missing required field: {field}")
+
+    cycle_type = data.get("cycle_type", "")
+    if cycle_type and cycle_type not in VALID_CYCLE_TYPES:
+        errors.append(f"Invalid cycle_type '{cycle_type}'. Valid: {VALID_CYCLE_TYPES}")
+
+    # Validate status_transitions structure
+    for i, t in enumerate(data.get("status_transitions", [])):
+        if not isinstance(t, dict):
+            errors.append(f"status_transitions[{i}] must be an object")
+            continue
+        for key in ("number", "from", "to"):
+            if key not in t:
+                errors.append(f"status_transitions[{i}] missing '{key}'")
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Post-cycle operations
+# ---------------------------------------------------------------------------
+
+
+def _do_status_transitions(data, role):
+    """Execute status transitions via tracker.py."""
+    transitions = data.get("status_transitions", [])
+    role_label = f"{role}-lead"
+
+    for t in transitions:
+        number = t.get("number")
+        from_status = t.get("from", "")
+        to_status = t.get("to", "")
+
+        if not number or not from_status or not to_status:
+            print(f"WARNING: Skipping invalid transition: {t}", file=sys.stderr)
+            continue
+
+        result = _run_script(
+            "tracker.py", "transition",
+            str(number), from_status, to_status,
+            "--role", role_label,
+        )
+
+        if result.returncode != 0:
+            print(f"WARNING: Transition #{number} {from_status} → {to_status} failed: "
+                  f"{result.stderr.strip()}", file=sys.stderr)
+        else:
+            print(f"  Transition: #{number} {from_status} → {to_status}")
+
+
+def _do_tracker_comments(data, role):
+    """Post tracker comments."""
+    comments = data.get("tracker_comments", [])
+    role_label = f"{role}-lead"
+
+    for c in comments:
+        number = c.get("number")
+        message = c.get("message", "")
+
+        if not number or not message:
+            continue
+
+        result = _run_script(
+            "tracker.py", "comment",
+            str(number), "--role", role_label, "--message", message,
+        )
+
+        if result.returncode != 0:
+            print(f"WARNING: Comment on #{number} failed: {result.stderr.strip()}",
+                  file=sys.stderr)
+
+
+def _do_iteration_log(data, role):
+    """Create iteration log entry."""
+    cycle_number = data.get("cycle_number", 0)
+    cycle_type = data.get("cycle_type", "quiet")
+    summary = data.get("iteration_summary", "")
+
+    if cycle_type == "quiet":
+        result = _run_script(
+            "cycle.py", "log-iteration", role, str(cycle_number),
+            "--quiet", "--notes", summary or "No actionable work",
+        )
+    else:
+        result = _run_script(
+            "cycle.py", "log-iteration", role, str(cycle_number),
+            "--work", summary or "Active cycle",
+            "--notes", "",
+        )
+
+    # Cleanup old logs
+    _run_script("cycle.py", "cleanup-iterations", role)
+
+    if result.returncode == 0:
+        print(f"  Iteration log: iter-{cycle_number}.md")
+
+
+def _do_commit_push(data, role):
+    """Handle git commit and push operations."""
+    cycle_type = data.get("cycle_type", "quiet")
+    commit_msg = data.get("commit_message") or data.get("state_commit_message", "")
+
+    if not commit_msg:
+        commit_msg = f"{role}: cycle {data.get('cycle_number', '?')} — {cycle_type}"
+
+    config_flags = data.get("config", {})
+    branch_workflow = config_flags.get("branch_workflow", False)
+
+    # Skill agent with branch workflow: split commits
+    code_commit = data.get("code_commit")
+    if role == "skill" and branch_workflow and code_commit:
+        branch = code_commit.get("branch", "")
+        code_msg = code_commit.get("message", "code changes")
+
+        if branch:
+            result = _run_script("git_ops.py", "commit-code", role, branch, code_msg)
+            if result.returncode != 0:
+                print(f"WARNING: Code commit failed: {result.stderr.strip()}",
+                      file=sys.stderr)
+            else:
+                print(f"  Code commit to {branch}")
+
+            # Create PR if needed
+            if code_commit.get("pr_needed"):
+                pr_title = code_commit.get("pr_title", f"{role}: {branch}")
+                pr_body = code_commit.get("pr_body", f"Branch: {branch}")
+                result = _run_script("git_ops.py", "pr-create", pr_title, pr_body)
+                if result.returncode == 0:
+                    print(f"  PR created: {result.stdout.strip()}")
+
+        # State commit to main
+        state_msg = data.get("state_commit_message", commit_msg)
+        # Need to be on main for state commit
+        current = _run(["git", "branch", "--show-current"], check=False)
+        current_branch = current.stdout.strip() if current.returncode == 0 else ""
+
+        if current_branch != "main":
+            _run(["git", "checkout", "main"], check=False)
+
+        result = _run_script("git_ops.py", "commit-state", role, state_msg)
+        if result.returncode != 0:
+            # Fallback: commit-push everything
+            _run_script("git_ops.py", "commit-push", role, state_msg)
+        else:
+            print(f"  State commit to main")
+
+    elif role == "qa":
+        # QA: switch back to main before committing
+        current = _run(["git", "branch", "--show-current"], check=False)
+        current_branch = current.stdout.strip() if current.returncode == 0 else ""
+
+        if current_branch != "main":
+            _run(["git", "checkout", "main"], check=False)
+
+        _run_script("git_ops.py", "commit-push", role, commit_msg)
+        print(f"  Committed and pushed (QA → main)")
+
+    else:
+        # Default: commit-push on current branch (main)
+        _run_script("git_ops.py", "commit-push", role, commit_msg)
+        print(f"  Committed and pushed")
+
+
+def _do_version_bump(data, role):
+    """Execute version bump sequence (DM only)."""
+    bump = data.get("version_bump")
+    if not bump or not bump.get("new_version"):
+        return
+
+    new_version = bump["new_version"]
+    items = bump.get("items_included", [])
+
+    print(f"  Version bump: → {new_version}")
+
+    # Update config.md version
+    _run_script("config.py", "set", "version", new_version)
+
+    # Update SKILL.md version (in frontmatter)
+    skill_md = REPO_ROOT / "SKILL.md"
+    if skill_md.exists():
+        content = skill_md.read_text(encoding="utf-8")
+        import re
+        content = re.sub(r'version:\s*[\d.]+', f'version: {new_version}', content, count=1)
+        skill_md.write_text(content, encoding="utf-8")
+
+    # Add CHANGELOG entry
+    changelog = REPO_ROOT / "CHANGELOG.md"
+    if changelog.exists():
+        old_content = changelog.read_text(encoding="utf-8")
+        date_str = datetime.now().strftime("%Y-%m-%d")
+        items_str = "\n".join(f"- #{n}" for n in items)
+        new_section = f"## [{new_version}] — {date_str}\n\n### Shipped\n{items_str}\n\n"
+        # Insert after first line (title)
+        lines = old_content.split("\n", 1)
+        if len(lines) > 1:
+            new_content = lines[0] + "\n\n" + new_section + lines[1]
+        else:
+            new_content = old_content + "\n\n" + new_section
+        changelog.write_text(new_content, encoding="utf-8")
+
+    # Commit, tag, push
+    _run(["git", "add", "-A"])
+    _run(["git", "commit", "-m", f"chore: bump version to v{new_version}"])
+
+    # Check if tag exists
+    tag_check = _run(["git", "tag", "-l", f"v{new_version}"])
+    if not tag_check.stdout.strip():
+        _run(["git", "tag", f"v{new_version}"])
+
+    _run(["git", "push"])
+    _run(["git", "push", "--tags"])
+
+    # Reset counter
+    _run_script("config.py", "set", "shipped-since-bump", "0")
+
+    print(f"  Version v{new_version} tagged and pushed")
+
+
+def _do_restart_sentinel(data, role):
+    """Write self-restart sentinel if needed."""
+    if not data.get("restart_needed"):
+        return False
+
+    reason = data.get("restart_reason", "unknown")
+    sentinel = SQUID_DIR / role / ".restart"
+    sentinel.write_text(reason, encoding="utf-8")
+    print(f"  Restart sentinel written: {reason}")
+    return True
+
+
+def _do_working_state_update(data, role):
+    """Update working state file if agent provided update content."""
+    update = data.get("working_state_update")
+    if not update:
+        return
+
+    ws_path = SQUID_DIR / role / "working-state.md"
+    ws_path.write_text(update, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: cycle_post.py <role>", file=sys.stderr)
+        sys.exit(1)
+
+    role = sys.argv[1]
+    ts = _timestamp_short()
+
+    # Read cycle-output.json
+    output_path = SQUID_DIR / role / "cycle-output.json"
+    if not output_path.exists():
+        print(f"[🦑 {ts}] WARNING: No cycle-output.json found for {role}. "
+              "Agent may have crashed. Skipping post-processing.", file=sys.stderr)
+        _write_status_bar(role, "idle", "")
+        return 0
+
+    try:
+        raw = output_path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(f"[🦑 {ts}] ERROR: Invalid JSON in cycle-output.json: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Validate
+    errors = _validate_output(data)
+    if errors:
+        print(f"[🦑 {ts}] ERROR: Invalid cycle-output.json:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"[🦑 {ts}] cycle_post starting for {role} (cycle {data.get('cycle_number', '?')})...")
+    _write_status_bar(role, "committing", f"git-commit — Post-processing cycle...")
+
+    # 1. Status transitions (before commits — so tracker reflects reality)
+    _do_status_transitions(data, role)
+
+    # 2. Tracker comments
+    _do_tracker_comments(data, role)
+
+    # 3. Working state update
+    _do_working_state_update(data, role)
+
+    # 4. Iteration log
+    _do_iteration_log(data, role)
+
+    # 5. Version bump (DM only)
+    if role == "dm":
+        _do_version_bump(data, role)
+
+    # 6. Commit and push
+    _do_commit_push(data, role)
+
+    # 7. Restart sentinel (after commit — safety rule)
+    restarting = _do_restart_sentinel(data, role)
+
+    # 8. Cleanup cycle-output.json
+    try:
+        output_path.unlink()
+    except OSError:
+        pass
+
+    # 9. Status bar
+    if restarting:
+        _write_status_bar(role, "restarting", f"Self-restart — {data.get('restart_reason', '')}")
+    else:
+        _write_status_bar(role, "idle", "")
+
+    ts = _timestamp_short()
+    print(f"[🦑 {ts}] cycle_post complete for {role}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/references/scripts/cycle_pre.py
+++ b/references/scripts/cycle_pre.py
@@ -1,0 +1,754 @@
+#!/usr/bin/env python3
+"""SquidSquad cycle_pre — pre-cycle mechanical operations.
+
+Runs before the agent's creative phase. Handles git pull, context pressure,
+working state, triage, branch setup, and writes cycle-input.json.
+
+Usage:
+    python references/scripts/cycle_pre.py <role>
+    python references/scripts/cycle_pre.py skill
+    python references/scripts/cycle_pre.py pm
+    python references/scripts/cycle_pre.py qa
+    python references/scripts/cycle_pre.py dm
+
+Exit codes:
+    0 — success (cycle-input.json written, possibly degraded)
+    1 — fatal error (cannot continue)
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# Ensure UTF-8 output on Windows
+if sys.stdout.encoding != "utf-8":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if sys.stderr.encoding != "utf-8":
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+SQUID_DIR = REPO_ROOT / ".squidsquad"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(cmd, check=False):
+    """Run a command from repo root."""
+    return subprocess.run(
+        cmd, capture_output=True, text=True,
+        encoding="utf-8", errors="replace",
+        check=check, cwd=str(REPO_ROOT),
+    )
+
+
+def _run_script(script, *args, check=False):
+    """Run a Python script in references/scripts/."""
+    return _run([sys.executable, str(SCRIPT_DIR / script)] + list(args), check=check)
+
+
+def _read_file(path):
+    """Read a file, return content or empty string."""
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError):
+        return ""
+
+
+def _config_get(field):
+    """Get a config field value. Returns empty string on failure."""
+    result = _run_script("config.py", "get", field)
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def _write_status_bar(role, phase, description):
+    """Write status bar state atomically."""
+    state_file = SQUID_DIR / role / "current-state"
+    tmp_file = state_file.with_suffix(".tmp")
+    content = f"{phase}|{description}"
+    try:
+        tmp_file.write_text(content, encoding="utf-8")
+        tmp_file.replace(state_file)
+    except OSError:
+        pass
+
+
+def _timestamp():
+    """Get current timestamp in ISO 8601 format."""
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def _timestamp_short():
+    """Get HH:MM:SS timestamp."""
+    return datetime.now().strftime("%H:%M:%S")
+
+
+# ---------------------------------------------------------------------------
+# Common operations (all roles)
+# ---------------------------------------------------------------------------
+
+
+def _do_pull():
+    """Run git pull. Returns pull_result string."""
+    result = _run_script("git_ops.py", "pull")
+    stdout = result.stdout.strip().lower()
+    if result.returncode != 0:
+        return "error"
+    if "stash pop conflict" in stdout or "stash_conflict" in stdout:
+        return "stash_conflict"
+    if "conflict" in stdout:
+        return "conflict"
+    return "ok"
+
+
+def _get_context_pressure():
+    """Read context pressure and threshold."""
+    pressure_file = None
+    try:
+        # The role's context-pressure file is written by the statusline hook
+        # We don't know role here — caller passes it
+        return None  # Caller handles this
+    except Exception:
+        return None
+
+
+def _read_context_pressure(role):
+    """Read context pressure for a role."""
+    pressure_file = SQUID_DIR / role / "context-pressure"
+    try:
+        used_pct = int(_read_file(pressure_file).strip() or "0")
+    except (ValueError, TypeError):
+        used_pct = 0
+
+    threshold_str = _config_get("context-threshold")
+    try:
+        threshold = int(threshold_str)
+    except (ValueError, TypeError):
+        threshold = 70
+
+    return {
+        "used_pct": used_pct,
+        "threshold": threshold,
+        "exceeded": used_pct >= threshold,
+    }
+
+
+def _read_working_state(role):
+    """Parse working-state.md into structured data."""
+    ws_path = SQUID_DIR / role / "working-state.md"
+    raw = _read_file(ws_path)
+
+    task = "none"
+    status = "none"
+    phase = None
+    suppressed = False
+    completed_steps = []
+    remaining_steps = []
+    key_decisions = []
+    quiet_cycles = 0
+
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- **Task**:"):
+            task = stripped.split(":", 1)[1].strip()
+        elif stripped.startswith("- **Status**:"):
+            status = stripped.split(":", 1)[1].strip()
+        elif stripped.startswith("- **Phase**:"):
+            phase = stripped.split(":", 1)[1].strip()
+            suppressed = True
+        elif stripped.startswith("- **Quiet Cycles**:"):
+            try:
+                quiet_cycles = int(stripped.split(":", 1)[1].strip())
+            except ValueError:
+                quiet_cycles = 0
+
+    # Parse list sections
+    current_section = None
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("## Completed Steps"):
+            current_section = "completed"
+        elif stripped.startswith("## Remaining Steps"):
+            current_section = "remaining"
+        elif stripped.startswith("## Key Decisions"):
+            current_section = "decisions"
+        elif stripped.startswith("## ") or stripped.startswith("# "):
+            current_section = None
+        elif stripped.startswith("- ") and current_section:
+            item = stripped[2:].strip()
+            if current_section == "completed":
+                completed_steps.append(item)
+            elif current_section == "remaining":
+                remaining_steps.append(item)
+            elif current_section == "decisions":
+                key_decisions.append(item)
+
+    result = {
+        "task": task,
+        "status": status,
+        "raw_content": raw,
+    }
+
+    # Role-specific fields
+    if phase is not None:
+        result["phase"] = phase
+        result["suppressed"] = suppressed
+    else:
+        result["suppressed"] = False
+
+    result["completed_steps"] = completed_steps
+    result["remaining_steps"] = remaining_steps
+    result["key_decisions"] = key_decisions
+    result["quiet_cycles"] = quiet_cycles
+
+    return result
+
+
+def _get_cycle_number(role):
+    """Compute next cycle number from existing iteration logs."""
+    iter_dir = SQUID_DIR / role / "iterations"
+    if not iter_dir.exists():
+        return 1
+
+    max_n = 0
+    for f in iter_dir.glob("iter-*.md"):
+        try:
+            n = int(f.stem.split("-")[1])
+            max_n = max(max_n, n)
+        except (IndexError, ValueError):
+            pass
+    return max_n + 1
+
+
+def _check_template_changed(role):
+    """Check if CLAUDE.md has been updated since session start."""
+    template_path = SQUID_DIR / role / "CLAUDE.md"
+    if not template_path.exists():
+        return False
+    # Compare against the restart sentinel or just report mtime
+    # For now, we can't know session start time from here — return False
+    # The agent checks this separately via Step 1c
+    return False
+
+
+def _read_config_flags():
+    """Read common config flags."""
+    return {
+        "branch_workflow": _config_get("branch-workflow").lower() == "yes",
+        "pr_flow": _config_get("pr-flow").lower() == "yes",
+        "improvement_scanning": _config_get("improvement-scanning").lower() == "yes",
+        "vault_remember": _config_get("vault-remember").lower() == "yes",
+        "vault_optimize": _config_get("vault-optimize").lower() == "yes",
+    }
+
+
+def _dir_exists(role):
+    """Check if a role's directory exists."""
+    return (SQUID_DIR / role).is_dir()
+
+
+# ---------------------------------------------------------------------------
+# Role-specific: Skill
+# ---------------------------------------------------------------------------
+
+
+def _build_skill_input(role):
+    """Build cycle-input.json fields specific to the skill agent."""
+    # QA-rejected items
+    result = _run_script("triage.py", "qa-rejected", role, "--json")
+    try:
+        qa_rejected = json.loads(result.stdout) if result.returncode == 0 else []
+    except (json.JSONDecodeError, ValueError):
+        qa_rejected = []
+
+    # Work queue
+    result = _run_script("tracker.py", "work-queue", role)
+    try:
+        queue = json.loads(result.stdout) if result.returncode == 0 else []
+    except (json.JSONDecodeError, ValueError):
+        queue = []
+
+    # Planning artifacts for queued tasks
+    planning_artifacts = {}
+    for item in queue:
+        num = str(item.get("number", ""))
+        if not num:
+            continue
+        artifacts = {}
+        # Check PM planning dir first, then skill planning dir
+        for planning_dir in [SQUID_DIR / "pm" / "planning", SQUID_DIR / role / "planning"]:
+            if not planning_dir.exists():
+                continue
+            for f in planning_dir.glob(f"*{num}*"):
+                name = f.name.upper()
+                if "RESEARCH" in name:
+                    artifacts["research"] = str(f.relative_to(REPO_ROOT))
+                elif "CONTEXT" in name and "PHASE2" not in name:
+                    artifacts["context"] = str(f.relative_to(REPO_ROOT))
+                elif "TEST-PLAN" in name:
+                    artifacts["test_plan"] = str(f.relative_to(REPO_ROOT))
+        if artifacts:
+            planning_artifacts[num] = artifacts
+
+    # Interval
+    interval_str = _config_get("interval")
+    try:
+        interval_minutes = int(interval_str)
+    except (ValueError, TypeError):
+        interval_minutes = 30
+
+    # Test command
+    test_command = _config_get("test-command") or "python tests/run_tests.py"
+
+    config = _read_config_flags()
+    config["test_command"] = test_command
+
+    return {
+        "work_queue": {
+            "qa_rejected": qa_rejected,
+            "queue": queue,
+        },
+        "planning_artifacts": planning_artifacts,
+        "config": config,
+        "quiet_cycle_counter": 0,  # Will be read from working_state
+        "interval_minutes": interval_minutes,
+        "interval_changed": False,  # Agent checks this
+        "template_changed": _check_template_changed(role),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Role-specific: PM
+# ---------------------------------------------------------------------------
+
+
+def _build_pm_input(role):
+    """Build cycle-input.json fields specific to the PM agent."""
+    # Check agent presence
+    qa_present = _dir_exists("qa")
+    dm_present = _dir_exists("dm")
+
+    # Tracker queries
+    tracker_data = {
+        "pending_test_issues": [],
+        "pending_test_tasks": [],
+        "pending_ship_tasks": [],
+        "external_issues": [],
+        "open_prs": [],
+    }
+
+    # Pending test issues (for all dev roles)
+    result = _run_script("tracker.py", "list-issues", "skill", "--status", "pending-test")
+    try:
+        if result.returncode == 0 and result.stdout.strip():
+            items = json.loads(result.stdout)
+            tracker_data["pending_test_issues"] = items if isinstance(items, list) else []
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # Pending test tasks
+    result = _run_script("tracker.py", "list-tasks", "skill", "--status", "pending-test")
+    try:
+        if result.returncode == 0 and result.stdout.strip():
+            items = json.loads(result.stdout)
+            tracker_data["pending_test_tasks"] = items if isinstance(items, list) else []
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # Pending ship
+    result = _run_script("tracker.py", "list-by-labels", "status:pending-ship")
+    try:
+        if result.returncode == 0 and result.stdout.strip():
+            items = json.loads(result.stdout)
+            tracker_data["pending_ship_tasks"] = items if isinstance(items, list) else []
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # External issues (unlabeled)
+    result = _run_script("tracker.py", "list-all-open")
+    try:
+        if result.returncode == 0 and result.stdout.strip():
+            items = json.loads(result.stdout)
+            tracker_data["external_issues"] = [
+                i for i in (items if isinstance(items, list) else [])
+                if "squidsquad" not in [l.get("name", "") for l in i.get("labels", [])]
+            ]
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # Open PRs
+    pr_result = _run(["gh", "pr", "list", "--search", "squidsquad/", "--state", "open",
+                       "--json", "number,title,state,url,headRefName", "--limit", "20"])
+    try:
+        if pr_result.returncode == 0 and pr_result.stdout.strip():
+            tracker_data["open_prs"] = json.loads(pr_result.stdout)
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # Agent health
+    health_result = _run_script("health_check.py", "--json")
+    agent_health = {}
+    try:
+        if health_result.returncode == 0 and health_result.stdout.strip():
+            health_data = json.loads(health_result.stdout)
+            for entry in (health_data if isinstance(health_data, list) else []):
+                r = entry.get("role", "")
+                s = entry.get("status", "unknown")
+                if r:
+                    agent_health[r] = s
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # Merged branches (for recompose check)
+    merged_branches = []
+    merge_result = _run(["git", "log", "--merges", "--oneline", "--since=2 hours ago"])
+    if merge_result.returncode == 0:
+        for line in merge_result.stdout.splitlines():
+            if "squidsquad/" in line.lower():
+                merged_branches.append(line.strip())
+
+    config = _read_config_flags()
+    config["ship_threshold"] = int(_config_get("ship-threshold") or "10")
+    config["shipped_since_bump"] = int(_config_get("shipped-since-bump") or "0")
+    config["auto_boot_agents"] = _config_get("auto-boot-agents").lower() == "yes"
+
+    return {
+        "qa_present": qa_present,
+        "dm_present": dm_present,
+        "e2e_test_result": None,  # PM runs E2E during creative phase if QA absent
+        "tracker": tracker_data,
+        "agent_health": agent_health,
+        "config": config,
+        "merged_branches": merged_branches,
+        "template_changed": _check_template_changed(role),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Role-specific: QA
+# ---------------------------------------------------------------------------
+
+
+def _build_qa_input(role):
+    """Build cycle-input.json fields specific to the QA agent."""
+    # Verification queue — pending test issues with branch info
+    verification_queue = {
+        "pending_test_issues": [],
+        "pending_test_tasks": [],
+    }
+
+    # Pending test issues
+    result = _run_script("tracker.py", "list-issues", "skill", "--status", "pending-test")
+    try:
+        if result.returncode == 0 and result.stdout.strip():
+            items = json.loads(result.stdout)
+            for item in (items if isinstance(items, list) else []):
+                num = item.get("number", "")
+                branch = f"squidsquad/skill/{num}" if num else ""
+                item["branch"] = branch
+                # Check for test plan
+                test_plan_path = ""
+                for planning_dir in [SQUID_DIR / "pm" / "planning", SQUID_DIR / "qa" / "planning"]:
+                    if planning_dir.exists():
+                        for f in planning_dir.glob(f"*{num}*TEST-PLAN*"):
+                            test_plan_path = str(f.relative_to(REPO_ROOT))
+                            break
+                item["test_plan_path"] = test_plan_path
+                verification_queue["pending_test_issues"].append(item)
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # Pending test tasks
+    result = _run_script("tracker.py", "list-tasks", "skill", "--status", "pending-test")
+    try:
+        if result.returncode == 0 and result.stdout.strip():
+            items = json.loads(result.stdout)
+            for item in (items if isinstance(items, list) else []):
+                num = item.get("number", "")
+                branch = f"squidsquad/skill/{num}" if num else ""
+                item["branch"] = branch
+                test_plan_path = ""
+                for planning_dir in [SQUID_DIR / "pm" / "planning", SQUID_DIR / "qa" / "planning"]:
+                    if planning_dir.exists():
+                        for f in planning_dir.glob(f"*{num}*TEST-PLAN*"):
+                            test_plan_path = str(f.relative_to(REPO_ROOT))
+                            break
+                item["test_plan_path"] = test_plan_path
+                verification_queue["pending_test_tasks"].append(item)
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # Open PRs
+    open_prs = []
+    pr_result = _run(["gh", "pr", "list", "--state", "open",
+                       "--json", "number,title,state,url,headRefName,reviews", "--limit", "20"])
+    try:
+        if pr_result.returncode == 0 and pr_result.stdout.strip():
+            open_prs = json.loads(pr_result.stdout)
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # Agent health
+    health_result = _run_script("health_check.py", "--json")
+    agent_health = {}
+    try:
+        if health_result.returncode == 0 and health_result.stdout.strip():
+            health_data = json.loads(health_result.stdout)
+            for entry in (health_data if isinstance(health_data, list) else []):
+                r = entry.get("role", "")
+                s = entry.get("status", "unknown")
+                if r:
+                    agent_health[r] = s
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    config = _read_config_flags()
+    config["iteration_interval"] = int(_config_get("interval") or "30")
+
+    # E2E test result (run if configured)
+    e2e_result = {"result": "skipped", "tests_run": 0, "failures": []}
+    e2e_cmd = _config_get("e2e-tests")
+    if e2e_cmd and e2e_cmd.strip():
+        test_run = _run(e2e_cmd.split(), check=False)
+        if test_run.returncode == 0:
+            e2e_result["result"] = "passed"
+        else:
+            e2e_result["result"] = "failed"
+        # Basic parsing — agent interprets details during creative phase
+
+    # Branch setup for first verification item
+    branch_workflow = config.get("branch_workflow", False)
+    first_item = None
+    if verification_queue["pending_test_issues"]:
+        first_item = verification_queue["pending_test_issues"][0]
+    elif verification_queue["pending_test_tasks"]:
+        first_item = verification_queue["pending_test_tasks"][0]
+
+    if branch_workflow and first_item and first_item.get("branch"):
+        branch = first_item["branch"]
+        # Check if branch exists and switch to it
+        exists_result = _run(["git", "rev-parse", "--verify", branch], check=False)
+        if exists_result.returncode != 0:
+            # Try remote
+            exists_result = _run(["git", "rev-parse", "--verify", f"origin/{branch}"], check=False)
+            if exists_result.returncode == 0:
+                _run(["git", "checkout", "-b", branch, f"origin/{branch}"], check=False)
+        else:
+            _run(["git", "checkout", branch], check=False)
+
+    return {
+        "e2e_test_result": e2e_result,
+        "verification_queue": verification_queue,
+        "open_prs": open_prs,
+        "agent_health": agent_health,
+        "config": config,
+        "template_changed": _check_template_changed(role),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Role-specific: DM
+# ---------------------------------------------------------------------------
+
+
+def _build_dm_input(role):
+    """Build cycle-input.json fields specific to the DM agent."""
+    # Bugs assigned to DM
+    bugs = []
+    result = _run_script("tracker.py", "list-issues", "dm")
+    try:
+        if result.returncode == 0 and result.stdout.strip():
+            bugs = json.loads(result.stdout)
+            if not isinstance(bugs, list):
+                bugs = []
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # Pending ship items
+    pending_ship = []
+    result = _run_script("tracker.py", "list-by-labels", "status:pending-ship")
+    try:
+        if result.returncode == 0 and result.stdout.strip():
+            items = json.loads(result.stdout)
+            for item in (items if isinstance(items, list) else []):
+                # Check for delivery:skip in comments
+                num = item.get("number", "")
+                delivery_skip = False
+                if num:
+                    comment_result = _run(
+                        ["gh", "issue", "view", str(num), "--json", "comments"],
+                        check=False,
+                    )
+                    try:
+                        if comment_result.returncode == 0:
+                            comment_data = json.loads(comment_result.stdout)
+                            for comment in comment_data.get("comments", []):
+                                if "delivery: skip" in comment.get("body", "").lower() or \
+                                   "delivery:skip" in comment.get("body", "").lower():
+                                    delivery_skip = True
+                                    break
+                    except (json.JSONDecodeError, ValueError):
+                        pass
+                item["delivery_skip"] = delivery_skip
+                pending_ship.append(item)
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # Version bump info
+    ship_threshold = int(_config_get("ship-threshold") or "10")
+    shipped_since_bump = int(_config_get("shipped-since-bump") or "0")
+    current_version = _config_get("version") or "0.0.0"
+
+    # Count open issues across all roles
+    open_count = 0
+    for check_role in ["skill", "pm", "qa", "dm"]:
+        result = _run_script("tracker.py", "list-issues", check_role, "--status", "open")
+        try:
+            if result.returncode == 0 and result.stdout.strip():
+                items = json.loads(result.stdout)
+                open_count += len(items) if isinstance(items, list) else 0
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    version_bump = {
+        "ship_threshold": ship_threshold,
+        "shipped_since_bump": shipped_since_bump,
+        "bump_due": shipped_since_bump >= ship_threshold,
+        "open_issues_count": open_count,
+        "current_version": current_version,
+    }
+
+    config = _read_config_flags()
+
+    return {
+        "bugs": bugs,
+        "pending_ship": pending_ship,
+        "version_bump": version_bump,
+        "config": config,
+        "template_changed": _check_template_changed(role),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Branch setup for skill agent
+# ---------------------------------------------------------------------------
+
+
+def _setup_skill_branch(working_state, config_flags):
+    """Ensure skill agent is on the correct branch."""
+    if not config_flags.get("branch_workflow", False):
+        return
+
+    task = working_state.get("task", "none")
+    if task == "none" or not task.startswith("#"):
+        return  # No active task — stay on main
+
+    number = task.lstrip("#")
+    branch = f"squidsquad/skill/{number}"
+
+    # Check current branch
+    current = _run(["git", "branch", "--show-current"], check=False)
+    current_branch = current.stdout.strip() if current.returncode == 0 else ""
+
+    if current_branch == branch:
+        return  # Already on correct branch
+
+    # Check if branch exists
+    exists = _run(["git", "rev-parse", "--verify", branch], check=False)
+    if exists.returncode == 0:
+        _run(["git", "checkout", branch], check=False)
+    else:
+        # Check remote
+        remote_exists = _run(["git", "rev-parse", "--verify", f"origin/{branch}"], check=False)
+        if remote_exists.returncode == 0:
+            _run(["git", "checkout", "-b", branch, f"origin/{branch}"], check=False)
+        # If branch doesn't exist at all, stay on main — agent will create it
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+ROLE_BUILDERS = {
+    "skill": _build_skill_input,
+    "pm": _build_pm_input,
+    "qa": _build_qa_input,
+    "dm": _build_dm_input,
+}
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: cycle_pre.py <role>", file=sys.stderr)
+        sys.exit(1)
+
+    role = sys.argv[1]
+    if role not in ROLE_BUILDERS:
+        print(f"ERROR: Unknown role '{role}'. Valid: {list(ROLE_BUILDERS.keys())}",
+              file=sys.stderr)
+        sys.exit(1)
+
+    ts = _timestamp_short()
+    print(f"[🦑 {ts}] cycle_pre starting for {role}...")
+    _write_status_bar(role, "pulling", "pull-latest — Syncing with remote...")
+
+    # 1. Pull
+    pull_result = _do_pull()
+
+    # 2. Context pressure
+    context_pressure = _read_context_pressure(role)
+
+    # 3. Working state
+    working_state = _read_working_state(role)
+
+    # 4. Cycle number
+    cycle_number = _get_cycle_number(role)
+
+    # 5. Branch setup (skill-specific)
+    config_flags = _read_config_flags()
+    if role == "skill":
+        _setup_skill_branch(working_state, config_flags)
+
+    # 6. Status bar
+    _write_status_bar(role, "triaging", "tracker-protocol — Building work queue...")
+
+    # 7. Role-specific input
+    role_input = ROLE_BUILDERS[role](role)
+
+    # 8. Build and write cycle-input.json
+    cycle_input = {
+        "role": role,
+        "cycle_number": cycle_number,
+        "timestamp": _timestamp(),
+        "pull_result": pull_result,
+        "context_pressure": context_pressure,
+        "working_state": working_state,
+    }
+    cycle_input.update(role_input)
+
+    # Update quiet_cycle_counter from working state for skill
+    if role == "skill":
+        cycle_input["quiet_cycle_counter"] = working_state.get("quiet_cycles", 0)
+
+    # Write cycle-input.json
+    output_path = SQUID_DIR / role / "cycle-input.json"
+    output_path.write_text(
+        json.dumps(cycle_input, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    ts = _timestamp_short()
+    print(f"[🦑 {ts}] cycle_pre complete — wrote {output_path.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/references/scripts/cycle_pre.py
+++ b/references/scripts/cycle_pre.py
@@ -516,7 +516,7 @@ def _build_qa_input(role):
     # E2E test result (run if configured)
     e2e_result = {"result": "skipped", "tests_run": 0, "failures": []}
     e2e_cmd = _config_get("e2e-tests")
-    if e2e_cmd and e2e_cmd.strip():
+    if e2e_cmd and e2e_cmd.strip() and e2e_cmd.strip().lower() not in ("(none)", "none", ""):
         test_run = _run(e2e_cmd.split(), check=False)
         if test_run.returncode == 0:
             e2e_result["result"] = "passed"

--- a/references/sub-skills/common/cycle-runner.md
+++ b/references/sub-skills/common/cycle-runner.md
@@ -1,0 +1,87 @@
+<!-- sub-skill: cycle-runner -->
+## Cycle Runner (Transport Layer)
+
+**Feature flag**: Check `Cycle Runner` in `config.md`. If set to `no` (default), skip this section entirely and use the existing Ralph Loop steps.
+
+When enabled (`Cycle Runner: yes`), the Ralph Loop simplifies to three phases:
+
+### Phase 1 — Pre-Cycle (Mechanical)
+
+```bash
+python references/scripts/cycle_pre.py [ROLE]
+```
+
+This script handles all mechanical operations: git pull, context pressure check, working state read, triage/queue queries, branch setup, and writes `.squidsquad/[ROLE]/cycle-input.json`.
+
+Read the output:
+
+```bash
+cat .squidsquad/[ROLE]/cycle-input.json
+```
+
+The JSON contains everything you need: `role`, `cycle_number`, `timestamp`, `pull_result`, `context_pressure`, `working_state`, and role-specific fields (work queue, verification queue, etc.).
+
+### Phase 2 — Creative Work (Agent)
+
+This is your core work — reasoning, code analysis, code writing, verification, human interaction. Use cycle-input.json to understand the current state. You still have full bash access for:
+- Running tests
+- Reading code
+- Spawning subagents
+- Running verification commands
+- Any creative work that requires shell access
+
+Do NOT use bash for mechanical operations that cycle_pre/post handles (git pull, git push, status bar writes, tracker transitions, iteration logging).
+
+### Phase 3 — Post-Cycle (Mechanical)
+
+Write your results to `.squidsquad/[ROLE]/cycle-output.json`:
+
+```json
+{
+  "role": "[ROLE]",
+  "cycle_number": N,
+  "cycle_type": "active" | "quiet" | "suppressed",
+  "status_transitions": [
+    {"number": 123, "from": "approved", "to": "in-progress"}
+  ],
+  "tracker_comments": [
+    {"number": 123, "message": "Picking up. Status → In Progress."}
+  ],
+  "iteration_summary": "Brief description of work done",
+  "commit_message": "[ROLE]: cycle N — brief description",
+  "working_state_update": "# Working State\n\n- **Task**: none\n...",
+  "restart_needed": false,
+  "restart_reason": null
+}
+```
+
+Then run:
+
+```bash
+python references/scripts/cycle_post.py [ROLE]
+```
+
+The script handles: status transitions, tracker comments, iteration logging, git commits, pushes, version bumps (DM), restart sentinels, and status bar cleanup.
+
+### Role-Specific Fields
+
+**Skill** cycle-output extras:
+- `code_commit`: `{branch, message, pr_needed, pr_title, pr_body}` — for branch workflow
+- `state_commit_message`: separate message for main branch state commit
+- `improvement_scan`: `{files_scanned, findings}` — if scan ran
+
+**PM** cycle-output extras:
+- `human_input_processed`: summary of human input handled
+- `issues_filed`, `issues_verified`, `tasks_verified`, `tasks_shipped`
+- `external_issues_triaged`, `health_alerts`, `vault_writes`
+- `version_bump`: `{new_version, items_included}` — if DM absent
+
+**QA** cycle-output extras:
+- `e2e_log`: `{result, tests_run, failures}`
+- `issues_filed`, `issues_verified`, `tasks_verified`
+- `pr_actions`: `[{pr_number, action, comment}]`
+
+**DM** cycle-output extras:
+- `bugs_fixed`, `deliveries`
+- `version_bump`: `{new_version, items_included}`
+<!-- /sub-skill: cycle-runner -->

--- a/references/sub-skills/manifest.md
+++ b/references/sub-skills/manifest.md
@@ -39,6 +39,7 @@ Entry file with includes (the role's own `SOUL.md` sits alongside `CLAUDE.md` in
 13. `common/file-conventions` — File/directory conventions
 14. `common/status-line` — Status line description
 15. `common/prohibitions` — "Never do" rules
+16. `common/cycle-runner` — (optional, feature-flagged) Cycle runner transport layer
 
 ### PM/QA Agent (`references/roles/pm/CLAUDE.md`)
 
@@ -183,7 +184,8 @@ references/sub-skills/
 │   ├── improvement-scan-slim.md     (Improvement filing only — QA, DM, designer)
 │   ├── status-line.md                (Status line description — shared by dev)
 │   ├── prohibitions.md               (Shared "never do" rules — shared by dev)
-│   └── capability-check.md          (Startup capability verification — shared by roles with requires_sub_skills)
+│   ├── capability-check.md          (Startup capability verification — shared by roles with requires_sub_skills)
+│   └── cycle-runner.md              (Cycle runner transport layer — opt-in via feature flag, all roles)
 ├── dev-specific/
 │   ├── triage-issues.md              (Step 2 — triage open issues)
 │   └── implement-tasks.md           (Step 3 — implement approved tasks)

--- a/tests/test_cycle_post.py
+++ b/tests/test_cycle_post.py
@@ -1,0 +1,262 @@
+"""Tests for references/scripts/cycle_post.py — post-cycle mechanical operations."""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import cycle_post
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def squid_dir(tmp_path):
+    """Create a minimal .squidsquad directory structure."""
+    squid = tmp_path / ".squidsquad"
+    for role in ("skill", "pm", "qa", "dm"):
+        (squid / role).mkdir(parents=True)
+        (squid / role / "iterations").mkdir()
+    return squid
+
+
+@pytest.fixture
+def patch_dirs(squid_dir, tmp_path, monkeypatch):
+    """Patch REPO_ROOT and SQUID_DIR to use tmp_path."""
+    monkeypatch.setattr(cycle_post, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(cycle_post, "SQUID_DIR", squid_dir)
+    return tmp_path
+
+
+def _write_output(squid_dir, role, data):
+    """Write cycle-output.json for a role."""
+    output_path = squid_dir / role / "cycle-output.json"
+    output_path.write_text(json.dumps(data), encoding="utf-8")
+    return output_path
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+class TestValidateOutput:
+    def test_valid_minimal(self):
+        data = {"role": "skill", "cycle_number": 205, "cycle_type": "quiet"}
+        assert cycle_post._validate_output(data) == []
+
+    def test_missing_required_fields(self):
+        data = {"role": "skill"}
+        errors = cycle_post._validate_output(data)
+        assert any("cycle_number" in e for e in errors)
+        assert any("cycle_type" in e for e in errors)
+
+    def test_invalid_cycle_type(self):
+        data = {"role": "skill", "cycle_number": 1, "cycle_type": "banana"}
+        errors = cycle_post._validate_output(data)
+        assert any("banana" in e for e in errors)
+
+    def test_not_a_dict(self):
+        errors = cycle_post._validate_output("not a dict")
+        assert len(errors) == 1
+        assert "object" in errors[0]
+
+    def test_invalid_transition_structure(self):
+        data = {
+            "role": "pm", "cycle_number": 1, "cycle_type": "active",
+            "status_transitions": [{"number": 123}],  # missing from/to
+        }
+        errors = cycle_post._validate_output(data)
+        assert any("from" in e for e in errors)
+        assert any("to" in e for e in errors)
+
+    def test_valid_with_transitions(self):
+        data = {
+            "role": "pm", "cycle_number": 1, "cycle_type": "active",
+            "status_transitions": [
+                {"number": 123, "from": "pending-test", "to": "pending-ship"},
+            ],
+        }
+        assert cycle_post._validate_output(data) == []
+
+
+# ---------------------------------------------------------------------------
+# Missing / Invalid Output File
+# ---------------------------------------------------------------------------
+
+class TestMissingOutput:
+    def test_missing_output_file(self, patch_dirs, capsys):
+        """cycle_post exits 0 with warning when no output file exists."""
+        result = cycle_post.main.__wrapped__(
+        ) if hasattr(cycle_post.main, '__wrapped__') else None
+        # Call main with role arg
+        with patch("sys.argv", ["cycle_post.py", "skill"]):
+            exit_code = cycle_post.main()
+        assert exit_code == 0
+        err = capsys.readouterr().err
+        assert "WARNING" in err or "No cycle-output.json" in err
+
+    def test_invalid_json(self, patch_dirs, squid_dir, capsys):
+        """cycle_post exits 1 on malformed JSON."""
+        output_path = squid_dir / "pm" / "cycle-output.json"
+        output_path.write_text('{"role": "pm", "cycle_number": 459, ', encoding="utf-8")
+
+        with patch("sys.argv", ["cycle_post.py", "pm"]):
+            with pytest.raises(SystemExit) as exc:
+                cycle_post.main()
+            assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "JSON" in err or "json" in err.lower()
+
+    def test_schema_validation_fails(self, patch_dirs, squid_dir, capsys):
+        """cycle_post exits 1 on schema-invalid output."""
+        _write_output(squid_dir, "pm", {"role": "pm"})  # missing cycle_number, cycle_type
+
+        with patch("sys.argv", ["cycle_post.py", "pm"]):
+            with pytest.raises(SystemExit) as exc:
+                cycle_post.main()
+            assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "cycle_number" in err or "cycle_type" in err
+
+
+# ---------------------------------------------------------------------------
+# Status Transitions
+# ---------------------------------------------------------------------------
+
+class TestStatusTransitions:
+    def test_calls_tracker_transition(self, monkeypatch):
+        calls = []
+
+        def fake_run_script(script, *args, **kwargs):
+            calls.append((script, args))
+            fake = MagicMock()
+            fake.returncode = 0
+            fake.stdout = ""
+            fake.stderr = ""
+            return fake
+
+        monkeypatch.setattr(cycle_post, "_run_script", fake_run_script)
+
+        data = {
+            "status_transitions": [
+                {"number": 123, "from": "pending-test", "to": "pending-ship"},
+            ],
+        }
+        cycle_post._do_status_transitions(data, "pm")
+
+        # Check tracker.py was called with correct args
+        tracker_calls = [c for c in calls if "tracker.py" in c[0]]
+        assert len(tracker_calls) == 1
+        args = tracker_calls[0][1]
+        assert "transition" in args
+        assert "123" in args
+        assert "pending-test" in args
+        assert "pending-ship" in args
+        assert "--role" in args
+        assert "pm-lead" in args
+
+    def test_skips_invalid_transition(self, monkeypatch, capsys):
+        calls = []
+        monkeypatch.setattr(cycle_post, "_run_script", lambda *a, **kw: MagicMock(returncode=0, stdout="", stderr=""))
+
+        data = {
+            "status_transitions": [
+                {"number": 123},  # missing from/to
+            ],
+        }
+        cycle_post._do_status_transitions(data, "pm")
+        err = capsys.readouterr().err
+        assert "WARNING" in err or "Skipping" in err
+
+
+# ---------------------------------------------------------------------------
+# Iteration Log
+# ---------------------------------------------------------------------------
+
+class TestIterationLog:
+    def test_creates_active_log(self, monkeypatch):
+        calls = []
+
+        def fake_run_script(script, *args, **kwargs):
+            calls.append((script, args))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(cycle_post, "_run_script", fake_run_script)
+
+        data = {
+            "cycle_number": 459,
+            "cycle_type": "active",
+            "iteration_summary": "Verified #123",
+        }
+        cycle_post._do_iteration_log(data, "pm")
+
+        log_calls = [c for c in calls if "log-iteration" in c[1]]
+        assert len(log_calls) == 1
+        assert "459" in log_calls[0][1]
+        assert "--work" in log_calls[0][1]
+
+    def test_creates_quiet_log(self, monkeypatch):
+        calls = []
+
+        def fake_run_script(script, *args, **kwargs):
+            calls.append((script, args))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(cycle_post, "_run_script", fake_run_script)
+
+        data = {
+            "cycle_number": 460,
+            "cycle_type": "quiet",
+            "iteration_summary": "No work",
+        }
+        cycle_post._do_iteration_log(data, "pm")
+
+        log_calls = [c for c in calls if "log-iteration" in c[1]]
+        assert len(log_calls) == 1
+        assert "--quiet" in log_calls[0][1]
+
+
+# ---------------------------------------------------------------------------
+# Restart Sentinel
+# ---------------------------------------------------------------------------
+
+class TestRestartSentinel:
+    def test_writes_sentinel(self, patch_dirs, squid_dir):
+        data = {"restart_needed": True, "restart_reason": "context pressure at 85%"}
+        result = cycle_post._do_restart_sentinel(data, "pm")
+        assert result is True
+        sentinel = squid_dir / "pm" / ".restart"
+        assert sentinel.exists()
+        assert "context pressure" in sentinel.read_text(encoding="utf-8")
+
+    def test_no_sentinel_when_not_needed(self, patch_dirs, squid_dir):
+        data = {"restart_needed": False}
+        result = cycle_post._do_restart_sentinel(data, "pm")
+        assert result is False
+        assert not (squid_dir / "pm" / ".restart").exists()
+
+
+# ---------------------------------------------------------------------------
+# Status Bar
+# ---------------------------------------------------------------------------
+
+class TestStatusBar:
+    def test_idle_after_cycle(self, patch_dirs, squid_dir):
+        cycle_post._write_status_bar("pm", "idle", "")
+        state_file = squid_dir / "pm" / "current-state"
+        assert state_file.read_text(encoding="utf-8") == "idle|"
+
+    def test_atomic_write(self, patch_dirs, squid_dir):
+        """Status bar write should not leave .tmp files."""
+        cycle_post._write_status_bar("skill", "implementing", "#2050 — Working...")
+        tmp_file = squid_dir / "skill" / "current-state.tmp"
+        assert not tmp_file.exists()
+        state_file = squid_dir / "skill" / "current-state"
+        assert "implementing" in state_file.read_text(encoding="utf-8")

--- a/tests/test_cycle_pre.py
+++ b/tests/test_cycle_pre.py
@@ -1,0 +1,260 @@
+"""Tests for references/scripts/cycle_pre.py — pre-cycle mechanical operations."""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import cycle_pre
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def squid_dir(tmp_path):
+    """Create a minimal .squidsquad directory structure."""
+    squid = tmp_path / ".squidsquad"
+    for role in ("skill", "pm", "qa", "dm"):
+        (squid / role).mkdir(parents=True)
+        (squid / role / "iterations").mkdir()
+    return squid
+
+
+@pytest.fixture
+def patch_dirs(squid_dir, tmp_path, monkeypatch):
+    """Patch REPO_ROOT and SQUID_DIR to use tmp_path."""
+    monkeypatch.setattr(cycle_pre, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(cycle_pre, "SQUID_DIR", squid_dir)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Working State Parsing
+# ---------------------------------------------------------------------------
+
+class TestReadWorkingState:
+    def test_empty_file(self, patch_dirs, squid_dir):
+        ws = squid_dir / "skill" / "working-state.md"
+        ws.write_text("", encoding="utf-8")
+        result = cycle_pre._read_working_state("skill")
+        assert result["task"] == "none"
+        assert result["status"] == "none"
+        assert result["suppressed"] is False
+
+    def test_active_task(self, patch_dirs, squid_dir):
+        ws = squid_dir / "skill" / "working-state.md"
+        ws.write_text(
+            "# Working State\n\n"
+            "- **Task**: #2050\n"
+            "- **Status**: in-progress\n"
+            "- **Quiet Cycles**: 0\n\n"
+            "## Completed Steps\n"
+            "- Read issue details\n"
+            "- Located bug in parser.py\n\n"
+            "## Remaining Steps\n"
+            "- Write fix\n"
+            "- Run tests\n\n"
+            "## Key Decisions\n"
+            "- Use regex instead of string split\n",
+            encoding="utf-8",
+        )
+        result = cycle_pre._read_working_state("skill")
+        assert result["task"] == "#2050"
+        assert result["status"] == "in-progress"
+        assert result["completed_steps"] == ["Read issue details", "Located bug in parser.py"]
+        assert result["remaining_steps"] == ["Write fix", "Run tests"]
+        assert result["key_decisions"] == ["Use regex instead of string split"]
+        assert result["quiet_cycles"] == 0
+
+    def test_no_task(self, patch_dirs, squid_dir):
+        ws = squid_dir / "skill" / "working-state.md"
+        ws.write_text(
+            "# Working State\n\n"
+            "- **Task**: none\n"
+            "- **Status**: none\n"
+            "- **Quiet Cycles**: 3\n",
+            encoding="utf-8",
+        )
+        result = cycle_pre._read_working_state("skill")
+        assert result["task"] == "none"
+        assert result["status"] == "none"
+        assert result["quiet_cycles"] == 3
+
+    def test_missing_file(self, patch_dirs, squid_dir):
+        result = cycle_pre._read_working_state("skill")
+        assert result["task"] == "none"
+        assert result["raw_content"] == ""
+
+    def test_pm_planning_phase_suppression(self, patch_dirs, squid_dir):
+        ws = squid_dir / "pm" / "working-state.md"
+        ws.write_text(
+            "# Working State\n\n"
+            "- **Task**: #2070\n"
+            "- **Status**: in-progress\n"
+            "- **Phase**: researching #2070\n",
+            encoding="utf-8",
+        )
+        result = cycle_pre._read_working_state("pm")
+        assert result["suppressed"] is True
+        assert result["phase"] == "researching #2070"
+
+
+# ---------------------------------------------------------------------------
+# Cycle Number
+# ---------------------------------------------------------------------------
+
+class TestGetCycleNumber:
+    def test_no_iterations(self, patch_dirs, squid_dir):
+        assert cycle_pre._get_cycle_number("skill") == 1
+
+    def test_increments_from_last(self, patch_dirs, squid_dir):
+        iter_dir = squid_dir / "skill" / "iterations"
+        (iter_dir / "iter-204.md").write_text("# Iteration 204", encoding="utf-8")
+        (iter_dir / "iter-205.md").write_text("# Iteration 205", encoding="utf-8")
+        assert cycle_pre._get_cycle_number("skill") == 206
+
+    def test_handles_gaps(self, patch_dirs, squid_dir):
+        iter_dir = squid_dir / "skill" / "iterations"
+        (iter_dir / "iter-100.md").write_text("", encoding="utf-8")
+        (iter_dir / "iter-150.md").write_text("", encoding="utf-8")
+        assert cycle_pre._get_cycle_number("skill") == 151
+
+
+# ---------------------------------------------------------------------------
+# Context Pressure
+# ---------------------------------------------------------------------------
+
+class TestContextPressure:
+    def test_reads_pressure_file(self, patch_dirs, squid_dir):
+        (squid_dir / "skill" / "context-pressure").write_text("42", encoding="utf-8")
+        with patch.object(cycle_pre, "_config_get", return_value="70"):
+            result = cycle_pre._read_context_pressure("skill")
+        assert result["used_pct"] == 42
+        assert result["threshold"] == 70
+        assert result["exceeded"] is False
+
+    def test_exceeded_threshold(self, patch_dirs, squid_dir):
+        (squid_dir / "skill" / "context-pressure").write_text("85", encoding="utf-8")
+        with patch.object(cycle_pre, "_config_get", return_value="70"):
+            result = cycle_pre._read_context_pressure("skill")
+        assert result["exceeded"] is True
+
+    def test_missing_pressure_file(self, patch_dirs, squid_dir):
+        with patch.object(cycle_pre, "_config_get", return_value="70"):
+            result = cycle_pre._read_context_pressure("skill")
+        assert result["used_pct"] == 0
+        assert result["exceeded"] is False
+
+    def test_default_threshold_on_missing_config(self, patch_dirs, squid_dir):
+        with patch.object(cycle_pre, "_config_get", return_value=""):
+            result = cycle_pre._read_context_pressure("skill")
+        assert result["threshold"] == 70
+
+
+# ---------------------------------------------------------------------------
+# Pull
+# ---------------------------------------------------------------------------
+
+class TestDoPull:
+    def test_ok(self, monkeypatch):
+        fake = MagicMock()
+        fake.returncode = 0
+        fake.stdout = "Pulled"
+        monkeypatch.setattr(cycle_pre, "_run_script", lambda *a, **kw: fake)
+        assert cycle_pre._do_pull() == "ok"
+
+    def test_error(self, monkeypatch):
+        fake = MagicMock()
+        fake.returncode = 1
+        fake.stdout = "error"
+        monkeypatch.setattr(cycle_pre, "_run_script", lambda *a, **kw: fake)
+        assert cycle_pre._do_pull() == "error"
+
+    def test_stash_conflict(self, monkeypatch):
+        fake = MagicMock()
+        fake.returncode = 0
+        fake.stdout = "Pulled (stash pop conflict — run 'git stash show')"
+        monkeypatch.setattr(cycle_pre, "_run_script", lambda *a, **kw: fake)
+        assert cycle_pre._do_pull() == "stash_conflict"
+
+
+# ---------------------------------------------------------------------------
+# Config Flags
+# ---------------------------------------------------------------------------
+
+class TestReadConfigFlags:
+    def test_reads_all_flags(self, monkeypatch):
+        flags = {
+            "branch-workflow": "yes",
+            "pr-flow": "no",
+            "improvement-scanning": "yes",
+            "vault-remember": "no",
+            "vault-optimize": "yes",
+        }
+        monkeypatch.setattr(cycle_pre, "_config_get", lambda f: flags.get(f, ""))
+        result = cycle_pre._read_config_flags()
+        assert result["branch_workflow"] is True
+        assert result["pr_flow"] is False
+        assert result["improvement_scanning"] is True
+        assert result["vault_remember"] is False
+        assert result["vault_optimize"] is True
+
+
+# ---------------------------------------------------------------------------
+# Skill Input Builder
+# ---------------------------------------------------------------------------
+
+class TestBuildSkillInput:
+    def test_builds_with_empty_queue(self, patch_dirs, monkeypatch):
+        empty = MagicMock()
+        empty.returncode = 0
+        empty.stdout = "[]"
+        monkeypatch.setattr(cycle_pre, "_run_script", lambda *a, **kw: empty)
+        monkeypatch.setattr(cycle_pre, "_config_get", lambda f: {
+            "interval": "30", "test-command": "python tests/run_tests.py",
+            "branch-workflow": "no", "pr-flow": "no",
+            "improvement-scanning": "yes", "vault-remember": "yes",
+            "vault-optimize": "no",
+        }.get(f, ""))
+
+        result = cycle_pre._build_skill_input("skill")
+        assert result["work_queue"]["qa_rejected"] == []
+        assert result["work_queue"]["queue"] == []
+        assert result["planning_artifacts"] == {}
+        assert result["interval_minutes"] == 30
+        assert result["config"]["test_command"] == "python tests/run_tests.py"
+
+    def test_builds_with_queue_items(self, patch_dirs, squid_dir, monkeypatch):
+        queue_data = [
+            {"number": 2045, "type": "issue", "priority": "high", "title": "Bug"},
+        ]
+
+        def fake_run_script(*args, **kwargs):
+            fake = MagicMock()
+            fake.returncode = 0
+            if "triage.py" in args[0]:
+                fake.stdout = "[]"
+            elif "tracker.py" in args[0] and "work-queue" in args:
+                fake.stdout = json.dumps(queue_data)
+            else:
+                fake.stdout = "[]"
+            return fake
+
+        monkeypatch.setattr(cycle_pre, "_run_script", fake_run_script)
+        monkeypatch.setattr(cycle_pre, "_config_get", lambda f: {
+            "interval": "30", "test-command": "",
+            "branch-workflow": "no", "pr-flow": "no",
+            "improvement-scanning": "no", "vault-remember": "no",
+            "vault-optimize": "no",
+        }.get(f, ""))
+
+        result = cycle_pre._build_skill_input("skill")
+        assert len(result["work_queue"]["queue"]) == 1
+        assert result["work_queue"]["queue"][0]["number"] == 2045

--- a/tests/test_cycle_pre.py
+++ b/tests/test_cycle_pre.py
@@ -258,3 +258,47 @@ class TestBuildSkillInput:
         result = cycle_pre._build_skill_input("skill")
         assert len(result["work_queue"]["queue"]) == 1
         assert result["work_queue"]["queue"][0]["number"] == 2045
+
+
+# ---------------------------------------------------------------------------
+# QA Input Builder — e2e guard regression (#2070 QA feedback)
+# ---------------------------------------------------------------------------
+
+class TestBuildQaInputE2eGuard:
+    def test_none_placeholder_skips_e2e(self, patch_dirs, monkeypatch):
+        """Config value '(none)' for e2e-tests must not be treated as a command."""
+        empty = MagicMock()
+        empty.returncode = 0
+        empty.stdout = "[]"
+        monkeypatch.setattr(cycle_pre, "_run_script", lambda *a, **kw: empty)
+        monkeypatch.setattr(cycle_pre, "_run", lambda *a, **kw: MagicMock(
+            returncode=0, stdout="[]", stderr=""))
+        monkeypatch.setattr(cycle_pre, "_config_get", lambda f: {
+            "e2e-tests": "(none)",
+            "interval": "30",
+            "branch-workflow": "no", "pr-flow": "no",
+            "improvement-scanning": "no", "vault-remember": "no",
+            "vault-optimize": "no",
+        }.get(f, ""))
+
+        result = cycle_pre._build_qa_input("qa")
+        assert result["e2e_test_result"]["result"] == "skipped"
+
+    def test_empty_e2e_skips(self, patch_dirs, monkeypatch):
+        """Empty e2e-tests config must skip."""
+        empty = MagicMock()
+        empty.returncode = 0
+        empty.stdout = "[]"
+        monkeypatch.setattr(cycle_pre, "_run_script", lambda *a, **kw: empty)
+        monkeypatch.setattr(cycle_pre, "_run", lambda *a, **kw: MagicMock(
+            returncode=0, stdout="[]", stderr=""))
+        monkeypatch.setattr(cycle_pre, "_config_get", lambda f: {
+            "e2e-tests": "",
+            "interval": "30",
+            "branch-workflow": "no", "pr-flow": "no",
+            "improvement-scanning": "no", "vault-remember": "no",
+            "vault-optimize": "no",
+        }.get(f, ""))
+
+        result = cycle_pre._build_qa_input("qa")
+        assert result["e2e_test_result"]["result"] == "skipped"


### PR DESCRIPTION
Closes #2070

## #2070

- cycle_pre.py: pre-cycle mechanical ops (git pull, context pressure, working state, triage, branch setup) → writes cycle-input.json
- cycle_post.py: post-cycle mechanical ops (status transitions, tracker comments, iteration log, commits, pushes, version bumps, restart sentinels) → reads cycle-output.json
- Feature flag: Cycle Runner: yes/no in config.md (default: no for existing installs)
- cycle-runner.md sub-skill template documenting the 3-phase flow
- Config mapping for cycle-runner field
- Runtime files (cycle-input/output.json) gitignored
- 35 new unit tests, all passing
- UTF-8 encoding fix for Windows compatibility

### Acceptance Criteria
- [x] cycle_pre.py produces cycle-input.json with queue, context pressure, working state
- [x] cycle_post.py reads cycle-output.json and handles all git/tracker mechanics
- [x] Branch switching handled entirely in scripts
- [x] Ralph Loop sub-skill updated to use new flow
- [x] Existing test suite still passes

Status: Pending Test