### PR TITLE
skill: #7637 — fix stale stopping intent on manual reboot

### DIFF
--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -1,29 +1,23 @@
 # Working State
 
-- **Task**: #6581
+- **Task**: #7637
 - **Status**: in-progress
-- **Started**: 2026-05-11 06:01
+- **Started**: 2026-05-12 21:02
 - **Last Processed Event ID**: 0adb6a2b
 
 ## Completed Steps
-- Read all 3 planning artifacts (CONTEXT, RESEARCH, TEST-PLAN)
-- Transitioned to in-progress, checked out feature branch
-- Added domain_variants to software-dev preset manifest
-- Added load_preset_manifest() and resolve_domain_variants() helpers to wizard.py
-- Refactored apply_project_type() to use manifest-driven resolution with legacy fallback
-- Updated generate_default_spec() to derive variants from manifest instead of hardcoding
+- Read issue details
+- Transitioned to in-progress
+- Checked out feature branch squidsquad/task/7637
 
 ## Remaining Steps
-- Add L4 file writing to scaffold_install() (TC-3, TC-8)
-- Update WIZARD.md runbook for hybrid L4 writer (TC-4)
-- Rewrite TestApplyProjectType tests for new path (TC-10)
-- Add new tests for manifest resolution (TC-1, TC-2, TC-5, TC-6, TC-7, TC-9)
-- Add smoke test for fresh install (TC-11)
-- Run full test suite
-- Self-verify and submit to QA
+- Locate harness health monitoring code
+- Find where intent is checked against liveness
+- Add intent reset logic when agent is alive but intent is stopping/stopped
+- Write regression test
+- Run tests
+- Self-verify and external review
+- Transition to pending-test
 
 ## Key Decisions
-- Preset manifest domain_variants is single authority
-- Legacy PROJECT_TYPE_PRESETS retained as fallback for unmigrated project types
-- apply_project_type() now returns dict of {role: variant} instead of single variant string
-- generate_default_spec() uses resolve_domain_variants("software-dev") instead of hardcoded "skill"
+- (none yet)

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -185,6 +185,7 @@ class HarnessState:
                 # Direct PID check (#4966) — primary health detection
                 pid = agent.claude_pid
                 alive = False
+                pid_changed = False
                 if pid:
                     alive = boot_remote._is_process_alive(pid)
 
@@ -194,6 +195,8 @@ class HarnessState:
                     if file_pid and file_alive:
                         pid = file_pid
                         alive = True
+                        if agent.claude_pid != pid:
+                            pid_changed = True
                         agent.claude_pid = pid
                         state_changed = True
 
@@ -219,6 +222,16 @@ class HarnessState:
                     if agent.intent == AgentState.INTENT_RESTARTING:
                         agent.intent = AgentState.INTENT_RUNNING
                         state_changed = True
+                    elif agent.intent in (
+                        AgentState.INTENT_STOPPING,
+                        AgentState.INTENT_STOPPED,
+                    ) and pid_changed:
+                        # New PID appeared while intent was stale — manual reboot (#7637).
+                        # Only reset when PID changed to avoid undoing an in-flight stop.
+                        old_intent = agent.intent
+                        agent.intent = AgentState.INTENT_RUNNING
+                        state_changed = True
+                        _log(f"{role}: alive with new PID (stale intent={old_intent}), reset to running (#7637)")
                 elif agent.status != "starting":
                     # Check if explicitly stopped
                     stop_file = Path(clone_path) / ".squidsquad" / role / ".stop"

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -645,5 +645,90 @@ class TestIntentLifecycle(unittest.TestCase):
             self.assertEqual(hs.get_agent("skill").intent, AgentState.INTENT_RUNNING)
 
 
+class TestManualRebootClearsStoppingIntent(unittest.TestCase):
+    """#7637: Harness must clear stopping/stopped intent when agent is alive."""
+
+    def test_alive_agent_with_stopping_intent_resets_to_running(self):
+        """Agent stopped via harness, manually rebooted → intent resets to running."""
+        import tempfile
+        from harness import HarnessState, AgentState
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            role_dir = Path(tmpdir) / ".squidsquad" / "skill"
+            role_dir.mkdir(parents=True)
+            # Agent is alive (use current process PID)
+            (role_dir / ".claude-pid").write_text(str(os.getpid()), encoding="utf-8")
+
+            hs = HarnessState()
+            agent = AgentState("skill", tmpdir)
+            agent.status = "stopped"
+            agent.intent = AgentState.INTENT_STOPPING
+            agent.claude_pid = None  # PID cleared when agent died
+            hs.set_agent("skill", agent)
+
+            with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+                 patch("harness.boot_remote._get_clone_path", return_value=tmpdir), \
+                 patch("harness.HARNESS_STATE_FILE", Path(tmpdir) / ".harness-state.json"):
+                hs.update_health()
+
+            got = hs.get_agent("skill")
+            self.assertEqual(got.status, "running")
+            self.assertEqual(got.intent, AgentState.INTENT_RUNNING,
+                             "Alive agent with stopping intent must reset to running (#7637)")
+
+    def test_alive_agent_with_stopped_intent_resets_to_running(self):
+        """Agent fully stopped (intent=stopped), manually rebooted → intent resets."""
+        import tempfile
+        from harness import HarnessState, AgentState
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            role_dir = Path(tmpdir) / ".squidsquad" / "skill"
+            role_dir.mkdir(parents=True)
+            (role_dir / ".claude-pid").write_text(str(os.getpid()), encoding="utf-8")
+
+            hs = HarnessState()
+            agent = AgentState("skill", tmpdir)
+            agent.status = "stopped"
+            agent.intent = AgentState.INTENT_STOPPED
+            agent.claude_pid = None
+            hs.set_agent("skill", agent)
+
+            with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+                 patch("harness.boot_remote._get_clone_path", return_value=tmpdir), \
+                 patch("harness.HARNESS_STATE_FILE", Path(tmpdir) / ".harness-state.json"):
+                hs.update_health()
+
+            got = hs.get_agent("skill")
+            self.assertEqual(got.status, "running")
+            self.assertEqual(got.intent, AgentState.INTENT_RUNNING,
+                             "Alive agent with stopped intent must reset to running (#7637)")
+
+    def test_same_pid_stopping_intent_not_cleared(self):
+        """Agent told to stop but still alive (same PID) → intent stays stopping (#7637)."""
+        import tempfile
+        from harness import HarnessState, AgentState
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            role_dir = Path(tmpdir) / ".squidsquad" / "skill"
+            role_dir.mkdir(parents=True)
+
+            hs = HarnessState()
+            agent = AgentState("skill", tmpdir)
+            agent.status = "running"
+            agent.intent = AgentState.INTENT_STOPPING
+            agent.claude_pid = os.getpid()  # Same PID — stop is in-flight
+            hs.set_agent("skill", agent)
+
+            with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+                 patch("harness.boot_remote._get_clone_path", return_value=tmpdir), \
+                 patch("harness.HARNESS_STATE_FILE", Path(tmpdir) / ".harness-state.json"):
+                hs.update_health()
+
+            got = hs.get_agent("skill")
+            self.assertEqual(got.status, "running")
+            self.assertEqual(got.intent, AgentState.INTENT_STOPPING,
+                             "Same PID still alive — stopping intent must NOT be cleared (#7637)")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #7637

### Summary
When an agent was stopped via harness (intent=stopping), then manually rebooted in a new session, the harness detected the new PID but left intent=stopping. cycle_post.py then saw the stale intent and killed the agent on its first cycle.

### Acceptance Criteria
- [x] Harness resets stopping/stopped intent to running when a NEW PID is detected
- [x] Same PID with stopping intent is NOT cleared (prevents race with in-flight stop)
- [x] Intent auto-clear is logged for observability

### Changes
- **Files**: references/scripts/harness.py, tests/test_harness.py
- **What**: Added PID-change guard to update_health() intent reset. Only clears stopping/stopped intent when agent.claude_pid changed (new process appeared). Added _log() call for observability.
- **Why**: Prevents manual reboots from being killed by stale harness intent. PID guard avoids race where in-flight stop gets silently undone.

### QA Status
- [x] Unit tests passing (3 new regression tests)
- [x] Full test suite green (1774+ tests, 0 failures)
- [x] Acceptance criteria met
- [x] External code review addressed (race condition guard, logging)