### PR TITLE
skill: #7062 #7063 — remove dead prefix variable + redundant re imports

### DIFF
--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -235,7 +235,6 @@ def _resolve_includes_with_manifest(entry_file: Path, manifest: list) -> str:
                 # Check for a variant in the manifest that shares the
                 # same base name (e.g. vault-protocol-slim for vault-protocol)
                 base = include_path.rsplit("/", 1)[-1] if "/" in include_path else include_path
-                prefix = include_path.rsplit("/", 1)[0] + "/" if "/" in include_path else ""
                 found = False
                 for m in manifest:
                     m_base = m.rsplit("/", 1)[-1] if "/" in m else m
@@ -512,7 +511,6 @@ def _extract_code_blocks(text: str) -> list[tuple[int, int, str]]:
 
     Returns list of (start, end, content) tuples.
     """
-    import re
     blocks = []
     for m in re.finditer(r'(```[^\n]*\n.*?\n```)', text, re.DOTALL):
         blocks.append((m.start(), m.end(), m.group(0)))
@@ -521,7 +519,6 @@ def _extract_code_blocks(text: str) -> list[tuple[int, int, str]]:
 
 def _extract_markers(text: str) -> list[str]:
     """Extract all HTML comment markers for preservation check."""
-    import re
     return re.findall(r'<!--.*?-->', text)
 
 
@@ -533,7 +530,6 @@ def _generate_cqs_from_sources(layer_sources: dict[str, str]) -> list[dict]:
 
     Returns list of {question, source_heading, layer} dicts.
     """
-    import re
     cqs = []
     for layer_name, content in layer_sources.items():
         headings = re.findall(r'^#{2,3}\s+(.+)$', content, re.MULTILINE)

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -844,3 +844,33 @@ class TestNoDeprecatedMktemp:
         assert lines == [], (
             f"compose.py still uses deprecated tempfile.mktemp(): {lines}"
         )
+
+
+class TestNoDeadPrefixVariable:
+    """#7062: _resolve_includes_with_manifest must not have dead prefix variable."""
+
+    def test_no_dead_prefix_in_resolve_includes(self):
+        import inspect
+        source = inspect.getsource(compose._resolve_includes_with_manifest)
+        assert "prefix = " not in source, (
+            "#7062: dead prefix variable should be removed from _resolve_includes_with_manifest"
+        )
+
+
+class TestNoRedundantReImport:
+    """#7063: compose.py functions must not re-import re locally."""
+
+    def test_no_local_re_import_in_extract_code_blocks(self):
+        import inspect
+        source = inspect.getsource(compose._extract_code_blocks)
+        assert "import re" not in source
+
+    def test_no_local_re_import_in_extract_markers(self):
+        import inspect
+        source = inspect.getsource(compose._extract_markers)
+        assert "import re" not in source
+
+    def test_no_local_re_import_in_generate_cqs(self):
+        import inspect
+        source = inspect.getsource(compose._generate_cqs_from_sources)
+        assert "import re" not in source


### PR DESCRIPTION
Closes #7062
Closes #7063

### Summary
Two cleanup fixes in compose.py:
1. **#7062 (medium)**: Dead `prefix` variable in `_resolve_includes_with_manifest` — computed but never used. Manifest entries already include directory qualifiers.
2. **#7063 (low)**: Three redundant `import re` statements in `_extract_code_blocks`, `_extract_markers`, and `_generate_cqs_from_sources` — `re` is already imported at module level.

### Changes
- **compose.py**: Removed dead `prefix` variable (1 line) and 3 redundant `import re` statements
- **test_compose.py**: 4 regression tests

### QA Status
- [x] Unit tests passing (1350/1350, 4 new)