### PR TITLE
skill: #4608 — fix WinError 206 in agent compose

### DIFF
--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -573,9 +573,11 @@ def agent_compose(deterministic_output: str, role_name: str,
             f"Document to polish:\n\n{deterministic_output}"
         )
 
-        # Call Claude via the claude CLI
+        # Call Claude via the claude CLI — pipe prompt via stdin to avoid
+        # Windows command-line length limits (WinError 206 / MAX_PATH).
         result = subprocess.run(
-            ["claude", "-p", prompt, "--output-format", "text"],
+            ["claude", "-p", "--output-format", "text"],
+            input=prompt,
             capture_output=True, text=True, timeout=120,
             encoding="utf-8", errors="replace",
         )

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -790,3 +790,19 @@ class TestAgentComposeEnabled:
              patch("subprocess.run", return_value=mock_result):
             result = compose.agent_compose(original, "skill")
         assert result == original  # fell back due to lost code block
+
+    def test_pipes_prompt_via_stdin_not_cli_arg(self):
+        """Regression: #4608 — prompt must go via stdin to avoid WinError 206."""
+        from unittest.mock import MagicMock
+        mock_result = MagicMock(returncode=0, stdout="polished output")
+        with patch.object(compose, "_is_agent_compose_enabled", return_value=True), \
+             patch("subprocess.run", return_value=mock_result) as mock_run:
+            compose.agent_compose("original content", "skill")
+        args, kwargs = mock_run.call_args
+        # CLI args should NOT contain the prompt text
+        cli_args = args[0]
+        assert "original content" not in " ".join(cli_args), \
+            "prompt must not appear in CLI args (Windows MAX_PATH limit)"
+        # Prompt must be piped via input kwarg
+        assert "input" in kwargs, "prompt must be passed via input= kwarg"
+        assert "original content" in kwargs["input"]


### PR DESCRIPTION
Closes #4608

### Summary
Fixes Windows WinError 206 (filename too long) in agent compose by passing the prompt via subprocess stdin instead of as a CLI argument.

### Acceptance Criteria
- [x] Agent compose no longer hits WinError 206 on Windows
- [x] Prompt passed via stdin, not CLI arg
- [x] Regression test added

### Changes
- **Files**: `references/scripts/compose.py`, `tests/test_compose.py`
- **What**: Changed `subprocess.run(["claude", "-p", prompt, ...])` to `subprocess.run(["claude", "-p", ...], input=prompt)` — prompt goes via stdin
- **Why**: Windows cmd.exe limits CLI args to ~8191 chars. Compose output easily exceeds this, causing WinError 206 for all 5 agents during deploy-all.

### QA Status
- [x] Unit tests passing (1143/1144 — 1 pre-existing failure unrelated)
- [x] Regression test verifies prompt goes via stdin
- [x] Acceptance criteria met