### PR TITLE
skill: #7627 #7628 — fix migrate exit code + dead test code

### DIFF
--- a/references/scripts/migrate_state_branch.py
+++ b/references/scripts/migrate_state_branch.py
@@ -135,6 +135,9 @@ def migrate(dry_run=False):
         )
 
     print(f"\nMigrated {migrated}/{len(state_files)} files to state branch.")
+    if migrated == 0 and len(state_files) > 0:
+        print("ERROR: All migrations failed.", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/tests/test_per_agent_workdirs.py
+++ b/tests/test_per_agent_workdirs.py
@@ -153,21 +153,8 @@ class TestRelativePathResolution:
         )
         (ss / ".local-config").write_text(config_text, encoding="utf-8")
 
-        # Use a non-existent shared clones dir to force .local-config fallback
-        fake_shared = tmp_path / "nonexistent_shared_clones"
-        with patch.object(health_check, "REPO_ROOT", repo), \
-             patch.object(health_check, "LOCAL_CONFIG", ss / ".local-config"), \
-             patch.object(health_check, "SQUIDSQUAD_DIR", ss), \
-             patch("health_check.Path") as MockPath:
-            # Make Path.home() return a dir without .squidsquad/clones/
-            MockPath.home.return_value = fake_shared
-            # But let all other Path() calls work normally
-            MockPath.side_effect = Path
-            # Directly test by mocking the shared clones check
-            pass
-
-        # Simpler approach: just test the .local-config parsing branch directly
-        # by ensuring shared_clones dir doesn't exist
+        # Test the .local-config parsing branch by ensuring shared_clones
+        # dir doesn't exist (#7628: removed dead with-block)
         with patch.object(health_check, "REPO_ROOT", repo), \
              patch.object(health_check, "LOCAL_CONFIG", ss / ".local-config"), \
              patch.object(health_check, "SQUIDSQUAD_DIR", ss), \


### PR DESCRIPTION
Closes ​#7627, Closes ​#7628

### Summary
#7627: Return 1 when migrated==0 and state_files>0 (all failed).
#7628: Remove dead with-block in test_per_agent_workdirs.

### Changes (2 files)
- references/scripts/migrate_state_branch.py
- tests/test_per_agent_workdirs.py

### QA Status
- [x] 13 workdir tests passing
- [x] 2 files only