### PR TITLE
skill: #5856 — emit status-transition events on every tracker transition

### DIFF
--- a/references/scripts/cycle_pre.py
+++ b/references/scripts/cycle_pre.py
@@ -376,10 +376,10 @@ def _get_cycle_number(role):
 # Unlisted roles receive all events (no filtering).
 _ROLE_EVENT_TYPES = {
     "pm": {"pr-merge", "verification-failed", "verification-passed", "cycle-start",
-            "cycle-end", "task-transition", "agent-health"},
-    "qa": {"pr-merge", "task-transition", "cycle-end", "verification-failed"},
-    "skill": {"pr-merge", "verification-failed", "task-transition"},
-    "dm": {"task-transition", "verification-passed", "pr-merge"},
+            "cycle-end", "status-transition", "agent-health"},
+    "qa": {"pr-merge", "status-transition", "cycle-end", "verification-failed"},
+    "skill": {"pr-merge", "verification-failed", "status-transition"},
+    "dm": {"status-transition", "verification-passed", "pr-merge"},
 }
 
 

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -788,10 +788,11 @@ def _log_event(event: dict):
         detail = f"PR #{payload.get('pr_number', '?')}"
     elif event_type == "branch-checkout":
         detail = payload.get("branch", "")
-    elif event_type == "task-start":
-        detail = f"#{payload.get('task_number', '?')}"
-    elif event_type == "task-end":
-        detail = f"#{payload.get('task_number', '?')}"
+    elif event_type == "status-transition":
+        issue = payload.get("issue_number", "?")
+        from_s = payload.get("from", "?")
+        to_s = payload.get("to", "?")
+        detail = f"#{issue} {from_s} → {to_s}"
     elif event_type == "tracker-comment":
         preview = payload.get("comment_preview", "")
         detail = f"#{payload.get('issue_number', '?')} \"{preview[:40]}\""

--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -983,22 +983,15 @@ def transition(number, from_status, to_status, role=None, force=False):
                 print(f"WARNING: gh issue close #{number} failed: {result.stderr.strip()}",
                       file=sys.stderr)
 
-    # Emit task lifecycle events (#4709)
+    # Emit status-transition event on every transition (#5856)
     try:
         from event_bus import emit as _emit_event
-        # Determine caller role for the event
         emit_role = (role or "unknown").replace("-lead", "")
-        if to_label == "status:in-progress":
-            _emit_event("task-start", emit_role, payload={
-                "task_number": str(number),
-                "from_status": from_label.replace("status:", ""),
-                "assigned_role": emit_role,
-            })
-        elif to_label == "status:pending-test":
-            _emit_event("task-end", emit_role, payload={
-                "task_number": str(number),
-                "assigned_role": emit_role,
-            })
+        _emit_event("status-transition", emit_role, payload={
+            "issue_number": str(number),
+            "from": from_label.replace("status:", ""),
+            "to": to_label.replace("status:", ""),
+        })
     except (ImportError, Exception):
         pass
 

--- a/tests/test_tracker_authority.py
+++ b/tests/test_tracker_authority.py
@@ -505,6 +505,88 @@ class TestTransitionEnforcement:
         assert "--role is required" in err
 
 
+class TestStatusTransitionEventEmission:
+    """#5856: transition() emits status-transition event on every transition."""
+
+    def test_emits_status_transition_event(self, monkeypatch):
+        """Every transition emits a status-transition event with correct payload."""
+        emitted = []
+
+        class FakeResult:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        monkeypatch.setattr(tracker, "_run_list", lambda *a, **kw: FakeResult())
+        monkeypatch.setattr(tracker, "_get_issue_role_labels", lambda n: {"skill"})
+
+        # Mock event_bus.emit to capture calls
+        import types
+        fake_bus = types.ModuleType("event_bus")
+        fake_bus.emit = lambda event_type, role, payload=None, cycle_number=None: emitted.append(
+            {"event_type": event_type, "role": role, "payload": payload}
+        )
+        monkeypatch.setitem(sys.modules, "event_bus", fake_bus)
+
+        tracker.transition(42, "approved", "in-progress", role="skill-lead")
+
+        assert len(emitted) == 1
+        assert emitted[0]["event_type"] == "status-transition"
+        assert emitted[0]["role"] == "skill"
+        assert emitted[0]["payload"]["issue_number"] == "42"
+        assert emitted[0]["payload"]["from"] == "approved"
+        assert emitted[0]["payload"]["to"] == "in-progress"
+
+    def test_emits_on_all_transitions_not_just_in_progress(self, monkeypatch):
+        """Emission happens for pending-test, pending-ship, shipped — not just in-progress."""
+        emitted = []
+
+        class FakeResult:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        monkeypatch.setattr(tracker, "_run_list", lambda *a, **kw: FakeResult())
+        monkeypatch.setattr(tracker, "_get_issue_role_labels", lambda n: {"pm"})
+
+        import types
+        fake_bus = types.ModuleType("event_bus")
+        fake_bus.emit = lambda event_type, role, payload=None, cycle_number=None: emitted.append(
+            {"event_type": event_type, "payload": payload}
+        )
+        monkeypatch.setitem(sys.modules, "event_bus", fake_bus)
+
+        tracker.transition(99, "pending-test", "pending-ship", role="pm-lead", force=True)
+
+        assert len(emitted) == 1
+        assert emitted[0]["event_type"] == "status-transition"
+        assert emitted[0]["payload"]["from"] == "pending-test"
+        assert emitted[0]["payload"]["to"] == "pending-ship"
+
+    def test_no_dead_task_start_task_end_events(self, monkeypatch):
+        """#5856: task-start and task-end event types must not be emitted."""
+        emitted = []
+
+        class FakeResult:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        monkeypatch.setattr(tracker, "_run_list", lambda *a, **kw: FakeResult())
+        monkeypatch.setattr(tracker, "_get_issue_role_labels", lambda n: {"skill"})
+
+        import types
+        fake_bus = types.ModuleType("event_bus")
+        fake_bus.emit = lambda event_type, role, payload=None, cycle_number=None: emitted.append(event_type)
+        monkeypatch.setitem(sys.modules, "event_bus", fake_bus)
+
+        tracker.transition(42, "approved", "in-progress", role="skill-lead")
+
+        assert "task-start" not in emitted
+        assert "task-end" not in emitted
+        assert "status-transition" in emitted
+
+
 class TestPendingShipBackwardTransition:
     """pending-ship→in-progress backward transition for merge conflicts (#1727)."""
 


### PR DESCRIPTION
Closes #5856

### Summary
Every `tracker.py transition()` call now emits a `status-transition` event to the harness event bus. Replaces the dead-wire `task-start`/`task-end` events that only fired on two transitions and nobody consumed.

### Changes
- **tracker.py**: Replaced conditional `task-start`/`task-end` emission with universal `status-transition` event on all transitions. Payload: `{issue_number, from, to}`.
- **harness.py**: Updated TUI log branch — `status-transition` shows `#issue from → to`.
- **cycle_pre.py**: Renamed `task-transition` to `status-transition` in per-role event filter config.

### QA Status
- [x] 191/191 static tests pass
- [x] Integration test failures pre-exist on main (GitHub API flake)