### PR TITLE
skill: #6746 #6747 — fix external review git diff + add review gate to issue path

### DIFF
--- a/references/sub-skills/roles/dev/implement-tasks.md
+++ b/references/sub-skills/roles/dev/implement-tasks.md
@@ -43,7 +43,7 @@ Print: `[🦑 HH:MM:SS] Implementing #[NUMBER]...`
 
    **Get changed files and run review**:
    ```bash
-   CHANGED_FILES=$(git diff --name-only HEAD | paste -sd, -)
+   CHANGED_FILES=$(git diff --cached --name-only | paste -sd, -)
    python references/scripts/model_router.py code-review \
      --task-id "#[NUMBER]" \
      --input-files "$CHANGED_FILES" \

--- a/references/sub-skills/roles/dev/triage-issues.md
+++ b/references/sub-skills/roles/dev/triage-issues.md
@@ -48,7 +48,9 @@ If the queue returns an item, read it: `gh issue view [NUMBER] --json title,body
 5. Read the issue details, locate the relevant code, fix the issue.
 6. Run the test command: `[ROLE_TEST_CMD]`
 7. **Verify changes exist**: Run `python references/scripts/git_ops.py has-changes`. If output is `false`, do NOT transition — re-read the issue and apply the fix.
-8. If tests pass and changes exist:
+7b. **Self-verification reflection** — before marking pending-test, run the same self-review as for tasks (Step 9b in implement-tasks): regression, integration, philosophy, personas checks. Fix any concerns before proceeding.
+7c. **External code review** — run the external review loop (Step 9c in implement-tasks). Stage changes, get changed files, run model review, process findings. Same dispositions apply (fix, file-to-PM, justified-ignore).
+8. If tests pass, self-review passes, and changes exist:
    - Transition: `python references/scripts/tracker.py transition [NUMBER] in-progress pending-test --role [ROLE]-lead`
    - Comment: `python references/scripts/tracker.py comment [NUMBER] --role [ROLE]-lead --message "Fixed in commit [hash]. [Brief explanation]. Status → Pending Test."`
    - `python references/scripts/git_ops.py task-end [ROLE] [NUMBER]` — return to working branch.


### PR DESCRIPTION
Closes #6746
Closes #6747

### Summary
Two related fixes to the dev agent review workflow:

1. **#6746 (high)**: `implement-tasks.md` step 9c runs `git add -A` then `git diff --name-only HEAD` — after staging, this returns empty because all changes are in the index. Fixed to `git diff --cached --name-only`. Without this fix, external code review silently reviews nothing.

2. **#6747 (medium)**: `triage-issues.md` issue-fix path went straight from "tests pass" to "pending-test", skipping self-verification (step 9b) and external code review (step 9c). Added cross-references to these steps so bug fixes get the same review rigor as feature tasks.

### Changes
- **implement-tasks.md**: `git diff --name-only HEAD` → `git diff --cached --name-only`
- **triage-issues.md**: Added steps 7b (self-verification) and 7c (external review) before pending-test

### QA Status
- [x] Unit tests passing (1302/1302)
- [x] Template-only changes — no production code modified