### PR TITLE
skill: #4564 — remove duplicate manifest.md in installer-files.txt

### DIFF
--- a/references/installer-files.txt
+++ b/references/installer-files.txt
@@ -196,7 +196,6 @@ references/sub-skills/roles/dm/skill/domain-context.md
 references/sub-skills/roles/dm/status-line.md
 references/sub-skills/roles/dm/version-bumps.md
 references/sub-skills/roles/dm/web/domain-context.md
-references/sub-skills/manifest.md
 references/sub-skills/project/shared-instructions.md
 references/sub-skills/project/shared-soul-directives.md
 references/sub-skills/roles/pm/android/domain-context.md


### PR DESCRIPTION
Closes #4564

### Summary
Removes duplicate entry for `references/sub-skills/manifest.md` in `installer-files.txt`. One-line fix.

### Acceptance Criteria
- [x] No duplicate entries in installer-files.txt
- [x] test_no_duplicate_entries passes

### Changes
- **Files**: `references/installer-files.txt`
- **What**: Removed second occurrence of `references/sub-skills/manifest.md` (was on line 199, already listed on line 166)
- **Why**: Duplicate entry caused test_no_duplicate_entries to fail

### QA Status
- [x] Unit tests passing (1142/1143 — 1 pre-existing failure unrelated)
- [x] Regression test passes