### PR TITLE
skill: #7624 #7625 — fix vault_remember + forgejo_setup

### DIFF
--- a/references/scripts/forgejo_setup.py
+++ b/references/scripts/forgejo_setup.py
@@ -380,8 +380,6 @@ def main():
         print(f"Unknown command: {cmd}", file=sys.stderr)
         return 2
 
-    return 0
-
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/references/scripts/vault_remember.py
+++ b/references/scripts/vault_remember.py
@@ -301,7 +301,10 @@ def decay_scan():
         if md.name == ".gitkeep" or md.name == "BRIEFING.md":
             continue
 
-        text = md.read_text(encoding="utf-8")
+        try:
+            text = md.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue  # Skip unreadable files gracefully (#7624)
         if not text.startswith("---"):
             continue
 

--- a/tests/test_vault_remember.py
+++ b/tests/test_vault_remember.py
@@ -231,3 +231,29 @@ class TestResetWrites:
         assert "Vault Writes This Cycle**: 0" in content, (
             "reset_writes must create the field when absent (#4919)"
         )
+
+
+class TestDecayScanErrorHandling:
+    """#7624: decay_scan must handle unreadable vault files gracefully."""
+
+    def test_unreadable_file_does_not_abort_scan(self, tmp_path):
+        """A single unreadable .md file should not crash the entire scan."""
+        vault = tmp_path / "vault"
+        galaxy = vault / "galaxy"
+        galaxy.mkdir(parents=True)
+
+        # Write a valid note
+        good = galaxy / "decision-good.md"
+        good.write_text(
+            "---\ntype: decision\nupdated: 2020-01-01\nconfidence: high\n---\nGood note.\n",
+            encoding="utf-8",
+        )
+
+        # Write a binary/corrupt file that will fail read_text
+        bad = galaxy / "decision-corrupt.md"
+        bad.write_bytes(b"\x80\x81\x82\xff\xfe")
+
+        with patch.object(vault_remember, "VAULT_DIR", vault):
+            # Should not raise — corrupt file skipped
+            results = vault_remember.decay_scan()
+        assert isinstance(results, list)


### PR DESCRIPTION
Closes ​#7624, Closes ​#7625

### Summary
#7624: Wrap read_text in try/except (OSError, UnicodeDecodeError) in decay_scan.
#7625: Remove unreachable return 0 in forgejo_setup main().

### Changes (3 files)
- references/scripts/vault_remember.py
- references/scripts/forgejo_setup.py
- tests/test_vault_remember.py

### QA Status
- [x] 20 vault_remember tests passing
- [x] 3 files only