### PR TITLE
skill: #5435 — fix static test suite silently skipped

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -28,7 +28,7 @@ from integration.harness import cleanup_all, verify_clean
 STATIC_TEST_MODULES = [
     "test_labels", "test_references", "test_manifest",
     "test_composition", "test_config", "test_roles", "test_vault",
-    "test_start_scripts", "test_tracker_authority",
+    "test_tracker_authority",
     "test_manifest_registry", "test_wizard", "test_wizard_runbook",
     "test_installer_wiring", "test_config_schema",
     "test_statusline_schema", "test_feat328_coverage",

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -58,3 +58,23 @@ class TestAgentInstructions:
             "agent-instructions.md has no sub-skill markers — "
             "may not be composed from sub-skills"
         )
+
+
+class TestRunTestsModuleList:
+    """#5435 regression: all STATIC_TEST_MODULES entries must exist as files."""
+
+    def test_all_static_test_modules_exist(self):
+        """Every entry in STATIC_TEST_MODULES must have a corresponding .py file."""
+        import sys
+        sys.path.insert(0, str(REPO_ROOT / "tests"))
+        from run_tests import STATIC_TEST_MODULES
+
+        tests_dir = REPO_ROOT / "tests"
+        missing = [
+            m for m in STATIC_TEST_MODULES
+            if not (tests_dir / f"{m}.py").exists()
+        ]
+        assert missing == [], (
+            f"STATIC_TEST_MODULES references nonexistent test files: {missing}. "
+            "Remove stale entries or restore the missing files."
+        )


### PR DESCRIPTION
Closes #5435

### Summary
Removed `test_start_scripts` from `STATIC_TEST_MODULES` in `tests/run_tests.py`. The file was deleted in #4966 (wrapper elimination) but the module list reference was not updated, causing pytest to fail with "file not found" and collecting 0 static tests. The entire static test suite (1079 tests) was silently skipped.

### Acceptance Criteria
- [x] `test_start_scripts` removed from STATIC_TEST_MODULES
- [x] All 37 remaining modules verified to exist on disk
- [x] Static test suite runs (1079 tests pass)

### Changes
- **Files**: `tests/run_tests.py`
- **What**: Removed stale module reference
- **Why**: Static test quality gate was completely bypassed

### QA Status
- [x] Static tests passing (1079/1079)
- [x] Integration tests passing (17/17)
- [x] Acceptance criteria met

## Setup/Upgrade Sync Check
- [x] New config values: N/A
- [x] New files/directories: N/A
- [x] Modified template structure: N/A
- [x] Added/removed sub-skills: N/A
- [x] Changed role composition: N/A