### PR TITLE
skill: #4123 — fix wizard.py Research Model wrong key

### DIFF
--- a/.squidsquad/.backlog-cache
+++ b/.squidsquad/.backlog-cache
@@ -1,2 +1,1 @@
-skill:bugs=1:feats=1:pship=0
 pm:planning=

--- a/references/scripts/wizard.py
+++ b/references/scripts/wizard.py
@@ -594,7 +594,7 @@ def build_config_md(spec):
     lines.append("")
     routing = spec.get("model_routing") or {}
     lines.append(f"- **Default Model**: {routing.get('model', 'claude')}")
-    lines.append(f"- **Research Model**: {routing.get('model', 'claude')}")
+    lines.append(f"- **Research Model**: {routing.get('research_model', 'claude')}")
     lines.append("- **Discussion Prep Model**: claude")
     lines.append("- **Test Plan Model**: claude")
     lines.append("- **QA Execution Model**: claude")

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -460,6 +460,22 @@ class TestBuildConfigMdStructure:
         text = wizard.build_config_md(_minimal_spec())
         assert "Description" not in text
 
+    def test_research_model_uses_own_key(self):
+        """#4123 regression: Research Model must not duplicate Default Model."""
+        spec = _minimal_spec()
+        spec["model_routing"] = {"model": "claude", "research_model": "gpt-5.2"}
+        text = wizard.build_config_md(spec)
+        assert "**Default Model**: claude" in text
+        assert "**Research Model**: gpt-5.2" in text
+
+    def test_research_model_defaults_to_claude(self):
+        """Research Model defaults to claude when not specified."""
+        spec = _minimal_spec()
+        spec["model_routing"] = {"model": "gpt-5.2"}
+        text = wizard.build_config_md(spec)
+        assert "**Default Model**: gpt-5.2" in text
+        assert "**Research Model**: claude" in text
+
 
 class TestBuildConfigMdAgentBlock:
     """Agent entries must match Q-new17 shape exactly."""


### PR DESCRIPTION
Addresses #4123

### Summary
build_config_md used routing.get('model') for both Default Model and Research Model (copy-paste bug). Fixed Research Model to use routing.get('research_model', 'claude').

### Changes
- **Files**: `references/scripts/wizard.py`, `tests/test_wizard.py`
- **What**: 1-line key fix + 2 regression tests
- **Why**: Research Model always rendered same value as Default Model

### QA Status
- [x] Unit tests passing (211 wizard tests)
- [x] Regression tests verify correct key usage
- [x] Acceptance criteria met