### PR TITLE
skill: #6000 — Fix harness Ctrl+C on Windows

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -1156,16 +1156,29 @@ def main():
     ctrl_c = CtrlCHandler()
     signal.signal(signal.SIGINT, ctrl_c.handle)
 
-    # Run uvicorn
+    # Run uvicorn in a daemon thread so the main thread stays available
+    # for signal handling. On Windows, signal handlers set via
+    # signal.signal() only fire in the main thread — if uvicorn.run()
+    # blocks the main thread, Ctrl+C is never delivered to our handler.
+    config = uvicorn.Config(
+        app,
+        host="127.0.0.1",
+        port=actual_port,
+        log_level="warning",
+    )
+    server = uvicorn.Server(config)
+
+    server_thread = threading.Thread(target=server.run, daemon=True, name="uvicorn")
+    server_thread.start()
+
     try:
-        uvicorn.run(
-            app,
-            host="127.0.0.1",
-            port=actual_port,
-            log_level="warning",  # Suppress uvicorn access logs (harness has its own logging)
-        )
+        # Main thread waits — signal.signal handler fires here on Ctrl+C
+        while server_thread.is_alive():
+            server_thread.join(timeout=1.0)
     except KeyboardInterrupt:
         _log("Harness stopped.")
+        server.should_exit = True
+        server_thread.join(timeout=5)
     finally:
         # Ensure port file cleanup
         try:


### PR DESCRIPTION
Closes ​#6000

### Summary
Harness Ctrl+C had no effect because uvicorn.run() blocked the main thread, preventing Python signal handlers from firing on Windows. Fix: run uvicorn in a daemon thread so the main thread stays available for signal delivery.

### Changes
- **harness.py**: Replaced `uvicorn.run()` with `uvicorn.Server` + daemon thread pattern. Main thread waits with `join(timeout=1.0)` so SIGINT handler fires.

### QA Status
- [x] Unit tests passing (1107/1107)
- [x] No regressions