### PR TITLE
skill: #6262 — Revert pending-ship --state all to --state open

### DIFF
--- a/.squidsquad/skill/scan-history.md
+++ b/.squidsquad/skill/scan-history.md
@@ -1,5 +1,12 @@
 # Scan History
 
+## Scan — 2026-05-08 22:31
+
+- **Files scanned**: tests/test_cycle_pre.py, references/agent-instructions.md
+- **Findings**: none
+- **Items rejected by human**: none yet
+- **Notes**: test_cycle_pre.py clean (1320 lines, no stale pr-merge refs). agent-instructions.md clean (generated file, consistent with current arch).
+
 ## Scan — 2026-05-08 21:02
 
 - **Files scanned**: tests/run_tests.py, tests/test_git_ops.py, tests/test_wizard.py

--- a/references/scripts/cycle_pre.py
+++ b/references/scripts/cycle_pre.py
@@ -602,8 +602,8 @@ def _build_pm_input(role):
         except (json.JSONDecodeError, ValueError):
             pass
 
-    # Pending ship — use --state all to catch GitHub auto-closed issues (#6222)
-    result = _run_script("tracker.py", "list-by-labels", "status:pending-ship", "--state", "all")
+    # Pending ship — reverted to --state open (#6262: --state all included stale closed items)
+    result = _run_script("tracker.py", "list-by-labels", "status:pending-ship")
     try:
         if result.returncode == 0 and result.stdout.strip():
             items = json.loads(result.stdout)
@@ -870,9 +870,9 @@ def _build_dm_input(role):
     except (json.JSONDecodeError, ValueError):
         pass
 
-    # Pending ship items — use --state all to catch GitHub auto-closed issues (#6222)
+    # Pending ship items — reverted to --state open (#6262: --state all included stale closed items)
     pending_ship = []
-    result = _run_script("tracker.py", "list-by-labels", "status:pending-ship", "--state", "all")
+    result = _run_script("tracker.py", "list-by-labels", "status:pending-ship")
     try:
         if result.returncode == 0 and result.stdout.strip():
             items = json.loads(result.stdout)


### PR DESCRIPTION
Closes #6262

### Summary
Revert #6222 fix that changed pending-ship queries to --state all. The --state all approach included 40+ closed items with stale pending-ship labels, polluting DM/PM pipeline views.

### Changes
- cycle_pre.py: PM + DM pending-ship queries reverted to --state open

### QA Status
- [x] Unit tests passing (1169/1169)