### PR TITLE
skill: #4084 — draft PR workflow for dev agents

### DIFF
--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -967,8 +967,8 @@ def transition(number, from_status, to_status, role=None, force=False):
     else:
         _run_list(["gh", "issue", "edit", str(number), "--remove-label", from_label, "--add-label", to_label])
 
-    # Auto-convert draft PR to ready on pending-ship
-    if to_label == "status:pending-ship":
+    # Auto-convert draft PR to ready on pending-test or pending-ship
+    if to_label in ("status:pending-test", "status:pending-ship"):
         _convert_draft_pr_to_ready(number)
 
     # Auto-close on shipped (handle already-closed from GitHub auto-close #3747)

--- a/references/sub-skills/common/git-commit.md
+++ b/references/sub-skills/common/git-commit.md
@@ -80,11 +80,16 @@ Split commits into code (feature branch) and state (main):
 
 4. **When PR Flow `yes`**: monitor PR comments each cycle for human feedback:
    ```bash
-   gh pr view [PR_NUMBER] --json comments,reviews
+   gh pr view [PR_NUMBER] --json comments,reviews,isDraft
    ```
+   - If human requested changes via review: **convert the PR to draft first** before making any code changes:
+     ```bash
+     gh pr ready --undo [PR_NUMBER]
+     ```
+     Then fix the issues and push to the branch.
    - If human posted new comments: read and address them (fix code, answer questions, reply on PR)
-   - If human requested changes via review: fix the issues and push to the branch
-   - After pushing fixes, re-request review if appropriate
+   - A PR must NEVER be in ready state while the agent is actively pushing commits to it.
+   - After all fixes are pushed and the task moves to pending-test, the tracker auto-converts the PR back to ready.
 
 5. **When PR Flow `yes`**: check own open PRs for merge conflicts and rebase:
    ```bash

--- a/tests/test_tracker_authority.py
+++ b/tests/test_tracker_authority.py
@@ -812,7 +812,7 @@ class TestShippedBranchGuard:
 
 
 class TestDraftPRConversion:
-    """Auto-convert draft PRs to ready on pending-ship transition (#1696)."""
+    """Auto-convert draft PRs to ready on pending-test and pending-ship transitions (#1696, #4084)."""
 
     def test_converts_draft_to_ready(self, monkeypatch):
         """pending-ship transition calls gh pr ready on matching draft PR."""
@@ -873,6 +873,36 @@ class TestDraftPRConversion:
 
         ready_calls = [c for c in gh_calls if "ready" in c]
         assert len(ready_calls) == 0
+
+    def test_pending_test_converts_draft_to_ready(self, monkeypatch):
+        """#4084: pending-test transition also converts draft PR to ready."""
+        gh_calls = []
+
+        class FakeResult:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        def _fake_run_list(cmd, **kw):
+            gh_calls.append(cmd)
+            if "pr" in cmd and "list" in cmd:
+                r = FakeResult()
+                r.stdout = json.dumps([
+                    {"number": 99, "headRefName": "squidsquad/skill/55",
+                     "isDraft": True, "url": "http://pr/99"}
+                ])
+                return r
+            return FakeResult()
+
+        monkeypatch.setattr(tracker, "_run_list", _fake_run_list)
+        monkeypatch.setattr(tracker, "_get_issue_role_labels", lambda n: {"skill"})
+        monkeypatch.setattr(tracker, "_check_unread_feedback", lambda n, r: [])
+
+        tracker.transition(55, "in-progress", "pending-test", role="skill-lead")
+
+        ready_calls = [c for c in gh_calls if "ready" in c and "--undo" not in c]
+        assert len(ready_calls) == 1
+        assert "99" in str(ready_calls[0])
 
     def test_no_pr_is_silent_noop(self, monkeypatch):
         """pending-ship with no matching PR is a silent no-op."""


### PR DESCRIPTION
Closes #4084

### Summary
Implements mechanical draft PR workflow for dev agents. PRs stay in draft while work is ongoing and auto-convert to ready when transitioning to pending-test.

### Acceptance Criteria
- [x] When creating a new PR → create as draft (already implemented via git_ops.py)
- [x] When picking up a PR with requested changes → convert to draft first
- [x] When implementation is complete and moving to pending-test → mark ready
- [x] A PR should NEVER be in ready state while the agent is actively pushing commits

### Changes
- **Files**: `references/scripts/tracker.py`, `references/sub-skills/common/git-commit.md`, `tests/test_tracker_authority.py`
- **What**: Extended draft→ready auto-conversion to fire on pending-test (was only pending-ship). Added instruction for agents to convert PR to draft when picking up human-requested changes.
- **Why**: Human reviews PRs and requests changes — while agent works on fixes, PR showing as ready is misleading. Draft state signals WIP.

### QA Status
- [x] Unit tests passing (1142/1144 — 2 pre-existing failures unrelated)
- [x] New regression test for pending-test draft conversion
- [x] Acceptance criteria met