### PR TITLE
skill: #7622 — fix tc_coverage.py unhandled read_text

### DIFF
--- a/references/scripts/tc_coverage.py
+++ b/references/scripts/tc_coverage.py
@@ -169,8 +169,16 @@ def check_coverage(
 
     Returns exit code: 0 (pass), 1 (fail), 2 (blocked).
     """
-    plan_text = Path(test_plan_path).read_text(encoding="utf-8")
-    results_text = Path(qa_results_path).read_text(encoding="utf-8")
+    try:
+        plan_text = Path(test_plan_path).read_text(encoding="utf-8")
+    except OSError as e:
+        print(f"ERROR: Cannot read test plan: {e}", file=sys.stderr)
+        return 1
+    try:
+        results_text = Path(qa_results_path).read_text(encoding="utf-8")
+    except OSError as e:
+        print(f"ERROR: Cannot read QA results: {e}", file=sys.stderr)
+        return 1
 
     plan_ids = parse_tc_ids(plan_text)
     result_map = parse_tc_results(results_text)

--- a/tests/test_tc_coverage.py
+++ b/tests/test_tc_coverage.py
@@ -372,3 +372,25 @@ class TestAutoDiscovery:
 
         tp, qr = tc_coverage._discover_files(9999)
         assert tp is None
+
+
+class TestCheckCoverageFileErrors:
+    """#7622: check_coverage must handle unreadable files gracefully."""
+
+    def test_missing_test_plan_returns_1(self, tmp_path):
+        """Missing test plan file returns exit code 1, not unhandled exception."""
+        result = tc_coverage.check_coverage(
+            str(tmp_path / "nonexistent-plan.md"),
+            str(tmp_path / "nonexistent-results.md"),
+        )
+        assert result == 1
+
+    def test_missing_qa_results_returns_1(self, tmp_path):
+        """Missing QA results file returns exit code 1."""
+        plan = tmp_path / "plan.md"
+        plan.write_text("### TC-1: Test\n- **Result**: PASS\n")
+        result = tc_coverage.check_coverage(
+            str(plan),
+            str(tmp_path / "nonexistent-results.md"),
+        )
+        assert result == 1


### PR DESCRIPTION
Closes ​#7622

### Summary
Wrap read_text calls in try/except OSError for clean error handling.

### Changes (2 files)
- references/scripts/tc_coverage.py: error handling around read_text
- tests/test_tc_coverage.py: 2 regression tests

### QA Status
- [x] 43 tests passing
- [x] 2 files only