### PR TITLE
skill: #7589 — fix state_bus.py commit_and_push false positive

### DIFF
--- a/references/scripts/state_bus.py
+++ b/references/scripts/state_bus.py
@@ -243,10 +243,14 @@ def commit_and_push(message, role="unknown"):
     if not result.stdout.strip():
         return True  # Nothing to commit
 
-    # Commit
-    _run([
+    # Commit — check return code to avoid pushing nothing (#7589)
+    commit_result = _run([
         "git", "commit", "-m", f"{role}: {message}",
     ], cwd=cwd, check=False)
+    if commit_result.returncode != 0:
+        print(f"WARNING: State commit failed: {commit_result.stderr.strip()[:200]}",
+              file=sys.stderr)
+        return False
 
     # Push with retry (up to 3 attempts for concurrent conflicts)
     for attempt in range(3):

--- a/tests/test_state_bus.py
+++ b/tests/test_state_bus.py
@@ -266,3 +266,40 @@ class TestCLI:
         sys.argv = ["state_bus.py", "badcmd"]
         code = state_bus.main()
         assert code == 2
+
+
+# ---------------------------------------------------------------------------
+# #7589: commit_and_push must detect failed git commit
+# ---------------------------------------------------------------------------
+
+class TestCommitAndPushFailedCommit:
+    """#7589: commit_and_push returns False when git commit fails."""
+
+    @patch("state_bus._worktree_exists", return_value=True)
+    @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
+    @patch("state_bus._run")
+    def test_returns_false_on_commit_failure(self, mock_run, mock_config, mock_wt):
+        """Failed git commit should return False, not proceed to push."""
+        mock_run.side_effect = [
+            MagicMock(stdout="", returncode=0),     # git add -A
+            MagicMock(stdout=" M file.md\n", returncode=0),  # git status --porcelain
+            MagicMock(stdout="", stderr="error: hook rejected", returncode=1),  # git commit FAILS
+        ]
+        result = state_bus.commit_and_push("test msg", role="skill")
+        assert result is False
+        # Push should NOT have been called (only 3 _run calls, not 4+)
+        assert mock_run.call_count == 3
+
+    @patch("state_bus._worktree_exists", return_value=True)
+    @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
+    @patch("state_bus._run")
+    def test_returns_true_on_commit_success(self, mock_run, mock_config, mock_wt):
+        """Successful commit + push returns True."""
+        mock_run.side_effect = [
+            MagicMock(stdout="", returncode=0),     # git add -A
+            MagicMock(stdout=" M file.md\n", returncode=0),  # git status --porcelain
+            MagicMock(stdout="", stderr="", returncode=0),  # git commit succeeds
+            MagicMock(stdout="", returncode=0),     # git push succeeds
+        ]
+        result = state_bus.commit_and_push("test msg", role="skill")
+        assert result is True


### PR DESCRIPTION
Closes ​#7589

### Summary
commit_and_push now checks git commit returncode and returns False on failure instead of proceeding to push nothing.

### Changes
- references/scripts/state_bus.py: check commit_result.returncode
- tests/test_state_bus.py: 2 regression tests (failure + success paths)

### QA Status
- [x] 33 state_bus tests passing
- [x] 2 files only