### PR TITLE
skill: #4125 — skip CHANGELOG when DM present

### DIFF
--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -355,9 +355,12 @@ def _do_version_bump(data, role):
         content = re.sub(r'version:\s*[\d.]+', f'version: {new_version}', content, count=1)
         skill_md.write_text(content, encoding="utf-8")
 
-    # Add CHANGELOG entry
+    # Add CHANGELOG entry — skip when DM is present (#4125).
+    # DM writes richer CHANGELOG entries (Added/Fixed descriptions).
+    # When DM is absent, PM fallback writes the basic shipped list.
+    dm_dir = REPO_ROOT / ".squidsquad" / "dm"
     changelog = REPO_ROOT / "CHANGELOG.md"
-    if changelog.exists():
+    if changelog.exists() and not dm_dir.exists():
         old_content = changelog.read_text(encoding="utf-8")
         date_str = datetime.now().strftime("%Y-%m-%d")
         items_str = "\n".join(f"- #{n}" for n in items)

--- a/tests/test_cycle_post.py
+++ b/tests/test_cycle_post.py
@@ -448,3 +448,31 @@ class TestDisposablePatterns:
     def test_test_file_does_not_match(self):
         import fnmatch
         assert not any(fnmatch.fnmatch("test_compose.py", p) for p in cycle_post._DISPOSABLE_PATTERNS)
+
+
+# ---------------------------------------------------------------------------
+# #4125 regression: CHANGELOG skip when DM present
+# ---------------------------------------------------------------------------
+
+class TestVersionBumpChangelogSkip:
+    """_do_version_bump skips CHANGELOG when DM is present."""
+
+    def test_skips_changelog_when_dm_present(self, patch_dirs, squid_dir):
+        """#4125: DM owns CHANGELOG — cycle_post must not write it."""
+        # Create DM dir (DM is present)
+        (squid_dir / "dm").mkdir(parents=True, exist_ok=True)
+        # Create a CHANGELOG
+        changelog = patch_dirs / "CHANGELOG.md"
+        changelog.write_text("# Changelog\n\nOld content.\n", encoding="utf-8")
+        # Create config.md for set_field
+        config_md = squid_dir.parent / ".squidsquad" / "config.md"
+        config_md.parent.mkdir(parents=True, exist_ok=True)
+        config_md.write_text("- **SquidSquad Version**: 0.28.0\n", encoding="utf-8")
+
+        data = {"version_bump": {"new_version": "0.29.0", "items_included": [100, 200]}}
+        cycle_post._do_version_bump(data, "pm")
+
+        content = changelog.read_text(encoding="utf-8")
+        # CHANGELOG should NOT have been modified (DM handles it)
+        assert "0.29.0" not in content
+        assert "Old content." in content


### PR DESCRIPTION
Addresses #4125

### Summary
cycle_post.py version bump now skips CHANGELOG writing when DM directory exists. DM owns CHANGELOG with richer content (Added/Fixed descriptions). PM fallback still writes basic shipped list when DM absent.

### Changes
- **Files**: `references/scripts/cycle_post.py`, `tests/test_cycle_post.py`
- **What**: Added DM presence check before CHANGELOG write + 1 regression test
- **Why**: Duplicate CHANGELOG headers when both cycle_post and DM wrote entries

### QA Status
- [x] Unit tests passing (37 cycle_post tests)
- [x] Regression test added
- [x] Acceptance criteria met