### PR TITLE
skill: #4918 — replace deprecated tempfile.mktemp in compose.py

### DIFF
--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -353,10 +353,13 @@ def compose_role(role_name: str) -> str:
     # Step 1: Assemble template from 3 layers
     assembled = _assemble_claude(role_name)
 
-    # Write to a temp file for include resolution (reuses existing logic)
+    # Write to a temp file for include resolution (reuses existing logic).
+    # Use NamedTemporaryFile to avoid TOCTOU race from deprecated mktemp (#4918).
     import tempfile
-    tmp = Path(tempfile.mktemp(suffix=".md"))
-    tmp.write_text(assembled, encoding="utf-8")
+    with tempfile.NamedTemporaryFile(suffix=".md", delete=False, mode="w",
+                                     encoding="utf-8") as tf:
+        tf.write(assembled)
+        tmp = Path(tf.name)
 
     try:
         # Step 2: Resolve includes

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -885,3 +885,21 @@ class TestAgentComposeEnabled:
         # Prompt must be piped via input kwarg
         assert "input" in kwargs, "prompt must be passed via input= kwarg"
         assert "original content" in kwargs["input"]
+
+
+# ---------------------------------------------------------------------------
+# Regression #4918: no deprecated tempfile.mktemp()
+# ---------------------------------------------------------------------------
+
+class TestNoDeprecatedMktemp:
+    """compose.py must not use deprecated tempfile.mktemp()."""
+
+    def test_source_does_not_call_mktemp(self):
+        import inspect
+        source = inspect.getsource(compose)
+        # mktemp() calls — exclude comments
+        lines = [l for l in source.splitlines()
+                 if "mktemp" in l and not l.strip().startswith("#")]
+        assert lines == [], (
+            f"compose.py still uses deprecated tempfile.mktemp(): {lines}"
+        )


### PR DESCRIPTION
Fixes #4918

### Summary
Replaced deprecated tempfile.mktemp() with NamedTemporaryFile(delete=False) to eliminate TOCTOU race condition.

### Changes
- **Files**: references/scripts/compose.py, tests/test_compose.py
- **What**: Atomic file creation via NamedTemporaryFile, regression test
- **Why**: mktemp() is deprecated — returns path without creating file

### QA Status
- [x] 95/95 compose tests pass
- [x] compose deploy verified functional
- [x] Full suite: 1168 passed, 0 failed