### PR TITLE
skill: #7801 — replace hardcoded event catalog sets with subset checks

### DIFF
--- a/tests/test_event_catalog.py
+++ b/tests/test_event_catalog.py
@@ -32,22 +32,32 @@ class TestTierClassification:
 
 
 class TestCatalogCompleteness:
-    """Verify the catalog matches actual emit() calls in scripts."""
+    """Verify catalog structure and core events (#7801: no hardcoded full sets)."""
 
-    def test_emitted_tier_has_expected_events(self):
-        expected = {
-            "cycle-start", "cycle-end", "git-pull", "git-push", "git-commit",
-            "status-transition", "tracker-comment", "branch-checkout",
-            "pr-create", "pr-merge", "pr-merged", "compose-completed",
-        }
-        assert set(event_catalog.EMITTED.keys()) == expected
+    # Core events that must always exist — stable subset, not exhaustive.
+    CORE_EMITTED = {
+        "cycle-start", "cycle-end", "git-pull", "git-push", "git-commit",
+        "status-transition", "tracker-comment", "pr-create",
+    }
+    CORE_RECOGNIZED = {
+        "verification-failed", "verification-passed", "request-merge",
+    }
 
-    def test_recognized_tier_has_expected_events(self):
-        expected = {
-            "verification-failed", "verification-passed",
-            "agent-health", "phase-change", "request-merge",
-        }
-        assert set(event_catalog.RECOGNIZED.keys()) == expected
+    def test_emitted_tier_contains_core_events(self):
+        actual = set(event_catalog.EMITTED.keys())
+        missing = self.CORE_EMITTED - actual
+        assert not missing, f"Core emitted events missing from catalog: {missing}"
+
+    def test_recognized_tier_contains_core_events(self):
+        actual = set(event_catalog.RECOGNIZED.keys())
+        missing = self.CORE_RECOGNIZED - actual
+        assert not missing, f"Core recognized events missing from catalog: {missing}"
+
+    def test_emitted_tier_is_non_empty(self):
+        assert len(event_catalog.EMITTED) >= len(self.CORE_EMITTED)
+
+    def test_recognized_tier_is_non_empty(self):
+        assert len(event_catalog.RECOGNIZED) >= len(self.CORE_RECOGNIZED)
 
     def test_all_event_types_is_union(self):
         all_types = event_catalog.all_event_types()


### PR DESCRIPTION
Closes #7801

### Summary
Replaced exact-equality assertions against hardcoded event type sets with core-event subset checks. Tests now verify the catalog contains known-stable events without requiring lockstep updates when events are added/removed/deprecated.

### Changes
- **Files**: tests/test_event_catalog.py
- **What**: CORE_EMITTED/CORE_RECOGNIZED define stable subset. Tests use subset checks (missing = core - actual) instead of == against full set. Added non-empty size guards.
- **Why**: Hardcoded full sets broke on any catalog change. Deprecated pr-merge alongside pr-merged made the drift problem concrete.

### QA Status
- [x] Unit tests passing (20/20 event catalog tests)
- [x] Full suite green (1775 passed)