### PR TITLE
skill: #7947 — add validate_interval test coverage

### DIFF
--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -186,6 +186,68 @@ class TestValidateRerunAction:
 
 
 # ===========================================================================
+# validate_interval (#7947, TC-49..TC-52)
+# ===========================================================================
+
+
+class TestValidateInterval:
+    """Tests for validate_interval — Ralph Loop interval validation."""
+
+    @pytest.mark.parametrize("value,expected_minutes", [
+        ("10", 10),
+        ("1", 1),
+        ("30", 30),
+        ("120", 120),
+        (" 15 ", 15),  # whitespace trimmed
+    ])
+    def test_valid_integers(self, value, expected_minutes):
+        result = wizard.validate_interval(value)
+        assert result["ok"] is True
+        assert result["minutes"] == expected_minutes
+        assert result["reason"] is None
+
+    @pytest.mark.parametrize("value", [
+        "", "  ", None,
+    ])
+    def test_empty_input_returns_default(self, value):
+        result = wizard.validate_interval(value)
+        assert result["ok"] is True
+        assert result["minutes"] == 10  # default
+
+    def test_empty_input_custom_default(self):
+        result = wizard.validate_interval("", default=30)
+        assert result["ok"] is True
+        assert result["minutes"] == 30
+
+    @pytest.mark.parametrize("value", [
+        "10.5", "3.0", "1,5", "0.1",
+    ])
+    def test_float_rejected(self, value):
+        result = wizard.validate_interval(value)
+        assert result["ok"] is False
+        assert result["minutes"] is None
+        assert "whole number" in result["reason"]
+
+    @pytest.mark.parametrize("value", [
+        "0", "-1", "-100",
+    ])
+    def test_zero_and_negative_rejected(self, value):
+        result = wizard.validate_interval(value)
+        assert result["ok"] is False
+        assert result["minutes"] is None
+        assert "at least 1" in result["reason"]
+
+    @pytest.mark.parametrize("value", [
+        "abc", "ten", "!@#", "5m",
+    ])
+    def test_non_numeric_rejected(self, value):
+        result = wizard.validate_interval(value)
+        assert result["ok"] is False
+        assert result["minutes"] is None
+        assert "not a number" in result["reason"]
+
+
+# ===========================================================================
 # Step 1 — project name validation
 # ===========================================================================
 


### PR DESCRIPTION
Closes #7947

### Summary
Adds parametrized test coverage for `validate_interval` in wizard.py. Covers all documented test cases (TC-49..TC-52): valid integers, empty/None input with default, custom default, float rejection, zero/negative rejection, and non-numeric rejection.

### Acceptance Criteria
- [x] Empty string and None tested (TC-49)
- [x] Float-as-string rejected (TC-50)
- [x] Zero and negative rejected (TC-51)
- [x] Non-numeric rejected (TC-52)
- [x] Valid integers accepted

### Changes
- **tests/test_wizard.py**: Added TestValidateInterval class (20 parametrized tests)

### QA Status
- [x] All 20 new tests passing
- [x] Full test suite: same 2 pre-existing failures, zero new failures