### PR TITLE
skill: #6316 — fetchRawFile path validation guard

### DIFF
--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -140,6 +140,11 @@ function assertWithinRoot(root, filePath) {
 // --- File fetching ---
 
 function fetchRawFile(repoPath) {
+  // Defense-in-depth: validate repoPath against shell metacharacter injection (#6316)
+  if (!/^[\w.\/\-]+$/.test(repoPath)) {
+    warn(`Unsafe repoPath rejected: ${repoPath}`);
+    return null;
+  }
   const url = `${RAW_BASE}/${repoPath}`;
   try {
     const content = execSync(

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -142,7 +142,7 @@ function assertWithinRoot(root, filePath) {
 function fetchRawFile(repoPath) {
   // Defense-in-depth: validate repoPath against shell metacharacter injection (#6316)
   if (!/^[\w.\/\-]+$/.test(repoPath)) {
-    warn(`Unsafe repoPath rejected: ${repoPath}`);
+    fail(`Unsafe repoPath rejected: ${repoPath}`);
     return null;
   }
   const url = `${RAW_BASE}/${repoPath}`;

--- a/tests/test_installer_wiring.py
+++ b/tests/test_installer_wiring.py
@@ -133,6 +133,13 @@ class TestCliIndexJs:
             "CLI must loop over manifest entries and fetchRawFile each one"
         )
 
+    def test_fetchRawFile_has_path_validation_guard(self, cli_js):
+        """#6316 — fetchRawFile must validate repoPath against shell metacharacters."""
+        assert "/^[\\w.\\/\\-]+$/" in cli_js, (
+            "fetchRawFile must have a regex guard rejecting shell metacharacters "
+            "before interpolating repoPath into shell commands"
+        )
+
     def test_writes_files_to_canonical_paths(self, cli_js):
         """Each fetched file must be written to a validated path in the target."""
         assert "assertWithinRoot(gitRoot, filePath)" in cli_js, (


### PR DESCRIPTION
Closes #6316

### Summary
Adds defense-in-depth path validation to fetchRawFile() to prevent shell metacharacter injection via compromised manifest entries.

### Changes
- **File**: packages/cli/index.js (line 143)
- **What**: Added regex guard `/^[\w.\/\-]+$/` that rejects repoPath containing shell metacharacters
- **Why**: repoPath is interpolated into shell commands (gh api, curl). If installer-files.txt on remote is compromised, crafted entries could execute arbitrary commands.

### QA Status
- [x] Unit tests passing (1247 passed)
- [x] Acceptance criteria met