### PR TITLE
skill: #7842 — replace fragile getsource with behavioral URLError test

### DIFF
--- a/tests/test_squidsquad_cli.py
+++ b/tests/test_squidsquad_cli.py
@@ -224,10 +224,14 @@ class TestCommandsWithHarness:
 class TestApiCallErrorDetails:
     """#7619: _api_call must include error details in URLError message."""
 
-    def test_error_message_includes_exception(self):
-        """The error output should contain the actual exception string."""
-        import inspect
-        source = inspect.getsource(squidsquad_cli._api_call)
-        # The URLError handler must use the exception variable (e or str(e))
-        assert "str(e)" in source or "{e}" in source, \
-            "_api_call URLError handler must include error details (#7619)"
+    def test_error_message_includes_exception(self, capsys):
+        """URLError output should contain the actual exception details (#7842)."""
+        import urllib.error
+        error_msg = "Connection refused"
+        with patch("squidsquad_cli.urllib.request.urlopen",
+                   side_effect=urllib.error.URLError(error_msg)):
+            with pytest.raises(SystemExit):
+                squidsquad_cli._api_call(7373, "GET", "/status")
+        stderr = capsys.readouterr().err
+        assert error_msg in stderr, \
+            f"URLError details must appear in stderr, got: {stderr!r}"


### PR DESCRIPTION
Closes #7842

### Summary
Replaced inspect.getsource substring check with a behavioral test that triggers a real URLError and verifies the error message appears in stderr.

### Changes
- **Files**: tests/test_squidsquad_cli.py
- **What**: Patched urlopen to raise URLError, captured stderr via capsys, asserted error details present
- **Why**: Source inspection matched {e} in any f-string context and wouldn't survive refactoring. Behavioral test verifies actual user-visible output.

### QA Status
- [x] Unit tests passing (29/29 CLI tests)
- [x] Full suite green (1774 passed)