### PR TITLE
skill: #6514 — scope confidence decay to frontmatter

### DIFF
--- a/.squidsquad/skill/scan-history.md
+++ b/.squidsquad/skill/scan-history.md
@@ -1,5 +1,12 @@
 # Scan History
 
+## Scan — 2026-05-09 10:04
+
+- **Files scanned**: references/sub-skills/common/git-commit.md
+- **Findings**: #6526 (git_ops.py get_branch_name default pattern stale — low)
+- **Items rejected by human**: none yet
+- **Notes**: Subagent also found PR creation path ambiguity (manual vs cycle_post) and ownership check gap with unified branches — both template clarity issues, not code bugs.
+
 ## Scan — 2026-05-09 09:05
 
 - **Files scanned**: references/scripts/vault_optimize.py

--- a/references/scripts/vault_optimize.py
+++ b/references/scripts/vault_optimize.py
@@ -380,8 +380,18 @@ def decay(dry_run=False):
                 decayed.append(f"[dry-run] {rel}: {confidence} -> {new_confidence}")
             else:
                 today = datetime.now().strftime("%Y-%m-%d")
-                new_text = text.replace(f"confidence: {confidence}", f"confidence: {new_confidence}", 1)
-                new_text = re.sub(r"updated: \S+", f"updated: {today}", new_text, count=1)
+                # Scope rewrites to frontmatter only (#6514) — avoid corrupting body
+                fm_end = text.find("---", 3)
+                if fm_end != -1:
+                    header = text[:fm_end + 3]
+                    body = text[fm_end + 3:]
+                    header = header.replace(f"confidence: {confidence}", f"confidence: {new_confidence}", 1)
+                    header = re.sub(r"updated: \S+", f"updated: {today}", header, count=1)
+                    new_text = header + body
+                else:
+                    # No frontmatter boundary — fall back to full-text (shouldn't happen)
+                    new_text = text.replace(f"confidence: {confidence}", f"confidence: {new_confidence}", 1)
+                    new_text = re.sub(r"updated: \S+", f"updated: {today}", new_text, count=1)
 
                 # Append changelog entry
                 changelog_entry = f"- {today} — Confidence decayed by vault-optimize (staleness)."

--- a/tests/test_vault_optimize.py
+++ b/tests/test_vault_optimize.py
@@ -231,6 +231,33 @@ class TestDecay:
         assert "confidence: medium" in text
         assert "Confidence decayed by vault-optimize" in text
 
+    def test_decay_does_not_corrupt_body_content(self, patched_vault):
+        """#6514: Body containing 'confidence: high' must not be modified."""
+        old_date = (datetime.now() - timedelta(days=90)).strftime("%Y-%m-%d")
+        body_with_confidence = (
+            "This note discusses confidence: high as a concept.\n"
+            "Example: confidence: high means human-confirmed.\n"
+            "Also updated: 2020-01-01 is an example date."
+        )
+        note_path = patched_vault / "galaxy" / "decision-body-trap.md"
+        note_path.write_text(
+            _note(type_="decision", confidence="high",
+                  created=old_date, updated=old_date,
+                  body=body_with_confidence),
+            encoding="utf-8",
+        )
+        vault_optimize.decay(dry_run=False)
+        text = note_path.read_text(encoding="utf-8")
+        # Frontmatter should be decayed
+        fm_end = text.find("---", 3)
+        header = text[:fm_end]
+        body = text[fm_end + 3:]
+        assert "confidence: medium" in header
+        # Body must be preserved exactly — not rewritten
+        assert "confidence: high as a concept" in body
+        assert "confidence: high means human-confirmed" in body
+        assert "updated: 2020-01-01 is an example date" in body
+
 
 # ---------------------------------------------------------------------------
 # Consolidate tests


### PR DESCRIPTION
Closes #6514

### Summary
Confidence decay in vault_optimize.py now only rewrites within the frontmatter block, preventing corruption of body content that happens to contain `confidence:` or `updated:` text.

### Changes
- **File**: references/scripts/vault_optimize.py (lines 382-394)
- **What**: Split text at frontmatter boundary before applying str.replace/re.sub
- **Why**: Previously operated on full file text — if body contained matching patterns, wrong content was rewritten

### QA Status
- [x] Unit tests passing (1275 passed)
- [x] Acceptance criteria met