### PR TITLE
skill: #7610 #7611 — fix cycle.py double output + health_check pid

### DIFF
--- a/references/scripts/cycle.py
+++ b/references/scripts/cycle.py
@@ -79,15 +79,19 @@ def _get_working_state_path(role):
     return _state_path(f"{role}/working-state.md")
 
 
-def get_counter(role):
-    """Read quiet cycle counter from working-state.md."""
+def _read_counter(role):
+    """Read quiet cycle counter without printing (#7610)."""
     ws_path = _get_working_state_path(role)
     if not ws_path.exists():
-        print("0")
         return 0
     text = ws_path.read_text(encoding="utf-8")
     match = re.search(r'Quiet Cycle Counter\*\*:\s*(\d+)', text)
-    count = int(match.group(1)) if match else 0
+    return int(match.group(1)) if match else 0
+
+
+def get_counter(role):
+    """Read quiet cycle counter from working-state.md."""
+    count = _read_counter(role)
     print(str(count))
     return count
 
@@ -109,8 +113,7 @@ def set_counter(role, value):
 
 def inc_counter(role):
     """Increment quiet cycle counter."""
-    count = get_counter(role)
-    # get_counter already printed, suppress duplicate
+    count = _read_counter(role)
     new_count = count + 1
     set_counter(role, new_count)
     print(str(new_count))

--- a/references/scripts/health_check.py
+++ b/references/scripts/health_check.py
@@ -370,8 +370,9 @@ def check_agent_health(role, clone_root, interval_minutes, now=None):
             return result
 
         elif health_status == "alive":
-            # Legacy format: PID cross-check
-            pid = _read_pid_file(squid)
+            # Legacy format: PID cross-check — use _read_any_pid to support
+            # thin-launcher agents that write .claude-pid only (#7611)
+            pid = _read_any_pid(squid)
             pid_alive = _is_process_alive(pid)
             result["pid"] = pid
 

--- a/tests/test_cycle.py
+++ b/tests/test_cycle.py
@@ -100,6 +100,16 @@ class TestCounters:
             result = cycle.inc_counter("skill")
         assert result == 3
 
+    def test_inc_counter_single_output_line(self, tmp_path, capsys):
+        """#7610: inc_counter must emit exactly one line (new value only)."""
+        self._setup_working_state(tmp_path, "skill", counter=5)
+        with self._patch(tmp_path):
+            cycle.inc_counter("skill")
+        output = capsys.readouterr().out.strip()
+        lines = [l for l in output.splitlines() if l.strip()]
+        assert len(lines) == 1, f"Expected 1 line, got {len(lines)}: {lines}"
+        assert lines[0] == "6"
+
     def test_reset_counter(self, tmp_path, capsys):
         self._setup_working_state(tmp_path, "skill", counter=5)
         with self._patch(tmp_path):

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -470,3 +470,26 @@ class TestReadClaudePidFile:
         squid = tmp_path / ".squidsquad" / "skill"
         squid.mkdir(parents=True)
         assert health_check._read_any_pid(squid) is None
+
+
+class TestAliveBranchUsesAnyPid:
+    """#7611: alive health branch must use _read_any_pid, not _read_pid_file."""
+
+    def test_alive_branch_reads_claude_pid(self):
+        """The alive branch source must call _read_any_pid, not _read_pid_file."""
+        import inspect
+        source = inspect.getsource(health_check.check_agent_health)
+        # Find the "alive" branch and verify it uses _read_any_pid
+        lines = source.splitlines()
+        in_alive = False
+        uses_any_pid = False
+        for line in lines:
+            if '"alive"' in line or "'alive'" in line:
+                in_alive = True
+            elif in_alive and "_read_any_pid" in line:
+                uses_any_pid = True
+                break
+            elif in_alive and ("elif" in line or "else:" in line):
+                break  # Left the alive branch
+        assert uses_any_pid, \
+            "alive branch must use _read_any_pid for thin-launcher compat (#7611)"


### PR DESCRIPTION
Closes ​#7610, Closes ​#7611

### Summary
#7610: Extract _read_counter() without printing. inc_counter now emits one line.
#7611: Replace _read_pid_file with _read_any_pid in alive branch.

### Changes (4 files)
- references/scripts/cycle.py: _read_counter extraction
- references/scripts/health_check.py: _read_any_pid in alive branch
- tests/test_cycle.py: 1 regression test
- tests/test_health_check.py: 1 regression test

### QA Status
- [x] 73 tests passing
- [x] 4 files only