### PR TITLE
skill: #2399 — scaffold_install boot script generation

### DIFF
--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -418,8 +418,9 @@ def generate_local_config(roles: list, target_root: Path = None) -> Path:
 TEMPLATES_DIR = REPO_ROOT / "references" / "templates"
 
 
-def boot_role(role_name: str) -> list:
+def boot_role(role_name: str, target_root: Path = None) -> list:
     """Generate boot scripts (start-[role].sh and start-[role].ps1) from templates."""
+    root = Path(target_root) if target_root else REPO_ROOT
     outputs = []
     for ext in ("sh", "ps1"):
         template_path = TEMPLATES_DIR / f"start-role.{ext}"
@@ -430,7 +431,7 @@ def boot_role(role_name: str) -> list:
         content = template_path.read_text(encoding="utf-8")
         content = content.replace("{{ROLE}}", role_name)
 
-        output_path = REPO_ROOT / ".squidsquad" / f"start-{role_name}.{ext}"
+        output_path = root / ".squidsquad" / f"start-{role_name}.{ext}"
         # .sh files must use LF line endings (not CRLF on Windows)
         # .ps1 files need UTF-8 BOM so PowerShell parses Unicode correctly
         newline = "\n" if ext == "sh" else None

--- a/references/scripts/wizard.py
+++ b/references/scripts/wizard.py
@@ -895,7 +895,19 @@ def scaffold_install(spec, target_root, overwrite_existing=False):
         all_roles = [a["id"] for a in spec["agents"]]
         generate_local_config(all_roles, target_root=target_root)
 
-    # 4. Save install spec for reproducibility and upgrade re-use (#13)
+    # 4. Generate boot scripts (start-[role].sh, start-[role].ps1)
+    try:
+        from compose import boot_role
+    except ImportError:
+        pass
+    else:
+        for agent in spec["agents"]:
+            try:
+                boot_role(agent["id"], target_root=target_root)
+            except (SystemExit, Exception) as e:
+                print(f"  WARNING: Failed to generate boot scripts for {agent['id']}: {e}", file=sys.stderr)
+
+    # 5. Save install spec for reproducibility and upgrade re-use (#13)
     spec_path = save_install_spec(spec, target_root)
     summary["install_spec"] = spec_path
 

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -887,6 +887,22 @@ class TestScaffoldInstallDesignPreset:
         roles = sorted(a["role"] for a in summary["agents"])
         assert roles == ["designer", "dm", "pm"]
 
+    def test_boot_scripts_generated(self, tmp_path):
+        """scaffold_install generates start-[role].sh and .ps1 for each agent (#2399)."""
+        spec = _design_preset_spec()
+        wizard.scaffold_install(spec, tmp_path)
+        squid = tmp_path / ".squidsquad"
+        for role in ("pm", "designer", "dm"):
+            sh_script = squid / f"start-{role}.sh"
+            ps1_script = squid / f"start-{role}.ps1"
+            assert sh_script.is_file(), f"start-{role}.sh not generated"
+            assert ps1_script.is_file(), f"start-{role}.ps1 not generated"
+            sh_content = sh_script.read_text(encoding="utf-8")
+            ps1_content = ps1_script.read_text(encoding="utf-8")
+            assert "{{ROLE}}" not in sh_content, f"raw placeholder in start-{role}.sh"
+            assert "{{ROLE}}" not in ps1_content, f"raw placeholder in start-{role}.ps1"
+            assert role in sh_content, f"start-{role}.sh missing role name"
+
 
 class TestScaffoldInstallDevVariants:
     def test_software_dev_preset_lays_down_all_six_agents(self, tmp_path):


### PR DESCRIPTION
Closes #2399

## #2399

- Added boot_role() call to scaffold_install() in wizard.py for each agent
- Added target_root parameter to boot_role() in compose.py for test compatibility
- Boot scripts (start-[role].sh, start-[role].ps1) now generated with {{ROLE}} substituted
- Added regression test verifying boot scripts exist and have no raw placeholders

Status: Pending Test