### PR TITLE
skill: #5782 — fix pull/push emit events with role

### DIFF
--- a/references/scripts/cycle_pre.py
+++ b/references/scripts/cycle_pre.py
@@ -103,12 +103,15 @@ def _timestamp_short():
 # ---------------------------------------------------------------------------
 
 
-def _do_pull():
+def _do_pull(role=None):
     """Run git pull. Returns pull_result string (#5378).
 
     Inspects stdout to distinguish normal states from real errors.
     """
-    result = _run_script("git_ops.py", "pull")
+    args = ["git_ops.py", "pull"]
+    if role:
+        args.append(role)
+    result = _run_script(*args)
     stdout = result.stdout.strip().lower()
     stderr = result.stderr.strip().lower()
     combined = stdout + " " + stderr
@@ -931,7 +934,7 @@ def main():
     branch_correction = _enforce_branch(role, working_state)
 
     # 1c. Pull
-    pull_result = _do_pull()
+    pull_result = _do_pull(role)
 
     # 1d. Ensure merge=ours driver for config.md (#5136)
     _run(["git", "config", "merge.ours.driver", "true"], check=False)

--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -81,26 +81,27 @@ def _log_diagnostic(severity, message):
         pass
 
 
-def _emit(event_type, payload=None, cycle_number=None):
-    """Fire-and-forget event emission (#4709). Role determined from sys.argv."""
+def _emit(event_type, payload=None, cycle_number=None, role=None):
+    """Fire-and-forget event emission (#4709). Role from arg or sys.argv."""
     try:
         from event_bus import emit
-        # Determine role from command args (git_ops.py is called with role as arg)
-        role = "unknown"
-        args = sys.argv[1:]
-        # For commands like: commit-code <role> <branch> <msg>
-        # or: task-begin <role> <number>
-        if len(args) >= 2 and args[1] in ("pm", "skill", "qa", "dm"):
-            role = args[1]
-        elif len(args) >= 2 and args[0] in ("commit-code", "commit-state", "commit-push",
-                                             "commit", "task-begin", "task-end"):
-            role = args[1]
+        # Use explicit role if provided, otherwise determine from sys.argv
+        if role is None:
+            role = "unknown"
+            args = sys.argv[1:]
+            # For commands like: commit-code <role> <branch> <msg>
+            # or: task-begin <role> <number>
+            if len(args) >= 2 and args[1] in ("pm", "skill", "qa", "dm"):
+                role = args[1]
+            elif len(args) >= 2 and args[0] in ("commit-code", "commit-state", "commit-push",
+                                                 "commit", "task-begin", "task-end"):
+                role = args[1]
         emit(event_type, role, payload=payload, cycle_number=cycle_number)
     except (ImportError, Exception):
         pass
 
 
-def pull():
+def pull(role=None):
     """Pull with merge (#5378, #5445).
 
     Returns True on success, False on failure. Never crashes.
@@ -108,14 +109,14 @@ def pull():
     result = _run("git pull", check=False)
     if result.returncode == 0:
         print("Pulled")
-        _emit("git-pull", {"result": "ok"})
+        _emit("git-pull", {"result": "ok"}, role=role)
         return True
 
     # Check if the failure is "already up to date" or branch divergence
     combined = (result.stdout + result.stderr).lower()
     if "already up to date" in combined or "up to date" in combined:
         print("Pulled (already up to date)")
-        _emit("git-pull", {"result": "ok"})
+        _emit("git-pull", {"result": "ok"}, role=role)
         return True
 
     # Try stash + pull + pop
@@ -139,10 +140,10 @@ def pull():
         _run("git stash drop", check=False)
         print("WARNING: stash pop failed -- dropped stale stash entry.", file=sys.stderr)
         print("Pulled (stash pop conflict -- stale stash dropped)")
-        _emit("git-pull", {"result": "stash"})
+        _emit("git-pull", {"result": "stash"}, role=role)
     else:
         print("Pulled (stashed and popped)")
-        _emit("git-pull", {"result": "stash"})
+        _emit("git-pull", {"result": "stash"}, role=role)
     return True
 
 
@@ -180,7 +181,7 @@ def commit(role, message):
     return True
 
 
-def push():
+def push(role=None):
     """Push to remote."""
     result = _run("git push", check=False)
     if result.returncode != 0:
@@ -190,7 +191,7 @@ def push():
     # Determine branch for event payload
     branch_result = _run("git branch --show-current", check=False)
     branch = branch_result.stdout.strip() if branch_result.returncode == 0 else ""
-    _emit("git-push", {"branch": branch})
+    _emit("git-push", {"branch": branch}, role=role)
     print("Pushed")
     return True
 
@@ -720,7 +721,7 @@ def main():
     cmd, rest = _parse_args()
 
     if cmd == "pull":
-        pull()
+        pull(role=rest[0] if rest else None)
     elif cmd == "add-all":
         add_all()
     elif cmd == "commit":
@@ -729,7 +730,7 @@ def main():
             sys.exit(1)
         commit(rest[0], " ".join(rest[1:]))
     elif cmd == "push":
-        push()
+        push(role=rest[0] if rest else None)
     elif cmd == "commit-push":
         if len(rest) < 2:
             print("Usage: git_ops.py commit-push <role> <message>", file=sys.stderr)

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -139,6 +139,54 @@ class TestPush:
 
 
 # ---------------------------------------------------------------------------
+# pull/push role propagation (#5782)
+# ---------------------------------------------------------------------------
+
+class TestPullEmitsRole:
+    @patch("git_ops._emit")
+    @patch("git_ops._run")
+    def test_pull_emits_role(self, mock_run, mock_emit):
+        """pull(role='pm') passes role to _emit()."""
+        mock_run.return_value = _mock_result()
+        git_ops.pull(role="pm")
+        mock_emit.assert_called()
+        _, kwargs = mock_emit.call_args
+        assert kwargs.get("role") == "pm"
+
+    @patch("git_ops._emit")
+    @patch("git_ops._run")
+    def test_pull_without_role_backward_compat(self, mock_run, mock_emit):
+        """pull() without role still works (role=None passed to _emit)."""
+        mock_run.return_value = _mock_result()
+        git_ops.pull()
+        mock_emit.assert_called()
+        _, kwargs = mock_emit.call_args
+        assert kwargs.get("role") is None
+
+
+class TestPushEmitsRole:
+    @patch("git_ops._emit")
+    @patch("git_ops._run")
+    def test_push_emits_role(self, mock_run, mock_emit):
+        """push(role='skill') passes role to _emit()."""
+        mock_run.return_value = _mock_result()
+        git_ops.push(role="skill")
+        mock_emit.assert_called()
+        _, kwargs = mock_emit.call_args
+        assert kwargs.get("role") == "skill"
+
+    @patch("git_ops._emit")
+    @patch("git_ops._run")
+    def test_push_without_role_backward_compat(self, mock_run, mock_emit):
+        """push() without role still works (role=None passed to _emit)."""
+        mock_run.return_value = _mock_result()
+        git_ops.push()
+        mock_emit.assert_called()
+        _, kwargs = mock_emit.call_args
+        assert kwargs.get("role") is None
+
+
+# ---------------------------------------------------------------------------
 # commit_push()
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #5782

### Summary
Fixed `git_ops.py` `pull()` and `push()` to accept an optional `role` parameter and pass it to `_emit()`. Updated `cycle_pre.py` to pass the agent role when calling pull. The harness TUI now shows the correct agent name instead of 'unknown'.

### Acceptance Criteria
- [x] `pull` and `push` accept optional role argument
- [x] `_emit()` uses provided role when available
- [x] `cycle_pre.py` passes role to pull
- [x] Backward compatible — omitting role still works

### Changes
- **Files**: references/scripts/git_ops.py, references/scripts/cycle_pre.py
- **What**: Added `role=None` param to `pull()`, `push()`, `_emit()`. Updated `main()` CLI dispatch. Updated `_do_pull()` in cycle_pre.
- **Why**: Harness TUI showed 'unknown' for pull/push events because those commands didn't pass role to the event bus

### QA Status
- [x] Unit tests passing (141/141 for git_ops + cycle_pre)
- [x] Full suite passing (pre-existing boot_remote failures unrelated)
- [x] Acceptance criteria met