### PR TITLE
skill: #4200 — fix forgejo_setup credential leak in error messages

### DIFF
--- a/references/scripts/forgejo_setup.py
+++ b/references/scripts/forgejo_setup.py
@@ -264,8 +264,14 @@ def create_token(username, password):
             result["ok"] = True
             result["token"] = token_data.get("sha1", "")
             result["message"] = "Token created"
-    except Exception as e:
-        result["message"] = f"Failed to create token: {e}"
+    except urllib.error.HTTPError as e:
+        # Sanitize: only expose status code, not headers/URL which may
+        # contain Base64-encoded credentials (#4200).
+        result["message"] = f"Failed to create token: HTTP {e.code}"
+    except urllib.error.URLError as e:
+        result["message"] = f"Failed to create token: connection error"
+    except Exception:
+        result["message"] = "Failed to create token: unexpected error"
     return result
 
 

--- a/tests/test_forgejo_setup.py
+++ b/tests/test_forgejo_setup.py
@@ -125,3 +125,39 @@ class TestTeardown:
         with patch.object(forgejo_setup, "DEPLOY_DIR", deploy_dir):
             result = forgejo_setup.teardown()
         assert result["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# #4200 regression: credential leak in error messages
+# ---------------------------------------------------------------------------
+
+class TestCreateTokenCredentialSafety:
+    """create_token must not leak credentials in error messages."""
+
+    def test_http_error_does_not_expose_credentials(self):
+        """#4200: HTTP error must show status code only, not headers/URL."""
+        import urllib.error
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.side_effect = urllib.error.HTTPError(
+                url="http://localhost:3000/api/v1/users/admin/tokens",
+                code=401,
+                msg="Unauthorized",
+                hdrs=None,
+                fp=None,
+            )
+            result = forgejo_setup.create_token("admin", "s3cret_password")
+        assert result["ok"] is False
+        assert "HTTP 401" in result["message"]
+        # Credentials must NOT appear in the error message
+        assert "s3cret_password" not in result["message"]
+        assert "admin:s3cret" not in result["message"]
+
+    def test_connection_error_does_not_expose_details(self):
+        """URLError must not expose internal details."""
+        import urllib.error
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.side_effect = urllib.error.URLError("connection refused")
+            result = forgejo_setup.create_token("admin", "password123")
+        assert result["ok"] is False
+        assert "connection error" in result["message"]
+        assert "password123" not in result["message"]


### PR DESCRIPTION
Addresses #4200

### Summary
create_token caught raw Exception and returned the full error string, which could include Base64-encoded credentials. Now catches HTTPError (status code only), URLError (generic), and Exception (generic) separately. No credentials in any error path.

### Changes
- **Files**: `references/scripts/forgejo_setup.py`, `tests/test_forgejo_setup.py`
- **What**: Sanitized error handling in create_token + 2 regression tests
- **Why**: Security — credentials could leak to stdout/logs on auth failure

### QA Status
- [x] Unit tests passing (13 forgejo tests)
- [x] Regression tests verify no credential leakage
- [x] Acceptance criteria met