### PR TITLE
skill: #5569 — improvement scan knowledge capture

### DIFF
--- a/.squidsquad/skill/CLAUDE.md
+++ b/.squidsquad/skill/CLAUDE.md
@@ -568,6 +568,14 @@ Write status bar state: `scanning|🔍 Scanning [target description]...`
    - **Items rejected by human**: [list of previously rejected items — never refile these]
    ```
 
+7. **Capture knowledge from navigation** (#5569): As you read files during the scan, you learn things — patterns, gaps, connections between systems. At the end of each scan, log up to **3 knowledge items** (subject to the vault write budget of 2 per cycle):
+
+   - **Vault writes**: learnings, patterns, or decisions discovered during navigation. Use vault-create for new notes, vault-update for existing ones. Apply the same 4-gate logic as vault-remember (write budget → dedup → reusability → fresh context).
+   - **Scan criteria adjustments**: if you notice your scan criteria consistently miss a category of issues, note it in scan-history.md under a `- **Criteria note**:` line for future scans.
+   - **Connection notes**: observations about how systems relate that aren't obvious from a single file — add as vault galaxy notes (`learning-*` or `pattern-*`).
+
+   Only capture genuinely useful knowledge — not noise. If nothing noteworthy was learned, skip this step.
+
 ### Rules
 
 - **PM is the single coordination point** — agents don't file directly to trackers. Report to PM via Discussion.

--- a/references/sub-skills/common/improvement-scan.md
+++ b/references/sub-skills/common/improvement-scan.md
@@ -74,6 +74,14 @@ Write status bar state: `scanning|🔍 Scanning [target description]...`
    - **Items rejected by human**: [list of previously rejected items — never refile these]
    ```
 
+7. **Capture knowledge from navigation** (#5569): As you read files during the scan, you learn things — patterns, gaps, connections between systems. At the end of each scan, log up to **3 knowledge items** (subject to the vault write budget of 2 per cycle):
+
+   - **Vault writes**: learnings, patterns, or decisions discovered during navigation. Use vault-create for new notes, vault-update for existing ones. Apply the same 4-gate logic as vault-remember (write budget → dedup → reusability → fresh context).
+   - **Scan criteria adjustments**: if you notice your scan criteria consistently miss a category of issues, note it in scan-history.md under a `- **Criteria note**:` line for future scans.
+   - **Connection notes**: observations about how systems relate that aren't obvious from a single file — add as vault galaxy notes (`learning-*` or `pattern-*`).
+
+   Only capture genuinely useful knowledge — not noise. If nothing noteworthy was learned, skip this step.
+
 ### Rules
 
 - **PM is the single coordination point** — agents don't file directly to trackers. Report to PM via Discussion.


### PR DESCRIPTION
Closes #5569

### Summary
Added step 7 to the improvement scan sub-skill: agents now capture up to 3 knowledge items learned during file navigation. Supports vault writes (learnings/patterns), scan criteria adjustments, and connection notes. Subject to existing vault write budget.

### Acceptance Criteria
- [x] Improvement scan sub-skill includes knowledge capture step
- [x] Up to 3 items, subject to vault write budget
- [x] Only genuinely useful knowledge — not noise
- [x] Recompose and verify all agents receive the update

### Changes
- **Files**: `references/sub-skills/common/improvement-scan.md`, `.squidsquad/skill/CLAUDE.md`
- **What**: Added step 7 with 3 knowledge capture categories
- **Why**: Navigation knowledge was lost unless it became a filed finding

### QA Status
- [x] 1085 static tests pass
- [x] Acceptance criteria met

## Setup/Upgrade Sync Check
- [x] Modified template structure: Yes — compose.py deploy for skill
- [x] All other items: N/A