### PR TITLE
skill: #6786 — remove shadowed duplicate test classes

### DIFF
--- a/tests/test_vault_remember.py
+++ b/tests/test_vault_remember.py
@@ -80,39 +80,6 @@ class TestWriteBudget:
         assert result == 2
 
 
-class TestIncWrites:
-    def test_increments_from_zero(self, tmp_path, capsys):
-        ws_dir = tmp_path / "skill"
-        ws_dir.mkdir(parents=True)
-        ws = ws_dir / "working-state.md"
-        ws.write_text("# Working State\n\n- **Vault Writes This Cycle**: 0\n")
-        with patch.object(vault_remember, "SQUIDSQUAD_DIR", tmp_path):
-            result = vault_remember.inc_writes("skill")
-        assert result == 1
-        assert "1" in ws.read_text()
-
-    def test_increments_existing(self, tmp_path, capsys):
-        ws_dir = tmp_path / "skill"
-        ws_dir.mkdir(parents=True)
-        ws = ws_dir / "working-state.md"
-        ws.write_text("# Working State\n\n- **Vault Writes This Cycle**: 3\n")
-        with patch.object(vault_remember, "SQUIDSQUAD_DIR", tmp_path):
-            result = vault_remember.inc_writes("skill")
-        assert result == 4
-
-
-class TestResetWrites:
-    def test_resets_to_zero(self, tmp_path, capsys):
-        ws_dir = tmp_path / "skill"
-        ws_dir.mkdir(parents=True)
-        ws = ws_dir / "working-state.md"
-        ws.write_text("# Working State\n\n- **Vault Writes This Cycle**: 5\n")
-        with patch.object(vault_remember, "SQUIDSQUAD_DIR", tmp_path):
-            result = vault_remember.reset_writes("skill")
-        assert result == 0
-        assert "0" in ws.read_text()
-
-
 class TestBriefingBudget:
     def test_empty_briefing_full_budget(self, tmp_path, capsys):
         with patch.object(vault_remember, "VAULT_DIR", tmp_path), \


### PR DESCRIPTION
Closes #6786

### Summary
Remove shadowed `TestIncWrites` and `TestResetWrites` class definitions (lines 83-113) from `test_vault_remember.py`. Python silently overwrote these with the later #4919 regression classes (lines 213-266), so the original tests were permanently dead code — never collected or run by pytest.

### Analysis
The #4919 versions cover all scenarios from the originals plus the critical "creates field when absent" edge case:
- Original `test_increments_from_zero` (0→1) → subsumed by #4919 `test_creates_field_when_absent` (absent→1)
- Original `test_increments_existing` (3→4) → subsumed by #4919 `test_increments_existing_counter` (1→2)
- Original `test_resets_to_zero` (5→0) → subsumed by #4919 `test_resets_existing_counter` (3→0)

### Changes
- **Files**: tests/test_vault_remember.py
- **What**: Deleted 3 shadowed test methods (31 lines)

### QA Status
- [x] Unit tests passing (1302/1302 — count unchanged, dead tests were never collected)