### PR TITLE
skill: #6733 — fix forge_adapter _api() HTTP 204 handling

### DIFF
--- a/references/scripts/forge_adapter.py
+++ b/references/scripts/forge_adapter.py
@@ -298,7 +298,10 @@ class ForgejoAdapter(ForgeAdapter):
 
         try:
             with urllib.request.urlopen(req, timeout=30) as resp:
-                return json.loads(resp.read().decode("utf-8"))
+                if resp.status == 204:
+                    return {}
+                body = resp.read().decode("utf-8")
+                return json.loads(body) if body.strip() else {}
         except urllib.error.HTTPError as e:
             print(f"[forge] HTTP {e.code}: {e.read().decode('utf-8', errors='replace')}",
                   file=sys.stderr)

--- a/tests/test_forge_adapter.py
+++ b/tests/test_forge_adapter.py
@@ -239,6 +239,33 @@ class TestForgejoAdapterErrorHandling:
         result = adapter.list_issues()
         assert result == []
 
+    @patch("urllib.request.urlopen")
+    def test_http_204_returns_empty_dict(self, mock_urlopen):
+        """#6733: HTTP 204 No Content returns {} instead of None."""
+        mock_resp = MagicMock()
+        mock_resp.status = 204
+        mock_resp.read.return_value = b""
+        mock_resp.__enter__ = lambda s: mock_resp
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+        adapter = self._make_adapter()
+        result = adapter._api("DELETE", "/repos/test/test/issues/1/labels/5")
+        assert result == {}
+        assert result is not None
+
+    @patch("urllib.request.urlopen")
+    def test_empty_body_200_returns_empty_dict(self, mock_urlopen):
+        """Empty body on 200 returns {} instead of raising JSONDecodeError."""
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.read.return_value = b""
+        mock_resp.__enter__ = lambda s: mock_resp
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+        adapter = self._make_adapter()
+        result = adapter._api("POST", "/repos/test/test")
+        assert result == {}
+
 
 class TestBaseAdapter:
     def test_edit_labels_calls_both(self):


### PR DESCRIPTION
Closes #6733

### Summary
Fix `_api()` in `forge_adapter.py` to handle HTTP 204 No Content responses from Forgejo DELETE endpoints. Previously, empty response body caused `json.loads("")` → `JSONDecodeError` → caught by bare `except Exception` → returned `None`, making `remove_labels()` always report failure even on successful label removal.

### Acceptance Criteria
- [x] HTTP 204 returns `{}` instead of `None`
- [x] Empty body on other success codes returns `{}` instead of raising
- [x] Error responses still return `None` (behavior unchanged)
- [x] Regression tests added

### Changes
- **forge_adapter.py**: Check `resp.status == 204` before parsing; handle empty body gracefully
- **test_forge_adapter.py**: Added `test_http_204_returns_empty_dict` and `test_empty_body_200_returns_empty_dict`

### QA Status
- [x] Unit tests passing (1302/1302, 2 new)
- [x] Acceptance criteria met