### PR TITLE
skill: #4124 — fix repo_scan.py FastAPI dead code detection

### DIFF
--- a/references/scripts/repo_scan.py
+++ b/references/scripts/repo_scan.py
@@ -89,7 +89,6 @@ FRAMEWORK_FILES = {
     "tsconfig.json": "typescript",
     "manage.py": "django",
     "app.py": "flask",
-    "fastapi": "fastapi",
 }
 
 # CI/CD detection
@@ -219,6 +218,32 @@ def _check_package_json_deps(root, *dep_names):
         return []
 
 
+def _check_python_deps(root, *dep_names):
+    """Check if requirements.txt or pyproject.toml contains specific Python packages."""
+    found = []
+    # Check requirements.txt
+    req = Path(root) / "requirements.txt"
+    if req.exists():
+        try:
+            text = req.read_text(encoding="utf-8").lower()
+            for dep in dep_names:
+                if dep.lower() in text:
+                    found.append(dep)
+        except OSError:
+            pass
+    # Check pyproject.toml [project.dependencies] or [tool.poetry.dependencies]
+    pyp = Path(root) / "pyproject.toml"
+    if pyp.exists():
+        try:
+            text = pyp.read_text(encoding="utf-8").lower()
+            for dep in dep_names:
+                if dep.lower() in text and dep not in found:
+                    found.append(dep)
+        except OSError:
+            pass
+    return found
+
+
 def scan(root=None):
     """Scan a repository and return structured detection results.
 
@@ -272,6 +297,10 @@ def scan(root=None):
                   "nestjs": "nestjs", "tailwindcss": "tailwind"}
         if dep in fw_map:
             detected_frameworks.add(fw_map[dep])
+    # Check Python deps for frameworks not detectable by file presence
+    py_deps = _check_python_deps(root, "fastapi", "flask", "django")
+    for dep in py_deps:
+        detected_frameworks.add(dep)
     result["frameworks"] = sorted(detected_frameworks)
 
     # CI/CD detection

--- a/tests/test_repo_scan.py
+++ b/tests/test_repo_scan.py
@@ -78,6 +78,21 @@ class TestFrameworkDetection:
         assert "tailwind" in result["frameworks"]
 
 
+    def test_detects_fastapi_from_requirements(self, tmp_path):
+        """#4124 regression: FastAPI detected via requirements.txt, not file presence."""
+        (tmp_path / "requirements.txt").write_text("fastapi>=0.100\nuvicorn\n")
+        result = repo_scan.scan(tmp_path)
+        assert "fastapi" in result["frameworks"]
+
+    def test_detects_fastapi_from_pyproject(self, tmp_path):
+        """#4124: FastAPI detected via pyproject.toml."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\ndependencies = ["fastapi", "uvicorn"]\n'
+        )
+        result = repo_scan.scan(tmp_path)
+        assert "fastapi" in result["frameworks"]
+
+
 class TestCICDDetection:
     def test_detects_github_actions(self, tmp_path):
         (tmp_path / ".github" / "workflows").mkdir(parents=True)


### PR DESCRIPTION
Addresses #4124

### Summary
Removed unreachable FastAPI file-presence check. Added _check_python_deps() that scans requirements.txt and pyproject.toml for Python packages. FastAPI, Flask, Django now detected via package dependencies.

### Changes
- **Files**: `references/scripts/repo_scan.py`, `tests/test_repo_scan.py`
- **What**: Removed dead FRAMEWORK_FILES entry, added Python dep scanner, 2 regression tests
- **Why**: "fastapi" as a filename never exists — detection was dead code

### QA Status
- [x] Unit tests passing (30 repo_scan tests)
- [x] Regression tests for requirements.txt and pyproject.toml detection
- [x] Acceptance criteria met