### PR TITLE
skill: #5126 — guard version bump against no staged changes

### DIFF
--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -407,6 +407,13 @@ def _do_version_bump(data, role):
     if skill_md.exists():
         bump_files.append("SKILL.md")
     _run(["git", "add", "--"] + bump_files)
+
+    # Guard: skip commit/tag/push if nothing was staged (#5126)
+    diff_check = _run(["git", "diff", "--cached", "--quiet"])
+    if diff_check.returncode == 0:
+        print(f"  Version bump v{new_version}: no staged changes — skipping commit/tag/push")
+        return
+
     _run(["git", "commit", "-m", f"chore: bump version to v{new_version}"])
 
     # Check if tag exists

--- a/tests/test_feat_3494_version_bump.py
+++ b/tests/test_feat_3494_version_bump.py
@@ -102,3 +102,77 @@ class TestVersionBumpStaging:
         assert len(add_calls) == 1
         add_cmd = add_calls[0]
         assert "SKILL.md" not in add_cmd
+
+
+class TestVersionBumpNoStagedChanges:
+    """#5126 — skip commit/tag/push when nothing was staged."""
+
+    def test_skips_commit_tag_push_when_no_staged_changes(self, tmp_path, monkeypatch):
+        """If git diff --cached --quiet returns 0 (no changes), skip commit/tag/push."""
+        monkeypatch.setattr(cycle_post, "REPO_ROOT", tmp_path)
+
+        squid = tmp_path / ".squidsquad"
+        squid.mkdir()
+        config_md = squid / "config.md"
+        config_md.write_text("- **SquidSquad Version**: 0.27.0\n", encoding="utf-8")
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("# Changelog\n", encoding="utf-8")
+
+        run_calls = []
+        def fake_run(cmd, check=False):
+            run_calls.append(cmd)
+            result = MagicMock()
+            result.stdout = ""
+            # git diff --cached --quiet returns 0 when nothing staged
+            if cmd[:4] == ["git", "diff", "--cached", "--quiet"]:
+                result.returncode = 0
+            else:
+                result.returncode = 0
+            return result
+        monkeypatch.setattr(cycle_post, "_run", fake_run)
+        monkeypatch.setattr(cycle_post, "_run_script", lambda *a: None)
+
+        data = {"version_bump": {"new_version": "0.28.0", "items_included": []}}
+        cycle_post._do_version_bump(data, "dm")
+
+        # Should NOT have commit, tag, or push calls
+        commit_calls = [c for c in run_calls if c[:2] == ["git", "commit"]]
+        tag_calls = [c for c in run_calls if c[:2] == ["git", "tag"] and "-l" not in c]
+        push_calls = [c for c in run_calls if c[:2] == ["git", "push"]]
+        assert len(commit_calls) == 0, f"Unexpected commit: {commit_calls}"
+        assert len(tag_calls) == 0, f"Unexpected tag: {tag_calls}"
+        assert len(push_calls) == 0, f"Unexpected push: {push_calls}"
+
+    def test_proceeds_when_staged_changes_exist(self, tmp_path, monkeypatch):
+        """If git diff --cached --quiet returns 1 (has changes), proceed normally."""
+        monkeypatch.setattr(cycle_post, "REPO_ROOT", tmp_path)
+
+        squid = tmp_path / ".squidsquad"
+        squid.mkdir()
+        config_md = squid / "config.md"
+        config_md.write_text("- **SquidSquad Version**: 0.27.0\n", encoding="utf-8")
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("# Changelog\n", encoding="utf-8")
+
+        run_calls = []
+        def fake_run(cmd, check=False):
+            run_calls.append(cmd)
+            result = MagicMock()
+            result.stdout = ""
+            # git diff --cached --quiet returns 1 when changes are staged
+            if cmd[:4] == ["git", "diff", "--cached", "--quiet"]:
+                result.returncode = 1
+            else:
+                result.returncode = 0
+            return result
+        monkeypatch.setattr(cycle_post, "_run", fake_run)
+        monkeypatch.setattr(cycle_post, "_run_script", lambda *a: None)
+
+        data = {"version_bump": {"new_version": "0.28.0", "items_included": []}}
+        cycle_post._do_version_bump(data, "dm")
+
+        # Should have commit and push calls
+        commit_calls = [c for c in run_calls if c[:2] == ["git", "commit"]]
+        push_calls = [c for c in run_calls if c[:2] == ["git", "push"]]
+        assert len(commit_calls) == 1, f"Expected 1 commit, got {commit_calls}"
+        assert len(push_calls) >= 1, f"Expected push calls, got {push_calls}"


### PR DESCRIPTION
Closes #5126

### Summary
Added a `git diff --cached --quiet` guard in `_do_version_bump` to skip commit/tag/push when no files were actually staged. Prevents duplicate tag creation and failed commits on idempotent re-runs.

### Acceptance Criteria
- [ ] `_do_version_bump` checks for staged changes before committing
- [ ] Skips commit, tag, and push when nothing was staged
- [ ] Logs a warning when skipping

### Changes
- **Files**: `references/scripts/cycle_post.py`, `tests/test_feat_3494_version_bump.py`
- **What**: Added `git diff --cached --quiet` check after `git add`. If returncode 0 (no changes), early returns with warning.
- **Why**: Prevents failed commits and duplicate tag creation on idempotent re-runs.

### QA Status
- [x] Unit tests passing (17/17 full suite)
- [x] Regression tests added (2 new: skip + proceed)
- [x] Acceptance criteria met