### PR TITLE
skill: #6222 — Fix auto-merge closing issues before DM delivery

### DIFF
--- a/.squidsquad/config.md
+++ b/.squidsquad/config.md
@@ -115,7 +115,7 @@
 ## Auto Versioning
 
 - **Ship Threshold**: 10
-- **Shipped Since Last Bump**: 9
+- **Shipped Since Last Bump**: 0
 
 ## Agent Effort
 

--- a/.squidsquad/config.md
+++ b/.squidsquad/config.md
@@ -1,6 +1,6 @@
 # SquidSquad Config
 
-- **SquidSquad Version**: 0.33.0
+- **SquidSquad Version**: 0.34.0
 - **Tracker**: github-issues
 - **Architecture Version**: 1
 

--- a/.squidsquad/skill/scan-history.md
+++ b/.squidsquad/skill/scan-history.md
@@ -1,5 +1,19 @@
 # Scan History
 
+## Scan — 2026-05-08 21:02
+
+- **Files scanned**: tests/run_tests.py, tests/test_git_ops.py, tests/test_wizard.py
+- **Findings**: #6254 (test_git_ops.py test_forge_adapter_routing is false-confidence — patches sys.modules after import, adapter mock never reached — low)
+- **Items rejected by human**: none yet
+- **Notes**: run_tests.py clean (137 lines). test_wizard.py clean (2077 lines).
+
+## Scan — 2026-05-08 19:32
+
+- **Files scanned**: references/scripts/compose.py, references/scripts/boot_remote.py, references/scripts/config.py
+- **Findings**: none (2 previously-seen minor items: compose.py dead prefix var — noted 2026-04-26; boot_remote.py duplicate PM regex — noted 2026-05-06)
+- **Items rejected by human**: none yet
+- **Notes**: config.py clean (603 lines).
+
 ## Scan — 2026-05-08 18:10
 
 - **Files scanned**: references/scripts/tracker.py, references/scripts/wizard.py, references/scripts/cycle_pre.py

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: squidsquad
 description: "Orchestrates a multi-agent AI development team — handles setup, workflow coordination, role management, and autonomous dev cycles."
-version: 0.33.0
+version: 0.34.0
 license: AGPL-3.0
 ---
 

--- a/references/scripts/cycle_pre.py
+++ b/references/scripts/cycle_pre.py
@@ -602,8 +602,8 @@ def _build_pm_input(role):
         except (json.JSONDecodeError, ValueError):
             pass
 
-    # Pending ship
-    result = _run_script("tracker.py", "list-by-labels", "status:pending-ship")
+    # Pending ship — use --state all to catch GitHub auto-closed issues (#6222)
+    result = _run_script("tracker.py", "list-by-labels", "status:pending-ship", "--state", "all")
     try:
         if result.returncode == 0 and result.stdout.strip():
             items = json.loads(result.stdout)
@@ -870,9 +870,9 @@ def _build_dm_input(role):
     except (json.JSONDecodeError, ValueError):
         pass
 
-    # Pending ship items
+    # Pending ship items — use --state all to catch GitHub auto-closed issues (#6222)
     pending_ship = []
-    result = _run_script("tracker.py", "list-by-labels", "status:pending-ship")
+    result = _run_script("tracker.py", "list-by-labels", "status:pending-ship", "--state", "all")
     try:
         if result.returncode == 0 and result.stdout.strip():
             items = json.loads(result.stdout)

--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -1230,9 +1230,9 @@ def main():
 
     elif cmd == "list-by-labels":
         if not pos:
-            print("Usage: tracker.py list-by-labels <labels>", file=sys.stderr)
+            print("Usage: tracker.py list-by-labels <labels> [--state open|closed|all]", file=sys.stderr)
             sys.exit(1)
-        list_by_labels(pos[0])
+        list_by_labels(pos[0], state=opts.get("state", "open"))
 
     elif cmd == "list-all-open":
         list_all_open()

--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -385,19 +385,24 @@ def list_issues(role, issue_type="bug", status=None):
     return issues
 
 
-def list_by_labels(labels_str):
-    """List issues by arbitrary label string (for cross-role queries)."""
+def list_by_labels(labels_str, state="open"):
+    """List issues by arbitrary label string (for cross-role queries).
+
+    Args:
+        labels_str: comma-separated label names
+        state: "open", "closed", or "all" (default: "open")
+    """
     label_list = [l.strip() for l in labels_str.split(",") if l.strip()]
 
     adapter = _get_forge_adapter()
     if adapter:
-        issues = adapter.list_issues(labels=label_list, state="open", limit=50)
+        issues = adapter.list_issues(labels=label_list, state=state, limit=50)
         print(json.dumps(issues, indent=2))
         return issues
 
     # Default: gh CLI
     result = _run_list(
-        ["gh", "issue", "list", "--label", labels_str, "--state", "open",
+        ["gh", "issue", "list", "--label", labels_str, "--state", state,
          "--json", "number,title,labels", "--limit", "50"],
         check=False,
     )

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -98,6 +98,42 @@ class TestListByLabels:
         adapter.list_issues.assert_called_once()
         assert len(result) == 1
 
+    def test_state_parameter_passed_to_gh(self, monkeypatch):
+        """list_by_labels passes --state parameter to gh CLI (#6222)."""
+        calls = []
+
+        def fake_run(cmd, **kw):
+            calls.append(cmd)
+            return _mock_result(stdout="[]")
+
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(tracker, "_run_list", fake_run)
+        tracker.list_by_labels("status:pending-ship", state="all")
+        assert any("--state" in cmd and "all" in cmd for cmd in calls)
+
+    def test_state_defaults_to_open(self, monkeypatch):
+        """list_by_labels defaults to --state open (#6222)."""
+        calls = []
+
+        def fake_run(cmd, **kw):
+            calls.append(cmd)
+            return _mock_result(stdout="[]")
+
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(tracker, "_run_list", fake_run)
+        tracker.list_by_labels("status:pending-ship")
+        assert any("--state" in cmd and "open" in cmd for cmd in calls)
+
+    def test_state_parameter_passed_to_adapter(self, monkeypatch):
+        """list_by_labels passes state to forge adapter (#6222)."""
+        adapter = MagicMock()
+        adapter.list_issues.return_value = []
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: adapter)
+        tracker.list_by_labels("status:pending-ship", state="all")
+        adapter.list_issues.assert_called_once_with(
+            labels=["status:pending-ship"], state="all", limit=50
+        )
+
 
 class TestListAllOpen:
     def test_returns_issues(self, monkeypatch):


### PR DESCRIPTION
Closes #6222

### Summary
Fix pending-ship query to find GitHub auto-closed issues. When PR auto-merge closes linked issues, DM's pending-ship query missed them because it hardcoded --state open.

### Changes
- **tracker.py**: list_by_labels() accepts state parameter (default: open)
- **cycle_pre.py**: DM + PM pending-ship queries use --state all
- **test_tracker.py**: 3 regression tests for state parameter

### QA Status
- [x] Unit tests passing (1169/1169)
- [x] Regression tests for state parameter
- [x] Root cause addressed