### PR TITLE
fix: agents boot with no startup instructions

### DIFF
--- a/references/scripts/thin_launcher.py
+++ b/references/scripts/thin_launcher.py
@@ -63,7 +63,7 @@ def main():
 
     try:
         proc = subprocess.Popen(
-            ["claude"],
+            ["claude", "--append-system-prompt", f"SQUIDSQUAD_ROLE={role}"],
             cwd=clone_path,
             env=env,
         )


### PR DESCRIPTION
## Summary

- `thin_launcher.py` set `SQUIDSQUAD_ROLE` as an env var only, but `CLAUDE.md` auto-boot checks the **system prompt** for `SQUIDSQUAD_ROLE=<role>`
- Env vars aren't surfaced in Claude's system prompt, so all 4 agents booted idle with no instructions
- Fix: pass `--append-system-prompt "SQUIDSQUAD_ROLE={role}"` to the `claude` CLI invocation

## Audit notes

Full harness audit performed. Other minor findings (non-blocking):
- `boot_remote.py`: `.booting` sentinel TTL of 30s could allow double-spawn on slow machines (mitigated by `.claude-pid` dedup)
- `reboot_agent.py`: `--all` reboots PM twice due to `["pm"] + _get_all_roles()` where `_get_all_roles()` already includes `pm`

## Test plan

- [ ] Boot team via harness — verify all 4 agents begin Ralph Loop immediately
- [ ] Confirm `SQUIDSQUAD_ROLE=<role>` appears in agent system prompt
- [ ] Verify agents read their role-specific CLAUDE.md on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)