### PR TITLE
skill: #6317 — remove dead allowSet variable

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -211,9 +211,6 @@ function downloadTarball(gitRoot, filePaths) {
     }
     const prefixDir = path.join(extractDir, entries[0]);
 
-    // Build allowlist set for fast lookup
-    const allowSet = new Set(filePaths.map((f) => f.replace(/\\/g, "/")));
-
     // Validate all manifest files exist in the tarball
     const missing = [];
     for (const filePath of filePaths) {


### PR DESCRIPTION
Closes #6317

### Summary
Removes unused `allowSet` variable from CLI installer's tarball extraction path.

### Changes
- **File**: packages/cli/index.js (line 215)
- **What**: Removed `const allowSet = new Set(...)` — constructed but never referenced
- **Why**: Dead code that misleads readers into thinking an allowlist guard is active

### QA Status
- [x] Unit tests passing (1247 passed)
- [x] Acceptance criteria met