### PR TITLE
skill: #7793 — fix ship counter double-counting risk

### DIFF
--- a/.squidsquad/pm/CLAUDE.md
+++ b/.squidsquad/pm/CLAUDE.md
@@ -1818,7 +1818,7 @@ These behavioral directives shape how the PM agent thinks on this project.
 
 - **Recursive awareness.** You are coordinating the team that builds the system you run on. Every process change affects your own next cycle.
 - **Active priorities context.** Read `.squidsquad/vault/BRIEFING.md` and vault before making decisions. Yesterday's priority may have shifted.
-- **Version/ship counter awareness.** Track `Shipped Since Last Bump` — trigger version bumps at threshold. Don't let the counter drift.
+- **Version/ship counter awareness.** Monitor `Shipped Since Last Bump` — coordinate version bumps when threshold is reached. QA owns the increment; PM owns bump coordination.
 - **General-purpose audience.** SquidSquad targets non-technical teams. Specs and user-facing text must be accessible.
 - **GitHub is the audit trail.** Issue comments, commit messages, PR descriptions — these are the project's institutional memory. Write them for a future reader.
 

--- a/.squidsquad/pm/CLAUDE.md
+++ b/.squidsquad/pm/CLAUDE.md
@@ -418,15 +418,7 @@ QA handles all testing and verification. PM does not verify, does not run E2E te
 Print: `[🦑 HH:MM:SS] QA handles verification — skipping Steps 3-6.`
 
 **PM's role in verification**: Hold QA accountable. If items stall at pending-test for >90 minutes, nudge QA via the pipeline sentinel (Step 6f). If QA rejects work, route the rejection back to the dev agent. PM never verifies directly.
-
-#### Step 6c — Increment Ship Counter for Closed Issues
-
-When an issue is shipped (DM marks Shipped), increment the `Shipped Since Last Bump` counter in `config.md`. DM handles version bumps.
 <!-- /sub-skill: testing-and-verification -->
-
-### Step 6c — Increment Ship Counter for Closed Issues
-
-When an issue is shipped (DM marks Shipped), increment the `Shipped Since Last Bump` counter in `config.md`. DM handles version bumps.
 
 <!-- sub-skill: delivery -->
 ### Delivery

--- a/.squidsquad/project/pm-soul-directives.md
+++ b/.squidsquad/project/pm-soul-directives.md
@@ -18,7 +18,7 @@ These behavioral directives shape how the PM agent thinks on this project.
 
 - **Recursive awareness.** You are coordinating the team that builds the system you run on. Every process change affects your own next cycle.
 - **Active priorities context.** Read `.squidsquad/vault/BRIEFING.md` and vault before making decisions. Yesterday's priority may have shifted.
-- **Version/ship counter awareness.** Track `Shipped Since Last Bump` — trigger version bumps at threshold. Don't let the counter drift.
+- **Version/ship counter awareness.** Monitor `Shipped Since Last Bump` — coordinate version bumps when threshold is reached. QA owns the increment; PM owns bump coordination.
 - **General-purpose audience.** SquidSquad targets non-technical teams. Specs and user-facing text must be accessible.
 - **GitHub is the audit trail.** Issue comments, commit messages, PR descriptions — these are the project's institutional memory. Write them for a future reader.
 

--- a/references/roles/pm/instructions.md
+++ b/references/roles/pm/instructions.md
@@ -96,10 +96,6 @@ If the file is empty or has no active task or planning phase, proceed normally t
 
 {{include: roles/pm/testing-and-verification}}
 
-### Step 6c — Increment Ship Counter for Closed Issues
-
-When an issue is shipped (DM marks Shipped), increment the `Shipped Since Last Bump` counter in `config.md`. DM handles version bumps.
-
 {{include: roles/pm/delivery}}
 
 {{include: roles/pm/pipeline-sentinel}}

--- a/references/sub-skills/roles/pm/testing-and-verification.md
+++ b/references/sub-skills/roles/pm/testing-and-verification.md
@@ -5,7 +5,3 @@ QA handles all testing and verification. PM does not verify, does not run E2E te
 Print: `[🦑 HH:MM:SS] QA handles verification — skipping Steps 3-6.`
 
 **PM's role in verification**: Hold QA accountable. If items stall at pending-test for >90 minutes, nudge QA via the pipeline sentinel (Step 6f). If QA rejects work, route the rejection back to the dev agent. PM never verifies directly.
-
-#### Step 6c — Increment Ship Counter for Closed Issues
-
-When an issue is shipped (DM marks Shipped), increment the `Shipped Since Last Bump` counter in `config.md`. DM handles version bumps.

--- a/tests/test_feat_1328_blocked_skip.py
+++ b/tests/test_feat_1328_blocked_skip.py
@@ -12,31 +12,34 @@ QA_VERIFICATION = REPO / "references/sub-skills/roles/qa/verification.md"
 
 
 class TestPMVerificationBlockedCheck:
-    """PM verification (Steps 5-6) skips blocked:human-action items."""
+    """PM delegates verification to QA — no direct verification steps."""
 
     @pytest.fixture
     def content(self):
         return PM_VERIFICATION.read_text(encoding="utf-8")
 
-    def test_step5_has_blocked_check(self, content):
-        """Step 5 (verify fixed issues) checks blocked:human-action before verifying."""
-        # Find Step 5 section and verify the blocked check appears before
-        # the first verification action
-        step5_start = content.index("Step 5")
-        step6_start = content.index("Step 6")
-        step5_text = content[step5_start:step6_start]
-        assert "blocked:human-action" in step5_text
+    def test_pm_does_not_verify_directly(self, content):
+        """PM template explicitly states QA handles verification."""
+        assert "QA handles all testing and verification" in content
 
-    def test_step6_has_blocked_check(self, content):
-        """Step 6 (verify pending test tasks) checks blocked:human-action before verifying."""
-        step6_start = content.index("Step 6 — Verify Pending Test Tasks")
-        step6c_start = content.index("Step 6c")
-        step6_text = content[step6_start:step6c_start]
-        assert "blocked:human-action" in step6_text
+    def test_pm_has_no_verification_steps(self, content):
+        """PM should not contain Step 5/6 verification sections."""
+        assert "Step 5" not in content
+        assert "Step 6 — Verify" not in content
 
-    def test_blocked_check_says_skip(self, content):
-        """Blocked check instructs to skip, not transition status."""
-        assert "skip it" in content.lower() or "Skip it" in content
+
+class TestShipCounterOwnership:
+    """Regression test for #7793 — only QA increments the ship counter."""
+
+    def test_qa_owns_ship_counter(self):
+        """QA verification.md is the authoritative owner of ship counter increment."""
+        content = QA_VERIFICATION.read_text(encoding="utf-8")
+        assert "Shipped Since Last Bump" in content
+
+    def test_pm_does_not_own_ship_counter(self):
+        """PM must never increment the ship counter (QA owns it)."""
+        content = PM_VERIFICATION.read_text(encoding="utf-8")
+        assert "Shipped Since Last Bump" not in content
 
 
 class TestQAVerificationBlockedCheck:


### PR DESCRIPTION
Closes #7793

### Summary
Removes ship counter increment instruction from PM's testing-and-verification.md. QA (verification.md line 115) is the single authoritative owner of `Shipped Since Last Bump` counter increments. PM retains monitoring/awareness of the counter for health checks and version bump coordination.

### Acceptance Criteria
- [x] PM testing-and-verification.md has no Shipped Since Last Bump reference
- [x] QA verification.md retains ship counter increment (line 115)
- [x] Composed PM CLAUDE.md reflects the change (zero Step 6c occurrences)
- [x] PM soul directive clarified: "Track" → "Monitor", explicit QA ownership
- [x] Regression tests added (TestShipCounterOwnership)
- [x] Pre-existing PM test failures fixed (TestPMVerificationBlockedCheck)

### Changes
- **references/sub-skills/roles/pm/testing-and-verification.md**: Removed Step 6c section
- **references/roles/pm/instructions.md**: Removed hardcoded duplicate Step 6c between includes
- **.squidsquad/project/pm-soul-directives.md**: "Track" → "Monitor", explicit QA ownership note
- **tests/test_feat_1328_blocked_skip.py**: Updated PM tests to assert delegation, added ship counter ownership regression tests
- **.squidsquad/pm/CLAUDE.md**: Recomposed

### QA Status
- [x] Unit tests passing (7/7 in test file, 2135/2137 total — 2 pre-existing failures on main)
- [x] Self-verification: regression, integration, philosophy, personas — all clear
- [x] External code review: 3 findings, 2 fixed, 1 accepted (step-label fragility — secondary guard)