### PR TITLE
skill: #6598 — replace stale shared-FS tests with post-#3100 contract tests

### DIFF
--- a/tests/test_feat_1496_shared_fs_fallback.py
+++ b/tests/test_feat_1496_shared_fs_fallback.py
@@ -8,7 +8,7 @@ behavior: missing .local-config exits with code 2.
 
 import sys
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 
@@ -19,7 +19,7 @@ import boot_remote
 
 
 class TestSharedFsFallback:
-    """#1496: _parse_local_config must read shared FS as fallback when .local-config is absent."""
+    """#1496/#3100: _parse_local_config reads .local-config (mandatory, no global fallback)."""
 
     def test_missing_local_config_exits_not_fallback(self, tmp_path):
         """#3100: When .local-config is missing, exit with code 2 — no global fallback."""
@@ -27,15 +27,13 @@ class TestSharedFsFallback:
         clones_dir.mkdir(parents=True)
         (clones_dir / "skill").write_text("/home/user/skill-clone", encoding="utf-8")
 
-        with patch("pathlib.Path.home", return_value=tmp_path), \
-             patch.object(boot_remote, "LOCAL_CONFIG", tmp_path / "nonexistent"):
+        with patch.object(boot_remote, "LOCAL_CONFIG", tmp_path / "nonexistent"):
             with pytest.raises(SystemExit) as exc_info:
                 boot_remote._parse_local_config()
         assert exc_info.value.code == 2
 
-    def test_falls_back_to_local_config(self, tmp_path):
-        """#1496: When shared FS is absent, fall back to .local-config."""
-        # No clones dir under home
+    def test_parses_absolute_paths_from_local_config(self, tmp_path):
+        """#3100: .local-config with absolute paths returns correct role→Path mapping."""
         skill_path = tmp_path / "clones" / "skill"
         qa_path = tmp_path / "clones" / "qa"
         skill_path.mkdir(parents=True)
@@ -47,60 +45,43 @@ class TestSharedFsFallback:
         )
         local_config.write_text(local_config_content, encoding="utf-8")
 
-        with patch("pathlib.Path.home", return_value=tmp_path / "empty_home"), \
-             patch.object(boot_remote, "LOCAL_CONFIG", local_config):
+        with patch.object(boot_remote, "LOCAL_CONFIG", local_config):
             result = boot_remote._parse_local_config()
 
         assert result["skill"] == skill_path
         assert result["qa"] == qa_path
 
-    def test_empty_shared_fs_falls_back(self, tmp_path):
-        """#1496: Empty clones dir (no files) should fall back to .local-config."""
-        clones_dir = tmp_path / ".squidsquad" / "clones"
-        clones_dir.mkdir(parents=True)
-        # clones_dir exists but is empty
-
-        fallback_path = tmp_path / "fallback" / "clone"
-        fallback_path.mkdir(parents=True)
+    def test_empty_local_config_exits(self, tmp_path):
+        """#3100: .local-config with no valid entries exits with code 2."""
         local_config = tmp_path / "local-config"
-        local_config.write_text(f"- **skill**: {fallback_path}\n", encoding="utf-8")
+        local_config.write_text("# just a comment, no entries\n", encoding="utf-8")
 
-        with patch("pathlib.Path.home", return_value=tmp_path), \
-             patch.object(boot_remote, "LOCAL_CONFIG", local_config):
+        with patch.object(boot_remote, "LOCAL_CONFIG", local_config):
+            with pytest.raises(SystemExit) as exc_info:
+                boot_remote._parse_local_config()
+        assert exc_info.value.code == 2
+
+    def test_relative_paths_resolve_against_repo_root(self, tmp_path):
+        """#3100: Relative paths in .local-config resolve against REPO_ROOT."""
+        local_config = tmp_path / "local-config"
+        local_config.write_text("- **skill**: relative/clone/path\n", encoding="utf-8")
+
+        with patch.object(boot_remote, "LOCAL_CONFIG", local_config):
             result = boot_remote._parse_local_config()
 
-        assert result.get("skill") == fallback_path
-
-    def test_shared_fs_ignores_dotfiles(self, tmp_path):
-        """#1496: Hidden files in clones/ should be ignored."""
-        clones_dir = tmp_path / ".squidsquad" / "clones"
-        clones_dir.mkdir(parents=True)
-        (clones_dir / ".gitkeep").write_text("", encoding="utf-8")
-        (clones_dir / "skill").write_text("/home/user/skill", encoding="utf-8")
-
-        with patch("pathlib.Path.home", return_value=tmp_path):
-            result = boot_remote._parse_local_config()
-
-        assert ".gitkeep" not in result
-        assert "skill" in result
+        expected = (boot_remote.REPO_ROOT / "relative" / "clone" / "path").resolve()
+        assert result["skill"] == expected
 
     def test_missing_local_config_exits_even_with_clones(self, tmp_path):
-        """#3100: Global clones with mixed content don't prevent exit when .local-config missing."""
-        clones_dir = tmp_path / ".squidsquad" / "clones"
-        clones_dir.mkdir(parents=True)
-        (clones_dir / "skill").write_text("", encoding="utf-8")
-        (clones_dir / "qa").write_text("/valid/path", encoding="utf-8")
-
-        with patch("pathlib.Path.home", return_value=tmp_path), \
-             patch.object(boot_remote, "LOCAL_CONFIG", tmp_path / "nonexistent"):
+        """#3100: Global clones dir is irrelevant — missing .local-config still exits."""
+        with patch.object(boot_remote, "LOCAL_CONFIG", tmp_path / "nonexistent"):
             with pytest.raises(SystemExit) as exc_info:
                 boot_remote._parse_local_config()
         assert exc_info.value.code == 2
 
     def test_no_config_exits(self, tmp_path):
-        """#3100: No shared FS and no .local-config exits with code 2."""
-        with patch("pathlib.Path.home", return_value=tmp_path / "nowhere"), \
-             patch.object(boot_remote, "LOCAL_CONFIG", tmp_path / "nonexistent"):
+        """#3100: No .local-config exits with code 2."""
+        with patch.object(boot_remote, "LOCAL_CONFIG", tmp_path / "nonexistent"):
             with pytest.raises(SystemExit) as exc_info:
                 boot_remote._parse_local_config()
         assert exc_info.value.code == 2


### PR DESCRIPTION
Closes #6598

### Summary
Replace two stale tests that verified removed shared-FS fallback behavior with tests exercising the actual post-#3100 `_parse_local_config` contract. Also cleaned up vestigial `Path.home` patches and stale docstrings from surviving tests.

### Acceptance Criteria
- [x] Remove tests verifying removed shared-FS fallback behavior
- [x] Add test for empty .local-config → exit 2
- [x] Add test for relative path resolution against REPO_ROOT
- [x] Clean up false documentation (docstrings, vestigial patches)

### Changes
- **Files**: tests/test_feat_1496_shared_fs_fallback.py
- **Deleted**: test_empty_shared_fs_falls_back (duplicate), test_shared_fs_ignores_dotfiles (non-deterministic)
- **Added**: test_empty_local_config_exits, test_relative_paths_resolve_against_repo_root
- **Fixed**: class/test docstrings, removed vestigial Path.home patches, removed unused MagicMock import

### QA Status
- [x] Unit tests passing (1289/1289)
- [x] External code review — 2 findings fixed (stale docstring, vestigial patches)
- [x] Acceptance criteria met