### PR TITLE
skill: #5734 — add path traversal guard to CLI installer

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -126,6 +126,17 @@ function checkClaudeCli() {
   success(`Claude Code CLI v${ver}`);
 }
 
+// --- Path safety ---
+
+function assertWithinRoot(root, filePath) {
+  const resolved = path.resolve(root, filePath);
+  if (!resolved.startsWith(path.resolve(root) + path.sep) && resolved !== path.resolve(root)) {
+    fail(`Path traversal blocked: ${filePath}`);
+    process.exit(1);
+  }
+  return resolved;
+}
+
 // --- File fetching ---
 
 function fetchRawFile(repoPath) {
@@ -221,7 +232,7 @@ function downloadTarball(gitRoot, filePaths) {
     let copied = 0;
     for (const filePath of filePaths) {
       const srcPath = path.join(prefixDir, filePath);
-      const destPath = path.join(gitRoot, filePath);
+      const destPath = assertWithinRoot(gitRoot, filePath);
       fs.mkdirSync(path.dirname(destPath), { recursive: true });
       fs.copyFileSync(srcPath, destPath);
       copied++;
@@ -254,7 +265,7 @@ function installFilesPerFile(gitRoot, filePaths) {
       fail(`Failed to fetch ${filePath}`);
       process.exit(1);
     }
-    const dest = path.join(gitRoot, filePath);
+    const dest = assertWithinRoot(gitRoot, filePath);
     fs.mkdirSync(path.dirname(dest), { recursive: true });
     fs.writeFileSync(dest, content, "utf-8");
     fetched++;
@@ -472,5 +483,5 @@ async function main() {
 if (require.main === module) {
   main();
 } else {
-  module.exports = { getCliVersion, downloadTarball, installFilesPerFile, fetchRawFile };
+  module.exports = { getCliVersion, downloadTarball, installFilesPerFile, fetchRawFile, assertWithinRoot };
 }

--- a/packages/cli/index.test.js
+++ b/packages/cli/index.test.js
@@ -74,3 +74,54 @@ describe("installFilesPerFile", () => {
     assert.equal(typeof cli.installFilesPerFile, "function");
   });
 });
+
+// --- assertWithinRoot ---
+
+describe("assertWithinRoot", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "squid-path-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("allows normal relative paths", () => {
+    const result = cli.assertWithinRoot(tmpDir, "references/scripts/foo.py");
+    assert.equal(result, path.resolve(tmpDir, "references/scripts/foo.py"));
+  });
+
+  it("allows nested paths", () => {
+    const result = cli.assertWithinRoot(tmpDir, "a/b/c/d.txt");
+    assert.equal(result, path.resolve(tmpDir, "a/b/c/d.txt"));
+  });
+
+  it("allows root-level files", () => {
+    const result = cli.assertWithinRoot(tmpDir, "SKILL.md");
+    assert.equal(result, path.resolve(tmpDir, "SKILL.md"));
+  });
+
+  it("blocks path traversal with ../", (t) => {
+    const originalExit = process.exit;
+    let exitCalled = false;
+    process.exit = () => { exitCalled = true; throw new Error("exit"); };
+    try {
+      cli.assertWithinRoot(tmpDir, "../../etc/passwd");
+    } catch { /* expected */ }
+    process.exit = originalExit;
+    assert.equal(exitCalled, true);
+  });
+
+  it("blocks path traversal in nested context", (t) => {
+    const originalExit = process.exit;
+    let exitCalled = false;
+    process.exit = () => { exitCalled = true; throw new Error("exit"); };
+    try {
+      cli.assertWithinRoot(tmpDir, "references/../../../.bashrc");
+    } catch { /* expected */ }
+    process.exit = originalExit;
+    assert.equal(exitCalled, true);
+  });
+});

--- a/tests/test_installer_wiring.py
+++ b/tests/test_installer_wiring.py
@@ -134,10 +134,10 @@ class TestCliIndexJs:
         )
 
     def test_writes_files_to_canonical_paths(self, cli_js):
-        """Each fetched file must be written to its canonical path in the target."""
-        assert "path.join(gitRoot, filePath)" in cli_js, (
-            "CLI must write each fetched file to its canonical path "
-            "relative to the target git root"
+        """Each fetched file must be written to a validated path in the target."""
+        assert "assertWithinRoot(gitRoot, filePath)" in cli_js, (
+            "CLI must write each fetched file to a validated path "
+            "relative to the target git root (via assertWithinRoot)"
         )
 
     def test_commits_references_directory(self, cli_js):


### PR DESCRIPTION
Closes #5734

### Summary
Added `assertWithinRoot()` path validation to `packages/cli/index.js` to prevent potential path traversal when writing files from the installer manifest. Applied in both `downloadTarball()` and `installFilesPerFile()`.

### Acceptance Criteria
- [x] Path traversal via `../` sequences is detected and blocked
- [x] Normal relative paths continue to work
- [x] Both write paths (tarball and per-file) are guarded

### Changes
- **Files**: packages/cli/index.js, packages/cli/index.test.js, tests/test_installer_wiring.py
- **What**: Added `assertWithinRoot(root, filePath)` that validates resolved path stays within root. Updated existing wiring test to match new pattern.
- **Why**: Defense-in-depth — a compromised manifest could write files outside the repository

### QA Status
- [x] CLI tests passing (11/11 via `node --test packages/cli/index.test.js`)
- [x] Project tests passing (pre-existing boot_remote failures unrelated)
- [x] Acceptance criteria met