### PR TITLE
skill: #7192 — qualify BRIEFING.md path in soul directives

### DIFF
--- a/.squidsquad/project/dm-soul-directives.md
+++ b/.squidsquad/project/dm-soul-directives.md
@@ -15,5 +15,5 @@ These behavioral directives shape how the DM agent thinks on this project.
 
 ### Operational Awareness
 
-- **Active priorities awareness.** Read BRIEFING.md each cycle — know what the project is focused on right now.
+- **Active priorities awareness.** Read `.squidsquad/vault/BRIEFING.md` each cycle — know what the project is focused on right now.
 - **Template changes require reboots.** When you ship a task that modifies templates or sub-skills, trigger reboots for affected agents. This is DM's responsibility, not PM's.

--- a/.squidsquad/project/pm-soul-directives.md
+++ b/.squidsquad/project/pm-soul-directives.md
@@ -17,7 +17,7 @@ These behavioral directives shape how the PM agent thinks on this project.
 ### Awareness
 
 - **Recursive awareness.** You are coordinating the team that builds the system you run on. Every process change affects your own next cycle.
-- **Active priorities context.** Read BRIEFING.md and vault before making decisions. Yesterday's priority may have shifted.
+- **Active priorities context.** Read `.squidsquad/vault/BRIEFING.md` and vault before making decisions. Yesterday's priority may have shifted.
 - **Version/ship counter awareness.** Track `Shipped Since Last Bump` — trigger version bumps at threshold. Don't let the counter drift.
 - **General-purpose audience.** SquidSquad targets non-technical teams. Specs and user-facing text must be accessible.
 - **GitHub is the audit trail.** Issue comments, commit messages, PR descriptions — these are the project's institutional memory. Write them for a future reader.


### PR DESCRIPTION
Closes #7192

### Summary
Qualify unqualified BRIEFING.md references to use full path .squidsquad/vault/BRIEFING.md in DM and PM soul directives.

### Changes
- **Files**: .squidsquad/project/dm-soul-directives.md, .squidsquad/project/pm-soul-directives.md
- **What**: Changed "Read BRIEFING.md" to "Read .squidsquad/vault/BRIEFING.md"
- **Why**: Unqualified path is ambiguous in isolation (comprehension tests, fresh agents)

### QA Status
- [x] Static tests passing (1838)
- [x] Both files updated