### PR TITLE
skill: #7285 — fix NameError in config.py sync_agents()

### DIFF
--- a/references/scripts/config.py
+++ b/references/scripts/config.py
@@ -501,10 +501,12 @@ def sync_agents():
     if dev_roles:
         set_field("dev-agents", ", ".join(dev_roles))
 
-    # Report
+    # Report — include fixed team roles that have CLAUDE.md
     roles = dev_roles + ["pm"]
-    if has_dm:
+    if (sqdir / "dm" / "CLAUDE.md").exists():
         roles.append("dm")
+    if (sqdir / "qa" / "CLAUDE.md").exists():
+        roles.append("qa")
     print(f"Synced agents: {', '.join(roles)}")
     return roles
 

--- a/tests/test_config_functions.py
+++ b/tests/test_config_functions.py
@@ -306,3 +306,47 @@ class TestFieldMapCoverage:
             f"FIELD_MAP['{key}'] → section='{section}', field='{field}' "
             f"not found in SAMPLE_CONFIG. Update the fixture."
         )
+
+
+# ---------------------------------------------------------------------------
+# #7285: sync_agents regression test
+# ---------------------------------------------------------------------------
+
+
+class TestSyncAgents:
+    """Regression test for sync_agents() — must not raise NameError (#7285)."""
+
+    def test_sync_agents_no_name_error(self, tmp_path):
+        """sync_agents() must not reference undefined variables."""
+        sqdir = tmp_path / ".squidsquad"
+        # Create skill + pm + dm + qa with CLAUDE.md
+        for role in ("skill", "pm", "dm", "qa"):
+            (sqdir / role).mkdir(parents=True)
+            (sqdir / role / "CLAUDE.md").write_text("# test", encoding="utf-8")
+        # Create config.md
+        (sqdir / "config.md").write_text(SAMPLE_CONFIG, encoding="utf-8")
+
+        with patch.object(config, "REPO_ROOT", tmp_path), \
+             patch.object(config, "CONFIG_PATH", sqdir / "config.md"):
+            roles = config.sync_agents()
+
+        assert "skill" in roles
+        assert "pm" in roles
+        assert "dm" in roles
+        assert "qa" in roles
+
+    def test_sync_agents_without_dm(self, tmp_path):
+        """sync_agents() handles missing DM gracefully."""
+        sqdir = tmp_path / ".squidsquad"
+        for role in ("skill", "pm"):
+            (sqdir / role).mkdir(parents=True)
+            (sqdir / role / "CLAUDE.md").write_text("# test", encoding="utf-8")
+        (sqdir / "config.md").write_text(SAMPLE_CONFIG, encoding="utf-8")
+
+        with patch.object(config, "REPO_ROOT", tmp_path), \
+             patch.object(config, "CONFIG_PATH", sqdir / "config.md"):
+            roles = config.sync_agents()
+
+        assert "skill" in roles
+        assert "pm" in roles
+        assert "dm" not in roles


### PR DESCRIPTION
Closes #7285

### Summary
Fix undefined `has_dm` variable in `sync_agents()` that caused NameError on every call. Replace with direct CLAUDE.md existence checks for DM and QA roles.

### Acceptance Criteria
- [x] `sync_agents()` no longer raises NameError
- [x] DM and QA included in report when their CLAUDE.md exists
- [x] DM/QA excluded when CLAUDE.md is missing
- [x] Regression tests added

### Changes
- **Files**: references/scripts/config.py, tests/test_config_functions.py
- **What**: Replaced `if has_dm:` with `if (sqdir / "dm" / "CLAUDE.md").exists():`, added QA check, added 2 regression tests
- **Why**: `has_dm` was never defined — every call to `config.py sync-agents` crashed with NameError

### QA Status
- [x] New regression tests passing (2/2)
- [x] Setup/Upgrade Sync Check: N/A (no config/template/sub-skill changes)