### PR TITLE
skill: #6526 — update default branch pattern

### DIFF
--- a/docs/sub-skill-guide.md
+++ b/docs/sub-skill-guide.md
@@ -74,7 +74,7 @@ You are the [ROLE] Lead on the SquidSquad autonomous dev team...
 
 ---
 
-{{include: common/tracker-protocol}}
+{{include: common/vault-protocol}}
 
 ---
 

--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -585,7 +585,7 @@ def commit_state(role, message):
 def get_branch_name(role, number):
     """Get the branch name for a task (#5040).
 
-    Reads branch-pattern from config. Default: squidsquad/{role}/{number}.
+    Reads branch-pattern from config. Default: squidsquad/task/{number} (#6526).
     Pattern supports {role} and {number} placeholders.
     """
     try:
@@ -595,7 +595,7 @@ def get_branch_name(role, number):
     except (SystemExit, Exception):
         pattern = ""
     if not pattern:
-        pattern = "squidsquad/{role}/{number}"
+        pattern = "squidsquad/task/{number}"
     return pattern.format(role=role, number=number)
 
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -53,6 +53,7 @@ STATIC_TEST_MODULES = [
     "test_event_derivation",
     "test_compose",
     "test_reboot_agent",
+    "test_feat_3296_task_boundary",
 ]
 
 

--- a/tests/test_feat_3296_task_boundary.py
+++ b/tests/test_feat_3296_task_boundary.py
@@ -50,7 +50,7 @@ class TestTaskBegin:
         with patch("config.get_field", side_effect=_mock_config_enabled):
             git_ops.task_begin("skill", "9999")
 
-        mock_checkout.assert_called_once_with("squidsquad/skill/9999")
+        mock_checkout.assert_called_once_with("squidsquad/task/9999")
 
     @patch("git_ops._run_list")
     def test_checks_out_from_remote(self, mock_run_list):
@@ -77,7 +77,7 @@ class TestTaskBegin:
 
         checkout_calls = [c for c in calls if "checkout" in c and "-b" in c]
         assert len(checkout_calls) == 1
-        assert "origin/squidsquad/skill/9999" in checkout_calls[0]
+        assert "origin/squidsquad/task/9999" in checkout_calls[0]
 
     @patch("git_ops._run_list")
     def test_missing_branch_exits_nonzero(self, mock_run_list):
@@ -116,7 +116,7 @@ class TestTaskBegin:
             with pytest.raises(SystemExit):
                 git_ops.task_begin("qa", "3100")
 
-        assert any("squidsquad/qa/3100" in c for c in checked)
+        assert any("squidsquad/task/3100" in c for c in checked)
 
 
 class TestTaskEnd:


### PR DESCRIPTION
Closes #6526

### Summary
Updates get_branch_name() fallback default from legacy `squidsquad/{role}/{number}` to `squidsquad/task/{number}` matching config.md.

### QA Status
- [x] Unit tests passing (1275 passed)