### PR TITLE
skill: #4991 — fix PR lifecycle flow ordering and gaps

### DIFF
--- a/.squidsquad/pm/CLAUDE.md
+++ b/.squidsquad/pm/CLAUDE.md
@@ -503,7 +503,7 @@ For each result:
    **PR Flow gate** (if PR Flow `yes` and a PR exists for this issue):
    - Check Auto Merge: `python references/scripts/config.py get auto-merge`
    - Check per-ticket override: look for `review:human-required` label on the issue.
-   - **Auto Merge ON + no `review:human-required`**: merge PR directly (`python references/scripts/git_ops.py pr-merge [PR_NUMBER]`), then transition to `Pending Ship`.
+   - **Auto Merge ON + no `review:human-required`**: convert draft PR to ready first (`python references/scripts/git_ops.py pr-ready [PR_NUMBER]`), then merge (`python references/scripts/git_ops.py pr-merge [PR_NUMBER]`), then transition to `Pending Ship`.
    - **Auto Merge OFF or `review:human-required`**: transition to `Pending Human Review` (`python references/scripts/tracker.py transition [NUMBER] pending-test pending-human-review --role pm-lead`).
    - If PR Flow `no` or no PR exists: proceed directly to `Pending Ship`.
 

--- a/.squidsquad/skill/CLAUDE.md
+++ b/.squidsquad/skill/CLAUDE.md
@@ -795,7 +795,7 @@ Split commits into code (feature branch) and state (main):
      Then fix the issues and push to the branch.
    - If human posted new comments: read and address them (fix code, answer questions, reply on PR)
    - A PR must NEVER be in ready state while the agent is actively pushing commits to it.
-   - After all fixes are pushed and the task moves to pending-test, the tracker auto-converts the PR back to ready.
+   - After all fixes are pushed and the task moves to pending-test, `cycle_post.py` commits and creates the PR first, then the status transition triggers auto-conversion of the draft PR to ready.
 
 5. **When PR Flow `yes`**: check own open PRs for merge conflicts and rebase:
    ```bash

--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -311,7 +311,14 @@ def _do_commit_push(data, role):
                     _run(["git", "checkout", branch], check=False)
                 result = _run_script("git_ops.py", "pr-create", pr_title, pr_body)
                 if result.returncode == 0:
-                    print(f"  PR created: {result.stdout.strip()}")
+                    pr_url = result.stdout.strip().split("PR created: ")[-1].strip()
+                    print(f"  PR created: {pr_url}")
+                    # Comment PR URL on tracker issue (#4991 GAP-9)
+                    issue_number = branch.split("/")[-1] if "/" in branch else ""
+                    if issue_number.isdigit() and pr_url:
+                        _run_script("tracker.py", "comment", issue_number,
+                                    "--role", f"{role}-lead",
+                                    "--message", f"PR opened: {pr_url}")
                 # Switch back — state commit below needs working branch
                 if cur_branch and cur_branch != branch:
                     _run(["git", "checkout", cur_branch], check=False)
@@ -529,24 +536,25 @@ def main():
     print(f"[🦑 {ts}] cycle_post starting for {role} (cycle {data.get('cycle_number', '?')})...")
     _write_status_bar(role, "committing", f"git-commit — Post-processing cycle...")
 
-    # 1. Status transitions (before commits — so tracker reflects reality)
+    # 1. Commit and push FIRST — PR must exist before status transitions (#4991 GAP-1)
+    #    Status transitions trigger auto-conversion (draft→ready) which needs the PR.
+    _do_commit_push(data, role)
+
+    # 2. Status transitions (after commits — PR exists for auto-conversion)
     _do_status_transitions(data, role)
 
-    # 2. Tracker comments
+    # 3. Tracker comments
     _do_tracker_comments(data, role)
 
-    # 3. Working state update
+    # 4. Working state update
     _do_working_state_update(data, role)
 
-    # 4. Iteration log
+    # 5. Iteration log
     _do_iteration_log(data, role)
 
-    # 5. Version bump (DM only)
+    # 6. Version bump (DM only)
     if role == "dm":
         _do_version_bump(data, role)
-
-    # 6. Commit and push
-    _do_commit_push(data, role)
 
     # 7. Legacy restart sentinel (deprecated — backward compat for one version)
     restarting = _do_restart_sentinel(data, role)

--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -237,6 +237,30 @@ def pr_create(title, body):
     return url
 
 
+def pr_ready(pr_number):
+    """Convert a draft PR to ready (#4991 GAP-5). Uses forge adapter pattern."""
+    try:
+        from forge_adapter import get_adapter, _read_forge_config
+        config = _read_forge_config()
+        if config["provider"] not in ("github", ""):
+            adapter = get_adapter(config)
+            adapter.pr_ready(pr_number)
+            print(f"PR #{pr_number} converted to ready (via adapter)")
+            return True
+    except (ImportError, AttributeError, Exception):
+        pass
+
+    # Default: gh CLI
+    result = _run_list(
+        ["gh", "pr", "ready", str(pr_number)], check=False)
+    if result.returncode != 0:
+        print(f"ERROR: Failed to convert PR #{pr_number} to ready: {result.stderr}",
+              file=sys.stderr)
+        return False
+    print(f"PR #{pr_number} converted to ready")
+    return True
+
+
 def pr_merge(pr_number, strategy="squash"):
     """Merge a PR. Uses forge adapter for non-GitHub backends,
     gh CLI for GitHub. Returns (success, message).
@@ -622,6 +646,12 @@ def main():
             print("Usage: git_ops.py pr-create <title> <body>", file=sys.stderr)
             sys.exit(1)
         pr_create(rest[0], " ".join(rest[1:]))
+    elif cmd == "pr-ready":
+        if not rest:
+            print("Usage: git_ops.py pr-ready <pr-number>", file=sys.stderr)
+            sys.exit(1)
+        success = pr_ready(rest[0])
+        sys.exit(0 if success else 1)
     elif cmd == "pr-merge":
         if not rest:
             print("Usage: git_ops.py pr-merge <pr-number> [--strategy squash|merge|rebase]", file=sys.stderr)

--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -750,9 +750,11 @@ def _convert_draft_pr_to_ready(number):
                 parts = head.split("/")
                 if len(parts) >= 3 and parts[2] == str(number):
                     if pr.get("isDraft", False):
-                        # Forgejo API: PATCH /repos/{owner}/{repo}/pulls/{number}
-                        # Not all adapters support this — fall through silently
-                        pass
+                        # Convert draft to ready via forge adapter (#4991 GAP-3)
+                        try:
+                            adapter.pr_ready(pr.get("number"))
+                        except (AttributeError, Exception):
+                            pass  # Adapter may not support pr_ready
         except Exception:
             pass
         return

--- a/references/sub-skills/common/git-commit.md
+++ b/references/sub-skills/common/git-commit.md
@@ -89,7 +89,7 @@ Split commits into code (feature branch) and state (main):
      Then fix the issues and push to the branch.
    - If human posted new comments: read and address them (fix code, answer questions, reply on PR)
    - A PR must NEVER be in ready state while the agent is actively pushing commits to it.
-   - After all fixes are pushed and the task moves to pending-test, the tracker auto-converts the PR back to ready.
+   - After all fixes are pushed and the task moves to pending-test, `cycle_post.py` commits and creates the PR first, then the status transition triggers auto-conversion of the draft PR to ready.
 
 5. **When PR Flow `yes`**: check own open PRs for merge conflicts and rebase:
    ```bash

--- a/references/sub-skills/roles/pm/testing-and-verification.md
+++ b/references/sub-skills/roles/pm/testing-and-verification.md
@@ -91,7 +91,7 @@ For each result:
    **PR Flow gate** (if PR Flow `yes` and a PR exists for this issue):
    - Check Auto Merge: `python references/scripts/config.py get auto-merge`
    - Check per-ticket override: look for `review:human-required` label on the issue.
-   - **Auto Merge ON + no `review:human-required`**: merge PR directly (`python references/scripts/git_ops.py pr-merge [PR_NUMBER]`), then transition to `Pending Ship`.
+   - **Auto Merge ON + no `review:human-required`**: convert draft PR to ready first (`python references/scripts/git_ops.py pr-ready [PR_NUMBER]`), then merge (`python references/scripts/git_ops.py pr-merge [PR_NUMBER]`), then transition to `Pending Ship`.
    - **Auto Merge OFF or `review:human-required`**: transition to `Pending Human Review` (`python references/scripts/tracker.py transition [NUMBER] pending-test pending-human-review --role pm-lead`).
    - If PR Flow `no` or no PR exists: proceed directly to `Pending Ship`.
 

--- a/tests/test_tracker_authority.py
+++ b/tests/test_tracker_authority.py
@@ -926,6 +926,52 @@ class TestDraftPRConversion:
         tracker.transition(42, "pending-test", "pending-ship", role="qa-lead")
 
 
+class TestForgejoAdapterDraftConversion:
+    """Regression #4991 GAP-3: Forgejo adapter must call pr_ready(), not pass."""
+
+    def test_forgejo_adapter_calls_pr_ready(self, monkeypatch):
+        """When forge adapter is available, _convert_draft_pr_to_ready uses it."""
+        from unittest.mock import MagicMock
+        mock_adapter = MagicMock()
+        mock_adapter.list_prs.return_value = [
+            {"number": 77, "headRefName": "squidsquad/skill/42", "isDraft": True}
+        ]
+
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: mock_adapter)
+
+        tracker._convert_draft_pr_to_ready(42)
+
+        mock_adapter.pr_ready.assert_called_once_with(77)
+
+    def test_forgejo_adapter_skips_non_draft(self, monkeypatch):
+        """Forgejo adapter skips non-draft PRs."""
+        from unittest.mock import MagicMock
+        mock_adapter = MagicMock()
+        mock_adapter.list_prs.return_value = [
+            {"number": 77, "headRefName": "squidsquad/skill/42", "isDraft": False}
+        ]
+
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: mock_adapter)
+
+        tracker._convert_draft_pr_to_ready(42)
+
+        mock_adapter.pr_ready.assert_not_called()
+
+    def test_forgejo_adapter_no_matching_pr(self, monkeypatch):
+        """Forgejo adapter handles no matching PR gracefully."""
+        from unittest.mock import MagicMock
+        mock_adapter = MagicMock()
+        mock_adapter.list_prs.return_value = [
+            {"number": 77, "headRefName": "squidsquad/pm/99", "isDraft": True}
+        ]
+
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: mock_adapter)
+
+        tracker._convert_draft_pr_to_ready(42)
+
+        mock_adapter.pr_ready.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # list_issues — label construction and status filtering (#471)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #4991

### Summary
Fix 5 of 9 gaps in PR lifecycle flow identified by e2e audit.

### Changes
- cycle_post.py: commit+PR before transitions (GAP-1), PR URL on tracker (GAP-9)
- tracker.py: Forgejo adapter calls pr_ready() (GAP-3)
- git_ops.py: pr-ready subcommand (GAP-5)
- git-commit.md: Fixed false auto-conversion claim (GAP-2)

### QA Status
- [x] 1172 passed, 0 failed