### PR TITLE
skill: #5772 — fix delivery-packaging.md --role dm to dm-lead

### DIFF
--- a/references/sub-skills/roles/dm/delivery-packaging.md
+++ b/references/sub-skills/roles/dm/delivery-packaging.md
@@ -21,7 +21,7 @@ If found:
 - Transition the issue to Shipped (auto-closes):
   ```bash
   python references/scripts/tracker.py transition [NUMBER] pending-ship shipped --role dm-lead
-  python references/scripts/tracker.py comment [NUMBER] --role dm --message "No delivery work needed (delivery: skip). Status → Shipped."
+  python references/scripts/tracker.py comment [NUMBER] --role dm-lead --message "No delivery work needed (delivery: skip). Status → Shipped."
   ```
 - Increment shipped count: `python references/scripts/config.py set shipped-since-bump [N+1]`
 - Clear working state.
@@ -62,7 +62,7 @@ For each Pending Ship task that is NOT skipped:
 5. Transition the issue to Shipped (auto-closes):
    ```bash
    python references/scripts/tracker.py transition [NUMBER] pending-ship shipped --role dm-lead
-   python references/scripts/tracker.py comment [NUMBER] --role dm --message "Delivery complete. Docs updated, CHANGELOG prepared. Status → Shipped."
+   python references/scripts/tracker.py comment [NUMBER] --role dm-lead --message "Delivery complete. Docs updated, CHANGELOG prepared. Status → Shipped."
    ```
 6. Increment shipped count: `python references/scripts/config.py set shipped-since-bump [N+1]`
 7. Clear working state.


### PR DESCRIPTION
Closes #5772

### Summary
Fixed tracker comment commands in `delivery-packaging.md` using `--role dm` instead of the required `--role dm-lead` suffix. Recomposed DM CLAUDE.md.

### Acceptance Criteria
- [x] Line 24: `--role dm` → `--role dm-lead`
- [x] Line 65: `--role dm` → `--role dm-lead`
- [x] DM CLAUDE.md recomposed with fix

### Changes
- **Files**: references/sub-skills/roles/dm/delivery-packaging.md, .squidsquad/dm/CLAUDE.md
- **What**: Fixed role suffix in 2 tracker comment commands
- **Why**: Inconsistent with tracker protocol convention and transition commands in the same file

### QA Status
- [x] Full test suite passing
- [x] Composed output verified (grep confirms dm-lead in delivery lines)