### PR TITLE
skill: #6125 — L2 task pickup for DM/QA/PM

### DIFF
--- a/references/roles/dm/includes.yml
+++ b/references/roles/dm/includes.yml
@@ -7,6 +7,7 @@ includes:
   - common/cycle-runner
   - common/event-reactions
   - common/context-pressure
+  - common/task-pickup
   - roles/dm/issue-triage
   - roles/dm/delivery-packaging
   - roles/dm/version-bumps

--- a/references/roles/pm/includes.yml
+++ b/references/roles/pm/includes.yml
@@ -5,6 +5,7 @@ includes:
   - common/cycle-runner
   - common/event-reactions
   - common/context-pressure
+  - common/task-pickup
   - roles/pm/checkin
   - roles/pm/testing-and-verification
   - roles/pm/delivery-fallback

--- a/references/roles/qa/includes.yml
+++ b/references/roles/qa/includes.yml
@@ -6,6 +6,7 @@ includes:
   - common/cycle-runner
   - common/event-reactions
   - common/context-pressure
+  - common/task-pickup
   - roles/qa/verification
   - common/improvement-scan-slim
   - roles/qa/issue-filing

--- a/references/sub-skills/common/task-pickup.md
+++ b/references/sub-skills/common/task-pickup.md
@@ -1,0 +1,30 @@
+### Task Pickup (Approved Tasks)
+
+Before role-specific work, check for approved tasks assigned to your role:
+
+```bash
+python references/scripts/tracker.py work-queue [ROLE]
+```
+
+If the queue returns an approved task (not just role-specific items like pending-ship or pending-test):
+
+1. Read the task: `gh issue view [NUMBER] --json title,body,labels,comments`
+2. **Design label check**: If `design:needed` or `design:in-progress`, skip — wait for designer.
+3. Transition to in-progress:
+   ```bash
+   python references/scripts/tracker.py transition [NUMBER] approved in-progress --role [ROLE]-lead
+   python references/scripts/tracker.py comment [NUMBER] --role [ROLE]-lead --message "Picking up. Status -> In Progress."
+   ```
+4. **Branch checkout**: `python references/scripts/git_ops.py task-begin [ROLE] [NUMBER]`
+5. Read planning artifacts if available (`.squidsquad/pm/planning/`).
+6. Implement the task per acceptance criteria.
+7. Run tests: `python tests/run_tests.py`
+8. **Verify changes exist**: `python references/scripts/git_ops.py has-changes`
+9. Transition to pending-test:
+   ```bash
+   python references/scripts/tracker.py transition [NUMBER] in-progress pending-test --role [ROLE]-lead
+   python references/scripts/tracker.py comment [NUMBER] --role [ROLE]-lead --message "Implementation complete. Status -> Pending Test."
+   ```
+10. Return to working branch: `python references/scripts/git_ops.py task-end [ROLE] [NUMBER]`
+
+If the queue is empty, proceed to role-specific work (delivery scanning, verification, etc.).


### PR DESCRIPTION
Closes ​#6125

### Summary
Creates common/task-pickup.md — an L2 sub-skill that gives all roles the ability to pick up approved tasks assigned to them. Previously only dev agents had triage/implement. DM, QA, and PM now query work-queue and implement approved tasks.

### Changes
- **common/task-pickup.md**: New L2 sub-skill
- **dm/includes.yml**: Added task-pickup
- **qa/includes.yml**: Added task-pickup
- **pm/includes.yml**: Added task-pickup

### QA Status
- [x] Unit tests passing (1166/1166)