### PR TITLE
skill: #4518 — fix GitHub auto-close on PR merge

### DIFF
--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -285,6 +285,10 @@ def _do_commit_push(data, role):
             if code_commit.get("pr_needed"):
                 pr_title = code_commit.get("pr_title", f"{role}: {branch}")
                 pr_body = code_commit.get("pr_body", f"Branch: {branch}")
+                # Sanitize PR body — GitHub auto-closes issues when PR body
+                # contains "Closes #N" and the PR is merged to default branch.
+                # SquidSquad manages issue lifecycle via tracker.py, not PR merges.
+                pr_body = _sanitize_commit_msg(pr_body)
                 result = _run_script("git_ops.py", "pr-create", pr_title, pr_body)
                 if result.returncode == 0:
                     print(f"  PR created: {result.stdout.strip()}")

--- a/tests/test_cycle_post.py
+++ b/tests/test_cycle_post.py
@@ -425,6 +425,13 @@ class TestSanitizeCommitMsg:
         msg = "skill: quiet cycle — pipeline clean"
         assert cycle_post._sanitize_commit_msg(msg) == msg
 
+    def test_closes_in_pr_body_escaped(self):
+        """#4518: PR body 'Closes #N' must be sanitized to prevent GitHub auto-close."""
+        body = "Closes #4459\n\n## Summary\nL4 shared content"
+        result = cycle_post._sanitize_commit_msg(body)
+        assert "Closes #4459" not in result
+        assert "#4459" in result
+
 
 # ---------------------------------------------------------------------------
 # #4081 regression: disposable file detection


### PR DESCRIPTION
Refs #4518

### Summary
PR bodies contained "Closes #N" which GitHub auto-closes on merge, bypassing SquidSquad's status lifecycle. Now sanitized via _sanitize_commit_msg before pr-create.

### Changes
- **Files**: `references/scripts/cycle_post.py`, `tests/test_cycle_post.py`
- **What**: Apply _sanitize_commit_msg to PR body in _do_commit_push
- **Why**: 5 issues (#4455-#4459) auto-closed at pending-ship instead of shipped

### QA Status
- [x] 38/38 tests passing
- [x] Regression test for PR body sanitization