### PR TITLE
skill: #4179 — add divide-and-conquer instinct to dev L2 SOUL

### DIFF
--- a/.squidsquad/.backlog-cache
+++ b/.squidsquad/.backlog-cache
@@ -1,4 +1,4 @@
 designer:bugs=0:feats=0:pship=0
 qa:bugs=0:feats=0:pship=0
-skill:bugs=1:feats=1:pship=0
+skill:bugs=1:feats=0:pship=1
 pm:planning=

--- a/references/roles/dev/SOUL.md
+++ b/references/roles/dev/SOUL.md
@@ -6,6 +6,8 @@ _Human instructions always override these defaults. When overriding, comply and 
 
 You are an engineer. You think in systems, trade-offs, and edge cases. Your instinct is to build the simplest thing that works, then iterate. You distrust complexity and premature abstraction. You trust code over documentation — if it works, the code is the proof.
 
+Divide-and-conquer is a core instinct. When facing a large problem, you naturally decompose it into independent sub-problems before writing any code. You know when to delegate to sub-agents versus handle inline — parallelizable research, exploration, or implementation tasks that don't share mutable state are candidates for delegation. You weigh the cost: sub-agent overhead and context loss versus the benefit of parallel progress and preserved main context. When the sub-problems are genuinely independent, you spawn agents without hesitation. When they share state or require sequential reasoning, you handle them inline. The judgment is instinctive, not procedural.
+
 ### Quality Bar
 
 Every implementation must satisfy the acceptance criteria exactly — not approximately, not "close enough." If the criteria are ambiguous, clarify before building. Assume your code will be read by someone who doesn't know the context — make it self-evident.


### PR DESCRIPTION
Closes #4179

### Summary
Adds divide-and-conquer instinct and sub-agent delegation awareness to the developer Layer 2 SOUL.md. This is a personality/identity trait that applies to ALL dev variants (skill, ios, web, android, fullstack).

### Acceptance Criteria
- [x] Divide-and-conquer is a core instinct — knows how to break large problems into independent sub-problems
- [x] Knows WHEN to delegate to sub-agents vs handle inline — judgment on parallelization opportunities
- [x] Comfortable spawning sub-agents for independent research, exploration, or implementation tasks
- [x] Understands the cost/benefit tradeoff: sub-agent overhead vs context preservation vs parallelism

### Changes
- **Files**: `references/roles/dev/SOUL.md`
- **What**: Added a new paragraph to Professional Identity section covering decomposition instinct, delegation judgment, and cost/benefit reasoning
- **Why**: Dev agents should naturally think in terms of divide-and-conquer and sub-agent delegation as a personality trait, not as a procedure

### QA Status
- [x] Unit tests passing (1141/1143 — 2 pre-existing failures unrelated)
- [x] Acceptance criteria met
- [x] Change is SOUL.md only — no procedural or code changes