### PR TITLE
skill: #4919 — fix vault_remember reset_writes silent no-op

### DIFF
--- a/references/scripts/vault_remember.py
+++ b/references/scripts/vault_remember.py
@@ -133,41 +133,39 @@ def write_budget(role):
     return remaining
 
 
+def _upsert_vault_writes(role, new_value):
+    """Set the Vault Writes This Cycle field, creating it if absent (#4919)."""
+    ws_text = _read_working_state(role)
+    match = re.search(r'Vault Writes This Cycle\*\*:\s*(\d+)', ws_text)
+    if match:
+        _write_working_state_field(
+            role,
+            r'(Vault Writes This Cycle\*\*:\s*)\d+',
+            rf'\g<1>{new_value}',
+        )
+    else:
+        ws_path = SQUIDSQUAD_DIR / role / "working-state.md"
+        if ws_path.exists():
+            text = ws_path.read_text(encoding="utf-8")
+            text += f"\n- **Vault Writes This Cycle**: {new_value}\n"
+            ws_path.write_text(text, encoding="utf-8")
+    return new_value
+
+
 def inc_writes(role):
     """Increment vault write counter in working-state.md."""
     ws_text = _read_working_state(role)
     match = re.search(r'Vault Writes This Cycle\*\*:\s*(\d+)', ws_text)
     current = int(match.group(1)) if match else 0
     new_count = current + 1
-
-    if match:
-        _write_working_state_field(
-            role,
-            r'(Vault Writes This Cycle\*\*:\s*)\d+',
-            rf'\g<1>{new_count}',
-        )
-    else:
-        # Add the field if missing
-        ws_path = SQUIDSQUAD_DIR / role / "working-state.md"
-        if ws_path.exists():
-            text = ws_path.read_text(encoding="utf-8")
-            text += f"\n- **Vault Writes This Cycle**: {new_count}\n"
-            ws_path.write_text(text, encoding="utf-8")
-
+    _upsert_vault_writes(role, new_count)
     print(str(new_count))
     return new_count
 
 
 def reset_writes(role):
     """Reset vault write counter to 0."""
-    ws_text = _read_working_state(role)
-    match = re.search(r'Vault Writes This Cycle\*\*:\s*(\d+)', ws_text)
-    if match:
-        _write_working_state_field(
-            role,
-            r'(Vault Writes This Cycle\*\*:\s*)\d+',
-            r'\g<1>0',
-        )
+    _upsert_vault_writes(role, 0)
     print("0")
     return 0
 

--- a/tests/test_vault_remember.py
+++ b/tests/test_vault_remember.py
@@ -204,3 +204,63 @@ class TestEffectiveConfidence:
             with pytest.raises(SystemExit) as exc_info:
                 vault_remember.effective_confidence(str(note))
             assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# inc_writes / reset_writes / _upsert_vault_writes — regression #4919
+# ---------------------------------------------------------------------------
+
+class TestIncWrites:
+    def test_increments_existing_counter(self, tmp_path):
+        role_dir = tmp_path / "skill"
+        role_dir.mkdir()
+        ws = role_dir / "working-state.md"
+        ws.write_text(
+            "# Working State\n\n- **Task**: none\n"
+            "- **Vault Writes This Cycle**: 1\n",
+            encoding="utf-8",
+        )
+        with patch.object(vault_remember, "SQUIDSQUAD_DIR", tmp_path):
+            result = vault_remember.inc_writes("skill")
+        assert result == 2
+        assert "**: 2" in ws.read_text(encoding="utf-8")
+
+    def test_creates_field_when_absent(self, tmp_path):
+        role_dir = tmp_path / "skill"
+        role_dir.mkdir()
+        ws = role_dir / "working-state.md"
+        ws.write_text("# Working State\n\n- **Task**: none\n", encoding="utf-8")
+        with patch.object(vault_remember, "SQUIDSQUAD_DIR", tmp_path):
+            result = vault_remember.inc_writes("skill")
+        assert result == 1
+        assert "Vault Writes This Cycle**: 1" in ws.read_text(encoding="utf-8")
+
+
+class TestResetWrites:
+    def test_resets_existing_counter(self, tmp_path):
+        role_dir = tmp_path / "skill"
+        role_dir.mkdir()
+        ws = role_dir / "working-state.md"
+        ws.write_text(
+            "# Working State\n\n- **Task**: none\n"
+            "- **Vault Writes This Cycle**: 3\n",
+            encoding="utf-8",
+        )
+        with patch.object(vault_remember, "SQUIDSQUAD_DIR", tmp_path):
+            result = vault_remember.reset_writes("skill")
+        assert result == 0
+        assert "**: 0" in ws.read_text(encoding="utf-8")
+
+    def test_creates_field_when_absent(self, tmp_path):
+        """Regression #4919: reset_writes must create the field if missing."""
+        role_dir = tmp_path / "skill"
+        role_dir.mkdir()
+        ws = role_dir / "working-state.md"
+        ws.write_text("# Working State\n\n- **Task**: none\n", encoding="utf-8")
+        with patch.object(vault_remember, "SQUIDSQUAD_DIR", tmp_path):
+            result = vault_remember.reset_writes("skill")
+        assert result == 0
+        content = ws.read_text(encoding="utf-8")
+        assert "Vault Writes This Cycle**: 0" in content, (
+            "reset_writes must create the field when absent (#4919)"
+        )


### PR DESCRIPTION
Fixes #4919

### Summary
reset_writes silently did nothing when the Vault Writes This Cycle field was absent. Extracted shared _upsert_vault_writes() helper used by both inc_writes and reset_writes.

### Changes
- **Files**: references/scripts/vault_remember.py, tests/test_vault_remember.py
- **What**: Extracted _upsert_vault_writes(), simplified both functions
- **Why**: reset_writes left counter absent instead of initialized to 0

### QA Status
- [x] 19/19 vault_remember tests pass
- [x] Full suite: 1168 passed, 0 failed