### PR TITLE
skill: #7631 — remove stale agent-instructions.md reference

### DIFF
--- a/.squidsquad/skill/CLAUDE.md
+++ b/.squidsquad/skill/CLAUDE.md
@@ -482,7 +482,7 @@ Print: `[🦑 HH:MM:SS] Implementing #[NUMBER]...`
 5. Run the test command: `python tests/run_tests.py`
 6. **Run smoke tests** from TEST-PLAN.md (if it exists) before marking as Pending Test.
 7. **Update docs**: Update only technical documentation (API docs, code comments, architecture notes). User-facing docs are handled by DM. If the change affects user-facing behavior, comment delivery notes on the Issue.
-8. **Copy changed references to live**: If any files in `references/` were modified (e.g. `statusline.sh`, `hints-*.txt`, `agent-instructions.md`), copy them to the live `.squidsquad/` location so changes take effect immediately.
+8. **Copy changed references to live**: If any files in `references/` were modified (e.g. `statusline.sh`, `hints-*.txt`), copy them to the live `.squidsquad/` location so changes take effect immediately.
 9. **Verify changes exist**: Run `python references/scripts/git_ops.py has-changes`. If output is `false`, do NOT transition — re-read the acceptance criteria and apply the implementation.
 9b. **Self-verification reflection** — before marking pending-test, stop and critically review your own work:
    - **Regression**: Does this change break existing behavior? Read the code paths you touched — what else depends on them?

--- a/references/sub-skills/roles/dev/implement-tasks.md
+++ b/references/sub-skills/roles/dev/implement-tasks.md
@@ -26,7 +26,7 @@ Print: `[🦑 HH:MM:SS] Implementing #[NUMBER]...`
 5. Run the test command: `[ROLE_TEST_CMD]`
 6. **Run smoke tests** from TEST-PLAN.md (if it exists) before marking as Pending Test.
 7. **Update docs**: Update only technical documentation (API docs, code comments, architecture notes). User-facing docs are handled by DM. If the change affects user-facing behavior, comment delivery notes on the Issue.
-8. **Copy changed references to live**: If any files in `references/` were modified (e.g. `statusline.sh`, `hints-*.txt`, `agent-instructions.md`), copy them to the live `.squidsquad/` location so changes take effect immediately.
+8. **Copy changed references to live**: If any files in `references/` were modified (e.g. `statusline.sh`, `hints-*.txt`), copy them to the live `.squidsquad/` location so changes take effect immediately.
 9. **Verify changes exist**: Run `python references/scripts/git_ops.py has-changes`. If output is `false`, do NOT transition — re-read the acceptance criteria and apply the implementation.
 9b. **Self-verification reflection** — before marking pending-test, stop and critically review your own work:
    - **Regression**: Does this change break existing behavior? Read the code paths you touched — what else depends on them?


### PR DESCRIPTION
Closes ​#7631

### Summary
Remove stale 'agent-instructions.md' example from step 8 in implement-tasks.md. This was the old monolith filename before sub-skill architecture.

### Changes (2 files)
- references/sub-skills/roles/dev/implement-tasks.md: removed stale reference
- .squidsquad/skill/CLAUDE.md: recomposed

### QA Status
- [x] Source template updated
- [x] Composed output regenerated
- [x] 2 files only