### PR TITLE
skill: #6304 — add timeout exit code 3 regression tests

### DIFF
--- a/.squidsquad/skill/scan-history.md
+++ b/.squidsquad/skill/scan-history.md
@@ -1,5 +1,12 @@
 # Scan History
 
+## Scan — 2026-05-09 02:04
+
+- **Files scanned**: tests/test_cycle_post.py, packages/cli/index.js
+- **Findings**: #6316 (index.js fetchRawFile shell injection via unescaped repoPath — low, defense-in-depth), #6317 (index.js dead allowSet variable — low)
+- **Items rejected by human**: none yet
+- **Notes**: test_cycle_post.py had 3 findings from subagent — dead __wrapped__ (low), untested _verify_remote_branch guard (medium), untested _do_stop_after_cycle_check fallback (medium). Deferred in favor of index.js findings which are more actionable. cycle_post test gaps noted for future scans.
+
 ## Scan — 2026-05-09 01:05
 
 - **Files scanned**: tests/test_model_router.py, references/roles/qa/instructions.md

--- a/tests/test_model_router.py
+++ b/tests/test_model_router.py
@@ -560,6 +560,55 @@ class TestQuotaNotification:
         assert mock_diag.call_args[0][0]["action"] == "api-error"
 
 
+    @patch("model_router._read_config", return_value="## Model Routing\n- **Research Model**: gpt-5.2\n")
+    @patch("model_router._load_provider_manifest")
+    @patch("model_router._ensure_deps")
+    @patch("model_router._log_diagnostic")
+    @patch("model_router._load_adapter")
+    def test_timeout_error_returns_exit_code_3(
+        self, mock_adapter, mock_diag, mock_deps, mock_manifest, mock_config, capsys
+    ):
+        """Timeout errors return exit code 3 (distinct from quota/generic errors)."""
+        mock_manifest.return_value = ("openai", {
+            "name": "openai", "auth": {"env_var": "OPENAI_API_KEY"},
+            "api_base": "", "deps": [],
+        })
+        fake_module = MagicMock()
+        fake_module.call.side_effect = Exception("Request timed out after 120s")
+        mock_adapter.return_value = fake_module
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            with patch("model_router.assemble_prompt", return_value="test"):
+                code = model_router.route("research", "test-1", "", "/tmp/out", "ctx")
+        assert code == 3
+        captured = capsys.readouterr()
+        assert "timeout" in captured.err.lower()
+        mock_diag.assert_called_once()
+        assert mock_diag.call_args[0][0]["action"] == "timeout"
+
+    @patch("model_router._read_config", return_value="## Model Routing\n- **Research Model**: gpt-5.2\n")
+    @patch("model_router._load_provider_manifest")
+    @patch("model_router._ensure_deps")
+    @patch("model_router._log_diagnostic")
+    @patch("model_router._load_adapter")
+    def test_timeout_error_type_returns_exit_code_3(
+        self, mock_adapter, mock_diag, mock_deps, mock_manifest, mock_config, capsys
+    ):
+        """TimeoutError exception type also returns exit code 3."""
+        mock_manifest.return_value = ("openai", {
+            "name": "openai", "auth": {"env_var": "OPENAI_API_KEY"},
+            "api_base": "", "deps": [],
+        })
+        fake_module = MagicMock()
+        fake_module.call.side_effect = TimeoutError("connection timed out")
+        mock_adapter.return_value = fake_module
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            with patch("model_router.assemble_prompt", return_value="test"):
+                code = model_router.route("research", "test-1", "", "/tmp/out", "ctx")
+        assert code == 3
+        mock_diag.assert_called_once()
+        assert mock_diag.call_args[0][0]["action"] == "timeout"
+
+
 class TestNoShellTrue:
     def test_no_shell_true_in_source(self):
         """model_router.py must not use shell=True (security layer 3)."""


### PR DESCRIPTION
Closes #6304

### Summary
Added regression tests for model_router.py's exit code 3 (timeout) path, which was the only untested exit code branch.

### Acceptance Criteria
- [x] Test for string-based timeout detection ("timed out" in error message)
- [x] Test for type-based timeout detection (TimeoutError exception)
- [x] Both assert exit code 3 and diagnostic action "timeout"

### Changes
- **Files**: tests/test_model_router.py
- **What**: Added 2 tests to TestQuotaNotification: `test_timeout_error_returns_exit_code_3` and `test_timeout_error_type_returns_exit_code_3`
- **Why**: exit code 3 was the only route() return value without test coverage. A refactor merging timeout and generic-error branches would go undetected.

### QA Status
- [x] Unit tests passing (1247 passed, 0 failed)
- [x] Smoke tests passing
- [x] Acceptance criteria met