### PR TITLE
skill: #5774 — add start scripts to installer manifest

### DIFF
--- a/references/installer-files.txt
+++ b/references/installer-files.txt
@@ -1,12 +1,14 @@
 # SquidSquad installer file manifest
 # Every file the wizard needs, fetched by npx squidsquad before
 # launching Claude. One path per line, relative to repo root.
-# Total: 253 files
+# Total: 255 files
 #
 # Maintained alongside the wizard - when you add a new role,
 # capability, preset, or sub-skill, add its files here too.
 
 SKILL.md
+start.sh
+start.ps1
 references/wizard/WIZARD.md
 references/scripts/add_role.py
 references/scripts/boot_remote.py


### PR DESCRIPTION
Closes #5774

### Summary
Added `start.sh` and `start.ps1` to `references/installer-files.txt` so they are distributed via the `npx squidsquad` installer. Scripts remain at repo root (their relative paths to `references/scripts/harness.py` require this location).

### Acceptance Criteria
- [x] start.sh and start.ps1 are in installer-files.txt
- [x] Installer will place them at project root in target repos
- [x] Scripts' relative path to harness.py still works

### Changes
- **Files**: references/installer-files.txt
- **What**: Added `start.sh` and `start.ps1` entries, updated file count (253 → 255)
- **Why**: Boot entry point scripts must be part of the distribution

### QA Status
- [x] Manifest tests passing (14/14)
- [x] Full test suite passing (pre-existing boot_remote failures unrelated)
- [x] Acceptance criteria met

### Note
Scripts kept at repo root rather than moved to `references/scripts/` because: (1) they `cd` to their own directory and use relative path `references/scripts/harness.py`, (2) the installer has no source→target path remapping, and (3) users expect boot scripts at root level.