### PR TITLE
skill: #4438 — fix dm-specific/ path in test

### DIFF
--- a/tests/test_dm_verify_before_block.py
+++ b/tests/test_dm_verify_before_block.py
@@ -12,7 +12,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 class TestDmVerifyBeforeBlock:
     def test_prohibitions_has_verify_requirement(self):
         """DM prohibitions sub-skill must require verification before human-block."""
-        path = REPO_ROOT / "references" / "sub-skills" / "dm-specific" / "prohibitions.md"
+        path = REPO_ROOT / "references" / "sub-skills" / "roles" / "dm" / "prohibitions.md"
         content = path.read_text(encoding="utf-8")
         assert "verify" in content.lower()
         assert "pending-human-setup" in content


### PR DESCRIPTION
Closes #4438

### Summary
Update `dm-specific/prohibitions.md` path to `roles/dm/prohibitions.md` in test_dm_verify_before_block.py.

### QA Status
- [x] 3/3 tests passing