### PR TITLE
skill: #4967 — PM planning artifact quality requirements

### DIFF
--- a/.squidsquad/pm/CLAUDE.md
+++ b/.squidsquad/pm/CLAUDE.md
@@ -1897,6 +1897,16 @@ These instructions apply to the PM agent on this project.
 - **CQ specs required for instruction changes**: any task touching LLM-consumed instructions needs comprehension questions in TEST-PLAN.md.
 - **Comprehension testing standard**: spawn fresh agent, give only modified files, answers must come from files alone.
 
+### Planning Artifact Quality (#4967)
+
+Task bodies and CONTEXT.md must include PRD-quality output when complexity warrants it:
+
+- **Implementation sequence** (always): recommended step order / migration path. What gets done first, what depends on what.
+- **Mermaid diagrams** (when task touches 3+ files, has state machine logic, or involves flow/pipeline changes): architecture diagrams, sequence diagrams, or state charts embedded in the task body or CONTEXT.md.
+- **PRD format** (for epic-scale tasks): vision statement, user stories, what gets added, what gets removed, migration impact.
+
+These requirements apply during Phase 3 (Planning) when PM creates CONTEXT.md and the task body. Simple bug fixes and single-file changes do not need diagrams or PRD format — use judgment on complexity threshold.
+
 ### Soul & Vault
 
 - **Soul shepherd**: 5-category evaluation (deliverable-type, tech-stack, domain-vocabulary, quality-preference, user-persona) on every new task/bug.

--- a/.squidsquad/project/pm-instructions.md
+++ b/.squidsquad/project/pm-instructions.md
@@ -29,6 +29,16 @@ These instructions apply to the PM agent on this project.
 - **CQ specs required for instruction changes**: any task touching LLM-consumed instructions needs comprehension questions in TEST-PLAN.md.
 - **Comprehension testing standard**: spawn fresh agent, give only modified files, answers must come from files alone.
 
+### Planning Artifact Quality (#4967)
+
+Task bodies and CONTEXT.md must include PRD-quality output when complexity warrants it:
+
+- **Implementation sequence** (always): recommended step order / migration path. What gets done first, what depends on what.
+- **Mermaid diagrams** (when task touches 3+ files, has state machine logic, or involves flow/pipeline changes): architecture diagrams, sequence diagrams, or state charts embedded in the task body or CONTEXT.md.
+- **PRD format** (for epic-scale tasks): vision statement, user stories, what gets added, what gets removed, migration impact.
+
+These requirements apply during Phase 3 (Planning) when PM creates CONTEXT.md and the task body. Simple bug fixes and single-file changes do not need diagrams or PRD format — use judgment on complexity threshold.
+
 ### Soul & Vault
 
 - **Soul shepherd**: 5-category evaluation (deliverable-type, tech-stack, domain-vocabulary, quality-preference, user-persona) on every new task/bug.


### PR DESCRIPTION
Fixes #4967

### Summary
Added Planning Artifact Quality section to PM L4 project instructions requiring implementation sequence, mermaid diagrams (3+ files), and PRD format (epic-scale tasks).

### Changes
- .squidsquad/project/pm-instructions.md — new section
- .squidsquad/pm/CLAUDE.md — recomposed

### QA Status
- [x] 1172 passed, 0 failed