### PR TITLE
skill: #4709 — Harness Phase 2: Event Bus + Agent Communication

### DIFF
--- a/references/installer-files.txt
+++ b/references/installer-files.txt
@@ -18,6 +18,7 @@ references/scripts/cycle.py
 references/scripts/cycle_post.py
 references/scripts/cycle_pre.py
 references/scripts/diagnostics.py
+references/scripts/event_bus.py
 references/scripts/forge_adapter.py
 references/scripts/forgejo_setup.py
 references/scripts/git_ops.py

--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -666,6 +666,16 @@ def main():
     except OSError:
         pass
 
+    # 8. Emit cycle-end event (#4709)
+    try:
+        from event_bus import emit as _emit_event
+        _emit_event("cycle-end", role, payload={
+            "cycle_type": data.get("cycle_type", ""),
+            "summary": data.get("iteration_summary", "")[:60],
+        }, cycle_number=data.get("cycle_number"))
+    except (ImportError, Exception):
+        pass
+
     # 9. Intent + context pressure check (MUST be last — after commit, after log)
     # Queries harness API for intent, checks context pressure. Exit 42 = harness respawns.
     stop_for_restart = _do_stop_after_cycle_check(data, role)

--- a/references/scripts/cycle_pre.py
+++ b/references/scripts/cycle_pre.py
@@ -978,6 +978,13 @@ def main():
         encoding="utf-8",
     )
 
+    # Emit cycle-start event AFTER cycle-input.json is written (#4709)
+    try:
+        from event_bus import emit as _emit_event
+        _emit_event("cycle-start", role, cycle_number=cycle_number)
+    except (ImportError, Exception):
+        pass
+
     ts = _timestamp_short()
     print(f"[🦑 {ts}] cycle_pre complete — wrote {output_path.relative_to(REPO_ROOT)}")
     return 0

--- a/references/scripts/event_bus.py
+++ b/references/scripts/event_bus.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""SquidSquad Event Bus — fire-and-forget event emission to the harness (#4709).
+
+Agents emit events via HTTP POST to the harness. Silent no-op on failure.
+Zero behavior change for agents — events are purely observational.
+
+Usage (from mechanical scripts only):
+    from event_bus import emit
+    emit("cycle-start", "skill", {"cycle_number": 862})
+"""
+
+import hashlib
+import json
+import sys
+import urllib.request
+import urllib.error
+from datetime import datetime
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+SQUID_DIR = REPO_ROOT / ".squidsquad"
+
+# Timeout: 500ms — never blocks agent cycle
+_TIMEOUT = 0.5
+
+
+def _discover_port():
+    """Discover harness port via .harness-port file with parent-dir walk.
+
+    Returns port number or None if not discoverable.
+    """
+    # Direct path first
+    port_file = SQUID_DIR / ".harness-port"
+    if port_file.exists():
+        try:
+            return int(port_file.read_text(encoding="utf-8").strip())
+        except (ValueError, OSError):
+            pass
+
+    # Parent-dir walk (clone isolation — agent clone may be a child of primary repo)
+    current = REPO_ROOT.parent
+    for _ in range(5):
+        candidate = current / ".squidsquad" / ".harness-port"
+        if candidate.exists():
+            try:
+                return int(candidate.read_text(encoding="utf-8").strip())
+            except (ValueError, OSError):
+                pass
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+
+    return None
+
+
+def _generate_id(event_type, role, timestamp, payload):
+    """Generate a short 8-char event ID from content hash."""
+    raw = f"{timestamp}{role}{event_type}{json.dumps(payload, sort_keys=True)}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:8]
+
+
+def emit(event_type, role, payload=None, cycle_number=None):
+    """Emit an event to the harness. Silent no-op on any failure.
+
+    Args:
+        event_type: Event type string (e.g. "cycle-start", "git-pull")
+        role: Agent role (e.g. "skill", "pm", "qa", "dm")
+        payload: Optional dict of event-specific data
+        cycle_number: Optional cycle number (included at top level if provided)
+    """
+    try:
+        port = _discover_port()
+        if port is None:
+            return
+
+        if payload is None:
+            payload = {}
+
+        timestamp = datetime.now().isoformat(timespec="seconds")
+        event_id = _generate_id(event_type, role, timestamp, payload)
+
+        event = {
+            "id": event_id,
+            "event_type": event_type,
+            "role": role,
+            "timestamp": timestamp,
+            "payload": payload,
+        }
+        if cycle_number is not None:
+            event["cycle_number"] = cycle_number
+
+        data = json.dumps(event).encode("utf-8")
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{port}/events",
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        urllib.request.urlopen(req, timeout=_TIMEOUT)
+    except Exception:
+        # Silent no-op — fire-and-forget contract
+        pass

--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -81,6 +81,25 @@ def _log_diagnostic(severity, message):
         pass
 
 
+def _emit(event_type, payload=None, cycle_number=None):
+    """Fire-and-forget event emission (#4709). Role determined from sys.argv."""
+    try:
+        from event_bus import emit
+        # Determine role from command args (git_ops.py is called with role as arg)
+        role = "unknown"
+        args = sys.argv[1:]
+        # For commands like: commit-code <role> <branch> <msg>
+        # or: task-begin <role> <number>
+        if len(args) >= 2 and args[1] in ("pm", "skill", "qa", "dm"):
+            role = args[1]
+        elif len(args) >= 2 and args[0] in ("commit-code", "commit-state", "commit-push",
+                                             "commit", "task-begin", "task-end"):
+            role = args[1]
+        emit(event_type, role, payload=payload, cycle_number=cycle_number)
+    except (ImportError, Exception):
+        pass
+
+
 def pull():
     """Pull with merge (#5378, #5445).
 
@@ -89,12 +108,14 @@ def pull():
     result = _run("git pull", check=False)
     if result.returncode == 0:
         print("Pulled")
+        _emit("git-pull", {"result": "ok"})
         return True
 
     # Check if the failure is "already up to date" or branch divergence
     combined = (result.stdout + result.stderr).lower()
     if "already up to date" in combined or "up to date" in combined:
         print("Pulled (already up to date)")
+        _emit("git-pull", {"result": "ok"})
         return True
 
     # Try stash + pull + pop
@@ -118,8 +139,10 @@ def pull():
         _run("git stash drop", check=False)
         print("WARNING: stash pop failed -- dropped stale stash entry.", file=sys.stderr)
         print("Pulled (stash pop conflict -- stale stash dropped)")
+        _emit("git-pull", {"result": "stash"})
     else:
         print("Pulled (stashed and popped)")
+        _emit("git-pull", {"result": "stash"})
     return True
 
 
@@ -164,6 +187,10 @@ def push():
         _log_diagnostic("error", f"push failed: {result.stderr.strip()[:200]}")
         print(f"ERROR: push failed: {result.stderr}", file=sys.stderr)
         return False
+    # Determine branch for event payload
+    branch_result = _run("git branch --show-current", check=False)
+    branch = branch_result.stdout.strip() if branch_result.returncode == 0 else ""
+    _emit("git-push", {"branch": branch})
     print("Pushed")
     return True
 
@@ -254,6 +281,11 @@ def pr_create(title, body):
         print(f"ERROR: PR creation failed: {result.stderr}", file=sys.stderr)
         return None
     url = result.stdout.strip()
+    # Extract PR number from URL (e.g. https://github.com/.../pull/123)
+    pr_num = url.rstrip("/").rsplit("/", 1)[-1] if url else ""
+    branch_result = _run("git branch --show-current", check=False)
+    branch = branch_result.stdout.strip() if branch_result.returncode == 0 else ""
+    _emit("pr-create", {"pr_number": pr_num, "title": title[:80], "branch": branch})
     print(f"PR created: {url}")
     return url
 
@@ -306,6 +338,7 @@ def pr_merge(pr_number, strategy="squash"):
                     return False, "PR closed without merge"
             success, msg = adapter.merge_pr(pr_number, strategy)
             if success:
+                _emit("pr-merge", {"pr_number": str(pr_number)})
                 print(f"PR #{pr_number} merged ({strategy})")
             else:
                 print(f"ERROR: PR #{pr_number} merge failed: {msg}", file=sys.stderr)
@@ -335,6 +368,7 @@ def pr_merge(pr_number, strategy="squash"):
     merge_args = ["gh", "pr", "merge", str(pr_number), f"--{strategy}", "--delete-branch"]
     result = _run_list(merge_args, check=False)
     if result.returncode == 0:
+        _emit("pr-merge", {"pr_number": str(pr_number)})
         print(f"PR #{pr_number} merged ({strategy})")
         # Extract linked issue number from branch name
         branch_result = _run_list(
@@ -467,6 +501,11 @@ def commit_code(role, branch, message):
         _safe_checkout(working)
         return False
 
+    # Emit git-commit (code) and git-push events (#4709)
+    _emit("git-commit", {"message": message[:80], "branch": branch,
+                         "files_changed": len(code_files), "commit_type": "code"})
+    _emit("git-push", {"branch": branch})
+
     print(f"Committed code to {branch}: {message}")
 
     # Switch back to working branch
@@ -524,6 +563,10 @@ def commit_state(role, message):
         print(f"ERROR: {result.stderr}", file=sys.stderr)
         return False
 
+    # Emit git-commit (state) event (#4709)
+    _emit("git-commit", {"message": message[:80], "branch": working,
+                         "files_changed": len(state_files), "commit_type": "state"})
+
     # Push main — failure logged but state is committed locally (#5444)
     push_result = _run("git push", check=False)
     if push_result.returncode != 0:
@@ -531,6 +574,8 @@ def commit_state(role, message):
         print(f"WARNING: state push failed: {push_result.stderr}", file=sys.stderr)
         # State push failure is non-fatal — state is committed locally,
         # next cycle's pull will sync. Return True since commit succeeded.
+    else:
+        _emit("git-push", {"branch": working})
 
     print(f"Committed state to main: {message}")
     return True
@@ -579,6 +624,7 @@ def task_begin(role, number):
         if not _safe_checkout(branch):
             print(f"ERROR: task-begin failed to checkout {branch}", file=sys.stderr)
             sys.exit(1)
+        _emit("branch-checkout", {"branch": branch, "task_number": str(number)})
         print(branch)
         return
 
@@ -591,6 +637,7 @@ def task_begin(role, number):
     if remote.returncode == 0:
         result = _run_list(["git", "checkout", "-b", branch, f"origin/{branch}"], check=False)
         if result.returncode == 0:
+            _emit("branch-checkout", {"branch": branch, "task_number": str(number)})
             print(branch)
             return
         print(f"ERROR: task-begin failed to checkout {branch} from origin: {result.stderr}", file=sys.stderr)
@@ -606,6 +653,7 @@ def task_begin(role, number):
         # Fallback: create from current HEAD if origin unreachable
         result = _run_list(["git", "checkout", "-b", branch], check=False)
     if result.returncode == 0:
+        _emit("branch-checkout", {"branch": branch, "task_number": str(number)})
         print(branch)
         return
     print(f"ERROR: task-begin failed to create {branch}: {result.stderr}",
@@ -640,6 +688,8 @@ def task_end(role, number):
     if not _safe_checkout(working):
         # Fallback to main if working branch checkout fails
         _safe_checkout("main")
+
+    _emit("branch-checkout", {"branch": working, "task_number": str(number)})
 
 
 def has_changes():

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -21,6 +21,7 @@ Usage:
 """
 
 import asyncio
+import collections
 import json
 import os
 import signal
@@ -47,7 +48,7 @@ import health_check
 import reboot_agent
 
 try:
-    from fastapi import FastAPI, HTTPException
+    from fastapi import FastAPI, HTTPException, Request
     from fastapi.responses import JSONResponse
     import uvicorn
 except ImportError:
@@ -67,7 +68,9 @@ class AgentState:
     """In-memory state for a single agent."""
 
     __slots__ = ("role", "status", "intent", "last_health_check", "boot_time",
-                 "clone_path", "claude_pid")
+                 "clone_path", "claude_pid",
+                 "current_cycle", "current_phase", "last_cycle_start",
+                 "last_cycle_end", "last_cycle_type")
 
     # Intent values:
     #   "running"    — agent should be alive; auto-reboot on death (#4949)
@@ -87,6 +90,12 @@ class AgentState:
         self.boot_time = None
         self.clone_path = clone_path
         self.claude_pid = None  # PID of claude process (#4966)
+        # Phase 2 event-derived state (#4709)
+        self.current_cycle = None
+        self.current_phase = None
+        self.last_cycle_start = None
+        self.last_cycle_end = None
+        self.last_cycle_type = None
 
     def to_dict(self):
         return {
@@ -97,6 +106,11 @@ class AgentState:
             "last_health_check": self.last_health_check,
             "clone_path": self.clone_path,
             "claude_pid": self.claude_pid,
+            "current_cycle": self.current_cycle,
+            "current_phase": self.current_phase,
+            "last_cycle_start": self.last_cycle_start,
+            "last_cycle_end": self.last_cycle_end,
+            "last_cycle_type": self.last_cycle_type,
         }
 
 
@@ -324,8 +338,38 @@ class HarnessState:
         _log(f"Restored state for {len(state_data.get('agents', {}))} agents from state file")
 
 
+# ---------------------------------------------------------------------------
+# Event stream (#4709 Phase 2)
+# ---------------------------------------------------------------------------
+
+class EventStream:
+    """Bounded event stream — thread-safe deque with max 1000 events."""
+
+    def __init__(self, maxlen=1000):
+        self._events = collections.deque(maxlen=maxlen)
+        self._lock = threading.Lock()
+
+    def append(self, event: dict):
+        with self._lock:
+            self._events.append(event)
+
+    def get_all(self) -> list[dict]:
+        with self._lock:
+            return list(self._events)
+
+    def get_recent(self, n: int = 50) -> list[dict]:
+        with self._lock:
+            items = list(self._events)
+            return items[-n:] if len(items) > n else items
+
+    def __len__(self):
+        with self._lock:
+            return len(self._events)
+
+
 # Global state
 state = HarnessState()
+event_stream = EventStream()
 
 
 # ---------------------------------------------------------------------------
@@ -595,6 +639,119 @@ async def get_agent_config(role: str):
         result["error"] = "Could not read config"
 
     return result
+
+
+# ---------------------------------------------------------------------------
+# Event bus helpers (#4709 Phase 2)
+# ---------------------------------------------------------------------------
+
+def _update_agent_from_event(event: dict):
+    """Update AgentState fields from a received event."""
+    role = event.get("role")
+    event_type = event.get("event_type")
+    payload = event.get("payload", {})
+    cycle_number = event.get("cycle_number")
+
+    agent = state.get_agent(role)
+    if agent is None:
+        agent = AgentState(role)
+        state.set_agent(role, agent)
+
+    if event_type == "cycle-start":
+        if cycle_number is not None:
+            agent.current_cycle = cycle_number
+        agent.last_cycle_start = event.get("timestamp")
+    elif event_type == "cycle-end":
+        agent.last_cycle_end = event.get("timestamp")
+        agent.last_cycle_type = payload.get("cycle_type")
+    elif event_type == "phase-change":
+        agent.current_phase = payload.get("phase")
+
+
+def _log_event(event: dict):
+    """Print an event to the harness console in compact format."""
+    ts = time.strftime("%H:%M:%S")
+    role = event.get("role", "?")
+    event_type = event.get("event_type", "?")
+    payload = event.get("payload", {})
+    cycle_number = event.get("cycle_number")
+
+    # Build detail string based on event type
+    detail = ""
+    if cycle_number is not None:
+        detail = f"#{cycle_number}"
+    if event_type == "cycle-end":
+        cycle_type = payload.get("cycle_type", "")
+        summary = payload.get("summary", "")
+        if cycle_type:
+            detail += f" ({cycle_type})"
+        if summary:
+            detail += f" — {summary[:60]}"
+    elif event_type == "git-commit":
+        msg = payload.get("message", "")
+        files = payload.get("files_changed", "")
+        if msg:
+            detail = f'"{msg[:40]}"'
+        if files:
+            detail += f" ({files} files)"
+    elif event_type == "git-pull":
+        detail = payload.get("result", "")
+    elif event_type == "git-push":
+        detail = payload.get("branch", "")
+    elif event_type == "pr-create":
+        detail = f"PR #{payload.get('pr_number', '?')}"
+    elif event_type == "pr-merge":
+        detail = f"PR #{payload.get('pr_number', '?')}"
+    elif event_type == "branch-checkout":
+        detail = payload.get("branch", "")
+    elif event_type == "task-start":
+        detail = f"#{payload.get('task_number', '?')}"
+    elif event_type == "task-end":
+        detail = f"#{payload.get('task_number', '?')}"
+    elif event_type == "tracker-comment":
+        preview = payload.get("comment_preview", "")
+        detail = f"#{payload.get('issue_number', '?')} \"{preview[:40]}\""
+    elif event_type == "phase-change":
+        detail = payload.get("phase", "")
+
+    print(f"[{ts}] {role:<6} {event_type:<18} {detail}", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Event bus endpoints (#4709 Phase 2)
+# ---------------------------------------------------------------------------
+
+@app.post("/events")
+async def receive_event(request: Request):
+    """Receive an event from an agent mechanical script.
+
+    Stores in bounded stream, updates AgentState, logs to console.
+    """
+    body = await request.json()
+
+    # Validate minimal fields
+    event_type = body.get("event_type")
+    role = body.get("role")
+    if not event_type or not role:
+        raise HTTPException(status_code=400, detail="event_type and role are required")
+
+    # Store in stream
+    event_stream.append(body)
+
+    # Update AgentState from event
+    _update_agent_from_event(body)
+
+    # Log to console
+    _log_event(body)
+
+    return {"status": "ok"}
+
+
+@app.get("/events")
+async def get_events(limit: int = 50):
+    """Retrieve recent events from the stream."""
+    events = event_stream.get_recent(limit)
+    return {"events": events, "total": len(event_stream)}
 
 
 @app.post("/agents/{role}/stop")

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -398,7 +398,7 @@ async def lifespan(app: FastAPI):
     state.update_health()
     state.start_poller()
 
-    # Write port discovery file (atomic)
+    # Write port discovery file (atomic) — primary repo
     try:
         tmp = HARNESS_PORT_FILE.with_suffix(".tmp")
         tmp.write_text(str(state.port), encoding="utf-8")
@@ -406,6 +406,25 @@ async def lifespan(app: FastAPI):
         _log(f"Port discovery file written: {HARNESS_PORT_FILE}")
     except OSError as e:
         _log(f"WARNING: Could not write port file: {e}")
+
+    # Write port file to each agent clone's .squidsquad/ directory (#4709 TC-7)
+    # Clone isolation: clones are siblings, not children — parent-dir walk won't find
+    # the primary .harness-port. Write directly to each clone.
+    try:
+        clone_paths = boot_remote._parse_local_config()
+        for role, clone_root in clone_paths.items():
+            clone_squid = Path(clone_root) / ".squidsquad"
+            if clone_squid.is_dir() and clone_root != REPO_ROOT:
+                clone_port_file = clone_squid / ".harness-port"
+                try:
+                    clone_tmp = clone_port_file.with_suffix(".tmp")
+                    clone_tmp.write_text(str(state.port), encoding="utf-8")
+                    clone_tmp.replace(clone_port_file)
+                except OSError:
+                    pass  # Non-fatal — clone may not exist yet
+        _log(f"Port file distributed to {len(clone_paths)} clone(s)")
+    except (SystemExit, Exception) as e:
+        _log(f"WARNING: Could not distribute port to clones: {e}")
 
     _log("Harness ready. Ctrl+C to stop.")
     _log(f"API: http://localhost:{state.port}/status")
@@ -423,7 +442,7 @@ async def lifespan(app: FastAPI):
     _log("Shutting down...")
     state.stop_poller()
 
-    # Clean up port file (retry for Windows file locking)
+    # Clean up port files (primary + clones, retry for Windows file locking)
     for attempt in range(3):
         try:
             if HARNESS_PORT_FILE.exists():
@@ -432,6 +451,18 @@ async def lifespan(app: FastAPI):
         except OSError as e:
             _log(f"WARNING: Could not delete port file (attempt {attempt + 1}/3): {e}")
             time.sleep(0.5)
+
+    # Clean up clone port files (#4709)
+    try:
+        clone_paths = boot_remote._parse_local_config()
+        for role, clone_root in clone_paths.items():
+            clone_port = Path(clone_root) / ".squidsquad" / ".harness-port"
+            try:
+                clone_port.unlink(missing_ok=True)
+            except OSError:
+                pass
+    except (SystemExit, Exception):
+        pass
 
     _log("Harness stopped.")
 

--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -983,6 +983,25 @@ def transition(number, from_status, to_status, role=None, force=False):
                 print(f"WARNING: gh issue close #{number} failed: {result.stderr.strip()}",
                       file=sys.stderr)
 
+    # Emit task lifecycle events (#4709)
+    try:
+        from event_bus import emit as _emit_event
+        # Determine caller role for the event
+        emit_role = (role or "unknown").replace("-lead", "")
+        if to_label == "status:in-progress":
+            _emit_event("task-start", emit_role, payload={
+                "task_number": str(number),
+                "from_status": from_label.replace("status:", ""),
+                "assigned_role": emit_role,
+            })
+        elif to_label == "status:pending-test":
+            _emit_event("task-end", emit_role, payload={
+                "task_number": str(number),
+                "assigned_role": emit_role,
+            })
+    except (ImportError, Exception):
+        pass
+
     print(f"#{number}: {from_label} -> {to_label}")
     return True
 
@@ -1032,7 +1051,7 @@ def _expand_issue_refs(text):
     return re.sub(r'(?<!\w)#(\d{1,5})\b', _replace, text)
 
 
-def comment(number, role, message):
+def comment(number, role, message, _suppress_event=False):
     """Add a discussion comment to an issue."""
     # No manual timestamps — GitHub provides them
     message = _expand_issue_refs(message)
@@ -1043,6 +1062,24 @@ def comment(number, role, message):
     else:
         _run_list(["gh", "issue", "comment", str(number), "--body", body])
     print(f"Commented on #{number}")
+
+    # Emit tracker-comment event (#4709) — suppressed for auto-comments from transition()
+    if not _suppress_event:
+        try:
+            import re as _re
+            from event_bus import emit as _emit_event
+            emit_role = role.split(" ")[0].replace("-lead", "")  # "skill-lead (Ralph)" → "skill"
+            # Extract mentioned roles from **role**: bold patterns
+            mentioned = _re.findall(r'\*\*(\w+)\*\*:', message)
+            preview = message[:120].replace("\n", " ")
+            _emit_event("tracker-comment", emit_role, payload={
+                "issue_number": str(number),
+                "commenter_role": emit_role,
+                "comment_preview": preview,
+                "mentioned_roles": mentioned,
+            })
+        except (ImportError, Exception):
+            pass
 
 
 def get_labels(number):

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -46,6 +46,7 @@ STATIC_TEST_MODULES = [
     "test_model_router",
     "test_comms_adapter",
     "test_comms_sub_skills",
+    "test_event_bus",
 ]
 
 

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1,0 +1,166 @@
+"""Tests for event_bus.py — fire-and-forget event emission (#4709)."""
+
+import json
+import sys
+import threading
+import time
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "references" / "scripts"))
+import event_bus
+
+
+class _EventCollector(BaseHTTPRequestHandler):
+    """Minimal HTTP server that collects POSTed events."""
+
+    events = []
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length)
+        self.events.append(json.loads(body))
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"status":"ok"}')
+
+    def log_message(self, format, *args):
+        pass  # Suppress server logs
+
+
+@pytest.fixture
+def mock_server():
+    """Start a local HTTP server that collects events."""
+    _EventCollector.events = []
+    server = HTTPServer(("127.0.0.1", 0), _EventCollector)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield port, _EventCollector.events
+    server.shutdown()
+
+
+@pytest.fixture
+def patch_dirs(tmp_path):
+    """Patch event_bus paths to use temp directory."""
+    squid = tmp_path / ".squidsquad"
+    squid.mkdir()
+    with patch.object(event_bus, "SQUID_DIR", squid), \
+         patch.object(event_bus, "REPO_ROOT", tmp_path):
+        yield squid
+
+
+class TestEmit:
+    """Tests for emit() function."""
+
+    def test_emits_event_to_harness(self, mock_server, patch_dirs):
+        """Successfully emits an event when harness is running."""
+        port, events = mock_server
+        (patch_dirs / ".harness-port").write_text(str(port), encoding="utf-8")
+
+        event_bus.emit("cycle-start", "skill", {"cycle_number": 42}, cycle_number=42)
+
+        assert len(events) == 1
+        evt = events[0]
+        assert evt["event_type"] == "cycle-start"
+        assert evt["role"] == "skill"
+        assert evt["cycle_number"] == 42
+        assert "id" in evt
+        assert len(evt["id"]) == 8
+        assert "timestamp" in evt
+        assert evt["payload"] == {"cycle_number": 42}
+
+    def test_silent_noop_when_port_file_missing(self, patch_dirs):
+        """No exception when .harness-port doesn't exist."""
+        # No port file written — should silently return
+        event_bus.emit("cycle-start", "pm", {"cycle_number": 1})
+        # No exception = pass
+
+    def test_silent_noop_when_harness_down(self, patch_dirs):
+        """No exception when harness is not running on the port."""
+        (patch_dirs / ".harness-port").write_text("19999", encoding="utf-8")
+        event_bus.emit("cycle-start", "qa", {"cycle_number": 1})
+        # No exception = pass
+
+    def test_timeout_respected(self, patch_dirs):
+        """Emit completes within ~500ms even if server doesn't respond."""
+        # Use a port that accepts connections but never responds
+        import socket
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(1)
+        port = sock.getsockname()[1]
+        (patch_dirs / ".harness-port").write_text(str(port), encoding="utf-8")
+
+        start = time.time()
+        event_bus.emit("cycle-start", "skill", {"cycle_number": 1})
+        elapsed = time.time() - start
+
+        sock.close()
+        # Should complete within 700ms (500ms timeout + overhead)
+        assert elapsed < 1.5  # generous for CI
+
+    def test_payload_defaults_to_empty_dict(self, mock_server, patch_dirs):
+        """Payload defaults to {} when not provided."""
+        port, events = mock_server
+        (patch_dirs / ".harness-port").write_text(str(port), encoding="utf-8")
+
+        event_bus.emit("git-pull", "skill")
+
+        assert len(events) == 1
+        assert events[0]["payload"] == {}
+
+    def test_cycle_number_optional(self, mock_server, patch_dirs):
+        """cycle_number is omitted from event when not provided."""
+        port, events = mock_server
+        (patch_dirs / ".harness-port").write_text(str(port), encoding="utf-8")
+
+        event_bus.emit("git-pull", "skill", {"result": "ok"})
+
+        assert "cycle_number" not in events[0]
+
+
+class TestDiscoverPort:
+    """Tests for _discover_port() function."""
+
+    def test_reads_direct_port_file(self, patch_dirs):
+        """Reads port from .squidsquad/.harness-port."""
+        (patch_dirs / ".harness-port").write_text("8080", encoding="utf-8")
+        assert event_bus._discover_port() == 8080
+
+    def test_returns_none_when_no_port_file(self, patch_dirs):
+        """Returns None when no .harness-port file exists anywhere."""
+        assert event_bus._discover_port() is None
+
+    def test_handles_invalid_port_file(self, patch_dirs):
+        """Returns None on invalid port file content (falls through to parent walk)."""
+        (patch_dirs / ".harness-port").write_text("not-a-number", encoding="utf-8")
+        # Will try parent walk, find nothing, return None
+        result = event_bus._discover_port()
+        assert result is None
+
+
+class TestGenerateId:
+    """Tests for _generate_id() function."""
+
+    def test_produces_8_char_hex(self):
+        """ID is exactly 8 hex characters."""
+        result = event_bus._generate_id("cycle-start", "skill", "2026-05-01T18:00:00", {})
+        assert len(result) == 8
+        assert all(c in "0123456789abcdef" for c in result)
+
+    def test_deterministic(self):
+        """Same inputs produce same ID."""
+        a = event_bus._generate_id("cycle-start", "skill", "2026-05-01T18:00:00", {})
+        b = event_bus._generate_id("cycle-start", "skill", "2026-05-01T18:00:00", {})
+        assert a == b
+
+    def test_different_inputs_different_ids(self):
+        """Different inputs produce different IDs."""
+        a = event_bus._generate_id("cycle-start", "skill", "2026-05-01T18:00:00", {})
+        b = event_bus._generate_id("cycle-end", "skill", "2026-05-01T18:00:00", {})
+        assert a != b


### PR DESCRIPTION
Closes #4709

### Summary
Implements Phase 2 of the Harness EPIC — event bus for agent observability.

### Changes
- **event_bus.py** (~100 lines): fire-and-forget event emission via HTTP POST. Port discovery via parent-dir walk. 500ms timeout. Silent no-op on any failure.
- **harness.py**: POST /events endpoint, GET /events endpoint, EventStream (bounded deque, 1000 max), AgentState extended with cycle/phase fields, _update_agent_from_event + _log_event helpers.
- **cycle_pre.py**: emits cycle-start after writing cycle-input.json
- **cycle_post.py**: emits cycle-end after all processing (commit, transitions, logging)
- **git_ops.py**: emits git-pull, git-push, git-commit (code+state), pr-create, pr-merge, branch-checkout
- **tracker.py**: emits task-start, task-end, tracker-comment (with suppression param)
- **installer-files.txt**: added event_bus.py
- **tests/test_event_bus.py**: 12 unit tests
- **run_tests.py**: registered test_event_bus in STATIC_TEST_MODULES

### Acceptance Criteria
- [x] event_bus.py emits events via HTTP POST
- [x] Silent no-op when harness down or port file missing
- [x] 500ms timeout never blocks agent cycle
- [x] Harness /events endpoint receives and stores events
- [x] Bounded event stream (1000 max)
- [x] AgentState updates from events
- [x] Console displays events in compact format
- [x] Backward compat: existing cycles unchanged without harness

### QA Status
- [x] Unit tests passing (12/12)
- [x] Full test suite passing (17 integration + 134 pytest)
- [x] Smoke tests: silent no-op verified