### PR TITLE
skill: #6774 — fix DM version bump by delegating to cycle_post.py

### DIFF
--- a/references/sub-skills/roles/dm/version-bumps.md
+++ b/references/sub-skills/roles/dm/version-bumps.md
@@ -9,13 +9,11 @@ After marking any item `Shipped`, check if a version bump is due:
    - If open issues exist: defer the bump. Print: `[🦑 HH:MM:SS] Version bump deferred — [N] open issues remain.` Counter stays at current value.
    - If zero open issues: **perform the bump**.
 
-**Bump sequence** (use working-state.md to track progress for crash recovery):
+**Bump sequence** (DM does creative work; `cycle_post.py` handles mechanical ops):
 
 1. Read current version from `config.md` (e.g. `0.6.0`).
 2. Increment minor version, reset patch to 0 (e.g. `0.6.0` → `0.7.0`).
-3. Update config: `python references/scripts/config.py set version X.Y.Z`
-4. Update `SKILL.md` YAML frontmatter: set `version` to new version.
-5. Add new section to top of `CHANGELOG.md`:
+3. Add new section to top of `CHANGELOG.md`:
    ```markdown
    ## [X.Y.Z] — YYYY-MM-DD
 
@@ -28,12 +26,15 @@ After marking any item `Shipped`, check if a version bump is due:
    ...
    ```
    List all items shipped since the last bump (scan tracker Discussions for `Status → Shipped` entries since the previous version's date).
-6. Commit: `python references/scripts/git_ops.py commit-push dm "bump version to vX.Y.Z"`
-7. Check if tag exists: `git tag -l "vX.Y.Z"`. If it exists, skip tagging.
-8. Create tag: `git tag vX.Y.Z` (bare git — tagging is too infrequent to warrant a git_ops.py subcommand)
-9. Push tags: `git push --tags` (bare git — same rationale; step 6 already enforced branch via commit-push)
-10. Reset shipped count: `python references/scripts/config.py set shipped-since-bump 0`
-11. Log in iteration log: add `Version Bumped: X.Y.Z` field.
+4. Include `version_bump` in `cycle-output.json`:
+   ```json
+   "version_bump": {
+     "new_version": "X.Y.Z",
+     "items_included": ["#123 — Title", "#456 — Title"]
+   }
+   ```
+   `cycle_post.py` handles the mechanical steps: config.md update, SKILL.md frontmatter, commit, tag, push, counter reset.
+5. Log in iteration log: add `Version Bumped: X.Y.Z` field.
 
 Print: `[🦑 HH:MM:SS] Version bumped to vX.Y.Z — tag created and pushed.`
 


### PR DESCRIPTION
Closes #6774

### Summary
Fix DM version bump not executing. Root cause: `version-bumps.md` told DM to perform manual commit/tag/push steps directly, conflicting with the cycle-runner contract which requires all mechanical ops to go through `cycle_post.py`. DM was not writing `version_bump` to `cycle-output.json`, so `cycle_post.py._do_version_bump()` (which already has the full mechanical implementation) never fired.

### Root Cause
- `version-bumps.md` steps 3-10 told DM to do: `config.py set version`, `git commit`, `git tag`, `git push --tags`, `config.py set shipped-since-bump 0` directly
- Cycle-runner sub-skill says: "Do NOT use bash for mechanical operations that cycle_pre/post handles"
- `cycle_post.py._do_version_bump()` already handles ALL these steps — but it reads `version_bump` from `cycle-output.json`, which DM was never told to write

### Fix
Updated `version-bumps.md` to:
1. Keep threshold check and CHANGELOG entry as DM creative work
2. Tell DM to write `version_bump: {new_version, items_included}` to `cycle-output.json`
3. Remove manual commit/tag/push steps — `cycle_post.py` handles them

### Changes
- **Files**: references/sub-skills/roles/dm/version-bumps.md
- Template rewrite only — no production code changes

### QA Status
- [x] Unit tests passing (1302/1302)
- [x] Template-only change
- [x] After compose deploy dm, DM will use the new flow