### PR TITLE
skill: #6043 — reboot_agent Path wrap fix

### DIFF
--- a/references/scripts/reboot_agent.py
+++ b/references/scripts/reboot_agent.py
@@ -97,7 +97,7 @@ def reboot(role, timeout=DEFAULT_TIMEOUT, force=False):
     (.pid). The wrapper stays alive, detects claude exit, reads .restart
     sentinel, and respawns claude automatically.
     """
-    clone_path = _get_clone_path(role)
+    clone_path = Path(_get_clone_path(role))
     squid = clone_path / ".squidsquad"
     pid_file = squid / role / ".pid"
     restart_file = squid / role / ".restart"


### PR DESCRIPTION
Closes ​#6043

### Summary
Downstream fix from #5915 — `_get_clone_path()` now returns `str` but `reboot_agent.py` line 101 used the `/` operator which requires a `Path` object. Wrapped in `Path()`.

### Changes
- **reboot_agent.py**: `clone_path = Path(_get_clone_path(role))`

### QA Status
- [x] Unit tests passing
- [x] No regressions