### PR TITLE
skill: #6287 — add test_compose to test runner, fix stale assertions

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -51,6 +51,7 @@ STATIC_TEST_MODULES = [
     "test_event_validator",
     "test_event_config",
     "test_event_derivation",
+    "test_compose",
 ]
 
 

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -510,30 +510,32 @@ class TestReadConfigValue:
 # ---------------------------------------------------------------------------
 
 class TestCollectAllRoles:
-    def test_includes_dev_agents_and_pm(self, tmp_path):
+    def test_includes_dev_agents_and_mandatory_roles(self, tmp_path):
         with patch.object(compose, "_read_config_value", return_value="skill,be"), \
              patch.object(compose, "REPO_ROOT", tmp_path):
             roles = compose._collect_all_roles()
-        assert roles == ["skill", "be", "pm"]
+        assert roles == ["skill", "be", "pm", "qa", "dm"]
 
-    def test_includes_dm_when_dir_exists(self, tmp_path):
-        (tmp_path / ".squidsquad" / "dm").mkdir(parents=True)
+    def test_mandatory_roles_not_duplicated_when_in_config(self, tmp_path):
+        with patch.object(compose, "_read_config_value", return_value="skill,dm"), \
+             patch.object(compose, "REPO_ROOT", tmp_path):
+            roles = compose._collect_all_roles()
+        assert roles == ["skill", "dm", "pm", "qa"]
+        assert roles.count("dm") == 1
+        assert roles.count("pm") == 1
+
+    def test_mandatory_roles_always_present(self, tmp_path):
         with patch.object(compose, "_read_config_value", return_value="skill"), \
              patch.object(compose, "REPO_ROOT", tmp_path):
             roles = compose._collect_all_roles()
-        assert roles == ["skill", "pm", "dm"]
-
-    def test_no_dm_when_dir_missing(self, tmp_path):
-        with patch.object(compose, "_read_config_value", return_value="skill"), \
-             patch.object(compose, "REPO_ROOT", tmp_path):
-            roles = compose._collect_all_roles()
-        assert "dm" not in roles
+        for mandatory in ("pm", "qa", "dm"):
+            assert mandatory in roles
 
     def test_empty_dev_agents(self, tmp_path):
         with patch.object(compose, "_read_config_value", return_value=""), \
              patch.object(compose, "REPO_ROOT", tmp_path):
             roles = compose._collect_all_roles()
-        assert roles == ["pm"]
+        assert roles == ["pm", "qa", "dm"]
 
     def test_strips_whitespace_from_agent_names(self, tmp_path):
         with patch.object(compose, "_read_config_value", return_value=" skill , be "), \


### PR DESCRIPTION
Closes #6287

### Summary
test_compose.py was excluded from STATIC_TEST_MODULES in run_tests.py, causing 76 tests (including 4 failing TestCollectAllRoles assertions) to never execute in CI.

### Acceptance Criteria
- [x] test_compose added to STATIC_TEST_MODULES in run_tests.py
- [x] TestCollectAllRoles assertions updated to match post-#6055 MANDATORY_ROLES behavior
- [x] Dedup test exercises real code path (mandatory role in config string)

### Changes
- **Files**: tests/run_tests.py, tests/test_compose.py
- **What**: Added test_compose to the static test module list. Updated 4 stale TestCollectAllRoles tests to assert mandatory roles (pm, qa, dm) are always present. Fixed dedup test to exercise actual dedup guard.
- **Why**: #6055 made pm/qa/dm unconditional in _collect_all_roles() but test assertions weren't updated. Tests silently failing because test_compose was never in the runner.

### QA Status
- [x] Unit tests passing (1245 passed, 0 failed)
- [x] Smoke tests passing
- [x] Acceptance criteria met