### PR TITLE
skill: #6581 — wizard reframing: manifest-driven domain variants

### DIFF
--- a/references/presets/software-dev/manifest.yaml
+++ b/references/presets/software-dev/manifest.yaml
@@ -17,6 +17,15 @@ description: >
   Includes an engineering specialist in one or more variants
   (backend, frontend, fullstack), and a verifier.
 
+# Default L3 domain variants per role. The wizard reads this to assign
+# variants during setup. "custom" presets omit this field (L1+L2 only).
+# This is the single authority for domain-to-agent mappings (#6581).
+domain_variants:
+  dev: skill
+  pm: skill
+  qa: skill
+  dm: skill
+
 # Order in which each specialist role's install-time questions are asked.
 # The wizard walks this list in order. Infrastructure roles
 # (pm, dm, qa) are not listed — they are always installed.

--- a/references/scripts/wizard.py
+++ b/references/scripts/wizard.py
@@ -874,6 +874,46 @@ def load_install_spec(target_root):
     return json.loads(raw)
 
 
+def _write_l4_project_files(spec, project_dir, summary):
+    """Write structured L4 project files from scan data in the spec (#6581).
+
+    This is the mechanical half of the hybrid L4 writer. Writes stack details,
+    test commands, and detected config as structured markdown. The WIZARD.md
+    runbook adds qualitative content (conventions, patterns) afterward.
+
+    Respects overwrite guards: existing files are preserved and recorded in
+    summary["preserved"].
+    """
+    # Extract scan data from agents (test_command, stack are per-agent)
+    scan_data = {}
+    for agent in spec.get("agents", []):
+        if agent.get("test_command"):
+            scan_data["test_command"] = agent["test_command"]
+        if agent.get("stack"):
+            scan_data["stack"] = agent["stack"]
+
+    project_info = spec.get("project", {})
+
+    # shared-stack-details.md — detected tech stack and test commands
+    stack_file = project_dir / "shared-stack-details.md"
+    if stack_file.exists():
+        summary.setdefault("preserved", []).append(str(stack_file))
+    else:
+        stack = scan_data.get("stack", "Not detected")
+        test_cmd = scan_data.get("test_command", "Not detected")
+        name = project_info.get("name", "Unknown")
+        stack_file.write_text(
+            f"## Project Stack Details — {name}\n\n"
+            f"These details apply to all agents on this project.\n\n"
+            f"### Stack\n\n- **Detected stack**: {stack}\n\n"
+            f"### Test Command\n\n- **Test command**: `{test_cmd}`\n\n"
+            f"### Conventions\n\n"
+            f"_To be populated by the installer agent or human with "
+            f"project-specific conventions, patterns, and preferences._\n",
+            encoding="utf-8",
+        )
+
+
 def scaffold_install(spec, target_root, overwrite_existing=False):
     """Write a full `.squidsquad/` tree from an install spec.
 
@@ -953,9 +993,13 @@ def scaffold_install(spec, target_root, overwrite_existing=False):
 
     # 1b. L4 project directory — create .squidsquad/project/ for project-local
     # L4 content. compose.py reads from here, not from references/sub-skills/project/.
-    # Start empty — PM/human populates later via L4 propagation flow.
     project_dir = squid / "project"
     project_dir.mkdir(parents=True, exist_ok=True)
+
+    # 1c. L4 structured files — write mechanically-detected project data (#6581).
+    # These are the "structured" half of the hybrid L4 writer. The WIZARD.md
+    # runbook adds qualitative notes (conventions, patterns) after scaffold.
+    _write_l4_project_files(spec, project_dir, summary)
 
     # 2. Per-agent directories
     for agent in spec["agents"]:

--- a/references/scripts/wizard.py
+++ b/references/scripts/wizard.py
@@ -54,12 +54,14 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent
 SQUIDSQUAD_DIR = REPO_ROOT / ".squidsquad"
+PRESETS_DIR = REPO_ROOT / "references" / "presets"
 
 # Re-run detection — actions the installer agent can take
 RERUN_ACTIONS = ("abort", "regenerate", "full-rebuild")
 
-# Project type → L3 variant mapping. Each preset applies the same variant
-# to all 4 core roles (dev, pm, qa, dm). "custom" = no L3 (base L1+L2 only).
+# Legacy project type → L3 variant mapping. Retained for backward compat
+# with project types not yet backed by a preset manifest (e.g. ios, android).
+# New code should use load_preset_manifest() + domain_variants instead (#6581).
 PROJECT_TYPE_PRESETS = {
     "ios": "ios",
     "android": "android",
@@ -71,6 +73,34 @@ PROJECT_TYPE_PRESETS = {
     "skill": "skill",
     "custom": None,                 # no L3 preset
 }
+
+
+def load_preset_manifest(preset_id):
+    """Load a preset manifest YAML and return as dict.
+
+    Returns None if the preset directory or manifest.yaml doesn't exist,
+    or if yaml parsing fails.
+    """
+    manifest_path = PRESETS_DIR / preset_id / "manifest.yaml"
+    if not manifest_path.exists():
+        return None
+    try:
+        import yaml
+        return yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def resolve_domain_variants(preset_id):
+    """Resolve per-role domain variants from a preset manifest.
+
+    Returns a dict mapping role → variant (e.g. {"dev": "skill", "pm": "skill"}).
+    Returns empty dict if the preset has no domain_variants or doesn't exist.
+    """
+    manifest = load_preset_manifest(preset_id)
+    if manifest is None:
+        return {}
+    return manifest.get("domain_variants", {}) or {}
 
 # Human-readable labels for project type selection
 PROJECT_TYPE_LABELS = {
@@ -511,29 +541,45 @@ _AGENT_NESTED_FIELD_ORDER = [
 def apply_project_type(spec, project_type):
     """Apply a project type preset to an install spec.
 
-    Sets the L3 variant for all core roles (dev, pm, qa, dm) based on the
-    selected project type. Designer keeps its own variant. "custom" = no
-    variant (L1+L2 only).
+    Reads the preset manifest's domain_variants field to assign per-role
+    L3 variants. Falls back to legacy PROJECT_TYPE_PRESETS for project
+    types not backed by a manifest. "custom" = no variant (L1+L2 only).
 
     Args:
         spec: the install spec dict (mutated in place).
-        project_type: key from PROJECT_TYPE_PRESETS.
+        project_type: key from PROJECT_TYPE_PRESETS or a preset ID.
 
     Returns:
-        The variant name applied (or None for custom).
+        Dict of {role: variant} applied (or None for custom/no variants).
     """
-    variant = PROJECT_TYPE_PRESETS.get(project_type)
-    if variant is None:
-        spec["project_type"] = project_type
+    spec["project_type"] = project_type
+
+    if project_type == "custom":
         return None
 
-    spec["project_type"] = project_type
+    # Try manifest-driven resolution first (#6581)
+    preset_id = spec.get("preset", "")
+    domain_variants = resolve_domain_variants(preset_id) if preset_id else {}
+
+    if domain_variants:
+        # Manifest is the single authority for domain-to-agent mappings
+        for agent in spec.get("agents", []):
+            role = agent.get("role", "")
+            variant = domain_variants.get(role)
+            if variant:
+                agent["variant"] = variant
+        return domain_variants
+
+    # Legacy fallback: uniform variant from PROJECT_TYPE_PRESETS
+    variant = PROJECT_TYPE_PRESETS.get(project_type)
+    if variant is None:
+        return None
+
     for agent in spec.get("agents", []):
         role = agent.get("role", "")
-        # Apply variant to core roles only
         if role in ("dev", "pm", "qa", "dm"):
             agent["variant"] = variant
-    return variant
+    return {role: variant for role in ("dev", "pm", "qa", "dm")}
 
 
 def build_config_md(spec):
@@ -2015,14 +2061,21 @@ def generate_default_spec(scan_data=None, repo_info=None):
         stack_parts.extend(l for l in langs[:3] if l not in stack_parts)
     stack = " + ".join(stack_parts) if stack_parts else "general"
 
-    # Default agents
+    # Resolve domain variants from the default preset manifest (#6581)
+    default_preset = "software-dev"
+    domain_variants = resolve_domain_variants(default_preset)
+
+    # Default agents — variants from manifest, not hardcoded
+    dev_variant = domain_variants.get("dev")
+    pm_variant = domain_variants.get("pm")
     agents = [
-        {"id": "pm", "alias": "pm", "role": "pm"},
+        {"id": "pm", "alias": "pm", "role": "pm",
+         **({"variant": pm_variant} if pm_variant else {})},
         {
             "id": "skill",
             "alias": "skill",
             "role": "dev",
-            "variant": "skill",
+            **({"variant": dev_variant} if dev_variant else {}),
             "stack": stack,
             "test_command": test_command,
         },
@@ -2042,7 +2095,7 @@ def generate_default_spec(scan_data=None, repo_info=None):
             "name": project_name,
             "repo": project_repo,
         },
-        "preset": "software-dev",
+        "preset": default_preset,
         "agents": agents,
         "tools": {},
         "loop": {

--- a/references/wizard/WIZARD.md
+++ b/references/wizard/WIZARD.md
@@ -638,6 +638,23 @@ this writes the full `.squidsquad/` tree:
 Parse the JSON summary. If `failed` is non-empty, stop and show the
 user the errors — they can re-run the wizard after fixing them.
 
+### 7.3b — Enrich L4 project files (#6581)
+
+`scaffold_install` wrote structured L4 files to `.squidsquad/project/`
+with mechanically-detected data (stack, test command). Now add
+qualitative project context:
+
+1. Read `.squidsquad/project/shared-stack-details.md` (if it exists).
+2. Under the `### Conventions` section, add project-specific notes:
+   - Coding conventions observed in the repo (naming, formatting, patterns)
+   - Domain vocabulary or terminology
+   - Key architectural patterns (monorepo, microservices, MVC, etc.)
+3. Do NOT overwrite the `### Stack` or `### Test Command` sections —
+   those were populated mechanically by `scaffold_install`.
+
+This is the "qualitative" half of the hybrid L4 writer. The structured
+data comes from `scaffold_install`; you add the human-readable context.
+
 ### 7.4 — Ensure GitHub labels
 
 Run `python references/scripts/wizard.py ensure-labels`. This creates

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -2011,27 +2011,52 @@ class TestGenerateDefaultSpec:
 # ---------------------------------------------------------------------------
 
 class TestApplyProjectType:
-    def test_ios_sets_variant_on_core_roles(self):
+    """#6581: apply_project_type uses manifest domain_variants (primary)
+    with legacy PROJECT_TYPE_PRESETS fallback."""
+
+    def test_manifest_driven_per_role_variants(self):
+        """TC-1: Preset manifest domain_variants resolved per role."""
         spec = {
+            "preset": "software-dev",
             "agents": [
                 {"id": "pm", "role": "pm"},
                 {"id": "skill", "role": "dev"},
                 {"id": "qa", "role": "qa"},
                 {"id": "dm", "role": "dm"},
-            ]
+            ],
         }
-        result = wizard.apply_project_type(spec, "ios")
-        assert result == "ios"
-        assert spec["project_type"] == "ios"
+        result = wizard.apply_project_type(spec, "skill")
+        # Returns dict of {role: variant}
+        assert isinstance(result, dict)
+        assert result.get("dev") == "skill"
+        assert spec["project_type"] == "skill"
+        # All agents should have variants from the manifest
         for agent in spec["agents"]:
-            assert agent["variant"] == "ios"
+            assert "variant" in agent, f"{agent['id']} missing variant"
+
+    def test_all_roles_get_variant(self):
+        """TC-2: All roles receive domain variant — none skipped."""
+        spec = {
+            "preset": "software-dev",
+            "agents": [
+                {"id": "pm", "role": "pm"},
+                {"id": "skill", "role": "dev"},
+                {"id": "qa", "role": "qa"},
+                {"id": "dm", "role": "dm"},
+            ],
+        }
+        wizard.apply_project_type(spec, "skill")
+        for agent in spec["agents"]:
+            assert agent.get("variant") is not None, \
+                f"{agent['role']} has no variant"
 
     def test_custom_sets_no_variant(self):
+        """TC-5: custom project type — no domain variant."""
         spec = {
             "agents": [
                 {"id": "pm", "role": "pm"},
                 {"id": "skill", "role": "dev"},
-            ]
+            ],
         }
         result = wizard.apply_project_type(spec, "custom")
         assert result is None
@@ -2039,11 +2064,67 @@ class TestApplyProjectType:
         assert "variant" not in spec["agents"][0]
         assert "variant" not in spec["agents"][1]
 
+    def test_legacy_fallback_when_no_preset(self):
+        """Legacy PROJECT_TYPE_PRESETS fallback when no preset in spec."""
+        spec = {
+            "agents": [
+                {"id": "pm", "role": "pm"},
+                {"id": "skill", "role": "dev"},
+                {"id": "qa", "role": "qa"},
+                {"id": "dm", "role": "dm"},
+            ],
+        }
+        result = wizard.apply_project_type(spec, "ios")
+        assert isinstance(result, dict)
+        assert result.get("dev") == "ios"
+        for agent in spec["agents"]:
+            assert agent["variant"] == "ios"
+
     def test_all_project_types_valid(self):
         for ptype in wizard.PROJECT_TYPE_PRESETS:
             spec = {"agents": [{"id": "pm", "role": "pm"}]}
             wizard.apply_project_type(spec, ptype)
             assert spec["project_type"] == ptype
+
+
+class TestManifestResolution:
+    """#6581: load_preset_manifest and resolve_domain_variants."""
+
+    def test_load_software_dev_manifest(self):
+        """Manifest loads and contains expected fields."""
+        manifest = wizard.load_preset_manifest("software-dev")
+        assert manifest is not None
+        assert manifest["id"] == "software-dev"
+        assert "domain_variants" in manifest
+
+    def test_resolve_domain_variants_software_dev(self):
+        """domain_variants returns per-role mapping."""
+        variants = wizard.resolve_domain_variants("software-dev")
+        assert variants.get("dev") == "skill"
+        assert variants.get("pm") == "skill"
+        assert variants.get("qa") == "skill"
+        assert variants.get("dm") == "skill"
+
+    def test_resolve_nonexistent_preset(self):
+        """Missing preset returns empty dict."""
+        variants = wizard.resolve_domain_variants("nonexistent-preset-xyz")
+        assert variants == {}
+
+    def test_resolve_design_preset_no_variants(self):
+        """TC-6: Design preset has no domain_variants."""
+        variants = wizard.resolve_domain_variants("design")
+        assert variants == {}
+
+    def test_generate_default_spec_uses_manifest(self):
+        """TC-7: generate_default_spec derives variants from manifest."""
+        spec = wizard.generate_default_spec()
+        assert spec["preset"] == "software-dev"
+        # Dev agent should have variant from manifest
+        dev_agents = [a for a in spec["agents"] if a["role"] == "dev"]
+        assert len(dev_agents) == 1
+        manifest = wizard.load_preset_manifest("software-dev")
+        expected_variant = manifest["domain_variants"]["dev"]
+        assert dev_agents[0].get("variant") == expected_variant
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1016,6 +1016,65 @@ class TestScaffoldInstallValidation:
         assert "WARNING" in stderr or "repo scan" in stderr.lower() or stderr == ""
 
 
+# ---------------------------------------------------------------------------
+# #6581: L4 project file writing in scaffold_install
+# ---------------------------------------------------------------------------
+
+class TestScaffoldL4Files:
+    """TC-3, TC-8: L4 project files written by scaffold_install."""
+
+    def test_l4_stack_details_created(self, tmp_path):
+        """TC-3: scaffold_install writes shared-stack-details.md."""
+        spec = _design_preset_spec()
+        # Add a dev agent with stack and test_command
+        spec["agents"].append({
+            "id": "skill", "alias": "skill", "role": "dev",
+            "variant": "skill", "stack": "Python + pytest",
+            "test_command": "pytest",
+        })
+        wizard.scaffold_install(spec, tmp_path)
+        l4_file = tmp_path / ".squidsquad" / "project" / "shared-stack-details.md"
+        assert l4_file.exists(), "shared-stack-details.md should be created"
+        content = l4_file.read_text(encoding="utf-8")
+        assert "Python + pytest" in content
+        assert "pytest" in content
+
+    def test_l4_overwrite_guard_preserves_existing(self, tmp_path):
+        """TC-8: existing L4 files not overwritten on re-run."""
+        spec = _design_preset_spec()
+        spec["agents"].append({
+            "id": "skill", "alias": "skill", "role": "dev",
+            "variant": "skill", "stack": "original",
+            "test_command": "original-test",
+        })
+        wizard.scaffold_install(spec, tmp_path)
+        l4_file = tmp_path / ".squidsquad" / "project" / "shared-stack-details.md"
+        original_content = l4_file.read_text(encoding="utf-8")
+        assert "original" in original_content
+
+        # Modify spec and re-run — L4 file should be preserved
+        spec["agents"][-1]["stack"] = "changed"
+        summary = wizard.scaffold_install(spec, tmp_path, overwrite_existing=True)
+        preserved_content = l4_file.read_text(encoding="utf-8")
+        assert preserved_content == original_content
+        assert any("shared-stack-details" in p for p in summary.get("preserved", []))
+
+    def test_l4_project_dir_always_created(self, tmp_path):
+        """TC-11 partial: .squidsquad/project/ exists even with no scan data."""
+        spec = _design_preset_spec()
+        wizard.scaffold_install(spec, tmp_path)
+        assert (tmp_path / ".squidsquad" / "project").is_dir()
+
+    def test_generate_default_spec_smoke(self):
+        """TC-11: generate_default_spec returns valid spec with preset."""
+        spec = wizard.generate_default_spec()
+        assert spec["preset"] == "software-dev"
+        assert len(spec["agents"]) >= 1
+        dev_agents = [a for a in spec["agents"] if a["role"] == "dev"]
+        assert len(dev_agents) == 1
+        assert dev_agents[0].get("variant") is not None
+
+
 # ===========================================================================
 # Step 7 — label inventory + ensure_labels + migrate_label
 # ===========================================================================


### PR DESCRIPTION
Closes ​#6581

### Summary
Reframes the setup wizard so preset manifests drive agent domain variants instead of hardcoded PROJECT_TYPE_PRESETS. L4 project files (shared-stack-details.md) are written during scaffold with detected project data. WIZARD.md runbook updated for hybrid L4 writer.

### Acceptance Criteria
- [x] TC-1: Preset manifest domain_variants resolved per role
- [x] TC-2: All roles receive domain variant
- [x] TC-3: scaffold_install writes L4 project files
- [x] TC-4: WIZARD.md runbook updated for L4 enrichment
- [x] TC-5: custom project type no variant
- [x] TC-6: Design preset no variants
- [x] TC-7: generate_default_spec uses manifest
- [x] TC-8: overwrite_existing guard for L4 files
- [x] TC-10: TestApplyProjectType rewritten
- [x] TC-11: Smoke test

### Changes
- references/presets/software-dev/manifest.yaml: added domain_variants
- references/scripts/wizard.py: load_preset_manifest(), resolve_domain_variants(), refactored apply_project_type(), _write_l4_project_files(), updated generate_default_spec()
- references/wizard/WIZARD.md: added Step 7.3b L4 enrichment
- tests/test_wizard.py: 14 new tests (TestApplyProjectType rewritten, TestManifestResolution, TestScaffoldL4Files)

### QA Status
- [x] Unit tests passing (230 wizard tests)
- [x] Full test suite green (0 failures)