### PR TITLE
skill: #4038 — fix commit message auto-close

### DIFF
--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -13,6 +13,7 @@ Exit codes:
 """
 
 import json
+import re
 import subprocess
 import sys
 from datetime import datetime
@@ -204,10 +205,37 @@ def _do_iteration_log(data, role):
         print(f"  Iteration log: iter-{cycle_number}.md")
 
 
+_AUTOCLOSE_RE = re.compile(
+    r'\b(fix(?:e[sd])?|close[sd]?|resolve[sd]?)\s+(#\d+)',
+    re.IGNORECASE,
+)
+
+
+def _sanitize_commit_msg(msg: str) -> str:
+    """Escape GitHub auto-close keywords in commit messages.
+
+    GitHub interprets 'fixed #123', 'closes #456', 'resolves #789' in commit
+    messages pushed to the default branch as directives to close those issues.
+    This is harmful for cycle commits that reference issues without intending
+    to close them (#4038). Replace the keyword with a hyphenated form that
+    preserves readability without triggering auto-close.
+    """
+    def _escape(m):
+        keyword = m.group(1)
+        ref = m.group(2)
+        return f"{keyword} {ref}"  # insert zero-width space before #
+
+    # Insert a zero-width space (U+200B) between keyword and #
+    return _AUTOCLOSE_RE.sub(
+        lambda m: f"{m.group(1)} \u200b{m.group(2)}", msg
+    )
+
+
 def _do_commit_push(data, role):
     """Handle git commit and push operations."""
     cycle_type = data.get("cycle_type", "quiet")
     commit_msg = data.get("commit_message") or data.get("state_commit_message", "")
+    commit_msg = _sanitize_commit_msg(commit_msg)
 
     if not commit_msg:
         commit_msg = f"{role}: cycle {data.get('cycle_number', '?')} — {cycle_type}"
@@ -219,7 +247,7 @@ def _do_commit_push(data, role):
     code_commit = data.get("code_commit")
     if role == "skill" and branch_workflow and code_commit:
         branch = code_commit.get("branch", "")
-        code_msg = code_commit.get("message", "code changes")
+        code_msg = _sanitize_commit_msg(code_commit.get("message", "code changes"))
 
         if branch:
             result = _run_script("git_ops.py", "commit-code", role, branch, code_msg)
@@ -238,7 +266,7 @@ def _do_commit_push(data, role):
                     print(f"  PR created: {result.stdout.strip()}")
 
         # State commit to working branch
-        state_msg = data.get("state_commit_message", commit_msg)
+        state_msg = _sanitize_commit_msg(data.get("state_commit_message", commit_msg))
         working = _get_working_branch()
         current = _run(["git", "branch", "--show-current"], check=False)
         current_branch = current.stdout.strip() if current.returncode == 0 else ""

--- a/tests/test_cycle_post.py
+++ b/tests/test_cycle_post.py
@@ -378,3 +378,49 @@ class TestStopAfterCycleCheck:
         assert result is True
         sentinel = squid_dir / "skill" / ".restart"
         assert sentinel.exists()
+
+
+# ---------------------------------------------------------------------------
+# #4038 regression: commit message auto-close sanitization
+# ---------------------------------------------------------------------------
+
+class TestSanitizeCommitMsg:
+    """_sanitize_commit_msg must neutralize GitHub auto-close keywords."""
+
+    def test_fixed_hash_escaped(self):
+        result = cycle_post._sanitize_commit_msg("skill: fixed #3465 QA failures")
+        assert "fixed #3465" not in result
+        assert "#3465" in result  # number still present
+
+    def test_fixes_hash_escaped(self):
+        result = cycle_post._sanitize_commit_msg("fixes #123 — typo")
+        assert "fixes #123" not in result
+        assert "#123" in result
+
+    def test_closes_hash_escaped(self):
+        result = cycle_post._sanitize_commit_msg("closes #456")
+        assert "closes #456" not in result
+        assert "#456" in result
+
+    def test_resolves_hash_escaped(self):
+        result = cycle_post._sanitize_commit_msg("Resolved #789 bug")
+        assert "Resolved #789" not in result
+        assert "#789" in result
+
+    def test_non_keyword_untouched(self):
+        result = cycle_post._sanitize_commit_msg("skill: cycle 458 -- implemented #3465")
+        assert "implemented #3465" in result
+
+    def test_multiple_refs_all_escaped(self):
+        result = cycle_post._sanitize_commit_msg("fixed #100, closes #200")
+        assert "fixed #100" not in result
+        assert "closes #200" not in result
+        assert "#100" in result
+        assert "#200" in result
+
+    def test_empty_string(self):
+        assert cycle_post._sanitize_commit_msg("") == ""
+
+    def test_no_issue_ref(self):
+        msg = "skill: quiet cycle — pipeline clean"
+        assert cycle_post._sanitize_commit_msg(msg) == msg


### PR DESCRIPTION
Closes #4038

### Summary
cycle_post.py commit messages containing GitHub auto-close keywords (fixed, fixes, closes, resolved, resolves) followed by issue numbers (#N) triggered unintended issue closure when pushed to main. Added _sanitize_commit_msg() that inserts a zero-width space to neutralize the trigger.

### Acceptance Criteria
- [x] Commit messages with "fixed #N" no longer trigger GitHub auto-close
- [x] Issue numbers still appear in commit messages (readability preserved)
- [x] All commit message paths in _do_commit_push() are sanitized

### Changes
- **Files**: `references/scripts/cycle_post.py`, `tests/test_cycle_post.py`
- **What**: _sanitize_commit_msg() + 8 regression tests
- **Why**: GitHub closed #3465 when "fixed #3465" appeared in a cycle commit on main

### QA Status
- [x] Unit tests passing (32 cycle_post tests)
- [x] Regression tests cover all auto-close keywords
- [x] Acceptance criteria met