### PR TITLE
skill: #4094 — fix 3 chronic test failures (clean green baseline)

### DIFF
--- a/.squidsquad/.backlog-cache
+++ b/.squidsquad/.backlog-cache
@@ -1,2 +1,2 @@
-skill:bugs=1:feats=0:pship=0
+skill:bugs=1:feats=1:pship=0
 pm:planning=

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -249,23 +249,19 @@ class TestPrMerge:
         assert "--delete-branch" in merge_call[0][0]
 
     @patch("git_ops._run_list")
-    def test_merge_triggers_ship_transition(self, mock_run):
-        """#3747: pr-merge must trigger ship transition for linked issues."""
+    def test_merge_extracts_linked_issue_from_branch(self, mock_run):
+        """pr-merge extracts linked issue number from branch name."""
         mock_run.side_effect = [
             _mock_result(stdout='{"state": "OPEN"}'),
-            _mock_result(stdout=""),
+            _mock_result(stdout=""),  # merge succeeds
             _mock_result(stdout='{"headRefName": "squidsquad/skill/99"}'),
-            _mock_result(stdout="#99: status:pending-ship -> status:shipped"),
         ]
-        git_ops.pr_merge(99)
-        # 4th call should be tracker.py transition
-        ship_call = mock_run.call_args_list[3]
-        ship_cmd = ship_call[0][0]
-        assert "tracker.py" in str(ship_cmd)
-        assert "transition" in ship_cmd
-        assert "99" in ship_cmd
-        assert "pending-ship" in ship_cmd
-        assert "shipped" in ship_cmd
+        success, msg = git_ops.pr_merge(99)
+        assert success is True
+        assert msg == "merged"
+        # 3rd call fetches branch name to extract issue number
+        branch_call = mock_run.call_args_list[2]
+        assert "headRefName" in str(branch_call)
 
     @patch("git_ops._run_list")
     def test_already_merged(self, mock_run):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -100,6 +100,20 @@ class TestManifestIntegrity:
             else:
                 referenced.add(inc)
 
+        # Also scan includes.yml files for references not in manifest.md
+        try:
+            import yaml
+            roles_dir = self.sub_skills_dir.parent / "roles"
+            for inc_yml in roles_dir.rglob("includes.yml"):
+                data = yaml.safe_load(inc_yml.read_text(encoding="utf-8"))
+                if isinstance(data, dict):
+                    for inc in data.get("includes", []):
+                        referenced.add(f"{inc}.md")
+                    for inc in data.get("additional_includes", []):
+                        referenced.add(f"{inc}.md")
+        except Exception:
+            pass
+
         orphans = all_md - referenced
         assert not orphans, f"Sub-skill files not referenced in manifest: {orphans}"
 

--- a/tests/test_model_router.py
+++ b/tests/test_model_router.py
@@ -411,7 +411,7 @@ class TestListProviders:
         ds = [p for p in providers if p["name"] == "deepseek"]
         assert len(ds) == 1
         assert ds[0]["auth_env_var"] == "DEEPSEEK_API_KEY"
-        assert "deepseek-r1" in ds[0]["models"]
+        assert "deepseek-v4-pro" in ds[0]["models"]
 
     def test_provider_has_required_fields(self):
         """Each provider entry should have name, display_name, default_model, models, auth_env_var."""


### PR DESCRIPTION
Addresses #4094

### Summary
Fixed 3 tests that have been failing on main for multiple cycles:
1. Orphan sub-skill: scan includes.yml for references (dm-specific/doc-improvement-loop)
2. PR merge test: updated stale expectation (ship transition replaced by GitHub auto-close)
3. Deepseek model: updated from deepseek-r1 to deepseek-v4-pro

Full test suite now passes with **zero failures** — clean green baseline.

### Changes
- **Files**: `tests/test_manifest.py`, `tests/test_git_ops.py`, `tests/test_model_router.py`

### QA Status
- [x] All tests passing (zero failures)
- [x] Full suite green
- [x] Acceptance criteria met