### PR TITLE
skill: #7590 — fix manifest.py yaml import + bare except

### DIFF
--- a/references/scripts/manifest.py
+++ b/references/scripts/manifest.py
@@ -395,11 +395,10 @@ def _load_kind(base_dir, kind_dir, validator):
                 is_variant = False
                 if inc_yml.exists():
                     try:
-                        import yaml as _y
-                        _d = _y.safe_load(inc_yml.read_text(encoding="utf-8"))
+                        _d = yaml.safe_load(inc_yml.read_text(encoding="utf-8"))
                         if isinstance(_d, dict) and "base_role" in _d:
                             is_variant = True
-                    except Exception:
+                    except (yaml.YAMLError, OSError):
                         pass
                 if not is_layer_source and not is_variant:
                     issues.append(Issue(

--- a/tests/test_manifest_registry.py
+++ b/tests/test_manifest_registry.py
@@ -485,3 +485,23 @@ class TestIssueFormatting:
     def test_severity_default_is_error(self):
         i = manifest.Issue("x", "", "y")
         assert i.severity == "error"
+
+
+# ---------------------------------------------------------------------------
+# #7590: _load_kind uses module-level yaml import, not redundant inner import
+# ---------------------------------------------------------------------------
+
+class TestLoadKindYamlImport:
+    """#7590: includes.yml parsing uses module-level yaml, catches YAMLError."""
+
+    def test_malformed_includes_yml_does_not_crash(self, tmp_path):
+        """Malformed includes.yml should be caught by yaml.YAMLError, not Exception."""
+        role_dir = tmp_path / "roles" / "testrole"
+        role_dir.mkdir(parents=True)
+        (role_dir / "instructions.md").write_text("# test")
+        (role_dir / "includes.yml").write_text(": invalid: yaml: {{{\n")
+        # Should not raise — malformed YAML caught gracefully
+        _, issues = manifest._load_kind(tmp_path, "roles", lambda m: [])
+        # The malformed includes.yml means it's not detected as a variant,
+        # so it may report a missing manifest issue — that's expected behavior
+        assert isinstance(issues, list)


### PR DESCRIPTION
Closes ​#7590

### Summary
Use module-level yaml import instead of redundant inner import. Tighten except from bare Exception to yaml.YAMLError + OSError.

### Changes
- references/scripts/manifest.py: 2 lines changed
- tests/test_manifest_registry.py: 1 regression test

### QA Status
- [x] 41 manifest tests passing
- [x] 2 files only