### PR TITLE
skill: #5572 — vault consultation before dev/QA work

### DIFF
--- a/.squidsquad/qa/CLAUDE.md
+++ b/.squidsquad/qa/CLAUDE.md
@@ -426,6 +426,11 @@ For each issue:
 
 0. **Blocked check**: If the item has a `blocked:human-action` label, skip it. Print: `[🦑 HH:MM:SS] Skipping #[NUMBER] — blocked:human-action (waiting for human).` Do not change its status. Move to the next item.
 1. Read details: `gh issue view [NUMBER] --json title,body,comments`
+1b. **Consult the vault** (#5572) — search for relevant context before verifying:
+   ```bash
+   grep -rl "[keyword from issue]" .squidsquad/vault/ --include="*.md" | head -5
+   ```
+   Check for: decisions that affect expected behavior, patterns the fix should follow, learnings from similar past issues, and human quality preferences (`[[human-profile]]`). This prevents false passes on code that violates vault-documented constraints.
 2. **Branch checkout** (#3296): Check out the task's feature branch before verification:
    ```bash
    python references/scripts/git_ops.py task-begin [role] [number]

--- a/.squidsquad/skill/CLAUDE.md
+++ b/.squidsquad/skill/CLAUDE.md
@@ -467,6 +467,11 @@ Print: `[🦑 HH:MM:SS] Implementing #[NUMBER]...`
    - Look for files matching the issue number (e.g. `FEAT-SKILL-195-CONTEXT.md`)
    - RESEARCH.md, CONTEXT.md, TEST-PLAN.md — respect locked decisions, note dev discretion areas
    - If PM comments reference planning artifacts but you cannot find them, **push back** (see Prohibitions)
+2c. **Consult the vault** (#5572) — before implementing, search the vault for relevant context:
+   ```bash
+   grep -rl "[keyword]" .squidsquad/vault/ --include="*.md" | head -5
+   ```
+   Check for: decisions that constrain the approach, patterns to follow, learnings from similar past work, and human preferences. Especially check `[[human-profile]]` and BRIEFING.md. This takes seconds and prevents rework from missed context.
 3. Write working state: update `.squidsquad/skill/working-state.md` with `Task: #[NUMBER]`, status `in-progress`, planned approach, and acceptance criteria checklist.
 4. Implement the task according to the acceptance criteria. Respect locked decisions from CONTEXT.md. Implement required side effect mitigations. Update working state as you complete sub-steps.
 5. Run the test command: `python tests/run_tests.py`

--- a/references/sub-skills/roles/dev/implement-tasks.md
+++ b/references/sub-skills/roles/dev/implement-tasks.md
@@ -16,6 +16,11 @@ Print: `[🦑 HH:MM:SS] Implementing #[NUMBER]...`
    - Look for files matching the issue number (e.g. `FEAT-SKILL-195-CONTEXT.md`)
    - RESEARCH.md, CONTEXT.md, TEST-PLAN.md — respect locked decisions, note dev discretion areas
    - If PM comments reference planning artifacts but you cannot find them, **push back** (see Prohibitions)
+2c. **Consult the vault** (#5572) — before implementing, search the vault for relevant context:
+   ```bash
+   grep -rl "[keyword]" .squidsquad/vault/ --include="*.md" | head -5
+   ```
+   Check for: decisions that constrain the approach, patterns to follow, learnings from similar past work, and human preferences. Especially check `[[human-profile]]` and BRIEFING.md. This takes seconds and prevents rework from missed context.
 3. Write working state: update `.squidsquad/[ROLE]/working-state.md` with `Task: #[NUMBER]`, status `in-progress`, planned approach, and acceptance criteria checklist.
 4. Implement the task according to the acceptance criteria. Respect locked decisions from CONTEXT.md. Implement required side effect mitigations. Update working state as you complete sub-steps.
 5. Run the test command: `[ROLE_TEST_CMD]`

--- a/references/sub-skills/roles/qa/verification.md
+++ b/references/sub-skills/roles/qa/verification.md
@@ -48,6 +48,11 @@ For each issue:
 
 0. **Blocked check**: If the item has a `blocked:human-action` label, skip it. Print: `[🦑 HH:MM:SS] Skipping #[NUMBER] — blocked:human-action (waiting for human).` Do not change its status. Move to the next item.
 1. Read details: `gh issue view [NUMBER] --json title,body,comments`
+1b. **Consult the vault** (#5572) — search for relevant context before verifying:
+   ```bash
+   grep -rl "[keyword from issue]" .squidsquad/vault/ --include="*.md" | head -5
+   ```
+   Check for: decisions that affect expected behavior, patterns the fix should follow, learnings from similar past issues, and human quality preferences (`[[human-profile]]`). This prevents false passes on code that violates vault-documented constraints.
 2. **Branch checkout** (#3296): Check out the task's feature branch before verification:
    ```bash
    python references/scripts/git_ops.py task-begin [role] [number]


### PR DESCRIPTION
Closes #5572

### Summary
Added vault consultation instructions to dev (implement-tasks) and QA (verification) sub-skills.

**Audit findings**: Neither dev nor QA had vault consultation before starting work. Only a passing mention in dev's self-verification step (line 29).

**Changes**:
- Dev: step 2c added to implement-tasks.md — search vault for decisions, patterns, learnings before implementing
- QA: step 1b added to verification.md — search vault for context before verifying fixes

### Acceptance Criteria
- [x] Audit findings documented
- [x] Dev vault consultation added (step 2c in implement-tasks.md)
- [x] QA vault consultation added (step 1b in verification.md)
- [x] Recompose and verify (skill + QA)

### QA Status
- [x] 1085 static tests pass
- [x] Acceptance criteria met

## Setup/Upgrade Sync Check
- [x] Modified template structure: Yes — compose.py deploy for skill + QA
- [x] All other items: N/A