### PR TITLE
skill: #7706 — fix log-iteration CLI error message

### DIFF
--- a/references/scripts/cycle.py
+++ b/references/scripts/cycle.py
@@ -251,7 +251,7 @@ def main():
         reset_counter(pos[0])
     elif cmd == "log-iteration":
         if len(pos) < 2:
-            print("Usage: cycle.py log-iteration <role> <n> --issues ... --tasks ...", file=sys.stderr)
+            print("Usage: cycle.py log-iteration <role> <n> [--quiet] [--work <w>] [--notes <n>]", file=sys.stderr)
             sys.exit(1)
         try:
             iter_n = int(pos[1])

--- a/tests/test_cycle.py
+++ b/tests/test_cycle.py
@@ -179,3 +179,20 @@ class TestCleanupIterations:
              patch.object(cycle, "_state_path", lambda rel: tmp_path / rel):
             removed = cycle.cleanup_iterations("skill")
         assert removed == 0
+
+
+class TestLogIterationUsageMessage:
+    """#7706: log-iteration error message must match documented interface."""
+
+    def test_error_message_matches_docstring(self):
+        """CLI error message for log-iteration should advertise --work/--notes, not --issues/--tasks."""
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, str(SCRIPTS / "cycle.py"), "log-iteration"],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+        )
+        assert result.returncode == 1
+        assert "--work" in result.stderr, \
+            f"Error message should mention --work, got: {result.stderr!r}"
+        assert "--issues" not in result.stderr, \
+            f"Error message should NOT mention --issues (legacy), got: {result.stderr!r}"


### PR DESCRIPTION
Closes #7706

### Summary
The log-iteration CLI error message advertised --issues/--tasks flags (legacy internal names) instead of the documented --work/--notes interface.

### Changes
- **Files**: references/scripts/cycle.py, tests/test_cycle.py
- **What**: Updated error message on line 254 to match docstring on line 14. Added regression test verifying CLI error output.
- **Why**: Agents/humans seeing the error would pass wrong flags.

### QA Status
- [x] Unit tests passing (17/17 cycle tests)
- [x] Full suite green (run_tests.py: 1773 passed, 0 failures)