### PR TITLE
skill: #4343 — remove dead _escape in cycle_post.py

### DIFF
--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -220,11 +220,6 @@ def _sanitize_commit_msg(msg: str) -> str:
     to close them (#4038). Replace the keyword with a hyphenated form that
     preserves readability without triggering auto-close.
     """
-    def _escape(m):
-        keyword = m.group(1)
-        ref = m.group(2)
-        return f"{keyword} {ref}"  # insert zero-width space before #
-
     # Insert a zero-width space (U+200B) between keyword and #
     return _AUTOCLOSE_RE.sub(
         lambda m: f"{m.group(1)} \u200b{m.group(2)}", msg


### PR DESCRIPTION
Closes #4343

### Summary
Remove dead inner function `_escape` in `_sanitize_commit_msg`. The actual substitution uses an inline lambda — the dead function was never called.

### Changes
- **Files**: `references/scripts/cycle_post.py`
- **What**: Deleted 4 lines of dead code (unused inner function)
- **Why**: Dead code with misleading comment

### QA Status
- [x] Unit tests passing (37/37)
- [x] No behavior change — dead code removal only