### PR TITLE
skill: #2468 — QA rebase-and-merge on conflict

### DIFF
--- a/.squidsquad/config.md
+++ b/.squidsquad/config.md
@@ -110,4 +110,4 @@
 ## Auto Versioning
 
 - **Ship Threshold**: 10
-- **Shipped Since Last Bump**: 8
+- **Shipped Since Last Bump**: 9

--- a/.squidsquad/dm/working-state.md
+++ b/.squidsquad/dm/working-state.md
@@ -4,8 +4,8 @@
 - **Status**: none
 - **Quiet Cycle Counter**: 0
 
-## Session Context (checkpoint at cycle 172)
+## Session Context (checkpoint at cycle 22)
 - Version: v0.25.0
-- Shipped count: 0/10 — fresh after version bump
+- Shipped count: 9/10
 - Pending bugs: #1772 (pending-test), #302 #303 (pending PM)
-- Last active delivery: cycle 172 (#2343 + version bump to v0.25.0)
+- Last active delivery: cycle 22 (#2469 shipped)

--- a/references/sub-skills/qa-specific/verification.md
+++ b/references/sub-skills/qa-specific/verification.md
@@ -197,11 +197,27 @@ python references/scripts/git_ops.py branch-switch main
    python references/scripts/git_ops.py pr-merge [PR_NUMBER]
    ```
    - **Merge succeeds**: proceed to pending-ship transition
-   - **Merge conflict**: back to in-progress, comment with conflict details, dev rebases
+   - **Merge conflict**: QA rebases the branch itself (code was already verified):
      ```bash
-     python references/scripts/tracker.py transition [NUMBER] pending-test in-progress --role qa-lead
-     python references/scripts/tracker.py comment [NUMBER] --role qa --message "Merge conflict on PR #[PR_NUMBER]. Dev: rebase and re-submit. Back to In Progress."
+     # Rebase the feature branch onto the working branch
+     git fetch origin
+     git checkout [BRANCH_NAME]
+     git rebase origin/[WORKING_BRANCH]
      ```
+     - **Rebase succeeds (no code conflicts)**: push and retry merge
+       ```bash
+       git push --force-with-lease origin [BRANCH_NAME]
+       python references/scripts/git_ops.py pr-merge [PR_NUMBER]
+       ```
+       If merge now succeeds, proceed to pending-ship. Code was already verified — no re-verification needed.
+     - **Rebase has code conflicts** (not just .squidsquad/ state files): reject back to dev with specific conflicting files
+       ```bash
+       git rebase --abort
+       git checkout [WORKING_BRANCH]
+       python references/scripts/tracker.py transition [NUMBER] pending-test in-progress --role qa-lead
+       python references/scripts/tracker.py comment [NUMBER] --role qa --message "Merge conflict with code changes on PR #[PR_NUMBER]. Conflicting files: [list]. Dev: resolve conflicts and re-submit."
+       ```
+     - **Only .squidsquad/ state file conflicts**: resolve by keeping both versions, then force-push and merge. State files are always auto-resolvable.
    - **No PR found**: proceed (direct-to-main workflow, no merge needed)
 
    After successful merge (or no PR):


### PR DESCRIPTION
Closes #2468

## #2468

- QA now rebases feature branches itself on merge conflict (code already verified)
- Only rejects back to dev for actual code conflicts
- State file conflicts (.squidsquad/) auto-resolved by keeping both versions
- Eliminates wasteful rebase-reject loops (e.g. #2411 had 3 cycles of this)
- Updated qa-specific/verification.md sub-skill and recomposed QA template

Status: Pending Test