### PR TITLE
skill: #5843 — fix reboot_agent --all duplicate PM

### DIFF
--- a/references/scripts/reboot_agent.py
+++ b/references/scripts/reboot_agent.py
@@ -231,8 +231,10 @@ def main():
     args = parser.parse_args()
 
     if args.all:
-        # Get all agent roles from config.md via boot_remote (includes PM)
-        agents = ["pm"] + boot_remote._get_all_roles()
+        # Get all agent roles from config.md via boot_remote, ensure PM included
+        roles = set(boot_remote._get_all_roles())
+        roles.add("pm")  # PM always rebooted — config may omit the explicit line
+        agents = sorted(roles)
 
         exit_code = 0
         for role in agents:

--- a/tests/test_reboot_agent.py
+++ b/tests/test_reboot_agent.py
@@ -405,6 +405,31 @@ class TestRebootAll:
         assert "skill" in rebooted_roles
 
 
+    def test_all_no_duplicate_pm(self, patch_dirs, squid_dir, monkeypatch):
+        """#5843: --all must not reboot PM twice when _get_all_roles includes pm."""
+        config_md = squid_dir / "config.md"
+        config_md.write_text(
+            "- **Dev Agents**: skill\n"
+            "- **PM**: always present\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(boot_remote, "CONFIG_MD", config_md)
+
+        rebooted_roles = []
+
+        def fake_reboot(role, timeout=60, force=False):
+            rebooted_roles.append(role)
+            return 0
+
+        monkeypatch.setattr(reboot_agent, "reboot", fake_reboot)
+
+        with patch("sys.argv", ["reboot_agent.py", "--all"]):
+            rc = reboot_agent.main()
+
+        assert rc == 0
+        assert rebooted_roles.count("pm") == 1, f"PM rebooted {rebooted_roles.count('pm')} times: {rebooted_roles}"
+
+
 # ---------------------------------------------------------------------------
 # Double-start prevention (#2496)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #5843

### Summary
Fixed `reboot_agent.py --all` double-rebooting PM. The agent list was constructed as `["pm"] + _get_all_roles()` but `_get_all_roles()` already includes PM when `**PM**: always present` is in config. Changed to set union + sorted() to deduplicate while ensuring PM is always included even when config lacks the explicit line.

### Changes
- **Files**: references/scripts/reboot_agent.py, tests/test_reboot_agent.py
- **What**: Set dedup for agent list + regression test
- **Why**: PM was rebooted twice per `--all` invocation

### QA Status
- [x] 24/24 reboot_agent tests pass (including new regression test)
- [x] Full suite passing