### PR TITLE
skill: #2361 — TC coverage gate

### DIFF
--- a/references/scripts/tc_coverage.py
+++ b/references/scripts/tc_coverage.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""TC coverage gate — verify all TEST-PLAN TCs are accounted for in QA-RESULTS.
+
+Exit codes:
+    0 — 100% coverage, no BLOCKED results (or no test plan found / 0 TCs)
+    1 — coverage gap, invalid results, duplicates, or other errors
+    2 — 100% coverage but BLOCKED results exist (cannot ship)
+
+Usage:
+    python tc_coverage.py --test-plan PATH --qa-results PATH
+    python tc_coverage.py --issue NUMBER
+    python tc_coverage.py --help
+"""
+
+import argparse
+import glob
+import os
+import re
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+SQUID_DIR = REPO_ROOT / ".squidsquad"
+
+# --- TC ID parsing ---
+
+# Heading pattern: ### TC-1: or ### TC-01: or ### TC 01: (must be at heading position)
+_TC_HEADING_RE = re.compile(
+    r"^#{1,6}\s+TC[\s\-]?(\d+)\s*:", re.IGNORECASE
+)
+
+# Table row pattern: | TC-1 | RESULT | ... | (TC at start of a table cell)
+_TC_TABLE_RE = re.compile(
+    r"^\|\s*TC[\s\-]?(\d+)\s*\|", re.IGNORECASE
+)
+
+# Valid result tokens (case-insensitive matching)
+_VALID_RESULTS = {"PASS", "FAIL", "BLOCKED"}
+
+# Invalid result tokens to explicitly reject
+_INVALID_RESULTS_RE = re.compile(
+    r"\b(not[\s\-]?applicable|n/?a|deferred)\b", re.IGNORECASE
+)
+
+# Result extraction from heading line or next few lines
+_RESULT_RE = re.compile(
+    r"\b(PASS|FAIL|BLOCKED|HUMAN[\s\-]?REQUIRED)\b", re.IGNORECASE
+)
+
+
+def _normalize_tc_id(raw_num: str) -> int:
+    """Normalize a TC number string to an integer (strips zero-padding)."""
+    return int(raw_num)
+
+
+def parse_tc_ids(text: str) -> list[int]:
+    """Extract TC IDs from a markdown file in heading or table-row position.
+
+    Returns a list of TC IDs (as ints). May contain duplicates.
+    """
+    ids = []
+    for line in text.splitlines():
+        m = _TC_HEADING_RE.match(line) or _TC_TABLE_RE.match(line)
+        if m:
+            ids.append(_normalize_tc_id(m.group(1)))
+    return ids
+
+
+def parse_tc_results(text: str) -> dict[int, str]:
+    """Extract TC IDs and their results from a QA-RESULTS markdown file.
+
+    Returns {tc_id: result_string}. result_string is uppercased.
+    Detects invalid results (not-applicable, deferred, N/A).
+    """
+    results = {}
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        m = _TC_HEADING_RE.match(line) or _TC_TABLE_RE.match(line)
+        if not m:
+            continue
+        tc_id = _normalize_tc_id(m.group(1))
+
+        # Search for result on this line and the next few lines
+        search_block = "\n".join(lines[i : i + 5])
+
+        # Check for invalid results first
+        if _INVALID_RESULTS_RE.search(search_block):
+            results[tc_id] = "INVALID"
+            continue
+
+        # Look for valid result
+        rm = _RESULT_RE.search(search_block)
+        if rm:
+            result = rm.group(1).upper().replace(" ", "-").replace("\t", "-")
+            if result.startswith("HUMAN"):
+                result = "HUMAN-REQUIRED"
+            results[tc_id] = result
+        else:
+            # TC present but no recognizable result
+            results[tc_id] = "UNKNOWN"
+
+    return results
+
+
+# --- Auto-discovery ---
+
+
+def _discover_files(issue_number: int) -> tuple[Path | None, Path | None]:
+    """Auto-discover TEST-PLAN and QA-RESULTS files for an issue number.
+
+    Searches .squidsquad/*/planning/ directories.
+    PM planning dir is preferred over other roles.
+    For QA-RESULTS, picks highest -RN revision.
+    """
+    planning_dirs = sorted(SQUID_DIR.glob("*/planning"))
+
+    # Sort to put pm first (PM owns test plans)
+    planning_dirs = sorted(
+        planning_dirs, key=lambda p: (0 if p.parent.name == "pm" else 1, p.parent.name)
+    )
+
+    test_plan = None
+    qa_results = None
+
+    for pdir in planning_dirs:
+        # Find TEST-PLAN
+        if test_plan is None:
+            matches = list(pdir.glob(f"*-{issue_number}-TEST-PLAN.md"))
+            if matches:
+                test_plan = matches[0]
+
+        # Find QA-RESULTS (prefer highest -RN revision)
+        if qa_results is None:
+            base_matches = list(pdir.glob(f"*-{issue_number}-QA-RESULTS.md"))
+            rev_matches = list(pdir.glob(f"*-{issue_number}-QA-RESULTS-R*.md"))
+
+            if rev_matches:
+                # Sort by revision number, pick highest
+                def _rev_num(p):
+                    m = re.search(r"-R(\d+)\.md$", p.name)
+                    return int(m.group(1)) if m else 0
+
+                rev_matches.sort(key=_rev_num)
+                qa_results = rev_matches[-1]
+            elif base_matches:
+                qa_results = base_matches[0]
+
+    return test_plan, qa_results
+
+
+# --- Main logic ---
+
+
+def check_coverage(
+    test_plan_path: str,
+    qa_results_path: str,
+    debug: bool = False,
+) -> int:
+    """Check TC coverage between a TEST-PLAN and QA-RESULTS file.
+
+    Returns exit code: 0 (pass), 1 (fail), 2 (blocked).
+    """
+    plan_text = Path(test_plan_path).read_text(encoding="utf-8")
+    results_text = Path(qa_results_path).read_text(encoding="utf-8")
+
+    plan_ids = parse_tc_ids(plan_text)
+    result_map = parse_tc_results(results_text)
+
+    # Check for duplicates in TEST-PLAN
+    seen = set()
+    duplicates = []
+    for tc_id in plan_ids:
+        if tc_id in seen:
+            duplicates.append(tc_id)
+        seen.add(tc_id)
+
+    if duplicates:
+        dup_strs = [f"TC-{d}" for d in sorted(set(duplicates))]
+        print(
+            f"ERROR: Duplicate TC IDs in TEST-PLAN: {', '.join(dup_strs)}",
+            file=sys.stderr,
+        )
+        return 1
+
+    plan_set = set(plan_ids)
+    results_set = set(result_map.keys())
+
+    # Handle empty plan
+    if not plan_set:
+        print("No TCs found in TEST-PLAN. Gate skipped (0/0).")
+        return 0
+
+    # Check for missing TCs
+    missing = plan_set - results_set
+    extra = results_set - plan_set
+
+    # Check for invalid results
+    invalid = {
+        tc_id: result
+        for tc_id, result in result_map.items()
+        if tc_id in plan_set and result == "INVALID"
+    }
+
+    # Check for BLOCKED results
+    blocked = {
+        tc_id
+        for tc_id, result in result_map.items()
+        if tc_id in plan_set and result == "BLOCKED"
+    }
+
+    covered = plan_set - missing
+    coverage_pct = (len(covered) / len(plan_set) * 100) if plan_set else 100
+
+    # Print report
+    print(f"TC Coverage: {len(covered)}/{len(plan_set)} ({coverage_pct:.0f}%)")
+
+    if debug:
+        # Print unmatched lines from QA-RESULTS
+        print("\n--- Debug: unmatched lines in QA-RESULTS ---", file=sys.stderr)
+        for i, line in enumerate(results_text.splitlines(), 1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            m = _TC_HEADING_RE.match(line) or _TC_TABLE_RE.match(line)
+            if not m:
+                print(f"  L{i}: {line}", file=sys.stderr)
+
+    errors = False
+
+    if missing:
+        missing_strs = [f"TC-{m}" for m in sorted(missing)]
+        print(f"Missing TCs: {', '.join(missing_strs)}", file=sys.stderr)
+        errors = True
+
+    if invalid:
+        for tc_id in sorted(invalid):
+            print(
+                f"Invalid result for TC-{tc_id}: only PASS, FAIL, BLOCKED are valid",
+                file=sys.stderr,
+            )
+        errors = True
+
+    if extra:
+        extra_strs = [f"TC-{e}" for e in sorted(extra)]
+        print(f"Extra TCs in QA-RESULTS not in TEST-PLAN: {', '.join(extra_strs)}", file=sys.stderr)
+        errors = True
+
+    if errors:
+        return 1
+
+    if blocked:
+        blocked_strs = [f"TC-{b}" for b in sorted(blocked)]
+        print(f"BLOCKED TCs: {', '.join(blocked_strs)} — cannot ship", file=sys.stderr)
+        return 2
+
+    print("All TCs accounted for. Gate passed.")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="TC coverage gate — verify TEST-PLAN TCs are covered in QA-RESULTS"
+    )
+    parser.add_argument("--test-plan", help="Path to TEST-PLAN.md")
+    parser.add_argument("--qa-results", help="Path to QA-RESULTS.md")
+    parser.add_argument("--issue", type=int, help="Issue number for auto-discovery")
+    parser.add_argument("--debug", action="store_true", help="Print unmatched lines")
+
+    args = parser.parse_args()
+
+    if args.test_plan and args.qa_results:
+        test_plan_path = args.test_plan
+        qa_results_path = args.qa_results
+    elif args.issue:
+        tp, qr = _discover_files(args.issue)
+        if tp is None:
+            print(f"No test plan found for issue #{args.issue}. Gate skipped.")
+            return 0
+        if qr is None:
+            print(
+                f"Test plan found but no QA-RESULTS for issue #{args.issue}.",
+                file=sys.stderr,
+            )
+            return 1
+        test_plan_path = str(tp)
+        qa_results_path = str(qr)
+        print(f"Discovered: {tp.name} / {qr.name}")
+    else:
+        parser.print_help()
+        return 1
+
+    return check_coverage(test_plan_path, qa_results_path, debug=args.debug)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -891,7 +891,44 @@ def transition(number, from_status, to_status, role=None, force=False):
             )
             sys.exit(1)
 
-    # 4. Guard: block shipped if unmerged PR or unmerged branch exists
+    # 4. Guard: TC coverage gate for pending-test -> pending-ship
+    #    (NEVER bypassed, even with --force)
+    if from_label == "status:pending-test" and to_label == "status:pending-ship":
+        try:
+            from tc_coverage import _discover_files, check_coverage
+            tp, qr = _discover_files(number)
+            if tp is not None:
+                if qr is None:
+                    _log_diagnostic(
+                        "error",
+                        f"TC coverage gate blocked #{number}: test plan found but no QA-RESULTS",
+                    )
+                    print(
+                        f"BLOCKED: #{number} has a test plan ({tp.name}) but no QA-RESULTS. "
+                        f"QA must complete all TCs before shipping.",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
+                rc = check_coverage(str(tp), str(qr))
+                if rc != 0:
+                    _log_diagnostic(
+                        "error",
+                        f"TC coverage gate blocked #{number}: exit code {rc}",
+                    )
+                    print(
+                        f"BLOCKED: #{number} failed TC coverage gate (exit {rc}). "
+                        f"All TCs in the test plan must have valid results in QA-RESULTS.",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
+        except ImportError:
+            # tc_coverage.py not available — graceful degradation
+            print(
+                "WARNING: tc_coverage.py not found — TC coverage gate skipped.",
+                file=sys.stderr,
+            )
+
+    # 5. Guard: block shipped if unmerged PR or unmerged branch exists
     #    (never bypassed, even with --force)
     if to_label == "status:shipped":
         unmerged = _check_unmerged_pr(number)

--- a/tests/test_tc_coverage.py
+++ b/tests/test_tc_coverage.py
@@ -1,0 +1,351 @@
+"""Tests for references/scripts/tc_coverage.py — TC coverage gate (#2361)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import tc_coverage
+
+
+# --- parse_tc_ids ---
+
+
+class TestParseTcIds:
+    """TC ID extraction from TEST-PLAN and QA-RESULTS markdown."""
+
+    def test_heading_dash_format(self):
+        text = "### TC-1: Happy path\n### TC-2: Edge case\n"
+        assert tc_coverage.parse_tc_ids(text) == [1, 2]
+
+    def test_heading_zero_padded(self):
+        text = "### TC-01: First\n### TC-02: Second\n"
+        assert tc_coverage.parse_tc_ids(text) == [1, 2]
+
+    def test_heading_space_format(self):
+        text = "### TC 01: Space separated\n### TC 02: Another\n"
+        assert tc_coverage.parse_tc_ids(text) == [1, 2]
+
+    def test_table_row_format(self):
+        text = "| TC-1 | PASS | notes |\n| TC-2 | FAIL | notes |\n"
+        assert tc_coverage.parse_tc_ids(text) == [1, 2]
+
+    def test_cross_format_normalization(self):
+        """TC-01 and TC-1 both normalize to 1."""
+        text = "### TC-01: Zero padded\n### TC-1: No padding\n"
+        ids = tc_coverage.parse_tc_ids(text)
+        assert ids == [1, 1]  # Both normalize to 1 — duplicate detection happens elsewhere
+
+    def test_prose_reference_not_matched(self):
+        """Prose like 'see TC-2 for details' should NOT be extracted."""
+        text = "### TC-1: Title\nSee TC-2 for details in the related section.\n"
+        assert tc_coverage.parse_tc_ids(text) == [1]
+
+    def test_empty_text(self):
+        assert tc_coverage.parse_tc_ids("") == []
+
+    def test_no_tcs(self):
+        text = "# Test Plan\n\nSome prose without any TC markers.\n"
+        assert tc_coverage.parse_tc_ids(text) == []
+
+
+# --- parse_tc_results ---
+
+
+class TestParseTcResults:
+    """TC result extraction from QA-RESULTS markdown."""
+
+    def test_pass_result(self):
+        text = "### TC-1: Happy path\n- **Result**: PASS\n"
+        results = tc_coverage.parse_tc_results(text)
+        assert results == {1: "PASS"}
+
+    def test_fail_result(self):
+        text = "### TC-1: Title\n- **Result**: FAIL\n- **Notes**: broken\n"
+        results = tc_coverage.parse_tc_results(text)
+        assert results == {1: "FAIL"}
+
+    def test_blocked_result(self):
+        text = "### TC-1: Title\n- **Result**: BLOCKED\n"
+        results = tc_coverage.parse_tc_results(text)
+        assert results == {1: "BLOCKED"}
+
+    def test_invalid_not_applicable(self):
+        text = "### TC-1: Title\n- **Result**: Not Applicable\n"
+        results = tc_coverage.parse_tc_results(text)
+        assert results == {1: "INVALID"}
+
+    def test_invalid_na(self):
+        text = "### TC-1: Title\n- **Result**: N/A\n"
+        results = tc_coverage.parse_tc_results(text)
+        assert results == {1: "INVALID"}
+
+    def test_invalid_deferred(self):
+        text = "### TC-1: Title\n- **Result**: Deferred\n"
+        results = tc_coverage.parse_tc_results(text)
+        assert results == {1: "INVALID"}
+
+    def test_table_row_result(self):
+        text = "| TC-1 | PASS | notes |\n"
+        results = tc_coverage.parse_tc_results(text)
+        assert results == {1: "PASS"}
+
+    def test_multiple_results(self):
+        text = (
+            "### TC-1: A\n- **Result**: PASS\n\n"
+            "### TC-2: B\n- **Result**: FAIL\n\n"
+            "### TC-3: C\n- **Result**: BLOCKED\n"
+        )
+        results = tc_coverage.parse_tc_results(text)
+        assert results == {1: "PASS", 2: "FAIL", 3: "BLOCKED"}
+
+
+# --- check_coverage ---
+
+
+class TestCheckCoverage:
+    """Full coverage check logic."""
+
+    def _write_files(self, tmp_path, plan_text, results_text):
+        plan = tmp_path / "TEST-PLAN.md"
+        results = tmp_path / "QA-RESULTS.md"
+        plan.write_text(plan_text, encoding="utf-8")
+        results.write_text(results_text, encoding="utf-8")
+        return str(plan), str(results)
+
+    def test_full_coverage_all_pass(self, tmp_path):
+        """TC-1: Full coverage, all PASS → exit 0."""
+        plan = "### TC-1: A\n### TC-2: B\n### TC-3: C\n### TC-4: D\n### TC-5: E\n"
+        results = (
+            "### TC-1: A\n- **Result**: PASS\n\n"
+            "### TC-2: B\n- **Result**: PASS\n\n"
+            "### TC-3: C\n- **Result**: PASS\n\n"
+            "### TC-4: D\n- **Result**: PASS\n\n"
+            "### TC-5: E\n- **Result**: PASS\n"
+        )
+        p, r = self._write_files(tmp_path, plan, results)
+        assert tc_coverage.check_coverage(p, r) == 0
+
+    def test_full_coverage_mixed_results(self, tmp_path):
+        """TC-2: Full coverage with FAIL → still exit 0 (coverage = presence)."""
+        plan = "### TC-1: A\n### TC-2: B\n### TC-3: C\n"
+        results = (
+            "### TC-1: A\n- **Result**: PASS\n\n"
+            "### TC-2: B\n- **Result**: FAIL\n\n"
+            "### TC-3: C\n- **Result**: PASS\n"
+        )
+        p, r = self._write_files(tmp_path, plan, results)
+        assert tc_coverage.check_coverage(p, r) == 0
+
+    def test_missing_tcs(self, tmp_path):
+        """TC-3: Missing TCs → exit 1."""
+        plan = "### TC-1: A\n### TC-2: B\n### TC-3: C\n### TC-4: D\n### TC-5: E\n"
+        results = (
+            "### TC-1: A\n- **Result**: PASS\n\n"
+            "### TC-3: C\n- **Result**: PASS\n\n"
+            "### TC-5: E\n- **Result**: PASS\n"
+        )
+        p, r = self._write_files(tmp_path, plan, results)
+        assert tc_coverage.check_coverage(p, r) == 1
+
+    def test_invalid_not_applicable(self, tmp_path):
+        """TC-4: 'not applicable' rejected → exit 1."""
+        plan = "### TC-1: A\n### TC-2: B\n"
+        results = (
+            "### TC-1: A\n- **Result**: PASS\n\n"
+            "### TC-2: B\n- **Result**: not applicable\n"
+        )
+        p, r = self._write_files(tmp_path, plan, results)
+        assert tc_coverage.check_coverage(p, r) == 1
+
+    def test_invalid_deferred(self, tmp_path):
+        """TC-5: 'deferred' rejected → exit 1."""
+        plan = "### TC-1: A\n### TC-2: B\n"
+        results = (
+            "### TC-1: A\n- **Result**: PASS\n\n"
+            "### TC-2: B\n- **Result**: Deferred\n"
+        )
+        p, r = self._write_files(tmp_path, plan, results)
+        assert tc_coverage.check_coverage(p, r) == 1
+
+    def test_tolerant_zero_padded(self, tmp_path):
+        """TC-6: Zero-padded format matched."""
+        plan = "### TC-01: A\n### TC-02: B\n"
+        results = (
+            "### TC-01: A\n- **Result**: PASS\n\n"
+            "### TC-02: B\n- **Result**: PASS\n"
+        )
+        p, r = self._write_files(tmp_path, plan, results)
+        assert tc_coverage.check_coverage(p, r) == 0
+
+    def test_tolerant_no_zero_pad(self, tmp_path):
+        """TC-7: No-zero-pad format matched."""
+        plan = "### TC-1: A\n### TC-2: B\n"
+        results = (
+            "### TC-1: A\n- **Result**: PASS\n\n"
+            "### TC-2: B\n- **Result**: PASS\n"
+        )
+        p, r = self._write_files(tmp_path, plan, results)
+        assert tc_coverage.check_coverage(p, r) == 0
+
+    def test_tolerant_space_format(self, tmp_path):
+        """TC-8: Space-separated format."""
+        plan = "### TC 01: A\n"
+        results = "### TC 01: A\n- **Result**: PASS\n"
+        p, r = self._write_files(tmp_path, plan, results)
+        assert tc_coverage.check_coverage(p, r) == 0
+
+    def test_cross_format_matching(self, tmp_path):
+        """TC-9: Plan uses TC-01, results use TC-1 — both normalize."""
+        plan = "### TC-01: A\n"
+        results = "### TC-1: A\n- **Result**: PASS\n"
+        p, r = self._write_files(tmp_path, plan, results)
+        assert tc_coverage.check_coverage(p, r) == 0
+
+    def test_blocked_results_exit_2(self, tmp_path):
+        """TC-15: BLOCKED counted as covered but exit 2."""
+        plan = "### TC-1: A\n### TC-2: B\n### TC-3: C\n"
+        results = (
+            "### TC-1: A\n- **Result**: PASS\n\n"
+            "### TC-2: B\n- **Result**: BLOCKED\n\n"
+            "### TC-3: C\n- **Result**: PASS\n"
+        )
+        p, r = self._write_files(tmp_path, plan, results)
+        assert tc_coverage.check_coverage(p, r) == 2
+
+    def test_duplicate_tc_in_plan(self, tmp_path):
+        """TC-20: Duplicate TC IDs in plan → exit 1."""
+        plan = "### TC-1: First\n### TC-1: Duplicate\n"
+        results = "### TC-1: First\n- **Result**: PASS\n"
+        p, r = self._write_files(tmp_path, plan, results)
+        assert tc_coverage.check_coverage(p, r) == 1
+
+    def test_extra_tcs_in_results(self, tmp_path):
+        """TC-21: Extra TCs in results → exit 1."""
+        plan = "### TC-1: A\n### TC-2: B\n"
+        results = (
+            "### TC-1: A\n- **Result**: PASS\n\n"
+            "### TC-2: B\n- **Result**: PASS\n\n"
+            "### TC-3: C\n- **Result**: PASS\n"
+        )
+        p, r = self._write_files(tmp_path, plan, results)
+        assert tc_coverage.check_coverage(p, r) == 1
+
+    def test_empty_plan(self, tmp_path):
+        """TC-22: Empty plan (no TCs) → exit 0."""
+        plan = "# Test Plan\n\nSome prose.\n"
+        results = "# QA Results\n"
+        p, r = self._write_files(tmp_path, plan, results)
+        assert tc_coverage.check_coverage(p, r) == 0
+
+    def test_empty_results(self, tmp_path):
+        """TC-23: Empty results with TCs in plan → exit 1."""
+        plan = "### TC-1: A\n### TC-2: B\n### TC-3: C\n"
+        results = "# QA Results\n\nNo entries yet.\n"
+        p, r = self._write_files(tmp_path, plan, results)
+        assert tc_coverage.check_coverage(p, r) == 1
+
+    def test_prose_reference_not_counted(self, tmp_path):
+        """TC-25: Prose mention of TC-2 should not count as a marker."""
+        plan = "### TC-1: A\n### TC-2: B\n"
+        results = (
+            "### TC-1: A\n- **Result**: PASS\n\n"
+            "See TC-2 for details in the related section.\n"
+        )
+        p, r = self._write_files(tmp_path, plan, results)
+        assert tc_coverage.check_coverage(p, r) == 1
+
+    def test_table_row_recognized(self, tmp_path):
+        """TC-26: Table row format recognized."""
+        plan = "### TC-1: A\n"
+        results = "| TC-1 | PASS | notes |\n"
+        p, r = self._write_files(tmp_path, plan, results)
+        assert tc_coverage.check_coverage(p, r) == 0
+
+    def test_debug_flag(self, tmp_path, capsys):
+        """TC-24: --debug prints unmatched lines."""
+        plan = "### TC-1: A\n"
+        results = "### TC-1: A\n- **Result**: PASS\nSome random prose line.\n"
+        p, r = self._write_files(tmp_path, plan, results)
+        tc_coverage.check_coverage(p, r, debug=True)
+        captured = capsys.readouterr()
+        assert "random prose" in captured.err
+
+
+# --- Auto-discovery ---
+
+
+class TestAutoDiscovery:
+    """File auto-discovery by issue number."""
+
+    def _setup_planning(self, tmp_path, role, issue, files):
+        """Create planning dir structure under tmp_path/.squidsquad/."""
+        planning = tmp_path / ".squidsquad" / role / "planning"
+        planning.mkdir(parents=True, exist_ok=True)
+        for fname, content in files.items():
+            (planning / fname).write_text(content, encoding="utf-8")
+        return planning
+
+    def test_discovers_pm_planning(self, tmp_path, monkeypatch):
+        """TC-10: Auto-discovers files from PM planning dir."""
+        self._setup_planning(tmp_path, "pm", 2361, {
+            "FEAT-PM-2361-TEST-PLAN.md": "### TC-1: A\n",
+            "FEAT-PM-2361-QA-RESULTS.md": "### TC-1: A\n- **Result**: PASS\n",
+        })
+        monkeypatch.setattr(tc_coverage, "SQUID_DIR", tmp_path / ".squidsquad")
+
+        tp, qr = tc_coverage._discover_files(2361)
+        assert tp is not None
+        assert "PM-2361-TEST-PLAN" in tp.name
+        assert qr is not None
+
+    def test_pm_preferred_over_skill(self, tmp_path, monkeypatch):
+        """TC-11: PM planning dir preferred over skill."""
+        self._setup_planning(tmp_path, "pm", 2361, {
+            "FEAT-PM-2361-TEST-PLAN.md": "### TC-1: PM\n",
+        })
+        self._setup_planning(tmp_path, "skill", 2361, {
+            "FEAT-SKILL-2361-TEST-PLAN.md": "### TC-1: Skill\n",
+        })
+        monkeypatch.setattr(tc_coverage, "SQUID_DIR", tmp_path / ".squidsquad")
+
+        tp, _ = tc_coverage._discover_files(2361)
+        assert tp is not None
+        assert "PM" in tp.name
+
+    def test_highest_revision_picked(self, tmp_path, monkeypatch):
+        """TC-12: Highest -RN revision selected."""
+        self._setup_planning(tmp_path, "pm", 100, {
+            "FEAT-PM-100-TEST-PLAN.md": "### TC-1: A\n",
+            "FEAT-PM-100-QA-RESULTS.md": "### TC-1: A\n- **Result**: FAIL\n",
+            "FEAT-PM-100-QA-RESULTS-R2.md": "### TC-1: A\n- **Result**: FAIL\n",
+            "FEAT-PM-100-QA-RESULTS-R3.md": "### TC-1: A\n- **Result**: PASS\n",
+        })
+        monkeypatch.setattr(tc_coverage, "SQUID_DIR", tmp_path / ".squidsquad")
+
+        _, qr = tc_coverage._discover_files(100)
+        assert qr is not None
+        assert "R3" in qr.name
+
+    def test_base_file_when_no_revisions(self, tmp_path, monkeypatch):
+        """TC-13: Base file used when no -RN exists."""
+        self._setup_planning(tmp_path, "pm", 100, {
+            "FEAT-PM-100-TEST-PLAN.md": "### TC-1: A\n",
+            "FEAT-PM-100-QA-RESULTS.md": "### TC-1: A\n- **Result**: PASS\n",
+        })
+        monkeypatch.setattr(tc_coverage, "SQUID_DIR", tmp_path / ".squidsquad")
+
+        _, qr = tc_coverage._discover_files(100)
+        assert qr is not None
+        assert "R" not in qr.name.split("RESULTS")[1]
+
+    def test_no_test_plan_returns_none(self, tmp_path, monkeypatch):
+        """TC-14: No test plan → None."""
+        monkeypatch.setattr(tc_coverage, "SQUID_DIR", tmp_path / ".squidsquad")
+        (tmp_path / ".squidsquad" / "pm" / "planning").mkdir(parents=True)
+
+        tp, qr = tc_coverage._discover_files(9999)
+        assert tp is None


### PR DESCRIPTION
Closes #2361

## #2361

- New `references/scripts/tc_coverage.py` — parses TEST-PLAN.md and QA-RESULTS.md, reports coverage
- Tolerant regex parser: accepts TC-01, TC-1, TC 01, headings, table rows
- Auto-discovers files by issue number from planning dirs (PM preferred)
- Picks highest -RN revision for multiple QA-RESULTS
- Valid results: PASS, FAIL, BLOCKED only (rejects not-applicable, deferred, N/A)
- Exit codes: 0 (pass), 1 (fail/gaps), 2 (100% coverage but BLOCKED TCs)
- Wired into tracker.py as guard on pending-test → pending-ship transition
- --force does NOT bypass TC coverage gate (locked decision)
- Graceful degradation if tc_coverage.py missing (warns, skips gate)
- 38 unit tests covering all TC formats, edge cases, auto-discovery

Status: Pending Test