### PR TITLE
skill: #4765 — filter L4 project sub-skills by role identity

### DIFF
--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -310,14 +310,25 @@ def _assemble_claude(role_name: str) -> str:
             parts.append("")
             parts.append(variant_claude.read_text(encoding="utf-8").rstrip())
 
-    # Layer 4 — Project sub-skills (PM-owned, applied to all agents)
+    # Layer 4 — Project sub-skills (PM-owned, role-filtered)
     # Live project content is in .squidsquad/project/ (project-local).
     # references/sub-skills/project/ holds seed templates only.
+    # Filtering: shared-*.md → all roles, <identity>-*.md → matching role
+    # only, unprefixed files → all roles.
     project_skills_dir = REPO_ROOT / ".squidsquad" / "project"
     if project_skills_dir.is_dir():
+        role_identity = _get_entry_file_for_role(role_name)
+        known_prefixes = _list_known_role_identities()
         for skill_file in sorted(project_skills_dir.glob("*.md")):
-            content = skill_file.read_text(encoding="utf-8").rstrip()
             name = skill_file.stem
+            # Determine the file's target prefix (text before first hyphen)
+            file_prefix = name.split("-", 1)[0] if "-" in name else None
+            # Include if: shared, unprefixed, prefix not a known role, or
+            # prefix matches this role's identity
+            if file_prefix and file_prefix != "shared" and file_prefix in known_prefixes:
+                if file_prefix != role_identity:
+                    continue
+            content = skill_file.read_text(encoding="utf-8").rstrip()
             content = _strip_outer_markers(content, name)
             parts.append("")
             parts.append("---")

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -277,6 +277,85 @@ class TestComposeRole:
 
 
 # ---------------------------------------------------------------------------
+# Layer 4 — project sub-skill role filtering
+# ---------------------------------------------------------------------------
+
+class TestL4RoleFiltering:
+    """compose.py L4 should include only role-matched project sub-skills."""
+
+    def _setup_project_files(self, compose_env):
+        """Create project sub-skill files with role prefixes."""
+        # Ensure all role directories exist so known_prefixes includes them
+        roles_dir = compose_env / "references" / "roles"
+        for role in ("dm", "qa"):
+            role_dir = roles_dir / role
+            role_dir.mkdir(parents=True, exist_ok=True)
+            (role_dir / "instructions.md").write_text(
+                f"# {role.upper()} Agent\n", encoding="utf-8")
+        project_dir = compose_env / ".squidsquad" / "project"
+        project_dir.mkdir(parents=True, exist_ok=True)
+        (project_dir / "dev-instructions.md").write_text(
+            "## Dev Instructions\n\nDev-only content.", encoding="utf-8")
+        (project_dir / "pm-instructions.md").write_text(
+            "## PM Instructions\n\nPM-only content.", encoding="utf-8")
+        (project_dir / "dm-instructions.md").write_text(
+            "## DM Instructions\n\nDM-only content.", encoding="utf-8")
+        (project_dir / "qa-instructions.md").write_text(
+            "## QA Instructions\n\nQA-only content.", encoding="utf-8")
+        (project_dir / "shared-instructions.md").write_text(
+            "## Shared Instructions\n\nAll-role content.", encoding="utf-8")
+        (project_dir / "setup-upgrade-gate.md").write_text(
+            "## Setup Gate\n\nUnprefixed content.", encoding="utf-8")
+        return project_dir
+
+    def test_dev_role_gets_only_dev_and_shared(self, compose_env):
+        self._setup_project_files(compose_env)
+        with patch.object(compose, "ROLES_DIR", compose_env / "references" / "roles"), \
+             patch.object(compose, "SUB_SKILLS_DIR", compose_env / "references" / "sub-skills"), \
+             patch.object(compose, "REPO_ROOT", compose_env):
+            result = compose.compose_role("dev")
+        assert "Dev-only content" in result
+        assert "All-role content" in result
+        assert "Unprefixed content" in result
+        assert "PM-only content" not in result
+        assert "DM-only content" not in result
+        assert "QA-only content" not in result
+
+    def test_pm_role_gets_only_pm_and_shared(self, compose_env):
+        self._setup_project_files(compose_env)
+        with patch.object(compose, "ROLES_DIR", compose_env / "references" / "roles"), \
+             patch.object(compose, "SUB_SKILLS_DIR", compose_env / "references" / "sub-skills"), \
+             patch.object(compose, "REPO_ROOT", compose_env):
+            result = compose.compose_role("pm")
+        assert "PM-only content" in result
+        assert "All-role content" in result
+        assert "Unprefixed content" in result
+        assert "Dev-only content" not in result
+        assert "DM-only content" not in result
+        assert "QA-only content" not in result
+
+    def test_skill_variant_gets_dev_files(self, compose_env):
+        """skill agent maps to dev identity, should get dev-* files."""
+        self._setup_project_files(compose_env)
+        with patch.object(compose, "ROLES_DIR", compose_env / "references" / "roles"), \
+             patch.object(compose, "SUB_SKILLS_DIR", compose_env / "references" / "sub-skills"), \
+             patch.object(compose, "REPO_ROOT", compose_env):
+            result = compose.compose_role("skill")
+        assert "Dev-only content" in result
+        assert "All-role content" in result
+        assert "PM-only content" not in result
+
+    def test_no_project_dir_no_error(self, compose_env):
+        """No .squidsquad/project/ dir should not cause an error."""
+        with patch.object(compose, "ROLES_DIR", compose_env / "references" / "roles"), \
+             patch.object(compose, "SUB_SKILLS_DIR", compose_env / "references" / "sub-skills"), \
+             patch.object(compose, "REPO_ROOT", compose_env):
+            result = compose.compose_role("dev")
+        # Should compose fine without project sub-skills
+        assert "# Dev Agent" in result
+
+
+# ---------------------------------------------------------------------------
 # deploy_role
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #4765

### Summary
- compose.py L4 was including ALL `.squidsquad/project/*.md` files in every role's CLAUDE.md
- Now filters by filename prefix: `shared-*` and unprefixed → all roles, `<identity>-*` → matching role only
- dev-instructions.md no longer appears in DM/QA/PM templates

### Acceptance Criteria
- [x] `shared-*.md` included for ALL roles
- [x] `<role>-*.md` included ONLY for matching role identity
- [x] Unprefixed files (e.g. `setup-upgrade-gate.md`) included for all roles
- [x] `skill` agent correctly maps to `dev` identity and gets `dev-*` files

### Changes
- **Files**: `references/scripts/compose.py`, `tests/test_compose.py`
- **What**: Added role-prefix filtering in `_assemble_claude()` L4 section
- **Why**: Wasteful token budget — DM/QA had dev-specific instructions they'd ignore

### QA Status
- [x] Unit tests passing (4 new L4 filtering tests)
- [x] Full test suite passing (17 tests)
- [x] Acceptance criteria met