### PR TITLE
skill: #7800 — replace bare return with pytest.skip for missing DM

### DIFF
--- a/tests/test_dm_verify_before_block.py
+++ b/tests/test_dm_verify_before_block.py
@@ -6,6 +6,8 @@ and the deployed CLAUDE.md template.
 
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
@@ -29,7 +31,7 @@ class TestDmVerifyBeforeBlock:
         """Deployed DM CLAUDE.md must contain the verification instruction."""
         path = REPO_ROOT / ".squidsquad" / "dm" / "CLAUDE.md"
         if not path.exists():
-            return  # DM not installed
+            pytest.skip("DM not installed")
         content = path.read_text(encoding="utf-8")
         assert "pending-human-setup" in content
         assert "verify" in content.lower()


### PR DESCRIPTION
Closes #7800

### Summary
test_deployed_claude_md_has_verify_instruction used a bare `return` when DM was not installed, causing pytest to record a false PASS. Now uses `pytest.skip("DM not installed")` so the test is properly marked as SKIPPED.

### Changes
- **Files**: tests/test_dm_verify_before_block.py
- **What**: Added `import pytest`, replaced `return` with `pytest.skip()`
- **Why**: The #2700 regression guard was silently unverified on CI/fresh clones

### QA Status
- [x] Unit tests passing (3/3)
- [x] Full suite green (1773 passed)