### PR TITLE
skill: #4050 — fix shared_fs falsy secret check

### DIFF
--- a/references/scripts/shared_fs.py
+++ b/references/scripts/shared_fs.py
@@ -113,7 +113,7 @@ def read_secret_or_env(key):
     Priority: secrets file > environment variable.
     """
     value = read_secret(key)
-    if value:
+    if value is not None:
         return value
     return os.environ.get(key)
 

--- a/tests/test_shared_fs.py
+++ b/tests/test_shared_fs.py
@@ -123,6 +123,17 @@ class TestReadSecretOrEnv:
             value = shared_fs.read_secret_or_env("MISSING_KEY_XYZ")
         assert value is None
 
+    def test_empty_string_secret_not_dropped(self, tmp_path, monkeypatch):
+        """#4050 regression: empty-string secret must not fall through to env."""
+        fake_home = tmp_path / ".squidsquad"
+        monkeypatch.setenv("EMPTY_KEY", "from_env")
+        with patch.object(shared_fs, "get_home", return_value=fake_home):
+            shared_fs.init()
+            shared_fs.write_secret("EMPTY_KEY", "")
+            value = shared_fs.read_secret_or_env("EMPTY_KEY")
+        # Secrets file takes precedence — even for empty string
+        assert value == ""
+
 
 class TestClones:
     def test_write_and_read(self, tmp_path):


### PR DESCRIPTION
Addresses #4050

### Summary
read_secret_or_env used falsy check (`if value:`) which dropped valid secrets set to empty string or "0". Changed to `if value is not None:` so secrets file always takes precedence when key exists.

### Changes
- **Files**: `references/scripts/shared_fs.py`, `tests/test_shared_fs.py`
- **What**: `if value:` → `if value is not None:` (1 line)
- **Why**: Falsy secrets silently fell through to env var, breaking priority order

### QA Status
- [x] Unit tests passing (21 shared_fs tests)
- [x] Regression test: empty-string secret not dropped
- [x] Acceptance criteria met