### PR TITLE
skill: #1328 — verification skips blocked:human-action items

### DIFF
--- a/references/sub-skills/pm-specific/testing-and-verification.md
+++ b/references/sub-skills/pm-specific/testing-and-verification.md
@@ -52,6 +52,7 @@ python references/scripts/tracker.py list-issues skill --status pending-test
 
 For each result:
 
+0. **Blocked check**: If the item has a `blocked:human-action` label, skip it. Print: `[🦑 HH:MM:SS] Skipping #[NUMBER] — blocked:human-action (waiting for human).` Do not change its status. Move to the next item.
 1. Run the relevant test or manually verify the fix.
 2. **Test coverage check**: Verify that the fix includes a regression test. Check for new or modified test files corresponding to the changed code. If the fix adds or changes code but includes no tests, reject it.
 3. **Run the full test suite**: `python tests/run_tests.py` — all tests must pass.
@@ -74,6 +75,7 @@ python references/scripts/tracker.py list-tasks skill --status pending-test
 
 For each result:
 
+0. **Blocked check**: If the item has a `blocked:human-action` label, skip it. Print: `[🦑 HH:MM:SS] Skipping #[NUMBER] — blocked:human-action (waiting for human).` Do not change its status. Move to the next item.
 1. Test against the acceptance criteria.
 2. **Test coverage check**: Verify that new code has corresponding unit tests. Check for new or modified test files. If the implementation adds new functions, scripts, or modules but includes no tests, reject it — tests are part of the implementation, not follow-up work.
 3. **Run the full test suite**: `python tests/run_tests.py` — all tests must pass.

--- a/references/sub-skills/qa-specific/verification.md
+++ b/references/sub-skills/qa-specific/verification.md
@@ -46,6 +46,7 @@ python references/scripts/tracker.py list-issues skill --status pending-test
 
 For each issue:
 
+0. **Blocked check**: If the item has a `blocked:human-action` label, skip it. Print: `[🦑 HH:MM:SS] Skipping #[NUMBER] — blocked:human-action (waiting for human).` Do not change its status. Move to the next item.
 1. Read details: `gh issue view [NUMBER] --json title,body,comments`
 2. **Branch checkout** (#3296): Check out the task's feature branch before verification:
    ```bash
@@ -88,7 +89,11 @@ python references/scripts/tracker.py list-tasks skill --status pending-test
 
 (Adjust role as needed for other agents.)
 
-For each task, read it: `gh issue view [NUMBER] --json title,body,labels,comments`
+For each task:
+
+0. **Blocked check**: If the item has a `blocked:human-action` label, skip it. Print: `[🦑 HH:MM:SS] Skipping #[NUMBER] — blocked:human-action (waiting for human).` Do not change its status. Move to the next item.
+
+Read it: `gh issue view [NUMBER] --json title,body,labels,comments`
 
 **Branch checkout** (#3296): Check out the task's feature branch before testing:
 ```bash

--- a/tests/test_feat_1328_blocked_skip.py
+++ b/tests/test_feat_1328_blocked_skip.py
@@ -1,0 +1,66 @@
+"""Tests for #1328 — verification skips blocked:human-action items.
+
+Structural assertions that both PM and QA verification sub-skills
+include the blocked:human-action check before attempting verification.
+"""
+import pytest
+from pathlib import Path
+
+REPO = Path(__file__).parent.parent
+PM_VERIFICATION = REPO / "references/sub-skills/pm-specific/testing-and-verification.md"
+QA_VERIFICATION = REPO / "references/sub-skills/qa-specific/verification.md"
+
+
+class TestPMVerificationBlockedCheck:
+    """PM verification (Steps 5-6) skips blocked:human-action items."""
+
+    @pytest.fixture
+    def content(self):
+        return PM_VERIFICATION.read_text(encoding="utf-8")
+
+    def test_step5_has_blocked_check(self, content):
+        """Step 5 (verify fixed issues) checks blocked:human-action before verifying."""
+        # Find Step 5 section and verify the blocked check appears before
+        # the first verification action
+        step5_start = content.index("Step 5")
+        step6_start = content.index("Step 6")
+        step5_text = content[step5_start:step6_start]
+        assert "blocked:human-action" in step5_text
+
+    def test_step6_has_blocked_check(self, content):
+        """Step 6 (verify pending test tasks) checks blocked:human-action before verifying."""
+        step6_start = content.index("Step 6 — Verify Pending Test Tasks")
+        step6c_start = content.index("Step 6c")
+        step6_text = content[step6_start:step6c_start]
+        assert "blocked:human-action" in step6_text
+
+    def test_blocked_check_says_skip(self, content):
+        """Blocked check instructs to skip, not transition status."""
+        assert "skip it" in content.lower() or "Skip it" in content
+
+
+class TestQAVerificationBlockedCheck:
+    """QA verification (Steps 4-5) skips blocked:human-action items."""
+
+    @pytest.fixture
+    def content(self):
+        return QA_VERIFICATION.read_text(encoding="utf-8")
+
+    def test_step4_has_blocked_check(self, content):
+        """Step 4 (verify fixed issues) checks blocked:human-action."""
+        step4_start = content.index("Step 4")
+        step5_start = content.index("Step 5")
+        step4_text = content[step4_start:step5_start]
+        assert "blocked:human-action" in step4_text
+
+    def test_step5_has_blocked_check(self, content):
+        """Step 5 (verify pending test tasks) checks blocked:human-action."""
+        step5_start = content.index("Step 5 — Verify Pending Test Tasks")
+        step5b_start = content.index("Step 5b")
+        step5_text = content[step5_start:step5b_start]
+        assert "blocked:human-action" in step5_text
+
+    def test_no_status_transition_for_blocked(self, content):
+        """Blocked items must not have their status changed."""
+        # Each blocked check should say "Do not change its status"
+        assert content.count("Do not change its status") >= 2


### PR DESCRIPTION
Closes #1328

### Summary
Add blocked:human-action label check to PM and QA verification steps. Items with this label are skipped silently (with log note) instead of being verified and bounced in a retry loop.

### Acceptance Criteria
- [x] PM verification (Steps 5-6) skips items with blocked:human-action label
- [x] QA verification (Steps 4-5) skips items with blocked:human-action label
- [x] Skip is logged (not silent — human can see what was skipped)
- [x] No status transition occurs for blocked items
- [x] When human removes the label, next cycle picks it up normally

### Changes
- **references/sub-skills/pm-specific/testing-and-verification.md**: Added blocked check (step 0) before Steps 5 and 6
- **references/sub-skills/qa-specific/verification.md**: Added blocked check (step 0) before Steps 4 and 5
- **tests/test_feat_1328_blocked_skip.py**: 6 structural tests verifying both sub-skills have the check
- Regenerated deployed PM and QA CLAUDE.md

### QA Status
- [x] 6 feature tests passing
- [x] Full suite green (1102 passed)
- [x] Acceptance criteria met