### PR TITLE
skill: #7843 — fix mock namespace for shutil.which in comprehension tests

### DIFF
--- a/tests/test_run_comprehension_test.py
+++ b/tests/test_run_comprehension_test.py
@@ -122,12 +122,12 @@ class TestFindClaude:
         assert result is None or isinstance(result, str)
 
     def test_finds_claude_on_path(self):
-        with patch("shutil.which", return_value="/usr/bin/claude"):
+        with patch.object(rct.shutil, "which", return_value="/usr/bin/claude"):
             result = rct._find_claude()
         assert result == "/usr/bin/claude"
 
     def test_returns_none_when_not_found(self):
-        with patch("shutil.which", return_value=None), \
+        with patch.object(rct.shutil, "which", return_value=None), \
              patch.dict("os.environ", {"APPDATA": "/nonexistent"}, clear=False):
             result = rct._find_claude()
         assert result is None


### PR DESCRIPTION
Closes #7843

### Summary
Changed mock targets from `patch("shutil.which", ...)` to `patch.object(rct.shutil, "which", ...)` for refactor-proof test isolation.

### Changes
- **Files**: tests/test_run_comprehension_test.py
- **What**: Updated patch targets in test_finds_claude_on_path and test_returns_none_when_not_found
- **Why**: Original patches targeted the global shutil namespace. Works today via attribute lookup but breaks if `from shutil import which` refactor occurs.

### QA Status
- [x] Unit tests passing (17/17 comprehension tests)
- [x] Full suite green (1774 passed)