### PR TITLE
skill: #4879 — expand config.py test coverage

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -123,3 +123,239 @@ class TestSetFieldGuards:
         result = config_file.read_text(encoding="utf-8")
         assert result.count("0.29.0") == 1
         assert result.count("0.28.0") == 0
+
+
+# ---------------------------------------------------------------------------
+# get_field — public API (#4879)
+# ---------------------------------------------------------------------------
+
+class TestGetField:
+    """Test config.get_field() directly instead of duplicate regex."""
+
+    SAMPLE_CONFIG = (
+        "# Config\n\n"
+        "- **SquidSquad Version**: 0.31.0\n\n"
+        "## Project\n\n"
+        "- **Name**: TestProject\n"
+        "- **Repo**: test/repo\n\n"
+        "## Iteration Interval\n\n"
+        "- **Minutes**: 30\n\n"
+        "## PR Flow\n\n"
+        "- **Enabled**: yes\n\n"
+        "## Improvement Scanning\n\n"
+        "- **Enabled**: no\n\n"
+        "## Aliases\n\n"
+        "- **skill**: SkillBot\n"
+        "- **pm**: PMBot\n"
+    )
+
+    def test_get_known_field(self, tmp_path):
+        """get_field returns correct value for a FIELD_MAP short name."""
+        f = tmp_path / "config.md"
+        f.write_text(self.SAMPLE_CONFIG, encoding="utf-8")
+        with patch.object(config, "CONFIG_PATH", f):
+            assert config.get_field("version") == "0.31.0"
+
+    def test_get_section_scoped_field(self, tmp_path):
+        """get_field resolves section-scoped fields correctly."""
+        f = tmp_path / "config.md"
+        f.write_text(self.SAMPLE_CONFIG, encoding="utf-8")
+        with patch.object(config, "CONFIG_PATH", f):
+            assert config.get_field("project-name") == "TestProject"
+            assert config.get_field("interval") == "30"
+
+    def test_get_disambiguates_enabled_fields(self, tmp_path):
+        """get_field returns the correct 'Enabled' for the right section."""
+        f = tmp_path / "config.md"
+        f.write_text(self.SAMPLE_CONFIG, encoding="utf-8")
+        with patch.object(config, "CONFIG_PATH", f):
+            assert config.get_field("pr-flow") == "yes"
+            assert config.get_field("improvement-scanning") == "no"
+
+    def test_get_unknown_field_exits(self, tmp_path):
+        """get_field exits with code 1 when field not found."""
+        f = tmp_path / "config.md"
+        f.write_text(self.SAMPLE_CONFIG, encoding="utf-8")
+        with patch.object(config, "CONFIG_PATH", f):
+            with pytest.raises(SystemExit):
+                config.get_field("nonexistent-field")
+
+    def test_get_raw_field_name(self, tmp_path):
+        """get_field falls back to raw field name search when not in FIELD_MAP."""
+        f = tmp_path / "config.md"
+        f.write_text(self.SAMPLE_CONFIG, encoding="utf-8")
+        with patch.object(config, "CONFIG_PATH", f):
+            assert config.get_field("Repo") == "test/repo"
+
+
+# ---------------------------------------------------------------------------
+# set_field — happy path (#4879)
+# ---------------------------------------------------------------------------
+
+class TestSetFieldHappyPath:
+    """Test set_field actually writes the new value correctly."""
+
+    def test_set_sectionless_field(self, tmp_path):
+        """set_field updates a top-level field."""
+        config_text = (
+            "# Config\n\n"
+            "- **SquidSquad Version**: 0.28.0\n\n"
+            "## Agents\n\n"
+            "- **Dev Agents**: skill\n"
+        )
+        f = tmp_path / "config.md"
+        f.write_text(config_text, encoding="utf-8")
+        with patch.object(config, "CONFIG_PATH", f):
+            result = config.set_field("version", "0.29.0")
+        assert result == "0.29.0"
+        content = f.read_text(encoding="utf-8")
+        assert "0.29.0" in content
+        assert "0.28.0" not in content
+
+    def test_set_section_scoped_field(self, tmp_path):
+        """set_field updates a field within the correct section."""
+        config_text = (
+            "# Config\n\n"
+            "## Iteration Interval\n\n"
+            "- **Minutes**: 30\n\n"
+            "## PR Flow\n\n"
+            "- **Enabled**: yes\n"
+        )
+        f = tmp_path / "config.md"
+        f.write_text(config_text, encoding="utf-8")
+        with patch.object(config, "CONFIG_PATH", f):
+            config.set_field("interval", "45")
+        content = f.read_text(encoding="utf-8")
+        assert "- **Minutes**: 45" in content
+        # PR Flow Enabled should be unchanged
+        assert "- **Enabled**: yes" in content
+
+    def test_set_field_not_found_exits(self, tmp_path):
+        """set_field exits when the field doesn't exist in config."""
+        f = tmp_path / "config.md"
+        f.write_text("# Config\n\n- **Other**: value\n", encoding="utf-8")
+        with patch.object(config, "CONFIG_PATH", f):
+            with pytest.raises(SystemExit):
+                config.set_field("version", "1.0.0")
+
+
+# ---------------------------------------------------------------------------
+# get_alias (#4879)
+# ---------------------------------------------------------------------------
+
+class TestGetAlias:
+    """Test config.get_alias() with and without alias values."""
+
+    def test_alias_present(self, tmp_path):
+        """get_alias returns the configured alias."""
+        config_text = (
+            "# Config\n\n"
+            "## Aliases\n\n"
+            "- **skill**: SkillBot\n"
+            "- **pm**: PMBot\n"
+        )
+        f = tmp_path / "config.md"
+        f.write_text(config_text, encoding="utf-8")
+        with patch.object(config, "CONFIG_PATH", f):
+            assert config.get_alias("skill") == "SkillBot"
+            assert config.get_alias("pm") == "PMBot"
+
+    def test_alias_missing_falls_back(self, tmp_path):
+        """get_alias returns bare role name when no alias configured."""
+        config_text = "# Config\n\n## Aliases\n\n"
+        f = tmp_path / "config.md"
+        f.write_text(config_text, encoding="utf-8")
+        with patch.object(config, "CONFIG_PATH", f):
+            assert config.get_alias("skill") == "skill"
+
+    def test_alias_unknown_role(self, tmp_path):
+        """get_alias for a role not in FIELD_MAP returns bare role name."""
+        config_text = "# Config\n\n"
+        f = tmp_path / "config.md"
+        f.write_text(config_text, encoding="utf-8")
+        with patch.object(config, "CONFIG_PATH", f):
+            assert config.get_alias("unknown-role") == "unknown-role"
+
+
+# ---------------------------------------------------------------------------
+# detect_schema_version (#4879)
+# ---------------------------------------------------------------------------
+
+class TestDetectSchemaVersion:
+    """Test config.detect_schema_version()."""
+
+    def test_v1_explicit(self):
+        text = "- **Architecture Version**: 1\n"
+        assert config.detect_schema_version(text) == 1
+
+    def test_v2_explicit(self):
+        text = "- **Architecture Version**: 2\n"
+        assert config.detect_schema_version(text) == 2
+
+    def test_missing_field_defaults_v1(self):
+        text = "# Config\n\n- **Version**: 0.31.0\n"
+        assert config.detect_schema_version(text) == 1
+
+    def test_non_integer_defaults_v1(self):
+        text = "- **Architecture Version**: beta\n"
+        assert config.detect_schema_version(text) == 1
+
+    def test_v3_returns_v2(self):
+        """Values >= 2 are treated as v2."""
+        text = "- **Architecture Version**: 3\n"
+        assert config.detect_schema_version(text) == 2
+
+
+# ---------------------------------------------------------------------------
+# _parse_sections (#4879)
+# ---------------------------------------------------------------------------
+
+class TestParseSections:
+    """Test internal section parsing for correctness."""
+
+    def test_splits_sections(self):
+        text = (
+            "preamble\n"
+            "## Section A\n"
+            "content a\n"
+            "## Section B\n"
+            "content b\n"
+        )
+        sections = config._parse_sections(text)
+        assert "Section A" in sections
+        assert "Section B" in sections
+        assert "content a" in sections["Section A"]
+        assert "content b" in sections["Section B"]
+
+    def test_preamble_in_empty_key(self):
+        text = "top level\n## First\ndata\n"
+        sections = config._parse_sections(text)
+        assert "top level" in sections[""]
+
+    def test_heading_whitespace_stripped(self):
+        text = "## Padded Section  \ndata\n"
+        sections = config._parse_sections(text)
+        assert "Padded Section" in sections
+
+
+# ---------------------------------------------------------------------------
+# dump_all (#4879)
+# ---------------------------------------------------------------------------
+
+class TestDumpAll:
+    """Test config.dump_all() returns parsed fields."""
+
+    def test_returns_dict(self, tmp_path):
+        config_text = (
+            "# Config\n\n"
+            "- **SquidSquad Version**: 0.31.0\n\n"
+            "## Iteration Interval\n\n"
+            "- **Minutes**: 30\n"
+        )
+        f = tmp_path / "config.md"
+        f.write_text(config_text, encoding="utf-8")
+        with patch.object(config, "CONFIG_PATH", f):
+            result = config.dump_all()
+        assert isinstance(result, dict)
+        assert result["version"] == "0.31.0"
+        assert result["interval"] == "30"


### PR DESCRIPTION
Fixes #4879

### Summary
Expanded tests/test_config.py with 20 new unit tests covering config.py's public API directly. Previous tests used a duplicate regex instead of calling the module's functions.

### Changes
- **File**: tests/test_config.py
- **Added**: TestGetField (5), TestSetFieldHappyPath (3), TestGetAlias (3), TestDetectSchemaVersion (5), TestParseSections (3), TestDumpAll (1)
- **Coverage ratio**: 0.3 to 0.65

### QA Status
- [x] 32/32 config tests pass
- [x] Full suite: 1166 passed