### PR TITLE
skill: #6057 — Add in-progress -> planning transition

### DIFF
--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -123,6 +123,8 @@ LEGAL_TRANSITIONS = {
     "status:in-progress": {
         "status:pending-test",
         "status:approved",
+        # #6057: code review rejection path — dev sends task back to PM for re-planning
+        "status:planning",
         # #328 Phase E: worker self-pause edges (Q7 HITL + Q-new11 tool setup).
         # The assigned worker moves its own in-progress issue into a
         # human-waiting state when it needs human input or environment work.
@@ -175,6 +177,7 @@ ROLE_AUTHORITY = {
     ("status:approved", "status:in-progress"): {"_assignee"},
     ("status:in-progress", "status:pending-test"): {"_assignee"},
     ("status:in-progress", "status:approved"): {"_assignee"},
+    ("status:in-progress", "status:planning"): {"_assignee"},  # #6057 code review rejection
 
     # QA/PM owns verification. PM is always authorized because the PM agent
     # holds the combined PM/QA identity in deployments without a dedicated QA

--- a/references/sub-skills/common/tracker-protocol.md
+++ b/references/sub-skills/common/tracker-protocol.md
@@ -94,7 +94,7 @@ Legal flows and owning roles:
 - `planning` → `planned` — **PM**
 - `planned` → `approved` — **PM**
 - `approved` → `in-progress` — **assigned role**
-- `in-progress` → `pending-test` | `approved` | `pending-human-review` | `pending-human-setup` — **assigned role**
+- `in-progress` → `pending-test` | `approved` | `planning` | `pending-human-review` | `pending-human-setup` — **assigned role**
 - `pending-human-review` → `in-progress` | `pending-ship` — **assigned role** (HITL designer loop)
 - `pending-human-setup` → `in-progress` — **PM** (environment setup complete)
 - `pending-test` → `in-progress` | `pending-ship` — **PM or QA** (both authorized; QA handles verification when installed, PM falls back when QA absent)


### PR DESCRIPTION
Closes ​#6057

### Summary
Adds `in-progress -> planning` as a legal state machine transition, authorized for the assigned role. Enables code review rejection path: dev finds design-level flaw, sends task back to PM for re-planning.

### Changes
- **tracker.py**: Added to LEGAL_TRANSITIONS and ROLE_AUTHORITY
- **tracker-protocol.md**: Updated legal flows documentation

### QA Status
- [x] Unit tests passing (1166/1166)
- [x] No regressions