### PR TITLE
skill: #4746 — diagnostics test coverage

### DIFF
--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,9 +1,11 @@
-"""Tests for references/scripts/diagnostics.py — log, read, rotate, sanitize."""
+"""Tests for references/scripts/diagnostics.py — log, read, rotate, sanitize,
+generate_report, is_public_repo."""
 
 import json
+import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -116,3 +118,93 @@ class TestSanitizeConfig:
         assert "30" in result
         assert "yes" in result
         assert "[REDACTED]" not in result
+
+
+class TestIsPublicRepo:
+    def test_public_repo(self, capsys):
+        mock_result = MagicMock()
+        mock_result.stdout = '{"isPrivate": false}'
+        with patch("diagnostics.subprocess.run", return_value=mock_result):
+            result = diagnostics.is_public_repo()
+        assert result is True
+        assert "true" in capsys.readouterr().out
+
+    def test_private_repo(self, capsys):
+        mock_result = MagicMock()
+        mock_result.stdout = '{"isPrivate": true}'
+        with patch("diagnostics.subprocess.run", return_value=mock_result):
+            result = diagnostics.is_public_repo()
+        assert result is False
+        assert "false" in capsys.readouterr().out
+
+    def test_missing_field_defaults_private(self, capsys):
+        mock_result = MagicMock()
+        mock_result.stdout = '{}'
+        with patch("diagnostics.subprocess.run", return_value=mock_result):
+            result = diagnostics.is_public_repo()
+        assert result is False
+
+    def test_gh_command_fails(self, capsys):
+        with patch("diagnostics.subprocess.run",
+                   side_effect=subprocess.CalledProcessError(1, "gh")):
+            result = diagnostics.is_public_repo()
+        assert result is None
+        assert "unknown" in capsys.readouterr().out
+
+    def test_invalid_json_response(self, capsys):
+        mock_result = MagicMock()
+        mock_result.stdout = "not json"
+        with patch("diagnostics.subprocess.run", return_value=mock_result):
+            result = diagnostics.is_public_repo()
+        assert result is None
+        assert "unknown" in capsys.readouterr().out
+
+
+class TestGenerateReport:
+    def test_report_contains_version(self, capsys):
+        with patch.object(diagnostics, "get_field", return_value="0.30.0"), \
+             patch.object(diagnostics, "_sanitize_config", return_value="config here"), \
+             patch.object(diagnostics, "LOG_FILE", Path("/nonexistent")):
+            report = diagnostics.generate_report()
+        assert "0.30.0" in report
+        assert "config here" in report
+        assert "Issue Report" in report
+
+    def test_report_with_diagnostics_entries(self, tmp_path, capsys):
+        log_file = tmp_path / "diagnostic.jsonl"
+        log_file.write_text(
+            json.dumps({"severity": "warning", "message": "test"}) + "\n",
+            encoding="utf-8",
+        )
+        with patch.object(diagnostics, "get_field", return_value="1.0.0"), \
+             patch.object(diagnostics, "_sanitize_config", return_value="cfg"), \
+             patch.object(diagnostics, "LOG_FILE", log_file):
+            report = diagnostics.generate_report()
+        assert "Recent Diagnostics" in report
+        assert '"warning"' in report
+
+    def test_report_no_log_file(self, capsys):
+        with patch.object(diagnostics, "get_field", return_value="1.0.0"), \
+             patch.object(diagnostics, "_sanitize_config", return_value="cfg"), \
+             patch.object(diagnostics, "LOG_FILE", Path("/nonexistent")):
+            report = diagnostics.generate_report()
+        assert "Recent Diagnostics" not in report
+        assert "Issue Report" in report
+
+    def test_report_version_unknown_on_error(self, capsys):
+        with patch.object(diagnostics, "get_field", side_effect=SystemExit(1)), \
+             patch.object(diagnostics, "_sanitize_config", return_value="cfg"), \
+             patch.object(diagnostics, "LOG_FILE", Path("/nonexistent")):
+            report = diagnostics.generate_report()
+        assert "unknown" in report
+
+    def test_report_skips_malformed_log_lines(self, tmp_path, capsys):
+        log_file = tmp_path / "diagnostic.jsonl"
+        log_file.write_text("not json\n" + json.dumps({"ok": True}) + "\n",
+                            encoding="utf-8")
+        with patch.object(diagnostics, "get_field", return_value="1.0.0"), \
+             patch.object(diagnostics, "_sanitize_config", return_value="cfg"), \
+             patch.object(diagnostics, "LOG_FILE", log_file):
+            report = diagnostics.generate_report()
+        assert '"ok"' in report
+        assert "not json" not in report

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -218,5 +218,158 @@ class TestHarnessHealthPolling(unittest.TestCase):
         self.assertEqual(state.get_agent("dm").status, "stopped")
 
 
+class TestEndpointsViaTestClient(unittest.TestCase):
+    """Test FastAPI endpoints using TestClient with mocked dependencies."""
+
+    @classmethod
+    def setUpClass(cls):
+        from fastapi.testclient import TestClient
+        from harness import app, state, AgentState
+
+        # Pre-populate state so endpoints have data to work with
+        state.start_time = time.time()
+        state.port = 7373
+
+        cls.client = TestClient(app, raise_server_exceptions=False)
+        cls.app = app
+        cls.state = state
+
+    def test_get_status(self):
+        """GET /status returns harness and agent info."""
+        with patch("harness.health_check.check_all_agents", return_value={
+            "agents": [{"role": "skill", "health": "healthy", "clone_path": "/a"}],
+            "all_healthy": True,
+        }):
+            resp = self.client.get("/status")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("harness", data)
+        self.assertIn("agents", data)
+        self.assertEqual(data["harness"]["status"], "running")
+
+    def test_get_agents(self):
+        """GET /agents returns agent list."""
+        with patch("harness.health_check.check_all_agents", return_value={
+            "agents": [
+                {"role": "skill", "health": "healthy", "clone_path": "/a"},
+                {"role": "pm", "health": "stalled", "clone_path": "/b"},
+            ],
+            "all_healthy": False,
+        }):
+            resp = self.client.get("/agents")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("agents", data)
+        self.assertGreaterEqual(len(data["agents"]), 1)
+
+    def test_post_agents_all_start(self):
+        """POST /agents/all/start returns 200 with results."""
+        mock_result = {"role": "skill", "action": "skip", "success": True,
+                       "message": "skip: already running", "timestamp": 0}
+        with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+             patch("harness.boot_remote.boot_agent", return_value=mock_result):
+            resp = self.client.post("/agents/all/start")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("results", data)
+        self.assertEqual(len(data["results"]), 1)
+        self.assertTrue(data["results"][0]["success"])
+
+    def test_post_agents_all_stop_skips_stopped(self):
+        """POST /agents/all/stop skips already-stopped agents."""
+        with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+             patch("harness.boot_remote._get_clone_path", return_value="/fake"), \
+             patch("harness.boot_remote._has_stop_sentinel", return_value=True):
+            resp = self.client.post("/agents/all/stop")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["results"][0]["action"], "skip")
+        self.assertIn("Already stopped", data["results"][0]["message"])
+
+    def test_post_agent_start(self):
+        """POST /agents/{role}/start spawns agent."""
+        mock_result = {"role": "skill", "action": "spawn", "success": True,
+                       "message": "spawned", "timestamp": 0}
+        with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+             patch("harness.boot_remote.boot_agent", return_value=mock_result):
+            # Clear any cached running state
+            from harness import state as harness_state
+            if harness_state.get_agent("skill"):
+                harness_state.get_agent("skill").status = "stopped"
+            resp = self.client.post("/agents/skill/start")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertTrue(data["success"])
+
+    def test_post_agent_stop(self):
+        """POST /agents/{role}/stop writes sentinel."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            role_dir = Path(tmpdir) / ".squidsquad" / "skill"
+            role_dir.mkdir(parents=True)
+            with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+                 patch("harness.boot_remote._get_clone_path", return_value=tmpdir):
+                resp = self.client.post("/agents/skill/stop")
+            self.assertEqual(resp.status_code, 200)
+            self.assertTrue((role_dir / ".stop").exists())
+
+    def test_post_agent_restart(self):
+        """POST /agents/{role}/restart calls reboot."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            role_dir = Path(tmpdir) / ".squidsquad" / "skill"
+            role_dir.mkdir(parents=True)
+            with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+                 patch("harness.boot_remote._get_clone_path", return_value=tmpdir), \
+                 patch("harness.reboot_agent.reboot", return_value=0):
+                resp = self.client.post("/agents/skill/restart")
+            self.assertEqual(resp.status_code, 200)
+            data = resp.json()
+            self.assertTrue(data["success"])
+            self.assertEqual(data["action"], "restart")
+
+    def test_post_agent_restart_failure(self):
+        """POST /agents/{role}/restart reports failure."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            role_dir = Path(tmpdir) / ".squidsquad" / "skill"
+            role_dir.mkdir(parents=True)
+            with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+                 patch("harness.boot_remote._get_clone_path", return_value=tmpdir), \
+                 patch("harness.reboot_agent.reboot", return_value=1):
+                resp = self.client.post("/agents/skill/restart")
+            self.assertEqual(resp.status_code, 200)
+            data = resp.json()
+            self.assertFalse(data["success"])
+
+    def test_post_shutdown_returns_202(self):
+        """POST /shutdown returns 202 Accepted (non-blocking)."""
+        with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+             patch("harness.boot_remote._get_clone_path", return_value="/fake"), \
+             patch("harness.boot_remote._has_stop_sentinel", return_value=True), \
+             patch("harness.os._exit"):  # Prevent actual exit
+            resp = self.client.post("/shutdown")
+        self.assertEqual(resp.status_code, 202)
+        data = resp.json()
+        self.assertEqual(data["status"], "shutting_down")
+
+    def test_unknown_role_returns_404(self):
+        """POST /agents/{unknown}/start returns 404."""
+        with patch("harness.boot_remote._get_all_roles", return_value=["skill"]):
+            resp = self.client.post("/agents/nonexistent/start")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_agents_all_start_not_captured_by_role_param(self):
+        """POST /agents/all/start should NOT hit the {role} handler."""
+        mock_result = {"role": "skill", "action": "skip", "success": True,
+                       "message": "skip", "timestamp": 0}
+        with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+             patch("harness.boot_remote.boot_agent", return_value=mock_result):
+            resp = self.client.post("/agents/all/start")
+        # Should be 200 from start_all, not 404 from _validate_role("all")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("results", resp.json())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #4746

### Summary
Add 10 tests for diagnostics.py `generate_report()` and `is_public_repo()` — both had zero test coverage.

### Tests Added
- is_public_repo: public repo, private repo, missing field defaults private, gh command fails, invalid JSON
- generate_report: version in report, diagnostics entries included, no log file, version unknown on error, malformed log lines skipped

### QA Status
- [x] 22 diagnostics tests pass (12 original + 10 new)
- [x] Full regression passes