### PR TITLE
skill: #7614 #7615 — fix scan_index + vault_entity

### DIFF
--- a/references/scripts/scan_index.py
+++ b/references/scripts/scan_index.py
@@ -173,16 +173,20 @@ def _walk_source_files(root=None):
 def suggest_targets(role, count=5, db_path=None):
     """Return top N files to scan, ranked by composite score."""
     resolved_db_path = db_path or DB_PATH
+
+    # Lazy churn refresh (if stale > 24h) — uses its own connection.
+    # Gracefully handle corrupt DB during refresh (#7614).
+    try:
+        _maybe_refresh_churn(resolved_db_path)
+    except (sqlite3.DatabaseError, sqlite3.OperationalError):
+        pass  # Churn refresh failed — proceed with stale data
+
+    # Open DB once after churn refresh (#7614)
     try:
         conn = _get_db(resolved_db_path)
     except (sqlite3.DatabaseError, sqlite3.OperationalError) as e:
         print(f"WARNING: DB error ({e}), returning empty list", file=sys.stderr)
         return []
-
-    # Lazy churn refresh (if stale > 24h) — uses its own connection
-    conn.close()
-    _maybe_refresh_churn(resolved_db_path)
-    conn = _get_db(resolved_db_path)
 
     # Get all source files on disk
     root = REPO_ROOT if db_path is None else db_path.parent.parent

--- a/references/scripts/vault_entity.py
+++ b/references/scripts/vault_entity.py
@@ -104,19 +104,22 @@ def extract_entities(text):
         name = match.group(1)
         if name not in seen and not _is_noise_name(name):
             seen.add(name)
-            # Heuristic: if followed by role-like words, it's a person
+            # Heuristic: check name itself and trailing context for type signals
+            name_lower = name.lower()
             after = text[match.end():match.end() + 30].lower()
-            if any(w in after for w in [" said", " asked", " from ", " at ", "'s "]):
-                entity_type = "person"
+            if any(w in name_lower for w in [" corp", " inc", " ltd", " llc", " co"]):
+                entity_type = "business"  # business suffix in name itself
             elif any(w in after for w in [" corp", " inc", " ltd", " llc", " co"]):
-                entity_type = "business"
+                entity_type = "business"  # business suffix after name
+            elif any(w in after for w in [" said", " asked", " from ", " at ", "'s "]):
+                entity_type = "person"
             else:
-                entity_type = "person"  # default for proper names
+                entity_type = "unknown"  # ambiguous — could be person, place, or brand (#7615)
             entities.append({
                 "type": entity_type,
                 "value": name,
                 "context": _get_context(text, match.start(), match.end()),
-                "confidence": "medium",
+                "confidence": "low" if entity_type == "unknown" else "medium",
             })
 
     # Projects

--- a/tests/test_scan_index.py
+++ b/tests/test_scan_index.py
@@ -595,3 +595,15 @@ class TestWalkSourceFiles:
         files = scan_index._walk_source_files(tmp_path)
         assert "visible.py" in files
         assert ".hidden" not in files
+
+
+class TestSuggestTargetsDbOpen:
+    """#7614: suggest_targets opens DB once after churn refresh, not twice."""
+
+    def test_no_redundant_db_open(self):
+        """Source code should have exactly one _get_db call in suggest_targets."""
+        import inspect
+        source = inspect.getsource(scan_index.suggest_targets)
+        count = source.count("_get_db(")
+        assert count == 1, \
+            f"suggest_targets should call _get_db once, found {count} calls (#7614)"

--- a/tests/test_vault_entity.py
+++ b/tests/test_vault_entity.py
@@ -39,7 +39,7 @@ class TestExtractURLs:
 class TestExtractNames:
     def test_finds_person_name(self):
         entities = vault_entity.extract_entities(
-            "Ask Sarah Johnson about the design."
+            "Sarah Johnson said the design is ready."
         )
         people = [e for e in entities if e["type"] == "person"]
         assert len(people) >= 1
@@ -57,7 +57,7 @@ class TestExtractNames:
             "This Monday we have a meeting about the Task."
         )
         # Monday, This, Task should be filtered
-        names = [e for e in entities if e["type"] in ("person", "business")]
+        names = [e for e in entities if e["type"] in ("person", "business", "unknown")]
         noise_values = [n["value"] for n in names]
         assert "Monday" not in noise_values
         assert "This Monday" not in noise_values
@@ -173,3 +173,17 @@ class TestCLI:
         sys.argv = ["vault_entity.py", "extract"]
         code = vault_entity.main()
         assert code == 2
+
+
+class TestProperNameClassification:
+    """#7615: ambiguous proper names should be 'unknown', not 'person'."""
+
+    def test_ambiguous_name_classified_as_unknown(self):
+        """A proper name without person or business context = unknown."""
+        text = "We evaluated Red Hat for the project."
+        entities = vault_entity.extract_entities(text)
+        red_hat = [e for e in entities if e["value"] == "Red Hat"]
+        if red_hat:
+            assert red_hat[0]["type"] == "unknown", \
+                f"Ambiguous name should be 'unknown', got '{red_hat[0]['type']}'"
+            assert red_hat[0]["confidence"] == "low"


### PR DESCRIPTION
Closes ​#7614, Closes ​#7615

### Summary
#7614: Remove redundant DB open/close in suggest_targets. Open once after churn refresh.
#7615: Change proper-name default from 'person' to 'unknown' with low confidence. Also check name itself for business suffixes.

### Changes (4 files)
- references/scripts/scan_index.py
- references/scripts/vault_entity.py
- tests/test_scan_index.py
- tests/test_vault_entity.py

### QA Status
- [x] 59 tests passing