### PR TITLE
skill: #4220 — fix --force reboot when claude is dead

### DIFF
--- a/references/scripts/reboot_agent.py
+++ b/references/scripts/reboot_agent.py
@@ -149,8 +149,38 @@ def reboot(role, timeout=DEFAULT_TIMEOUT, force=False):
     claude_pid, claude_alive = _read_claude_pid(clone_path, role)
 
     if not claude_alive:
-        # Claude already dead but wrapper alive — write sentinel so wrapper
-        # respawns on its next check (it may be between spawns already)
+        if force:
+            # Force mode: kill the wrapper and respawn fresh — sentinel approach
+            # won't work if wrapper is stuck or not checking sentinels
+            print(f"{role}: wrapper alive but claude not running — force-killing wrapper PID {wrapper_pid}")
+            _kill_process(wrapper_pid)
+            for _ in range(10):
+                if not _is_process_alive(wrapper_pid):
+                    break
+                time.sleep(0.5)
+            if _is_process_alive(wrapper_pid):
+                print(f"{role}: WARNING — wrapper PID {wrapper_pid} still alive after kill",
+                      file=sys.stderr)
+                return 1
+            # Clean up stale PID files so _spawn_wrapper doesn't reject
+            for f in [pid_file, squid / role / ".claude-pid"]:
+                try:
+                    f.unlink()
+                except OSError:
+                    pass
+            try:
+                restart_file.unlink()
+            except OSError:
+                pass
+            print(f"{role}: wrapper killed — respawning...")
+            success, msg = _spawn_wrapper(role, clone_path)
+            if success:
+                print(f"{role}: respawned ({msg})")
+            else:
+                print(f"{role}: respawn failed — {msg}", file=sys.stderr)
+                return 1
+            return 0
+        # Non-force: write sentinel so wrapper respawns on its next check
         restart_file.write_text("reboot requested by reboot_agent.py", encoding="utf-8")
         print(f"{role}: wrapper alive but claude not running — restart sentinel written")
         return 0

--- a/references/scripts/reboot_agent.py
+++ b/references/scripts/reboot_agent.py
@@ -152,15 +152,16 @@ def reboot(role, timeout=DEFAULT_TIMEOUT, force=False):
         if force:
             # Force mode: kill the wrapper and respawn fresh — sentinel approach
             # won't work if wrapper is stuck or not checking sentinels
-            print(f"{role}: wrapper alive but claude not running — force-killing wrapper PID {wrapper_pid}")
+            print(f"{role}: wrapper alive but claude not running"
+                  f" — force-killing wrapper PID {wrapper_pid}")
             _kill_process(wrapper_pid)
             for _ in range(10):
                 if not _is_process_alive(wrapper_pid):
                     break
                 time.sleep(0.5)
             if _is_process_alive(wrapper_pid):
-                print(f"{role}: WARNING — wrapper PID {wrapper_pid} still alive after kill",
-                      file=sys.stderr)
+                print(f"{role}: WARNING — wrapper PID {wrapper_pid}"
+                      " still alive after kill", file=sys.stderr)
                 return 1
             # Clean up stale PID files so _spawn_wrapper doesn't reject
             for f in [pid_file, squid / role / ".claude-pid"]:
@@ -181,8 +182,10 @@ def reboot(role, timeout=DEFAULT_TIMEOUT, force=False):
                 return 1
             return 0
         # Non-force: write sentinel so wrapper respawns on its next check
-        restart_file.write_text("reboot requested by reboot_agent.py", encoding="utf-8")
-        print(f"{role}: wrapper alive but claude not running — restart sentinel written")
+        restart_file.write_text(
+            "reboot requested by reboot_agent.py", encoding="utf-8")
+        print(f"{role}: wrapper alive but claude not running"
+              " — restart sentinel written")
         return 0
 
     # Write restart sentinel BEFORE killing so wrapper sees it on claude exit

--- a/tests/test_reboot_agent.py
+++ b/tests/test_reboot_agent.py
@@ -157,16 +157,46 @@ class TestRebootForce:
         assert spawned == []  # no _spawn_wrapper — wrapper handles respawn
         assert (squid_dir / "skill" / ".restart").exists()
 
-    def test_force_wrapper_alive_no_claude_pid(self, patch_dirs, squid_dir, monkeypatch):
-        """Force with wrapper alive but no .claude-pid writes sentinel only."""
+    def test_force_wrapper_alive_no_claude_pid_kills_wrapper(self, patch_dirs, squid_dir, monkeypatch):
+        """Force with wrapper alive but no .claude-pid kills wrapper and respawns (#4220)."""
         (squid_dir / "skill" / ".pid").write_text("12345", encoding="utf-8")
-        monkeypatch.setattr(reboot_agent, "_is_process_alive", lambda pid: pid == 12345)
+        alive_pids = {12345}
+        monkeypatch.setattr(reboot_agent, "_is_process_alive",
+                            lambda pid: pid in alive_pids)
+        killed = []
+        def fake_kill(pid):
+            killed.append(pid)
+            alive_pids.discard(pid)
+        monkeypatch.setattr(reboot_agent, "_kill_process", fake_kill)
         spawned = _stub_spawn(monkeypatch)
 
         result = reboot_agent.reboot("skill", force=True)
         assert result == 0
-        assert spawned == []
-        assert (squid_dir / "skill" / ".restart").exists()
+        assert 12345 in killed  # wrapper killed
+        assert "skill" in spawned  # respawned
+        assert not (squid_dir / "skill" / ".pid").exists()  # PID file cleaned up
+
+    def test_force_wrapper_alive_claude_dead_kills_wrapper(self, patch_dirs, squid_dir, monkeypatch):
+        """Force with wrapper alive but claude dead kills wrapper and respawns (#4220)."""
+        (squid_dir / "skill" / ".pid").write_text("12345", encoding="utf-8")
+        (squid_dir / "skill" / ".claude-pid").write_text("67890", encoding="utf-8")
+        alive_pids = {12345}  # wrapper alive, claude dead
+        monkeypatch.setattr(reboot_agent, "_is_process_alive",
+                            lambda pid: pid in alive_pids)
+        killed = []
+        def fake_kill(pid):
+            killed.append(pid)
+            alive_pids.discard(pid)
+        monkeypatch.setattr(reboot_agent, "_kill_process", fake_kill)
+        spawned = _stub_spawn(monkeypatch)
+
+        result = reboot_agent.reboot("skill", force=True)
+        assert result == 0
+        assert 12345 in killed  # wrapper killed
+        assert 67890 not in killed  # claude already dead, not killed
+        assert "skill" in spawned  # respawned
+        assert not (squid_dir / "skill" / ".pid").exists()
+        assert not (squid_dir / "skill" / ".claude-pid").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_reboot_agent.py
+++ b/tests/test_reboot_agent.py
@@ -157,16 +157,22 @@ class TestRebootForce:
         assert spawned == []  # no _spawn_wrapper — wrapper handles respawn
         assert (squid_dir / "skill" / ".restart").exists()
 
-    def test_force_wrapper_alive_no_claude_pid_kills_wrapper(self, patch_dirs, squid_dir, monkeypatch):
-        """Force with wrapper alive but no .claude-pid kills wrapper and respawns (#4220)."""
+    def test_force_wrapper_alive_no_claude_pid_kills_wrapper(
+        self, patch_dirs, squid_dir, monkeypatch
+    ):
+        """Force with wrapper alive but no .claude-pid kills wrapper
+        and respawns (#4220)."""
         (squid_dir / "skill" / ".pid").write_text("12345", encoding="utf-8")
         alive_pids = {12345}
-        monkeypatch.setattr(reboot_agent, "_is_process_alive",
-                            lambda pid: pid in alive_pids)
+        monkeypatch.setattr(
+            reboot_agent, "_is_process_alive",
+            lambda pid: pid in alive_pids)
         killed = []
+
         def fake_kill(pid):
             killed.append(pid)
             alive_pids.discard(pid)
+
         monkeypatch.setattr(reboot_agent, "_kill_process", fake_kill)
         spawned = _stub_spawn(monkeypatch)
 
@@ -174,26 +180,33 @@ class TestRebootForce:
         assert result == 0
         assert 12345 in killed  # wrapper killed
         assert "skill" in spawned  # respawned
-        assert not (squid_dir / "skill" / ".pid").exists()  # PID file cleaned up
+        assert not (squid_dir / "skill" / ".pid").exists()
 
-    def test_force_wrapper_alive_claude_dead_kills_wrapper(self, patch_dirs, squid_dir, monkeypatch):
-        """Force with wrapper alive but claude dead kills wrapper and respawns (#4220)."""
+    def test_force_wrapper_alive_claude_dead_kills_wrapper(
+        self, patch_dirs, squid_dir, monkeypatch
+    ):
+        """Force with wrapper alive but claude dead kills wrapper
+        and respawns (#4220)."""
         (squid_dir / "skill" / ".pid").write_text("12345", encoding="utf-8")
-        (squid_dir / "skill" / ".claude-pid").write_text("67890", encoding="utf-8")
+        (squid_dir / "skill" / ".claude-pid").write_text(
+            "67890", encoding="utf-8")
         alive_pids = {12345}  # wrapper alive, claude dead
-        monkeypatch.setattr(reboot_agent, "_is_process_alive",
-                            lambda pid: pid in alive_pids)
+        monkeypatch.setattr(
+            reboot_agent, "_is_process_alive",
+            lambda pid: pid in alive_pids)
         killed = []
+
         def fake_kill(pid):
             killed.append(pid)
             alive_pids.discard(pid)
+
         monkeypatch.setattr(reboot_agent, "_kill_process", fake_kill)
         spawned = _stub_spawn(monkeypatch)
 
         result = reboot_agent.reboot("skill", force=True)
         assert result == 0
         assert 12345 in killed  # wrapper killed
-        assert 67890 not in killed  # claude already dead, not killed
+        assert 67890 not in killed  # claude already dead
         assert "skill" in spawned  # respawned
         assert not (squid_dir / "skill" / ".pid").exists()
         assert not (squid_dir / "skill" / ".claude-pid").exists()


### PR DESCRIPTION
Closes #4220

### Summary
When `--force` is used and wrapper is alive but claude subprocess is not running, `reboot_agent.py` now kills the wrapper process directly and respawns fresh via `_spawn_wrapper()`, instead of just writing a `.restart` sentinel that may never be read by a stuck wrapper.

### Acceptance Criteria
- [x] `--force` kills wrapper and respawns when claude is dead but wrapper is alive
- [x] PID files cleaned up before respawn to prevent double-start rejection
- [x] Non-force path unchanged (sentinel-based)
- [x] Regression tests for both no-claude-pid and dead-claude-pid scenarios

### Changes
- **Files**: `references/scripts/reboot_agent.py`, `tests/test_reboot_agent.py`
- **What**: Added force-mode handling in the "wrapper alive, claude dead" path — kills wrapper PID, cleans up stale PID files, respawns fresh
- **Why**: Previously `--force` had no effect in this scenario — it just wrote a sentinel identical to non-force mode

### QA Status
- [x] Unit tests passing (22/22)
- [x] Full test suite passing
- [x] Acceptance criteria met