### PR TITLE
skill: #7441 — fix harness.py save_state race

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -286,6 +286,8 @@ class HarnessState:
         """Persist per-agent PIDs and intents to .harness-state.json (#4966).
 
         Called on spawn, death, intent change. Enables crash recovery.
+        Snapshot and disk write are under one lock to prevent concurrent
+        callers from clobbering each other's state (#7441).
         """
         with self._lock:
             state_data = {
@@ -303,12 +305,12 @@ class HarnessState:
                     for role, a in self.agents.items()
                 },
             }
-        try:
-            tmp = HARNESS_STATE_FILE.with_suffix(".tmp")
-            tmp.write_text(json.dumps(state_data, indent=2), encoding="utf-8")
-            tmp.replace(HARNESS_STATE_FILE)
-        except OSError as e:
-            _log(f"WARNING: Could not write state file: {e}")
+            try:
+                tmp = HARNESS_STATE_FILE.with_suffix(".tmp")
+                tmp.write_text(json.dumps(state_data, indent=2), encoding="utf-8")
+                tmp.replace(HARNESS_STATE_FILE)
+            except OSError as e:
+                _log(f"WARNING: Could not write state file: {e}")
 
     def load_state(self):
         """Load state from .harness-state.json for crash recovery (#4966).

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -132,6 +132,26 @@ class TestStatePersistence(unittest.TestCase):
                 self.assertTrue(state_file.exists())
                 self.assertFalse(state_file.with_suffix(".tmp").exists())
 
+    def test_save_state_holds_lock_during_write(self):
+        """#7441: Disk write must happen inside the lock to prevent races."""
+        import inspect
+        from harness import HarnessState
+        source = inspect.getsource(HarnessState.save_state)
+        lines = source.splitlines()
+        in_lock = False
+        write_inside_lock = False
+        for line in lines:
+            stripped = line.lstrip()
+            indent = len(line) - len(stripped)
+            if "with self._lock" in stripped:
+                in_lock = True
+                lock_indent = indent
+            elif in_lock and "write_text" in stripped:
+                write_inside_lock = indent > lock_indent
+                break
+        self.assertTrue(write_inside_lock,
+                        "save_state must hold lock during disk write (#7441)")
+
 
 class TestStartAllPersistence(unittest.TestCase):
     """#6820: start_all must set intent=running and call save_state."""


### PR DESCRIPTION
Closes ​#7441

### Summary
Moved disk write (tmp.write_text + tmp.replace) inside the existing `with self._lock:` block so that snapshot and disk write are one atomic critical section. Prevents concurrent save_state callers from clobbering each other's state file.

### Acceptance Criteria
- [x] Disk write happens under the same lock as the data snapshot
- [x] Regression test verifies lock is held during write

### Changes
- **Files**: references/scripts/harness.py, tests/test_harness.py
- **What**: Moved try/write_text/replace block inside with self._lock scope
- **Why**: Two concurrent save_state calls could interleave disk writes, with one silently overwriting the other

### QA Status
- [x] Unit tests passing
- [x] Full test suite green (0 failures)