### PR TITLE
skill: #5674 — .gitattributes vault merge strategies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,6 +13,14 @@
 .squidsquad/*/cycle-input.json merge=ours
 .squidsquad/*/cycle-output.json merge=ours
 
+# Vault files (#5674)
+# BRIEFING.md — last writer wins (staleness fix runs every cycle).
+.squidsquad/vault/BRIEFING.md merge=ours
+# Galaxy/areas/projects notes — append-friendly (changelogs are append-only).
+.squidsquad/vault/galaxy/*.md merge=union
+.squidsquad/vault/areas/*.md merge=union
+.squidsquad/vault/projects/*.md merge=union
+
 # Shared config — last writer wins (cycle_pre validates post-merge) (#5136)
 # merge=union would produce duplicate field lines (invalid config).
 # Version regressions caught by _validate_config_version().

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -835,6 +835,18 @@ class TestGitattributesMergeStrategies:
         assert "working-state.md merge=ours" in content
         assert "config.md merge=ours" in content
 
+    def test_vault_briefing_merge_ours(self):
+        """#5674: BRIEFING.md uses merge=ours (last writer wins)."""
+        content = (Path(__file__).resolve().parent.parent / ".gitattributes").read_text()
+        assert "vault/BRIEFING.md merge=ours" in content
+
+    def test_vault_notes_merge_union(self):
+        """#5674: vault galaxy/areas/projects use merge=union (append-friendly)."""
+        content = (Path(__file__).resolve().parent.parent / ".gitattributes").read_text()
+        assert "vault/galaxy/*.md merge=union" in content
+        assert "vault/areas/*.md merge=union" in content
+        assert "vault/projects/*.md merge=union" in content
+
 
 # ---------------------------------------------------------------------------
 # task_begin — regression #4942


### PR DESCRIPTION
Closes #5674

### Summary
Extends .gitattributes to cover vault directory files. BRIEFING.md uses `merge=ours` (last writer wins — staleness fix runs every cycle). Galaxy/areas/projects notes use `merge=union` (append-friendly changelogs).

### Changes
- `.gitattributes`: Added 4 patterns for vault files

### QA Status
- [x] `git check-attr merge` confirms correct pattern resolution
- [x] Full test suite passing