### PR TITLE
skill: #6683 — fix stale docstring in test_roles.py

### DIFF
--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -60,8 +60,9 @@ class TestRoleEntryFiles:
     """Verify role entry files exist in the role directory registry.
 
     Q-new22 moved every role's SOUL.md + CLAUDE.md into its self-contained
-    directory at `references/roles/<role>/`. The legacy
-    `references/sub-skills/{souls,roles}/` layout has been retired.
+    directory at `references/roles/<role>/`. The legacy `references/sub-skills/souls/`
+    directory was retired. `references/sub-skills/roles/` remains active as the home
+    for per-role sub-skill markdown files used by compose.py.
     """
 
     def test_dev_entry_exists(self):


### PR DESCRIPTION
Closes #6683

### Summary
Fix misleading docstring in `TestRoleEntryFiles` that claimed the entire `references/sub-skills/` layout was retired. Only `sub-skills/souls/` was retired — `sub-skills/roles/` remains active for per-role sub-skill markdown files.

### Changes
- **Files**: tests/test_roles.py
- **What**: Corrected class docstring (lines 62-65) to distinguish retired `souls/` from active `roles/`

### QA Status
- [x] Unit tests passing (1289/1289)
- [x] Docstring-only change — no code logic affected