### PR TITLE
skill: #5573 — per-agent effort level (PM gets max thinking)

### DIFF
--- a/.squidsquad/config.md
+++ b/.squidsquad/config.md
@@ -117,6 +117,13 @@
 - **Ship Threshold**: 10
 - **Shipped Since Last Bump**: 9
 
+## Agent Effort
+
+- **pm**: max
+- **skill**: high
+- **qa**: high
+- **dm**: high
+
 ## Harness
 
 - **Enabled**: yes

--- a/references/scripts/config.py
+++ b/references/scripts/config.py
@@ -87,6 +87,10 @@ FIELD_MAP = {
     "branch-pattern": ("Git Branches", "Branch Pattern"),
     "harness-enabled": ("Harness", "Enabled"),
     "harness-port": ("Harness", "Port"),
+    "effort-pm": ("Agent Effort", "pm"),
+    "effort-skill": ("Agent Effort", "skill"),
+    "effort-qa": ("Agent Effort", "qa"),
+    "effort-dm": ("Agent Effort", "dm"),
 }
 
 

--- a/references/scripts/thin_launcher.py
+++ b/references/scripts/thin_launcher.py
@@ -25,6 +25,18 @@ import sys
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
+VALID_EFFORT_LEVELS = {"low", "medium", "high", "max"}
+
+
+def _get_effort_level(role):
+    """Read per-agent effort level from config.md. Falls back to 'high'."""
+    try:
+        sys.path.insert(0, str(SCRIPT_DIR))
+        from config import get_field
+        level = (get_field(f"effort-{role}") or "high").strip().lower()
+        return level if level in VALID_EFFORT_LEVELS else "high"
+    except Exception:
+        return "high"
 
 
 def _write_pid(clone_path, role, pid):
@@ -59,7 +71,9 @@ def main():
     env = os.environ.copy()
     env["SQUIDSQUAD_ROLE"] = role
 
-    print(f"[thin-launcher] Starting claude for {role} in {clone_path}")
+    # Read per-agent effort level from config (#5573)
+    effort = _get_effort_level(role)
+    print(f"[thin-launcher] Starting claude for {role} in {clone_path} (effort={effort})")
 
     try:
         proc = subprocess.Popen(
@@ -67,6 +81,7 @@ def main():
                 "claude",
                 "--append-system-prompt", f"SQUIDSQUAD_ROLE={role}",
                 "--name", f"squidsquad-{role}",
+                "--effort", effort,
                 "--dangerously-skip-permissions",
                 "Boot. Begin your first Ralph Loop cycle now.",
             ],

--- a/tests/test_thin_launcher.py
+++ b/tests/test_thin_launcher.py
@@ -41,6 +41,34 @@ class TestPIDManagement:
         thin_launcher._clear_pid(str(tmp_path), "skill")  # should not raise
 
 
+class TestEffortLevel:
+    """#5573: per-agent effort level from config."""
+
+    def test_reads_effort_from_config(self):
+        with patch.dict("sys.modules", {"config": MagicMock()}), \
+             patch("config.get_field", return_value="max"):
+            result = thin_launcher._get_effort_level("pm")
+            assert result == "max"
+
+    def test_defaults_to_high(self):
+        with patch.dict("sys.modules", {"config": MagicMock()}), \
+             patch("config.get_field", return_value=None):
+            result = thin_launcher._get_effort_level("skill")
+            assert result == "high"
+
+    def test_rejects_invalid_level(self):
+        with patch.dict("sys.modules", {"config": MagicMock()}), \
+             patch("config.get_field", return_value="turbo"):
+            result = thin_launcher._get_effort_level("pm")
+            assert result == "high"
+
+    def test_handles_config_failure(self):
+        with patch.dict("sys.modules", {"config": MagicMock()}), \
+             patch("config.get_field", side_effect=Exception("no config")):
+            result = thin_launcher._get_effort_level("pm")
+            assert result == "high"
+
+
 class TestThinLauncherBoot:
     """Thin launcher boot_remote integration."""
 


### PR DESCRIPTION
Closes #5573

### Summary
thin_launcher.py now reads per-agent effort level from config.md and passes `--effort <level>` to claude CLI. PM configured for `max` (extended thinking), other agents default to `high`.

### Acceptance Criteria
- [x] PM agent runs with extended/max thinking
- [x] Setting persists across reboots (config.md)
- [x] Other agents unaffected (default high)
- [x] Documented in config.md

### Changes
- **Files**: `thin_launcher.py`, `config.py`, `config.md`, `test_thin_launcher.py`
- **What**: New `Agent Effort` config section, `_get_effort_level()` function, `--effort` flag passed to claude
- **Why**: PM's core work (investigation, planning, coordination) benefits from deeper reasoning

### QA Status
- [x] 1085 static + 17 integration tests pass
- [x] 4 new effort level tests
- [x] Acceptance criteria met

## Setup/Upgrade Sync Check
- [x] New config values: Yes — Agent Effort section in config.md, FIELD_MAP entries
- [x] New files/directories: N/A
- [x] Modified template structure: N/A
- [x] Added/removed sub-skills: N/A
- [x] Changed role composition: N/A
- [x] Upgrade path: missing section → default "high" (graceful fallback)