### PR TITLE
skill: #6055 — Enforce role separation (remove PM fallbacks)

### DIFF
--- a/references/roles/pm/SOUL.md
+++ b/references/roles/pm/SOUL.md
@@ -8,7 +8,7 @@ You are the squad's diplomat and strategist. Your purpose is to translate human 
 
 ### Quality Posture
 
-You carry a QA mindset as a core personality trait — almost half a QA agent in how you read plans, assess risk, and verify completeness. You are strict on quality without being rigid: you are comfortable sitting with uncertainty, but you are always working it toward certainty. Ambiguity is a temporary state you actively close. A loose acceptance criterion is not a judgment call left to dev — it is an unfinished spec.
+You hold QA accountable — you do not replace QA. You think in terms of quality, risk, and completeness when writing specs, but verification is QA's job. You are strict on quality without being rigid: you are comfortable sitting with uncertainty, but you are always working it toward certainty. Ambiguity is a temporary state you actively close. A loose acceptance criterion is not a judgment call left to dev — it is an unfinished spec.
 
 You keep agents honest. When dev says "done" and QA says "not quite," you side with QA. When a feature is technically complete but the edge cases were never discussed, you notice before it reaches review.
 

--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -1109,15 +1109,23 @@ def generate_local_config(roles: list, target_root: Path = None,
 
 
 
+MANDATORY_ROLES = {"pm", "qa", "dm"}  # #6055: always present, no fallbacks
+
+
 def _collect_all_roles() -> list:
-    """Return all configured roles: dev-agents from config + pm + dm (if present)."""
+    """Return all configured roles: dev-agents from config + pm + qa + dm."""
     agents = _read_config_value("dev-agents") or ""
     roles = [r.strip() for r in agents.split(",") if r.strip()]
-    roles.append("pm")  # PM always present
-    dm_dir = REPO_ROOT / ".squidsquad" / "dm"
-    if dm_dir.exists():
-        roles.append("dm")
+    # Mandatory roles — always required (#6055)
+    for role in ("pm", "qa", "dm"):
+        if role not in roles:
+            roles.append(role)
     return roles
+
+
+def _check_mandatory_roles(roles: list) -> list[str]:
+    """Check that all mandatory roles are present. Returns list of missing roles."""
+    return [r for r in MANDATORY_ROLES if r not in roles]
 
 
 
@@ -1163,6 +1171,13 @@ def main():
     elif cmd == "deploy-all":
         # Deploy all configured agents
         roles = _collect_all_roles()
+        # #6055: Check mandatory roles are present
+        missing = _check_mandatory_roles(roles)
+        if missing:
+            print(f"ERROR: Mandatory role(s) missing: {', '.join(missing)}", file=sys.stderr)
+            print(f"Every SquidSquad team requires PM, QA, and DM.", file=sys.stderr)
+            print(f"Add missing roles with: /squidsquad-setup or manually create .squidsquad/{missing[0]}/", file=sys.stderr)
+            sys.exit(1)
         failed = []
         for role in roles:
             try:

--- a/references/sub-skills/common/cycle-runner.md
+++ b/references/sub-skills/common/cycle-runner.md
@@ -80,7 +80,7 @@ The script handles: status transitions, tracker comments, iteration logging, git
 - `human_input_processed`: summary of human input handled
 - `issues_filed`, `issues_verified`, `tasks_verified`, `tasks_shipped`
 - `external_issues_triaged`, `health_alerts`, `vault_writes`
-- `version_bump`: `{new_version, items_included}` — if DM absent
+- `version_bump`: `{new_version, items_included}` — deprecated (DM always present)
 
 **QA** cycle-output extras:
 - `e2e_log`: `{result, tests_run, failures}`

--- a/references/sub-skills/manifest.md
+++ b/references/sub-skills/manifest.md
@@ -61,8 +61,8 @@ Entry file with includes. PM's `SOUL.md` sits alongside its `CLAUDE.md` and is c
 2. `common/cycle-runner` — Cycle runner transport layer
 3. `common/context-pressure` — Context pressure check
 4. `roles/pm/checkin` — Step 2: human check-in and input handling
-5. `roles/pm/testing-and-verification` — Steps 3-6c: E2E, investigate, verify issues/tasks, ship counter
-6. `roles/pm/delivery-fallback` — Step 6d: PM delivery when DM absent
+5. `roles/pm/testing-and-verification` — Steps 3-6c: QA handles verification (PM delegates)
+6. `roles/pm/delivery-fallback` — Delivery: DM handles all delivery (PM delegates)
 7. `roles/pm/post-merge-recompose` — Step 6e: recompose after branch merge
 8. `roles/pm/pipeline-sentinel` — Step 6f: pipeline health (conflict, stall, PR sync)
 9. `roles/pm/own-domain-autofix` — Auto-fix own-domain mechanical issues
@@ -212,7 +212,7 @@ references/sub-skills/
 │   ├── post-merge-recompose.md    (Step 6e — recompose after branch merge)
 │   ├── task-intake.md              (5-phase lifecycle + Open Artifacts)
 │   ├── task-approval.md            (Feature Approval Gate)
-│   ├── delivery-fallback.md           (Step 6d — PM delivery when DM absent)
+│   ├── delivery-fallback.md           (Delivery — DM handles all delivery)
 │   ├── discussion-protocol.md        (Discussion — pm/qa alias)
 │   ├── issue-filing.md                 (Bug Filing Protocol)
 │   ├── file-conventions.md           (PM file conventions)

--- a/references/sub-skills/roles/pm/delivery-fallback.md
+++ b/references/sub-skills/roles/pm/delivery-fallback.md
@@ -1,53 +1,5 @@
-### Step 6d — PM Delivery Fallback (when DM absent)
+### Delivery
 
-**DM presence check**: If `.squidsquad/dm/` directory exists, DM handles all delivery work — skip this step entirely.
+DM handles all delivery work: documentation updates, CHANGELOG, version bumps, user-facing communications. PM does not perform delivery.
 
-If `.squidsquad/dm/` directory does NOT exist (DM not installed), PM takes over delivery responsibilities. For each task just marked `Pending Ship` in Steps 6/6b:
-
-Print: `[🦑 HH:MM:SS] No DM present — PM performing delivery for #[NUMBER]...`
-
-**Note**: PR merging is handled by QA during verification (Step 5). By the time an item reaches pending-ship, the PR is already merged. PM delivery does NOT merge PRs.
-
-**1. Check for delivery:skip**: If the task's Discussion contains `delivery: skip`, mark it `Shipped` immediately, increment `Shipped Since Last Bump` in `config.md`, and append: `> [YYYY-MM-DD HH:MM] **pm**: No DM present. No delivery work needed (delivery: skip). Status → Shipped.` Skip to the version bump check below.
-
-**2. Create delivery package** (for tasks NOT marked delivery:skip):
-   - **Update user-facing docs**: Update `README.md` with user-story descriptions of the new functionality. Update any relevant sections of `SKILL.md` that describe user-facing behavior. Write in terms users understand — what's new, how to use it, what changed.
-   - **Prepare CHANGELOG entry**: Append a Discussion note with the CHANGELOG text (do NOT write to `CHANGELOG.md` yet — it will be included in the next version bump): `> [YYYY-MM-DD HH:MM] **pm**: CHANGELOG entry prepared: "#[NUMBER] — [Title]".`
-   - **Check for config/migration changes**: If the task introduces new config values, settings, or requires migration steps, document them in the Discussion.
-
-**3. Mark Shipped**: Update the task's status to `Shipped`. Append: `> [YYYY-MM-DD HH:MM] **pm**: No DM present — PM delivery complete. Docs updated, CHANGELOG prepared. Status → Shipped.`
-
-**4. Increment counter**: Increment `Shipped Since Last Bump` in `config.md`.
-
-**5. Version bump check** (after all tasks delivered this cycle):
-   - Read `Ship Threshold` from `config.md` (default 10).
-   - Read `Shipped Since Last Bump` from `config.md`.
-   - If counter < threshold: no bump needed, continue.
-   - If counter >= threshold: check all agent issue trackers for open issues (`**Status**: Open` or `**Status**: Investigating`).
-     - If open issues exist: defer the bump. Print: `[🦑 HH:MM:SS] Version bump deferred — [N] open issues remain.`
-     - If zero open issues: **perform the bump**.
-
-   **Bump sequence**:
-
-   1. Read current version from `config.md` (e.g. `0.6.0`).
-   2. Increment minor version, reset patch to 0 (e.g. `0.6.0` → `0.7.0`).
-   3. Update `config.md`: set `SquidSquad Version` to new version.
-   4. Update `SKILL.md` YAML frontmatter: set `version` to new version.
-   5. Add new section to top of `CHANGELOG.md`:
-      ```markdown
-      ## [X.Y.Z] — YYYY-MM-DD
-
-      ### Added
-      - #NUMBER — Title
-
-      ### Fixed
-      - #NUMBER — Title
-      ```
-      List all items shipped since the last bump (scan tracker Discussions for `Status → Shipped` entries since the previous version's date).
-   6. Commit: `git add -A && git commit -m "chore: bump version to vX.Y.Z"`
-   7. Check if tag exists: `git tag -l "vX.Y.Z"`. If it exists, skip tagging.
-   8. Create tag: `git tag vX.Y.Z`
-   9. Push: `git push && git push --tags`
-   10. Reset `Shipped Since Last Bump` to `0` in `config.md`.
-
-   Print: `[🦑 HH:MM:SS] Version bumped to vX.Y.Z — tag created and pushed.`
+**PM's role in delivery**: Ensure DM picks up pending-ship items promptly. If items stall at pending-ship for >90 minutes, nudge DM via the pipeline sentinel. PM never does delivery packaging directly.

--- a/references/sub-skills/roles/pm/prohibitions.md
+++ b/references/sub-skills/roles/pm/prohibitions.md
@@ -3,10 +3,11 @@
 - Never approve a task without explicit human confirmation.
 - Never edit another agent's Discussion entries.
 - Never push without pulling first.
-- Never touch application code or skill files — you are coordination and QA only.
+- Never touch application code or skill files — you are coordination only.
 - Never implement fixes or tasks directly — always file to the appropriate agent's issue or task tracker.
 - Never delete entries from tracker files.
-- Never mark an issue Verified without actually running a test or check.
+- Never verify work you planned — verification is QA's job, not PM's. PM holds QA accountable but does not replace QA.
+- Never perform delivery (docs, CHANGELOG, version bumps) — delivery is DM's job. PM holds DM accountable but does not replace DM.
 - After any status change, use `python references/scripts/tracker.py transition` — never construct `gh issue edit` label commands manually.
 - Shipped transitions auto-close the Issue via tracker.py.
 - Never proceed with ambiguous or incomplete context. If PM's comments reference planning artifacts (RESEARCH.md, CONTEXT.md, TEST-PLAN.md) you cannot find, or if the described scope clearly exceeds what you understand from the issue body alone, **stop and push back** — comment on the issue asking for clarification or alignment before implementing. Guessing wastes cycles and produces wrong output.

--- a/references/sub-skills/roles/pm/testing-and-verification.md
+++ b/references/sub-skills/roles/pm/testing-and-verification.md
@@ -1,104 +1,11 @@
-### Steps 3–6 — Testing & Verification (QA Fallback)
+### Steps 3–6 — Testing & Verification
 
-**QA presence check**: If `.squidsquad/qa/` directory exists and a QA agent is running (check `current-state` file exists), QA handles all testing and verification independently. Skip Steps 3–6 entirely and print: `[🦑 HH:MM:SS] QA agent present — skipping verification (QA handles it).`
+QA handles all testing and verification. PM does not verify, does not run E2E tests, does not test acceptance criteria.
 
-If QA is **not installed** (`.squidsquad/qa/` does not exist), PM falls back to combined PM/QA duties for Steps 3–6 below.
+Print: `[🦑 HH:MM:SS] QA handles verification — skipping Steps 3-6.`
 
----
-
-#### Step 3 — Run E2E Tests
-
-Print: `[🦑 HH:MM:SS] Running E2E tests...` (or `[🦑 HH:MM:SS] No E2E command — skipping tests.`)
-
-If `E2E Tests` is configured in `config.md`, run: `[E2E_TEST_CMD]`
-
-If no E2E command is configured, skip this step.
-
-Log results in `pm/qa-log.md`:
-
-```markdown
-## QA Run — YYYY-MM-DD HH:MM
-
-- **Result**: Passed | Failed | Skipped (no E2E command)
-- **Tests Run**: [N]
-- **Failures**: [list failing test names, or "none"]
-- **Notes**: [anything notable]
-```
-
-#### Step 4 — Investigate and Present Issues From Test Failures
-
-Print: `[🦑 HH:MM:SS] Investigating test failures...` (or skip if no failures)
-
-For each test failure:
-
-1. Determine which agent's domain the failure is in.
-2. Check if an issue for this failure already exists (search by keywords). If yes, append a Discussion note — do not duplicate.
-3. If new: **use the Issue Discussion Flow** (same as Step 2):
-   - **Investigate** the root cause — read relevant code, understand why the test failed, identify possible fixes.
-   - **Present** the failure analysis, root cause, and proposed fix to the human.
-   - **Wait for approval** before filing. If the human approves, file the issue with the agreed-upon fix approach in Description or Discussion. Increment the appropriate counter in `config.md`.
-   - **Non-blocking**: If the human doesn't respond, note "awaiting human input on fix approach for [test failure description]" in your working state and continue the loop. Revisit next cycle.
-4. If the failure spans multiple domains: investigate once, present once, and after approval file in each relevant tracker with cross-linking Discussion notes.
-
-#### Step 5 — Verify Fixed Issues
-
-Print: `[🦑 HH:MM:SS] Verifying fixed issues...`
-
-Query GitHub Issues for issues pending verification:
-
-```bash
-python references/scripts/tracker.py list-issues skill --status pending-test
-```
-
-For each result:
-
-0. **Blocked check**: If the item has a `blocked:human-action` label, skip it. Print: `[🦑 HH:MM:SS] Skipping #[NUMBER] — blocked:human-action (waiting for human).` Do not change its status. Move to the next item.
-1. Run the relevant test or manually verify the fix.
-2. **Test coverage check**: Verify that the fix includes a regression test. Check for new or modified test files corresponding to the changed code. If the fix adds or changes code but includes no tests, reject it.
-3. **Run the full test suite**: `python tests/run_tests.py` — all tests must pass.
-4. If verified (fix works, regression test exists, all tests pass):
-   - Update status to `Verified`, then `Closed`.
-   - Append Discussion entries for each transition.
-5. If not verified (fix doesn't work, no regression test, or tests fail):
-   - Update status back to `Open`.
-   - Append a Discussion entry explaining what failed — be specific about missing tests.
-
-#### Step 6 — Verify Pending Test Tasks
-
-Print: `[🦑 HH:MM:SS] Verifying pending test tasks...`
-
-Query GitHub Issues for tasks pending test:
-
-```bash
-python references/scripts/tracker.py list-tasks skill --status pending-test
-```
-
-For each result:
-
-0. **Blocked check**: If the item has a `blocked:human-action` label, skip it. Print: `[🦑 HH:MM:SS] Skipping #[NUMBER] — blocked:human-action (waiting for human).` Do not change its status. Move to the next item.
-1. Test against the acceptance criteria.
-2. **Test coverage check**: Verify that new code has corresponding unit tests. Check for new or modified test files. If the implementation adds new functions, scripts, or modules but includes no tests, reject it — tests are part of the implementation, not follow-up work.
-3. **Run the full test suite**: `python tests/run_tests.py` — all tests must pass.
-4. **Zero-gap gate**: If ANY gap, ambiguity, missing documentation, failed check, missing test coverage, or unresolved finding is discovered — update back to `In Progress` and append a Discussion entry listing every specific finding. Do NOT mark Pending Ship with "gaps noted for follow-up." ALL findings must be resolved before shipping.
-3. **Only exception**: The human explicitly says "ship with these gaps" — record the override in Discussion: `> [YYYY-MM-DD HH:MM] **pm**: Human override — shipping with [N] noted gaps: [list]. Status → Pending Ship.`
-4. If all criteria pass with zero gaps:
-   **Promote test files to tests/** (before transitioning):
-   If any test files exist in `.squidsquad/[ROLE]/planning/` matching `*-tests.py` or `*-QA-RESULTS*.md`:
-   - Copy test `.py` files to `tests/` with naming convention: `tests/test_feat_[NUMBER]_[short_name].py`
-   - Verify promoted tests still pass: `python -m pytest tests/test_feat_[NUMBER]_*.py`
-   - These tests persist as regression tests — NOT deleted during planning cleanup
-
-   **PR Flow gate** (if PR Flow `yes` and a PR exists for this issue):
-   - Check Auto Merge: `python references/scripts/config.py get auto-merge`
-   - Check per-ticket override: look for `review:human-required` label on the issue.
-   - **Auto Merge ON + no `review:human-required`**: convert draft PR to ready first (`python references/scripts/git_ops.py pr-ready [PR_NUMBER]`), then merge (`python references/scripts/git_ops.py pr-merge [PR_NUMBER]`), then transition to `Pending Ship`.
-   - **Auto Merge OFF or `review:human-required`**: transition to `Pending Human Review` (`python references/scripts/tracker.py transition [NUMBER] pending-test pending-human-review --role pm-lead`).
-   - If PR Flow `no` or no PR exists: proceed directly to `Pending Ship`.
-
-   Update to `Pending Ship` (or `Pending Human Review` per above), append Discussion entry: `> [YYYY-MM-DD HH:MM] **pm**: Verified — zero gaps. Status → Pending Ship.`
-5. **delivery:skip check**: If the task is internal-only (agent template changes, config changes, internal tooling, process improvements) with no user-facing delivery work needed, add `delivery: skip` to the Discussion entry when marking Pending Ship: `> [YYYY-MM-DD HH:MM] **pm**: Verified — zero gaps. delivery: skip (internal-only, no user-facing changes). Status → Pending Ship.` This tells the DM (or PM fallback) to skip delivery packaging and mark the task Shipped immediately.
-6. If criteria fail: update back to `In Progress`, append Discussion entry with specific failures.
+**PM's role in verification**: Hold QA accountable. If items stall at pending-test for >90 minutes, nudge QA via the pipeline sentinel (Step 6f). If QA rejects work, route the rejection back to the dev agent. PM never verifies directly.
 
 #### Step 6c — Increment Ship Counter for Closed Issues
 
-When marking any issue as `Closed` in Step 5, increment the `Shipped Since Last Bump` counter in `config.md`. If DM is present, it handles version bumps. If DM is absent, PM handles version bumps in Step 6d.
+When an issue is shipped (DM marks Shipped), increment the `Shipped Since Last Bump` counter in `config.md`. DM handles version bumps.


### PR DESCRIPTION
Closes ​#6055

### Summary
Enforces four mandatory L2 roles (PM, QA, DM, dev). Removes all fallback paths where PM absorbed QA/DM duties. compose.py deploy-all now fails if mandatory roles are missing.

### Changes
- **testing-and-verification.md**: Gutted — QA handles verification, PM delegates
- **delivery-fallback.md**: Gutted — DM handles delivery, PM delegates
- **PM SOUL.md**: Removed 'almost half a QA agent'
- **PM prohibitions.md**: Added 'never verify', 'never deliver'
- **compose.py**: MANDATORY_ROLES + _check_mandatory_roles enforcement
- **cycle-runner.md**: Updated DM version_bump comment
- **manifest.md**: Updated descriptions

### QA Status
- [x] Unit tests passing (1166/1166)
- [x] Code reviewed (1 finding fixed)