### PR TITLE
skill: #6760 #6759 — guard note for bare git tag + remove unused yaml import

### DIFF
--- a/references/sub-skills/roles/dm/version-bumps.md
+++ b/references/sub-skills/roles/dm/version-bumps.md
@@ -30,8 +30,8 @@ After marking any item `Shipped`, check if a version bump is due:
    List all items shipped since the last bump (scan tracker Discussions for `Status → Shipped` entries since the previous version's date).
 6. Commit: `python references/scripts/git_ops.py commit-push dm "bump version to vX.Y.Z"`
 7. Check if tag exists: `git tag -l "vX.Y.Z"`. If it exists, skip tagging.
-8. Create tag: `git tag vX.Y.Z`
-9. Push tags: `git push --tags`
+8. Create tag: `git tag vX.Y.Z` (bare git — tagging is too infrequent to warrant a git_ops.py subcommand)
+9. Push tags: `git push --tags` (bare git — same rationale; step 6 already enforced branch via commit-push)
 10. Reset shipped count: `python references/scripts/config.py set shipped-since-bump 0`
 11. Log in iteration log: add `Version Bumped: X.Y.Z` field.
 

--- a/tests/test_compose_capability.py
+++ b/tests/test_compose_capability.py
@@ -151,7 +151,6 @@ class TestCapabilityCheck:
     def test_any_of_with_one_available(self, tmp_path):
         """any_of exits 0 if at least one capability is available."""
         import capability_check
-        import yaml
 
         # Role with any_of
         role_dir = tmp_path / "roles" / "qa"


### PR DESCRIPTION
Closes #6760
Closes #6759

### Summary
Two small fixes:
1. **#6760**: Added guard notes to `version-bumps.md` steps 8-9 explaining why bare `git tag`/`git push --tags` intentionally bypass `git_ops.py` (tagging is infrequent, step 6 already enforced branch)
2. **#6759**: Removed unused `import yaml` from `test_compose_capability.py` that could cause false `ImportError` in environments without PyYAML

### Changes
- **version-bumps.md**: Guard notes on steps 8-9
- **test_compose_capability.py**: Removed unused import

### QA Status
- [x] Unit tests passing (1302/1302)
- [x] Trivial changes — no logic modified