### PR TITLE
skill: #5932 — External code review loop before pending-test

### DIFF
--- a/references/prompts/code-review.md.j2
+++ b/references/prompts/code-review.md.j2
@@ -8,13 +8,7 @@ You are reviewing code changes for a software development task. Your role is to 
 
 Review ONLY these files. Do not comment on code outside the changed files.
 
-{% for file in input_files %}
-### {{ file.path }}
-
-```
-{{ file.content }}
-```
-{% endfor %}
+{{ file_contents }}
 
 ## Review Criteria
 

--- a/references/prompts/code-review.md.j2
+++ b/references/prompts/code-review.md.j2
@@ -1,0 +1,52 @@
+You are reviewing code changes for a software development task. Your role is to find genuine issues — not style preferences.
+
+## Task Context
+
+{{ context }}
+
+## Changed Files
+
+Review ONLY these files. Do not comment on code outside the changed files.
+
+{% for file in input_files %}
+### {{ file.path }}
+
+```
+{{ file.content }}
+```
+{% endfor %}
+
+## Review Criteria
+
+Focus on (in priority order):
+1. **Correctness**: Does the code do what the acceptance criteria require?
+2. **Regressions**: Could this change break existing behavior?
+3. **Edge cases**: Are error paths, empty inputs, and boundary conditions handled?
+4. **Integration**: Does this work correctly with the rest of the system?
+5. **Philosophy violations**: Does this violate stated project principles or patterns?
+
+## What is NOT a finding
+
+- Style preferences (naming, spacing, import order)
+- Suggestions for "better" approaches when the current one is correct
+- Missing features not in the acceptance criteria
+- Code in unchanged files
+
+## Output Format
+
+For each finding, output a structured entry:
+
+```
+### Finding N
+
+- **File**: [path]
+- **Line**: [line number or range]
+- **Severity**: [error | warning]
+- **Issue**: [what is wrong — specific and testable]
+- **Evidence**: [why this is wrong, referencing ACs or project rules]
+- **Suggested fix**: [concrete fix, not vague advice]
+```
+
+If no issues found, output exactly: `NO_FINDINGS`
+
+Be specific. Every finding must have evidence. Do not invent problems.

--- a/references/scripts/config.py
+++ b/references/scripts/config.py
@@ -76,6 +76,7 @@ FIELD_MAP = {
     "qa-execution-model": ("Model Routing", "QA Execution Model"),
     "comprehension-model": ("Model Routing", "Comprehension Model"),
     "improvement-scan-model": ("Model Routing", "Improvement Scan Model"),
+    "code-review-model": ("Model Routing", "Code Review Model"),  # #5932
     "fallback-model": ("Model Routing", "Fallback Model"),
     "api-timeout-seconds": ("Model Routing", "API Timeout Seconds"),
     "forge-provider": ("Forge Backend", "Provider"),

--- a/references/scripts/model_router.py
+++ b/references/scripts/model_router.py
@@ -997,7 +997,7 @@ def main():
     route_parser.add_argument(
         "--task-type", default="research",
         choices=["research", "discussion-prep", "test-plan",
-                 "improvement-scan", "qa-execution", "comprehension"],
+                 "improvement-scan", "qa-execution", "comprehension", "code-review"],
         help="Task type when using bare 'route' subcommand (default: research)",
     )
     route_parser.add_argument("--task-id", required=True, help="Task identifier")

--- a/references/scripts/model_router.py
+++ b/references/scripts/model_router.py
@@ -141,6 +141,7 @@ def get_model_for_task(task_type):
         "improvement-scan": "improvement-scan-model",
         "qa-execution": "qa-execution-model",
         "comprehension": "comprehension-model",
+        "code-review": "code-review-model",  # #5932
     }
 
     key = key_map.get(task_type, f"{task_type}-model")
@@ -535,6 +536,7 @@ def _load_prompt_template(task_type):
         "discussion-prep": "discussion-prep.md.j2",
         "test-plan": "test-plan.md.j2",
         "improvement-scan": "improvement-scan.md.j2",
+        "code-review": "code-review.md.j2",  # #5932
     }
     filename = template_map.get(task_type)
     if not filename:
@@ -989,7 +991,7 @@ def main():
         "route", help="Route a subagent task to an external model",
         aliases=[
             "research", "discussion-prep", "test-plan",
-            "improvement-scan", "qa-execution", "comprehension",
+            "improvement-scan", "qa-execution", "comprehension", "code-review",
         ],
     )
     route_parser.add_argument(
@@ -1032,7 +1034,7 @@ def main():
         sys.exit(code)
     elif args.command in (
         "route", "research", "discussion-prep", "test-plan",
-        "improvement-scan", "qa-execution", "comprehension",
+        "improvement-scan", "qa-execution", "comprehension", "code-review",
     ):
         task_type = args.command if args.command != "route" else args.task_type
         code = route(task_type, args.task_id, args.input_files, args.output_file, args.context)

--- a/references/sub-skills/roles/dev/implement-tasks.md
+++ b/references/sub-skills/roles/dev/implement-tasks.md
@@ -34,6 +34,50 @@ Print: `[🦑 HH:MM:SS] Implementing #[NUMBER]...`
    - **Philosophy**: Does this violate any project philosophy, vault decisions, or established patterns?
    - **Personas**: Will this break workflows for any agent role (PM, QA, DM, human)? Think through each consumer of your change.
    If ANY of these checks reveal a concern — fix it before transitioning. Do not ship known concerns for QA to catch.
+9c. **External code review** — after self-review passes, run an external model review before marking pending-test. Self-review catches what you know; external review catches what you missed.
+
+   **Stage all changes first**:
+   ```bash
+   git add -A
+   ```
+
+   **Get changed files and run review**:
+   ```bash
+   CHANGED_FILES=$(git diff --name-only HEAD | paste -sd, -)
+   python references/scripts/model_router.py code-review \
+     --task-id "#[NUMBER]" \
+     --input-files "$CHANGED_FILES" \
+     --output-file ".squidsquad/[ROLE]/planning/CODE-REVIEW-[NUMBER].md" \
+     --context "Task: [title]. ACs: [acceptance criteria summary]. Project philosophy: [key constraints]."
+   ```
+
+   **If external model unavailable** (exit code 1 or 2): fall back to Claude via the Agent tool with the same review prompt (read the changed files, review against ACs and project philosophy, output structured findings).
+
+   **Process findings** — for each finding, choose one disposition:
+   - **Fix**: Apply the suggested fix. Re-run tests after fixing.
+   - **File-to-PM**: The finding reveals a design-level flaw (AC gap, philosophy violation, wrong approach). The review loop **exits immediately**. Transition to `planning`:
+     ```bash
+     python references/scripts/tracker.py create-issue --title "[finding summary]" --body "[evidence from review]" --role pm --severity medium --reporter [ROLE]-lead
+     python references/scripts/tracker.py transition [NUMBER] in-progress planning --role [ROLE]-lead
+     python references/scripts/tracker.py comment [NUMBER] --role [ROLE]-lead --message "External review found design-level flaw. Filed #[NEW]. Status → Planning for PM to re-plan."
+     ```
+     Stop here — do NOT proceed to pending-test.
+   - **Justified-ignore**: The finding is not applicable to this context. Document why in the PR comment. This is a valid, non-shameful outcome — not every finding is correct.
+
+   **Post dispositions as PR comment** (audit trail):
+   ```bash
+   gh pr comment [PR_NUMBER] --body "## External Code Review — Iteration [N]
+
+   [For each finding: finding summary + disposition (fix/file-to-pm/justified-ignore) + rationale]"
+   ```
+
+   **Re-run review** after applying fixes. Loop until:
+   - Clean review (zero findings) → exit loop immediately, proceed to step 10
+   - 5 iterations reached with remaining findings → proceed to step 10 with all findings noted in PR comment. QA decides whether to accept.
+   - File-to-PM disposition → exit loop, transition to planning (see above)
+
+   **Escalation**: If >50% of findings across 3+ iterations are justified-ignore, note in the PR comment: "High justified-ignore rate — review model or prompt may need tuning." This is a process signal for the human.
+
 10. If tests and smoke tests pass and changes exist:
    - Transition status:
      ```bash


### PR DESCRIPTION
Closes ​#5932

### Summary
Adds mandatory external code review step (9c) between self-review and pending-test in the dev agent Ralph Loop. Configurable model via config.md, disposition-based iteration loop with file-to-PM rejection path.

### Acceptance Criteria
- [x] AC-1: code-review task type in model_router + config + prompt
- [x] AC-2: Full changed files + ACs/philosophy in context
- [x] AC-3: Loop until clean or 5-iteration cap
- [x] AC-4: Three dispositions + PR comment audit trail
- [x] AC-5: File-to-PM exits loop, transitions to planning
- [x] AC-6: 5-iteration cap, QA decides at cap
- [x] AC-7: Justified-ignore escalation
- [x] AC-8: Step 9c in implement-tasks.md
- [x] AC-9: Backward compatible

### Changes
- **model_router.py**: code-review task type
- **config.py**: Code Review Model field
- **code-review.md.j2**: Prompt template
- **implement-tasks.md**: Step 9c (review loop)

### QA Status
- [x] Unit tests passing (1166/1166)
- [x] Code reviewed by Claude Agent (2 findings fixed)