### PR TITLE
skill: #7794 — replace stale 'tracker files' prohibition

### DIFF
--- a/.squidsquad/dm/CLAUDE.md
+++ b/.squidsquad/dm/CLAUDE.md
@@ -867,7 +867,7 @@ The status line updates automatically after each assistant message.
 - Never edit another agent's Discussion entries.
 - Never push without pulling first.
 - Never skip checking for `delivery:skip` before starting delivery work.
-- Never delete entries from tracker files.
+- Never delete entries from append-only files (qa-log.md, enhancements.md, CHANGELOG.md). Never delete GitHub Issue comments.
 - After any status change, use `python references/scripts/tracker.py transition` — never construct `gh issue edit` label commands manually.
 - Shipped transitions auto-close the Issue via tracker.py.
 - Never declare something blocked on human action without verifying first. Before transitioning to `pending-human-setup` or commenting that something requires human intervention, run the relevant verification command (e.g. `npm whoami` for npm auth, `gh auth status` for GitHub auth). Only declare blocked if the command fails. Claiming something is human-blocked without evidence wastes cycles and stalls the pipeline.

--- a/.squidsquad/pm/CLAUDE.md
+++ b/.squidsquad/pm/CLAUDE.md
@@ -1715,7 +1715,7 @@ The status line updates automatically after each assistant message. No action is
 - Never push without pulling first.
 - Never touch application code or skill files — you are coordination only.
 - Never implement fixes or tasks directly — always file to the appropriate agent's issue or task tracker.
-- Never delete entries from tracker files.
+- Never delete entries from qa-log.md or enhancements.md — append only. Never delete GitHub Issue comments.
 - Never verify work you planned — verification is QA's job, not PM's. PM holds QA accountable but does not replace QA.
 - Never perform delivery (docs, CHANGELOG, version bumps) — delivery is DM's job. PM holds DM accountable but does not replace DM.
 - After any status change, use `python references/scripts/tracker.py transition` — never construct `gh issue edit` label commands manually.

--- a/.squidsquad/templates/dm-agent.md
+++ b/.squidsquad/templates/dm-agent.md
@@ -800,7 +800,7 @@ The status line updates automatically after each assistant message.
 - Never edit another agent's Discussion entries.
 - Never push without pulling first.
 - Never skip checking for `delivery:skip` before starting delivery work.
-- Never delete entries from tracker files.
+- Never delete entries from append-only files (qa-log.md, enhancements.md, CHANGELOG.md). Never delete GitHub Issue comments.
 - After any status change to a tracker item, regenerate the relevant `INDEX.md` from the non-archived files in the directory.
 - After marking a bug with a terminal status (`Closed`/`Verified`), move the file to the `archived/` subdirectory.
 - After marking a feature with a terminal status (`Shipped`/`Rejected`), move the file to the `archived/` subdirectory.

--- a/references/sub-skills/roles/dm/prohibitions.md
+++ b/references/sub-skills/roles/dm/prohibitions.md
@@ -5,7 +5,7 @@
 - Never edit another agent's Discussion entries.
 - Never push without pulling first.
 - Never skip checking for `delivery:skip` before starting delivery work.
-- Never delete entries from tracker files.
+- Never delete entries from append-only files (qa-log.md, enhancements.md, CHANGELOG.md). Never delete GitHub Issue comments.
 - After any status change, use `python references/scripts/tracker.py transition` — never construct `gh issue edit` label commands manually.
 - Shipped transitions auto-close the Issue via tracker.py.
 - Never declare something blocked on human action without verifying first. Before transitioning to `pending-human-setup` or commenting that something requires human intervention, run the relevant verification command (e.g. `npm whoami` for npm auth, `gh auth status` for GitHub auth). Only declare blocked if the command fails. Claiming something is human-blocked without evidence wastes cycles and stalls the pipeline.

--- a/references/sub-skills/roles/pm/prohibitions.md
+++ b/references/sub-skills/roles/pm/prohibitions.md
@@ -5,7 +5,7 @@
 - Never push without pulling first.
 - Never touch application code or skill files — you are coordination only.
 - Never implement fixes or tasks directly — always file to the appropriate agent's issue or task tracker.
-- Never delete entries from tracker files.
+- Never delete entries from qa-log.md or enhancements.md — append only. Never delete GitHub Issue comments.
 - Never verify work you planned — verification is QA's job, not PM's. PM holds QA accountable but does not replace QA.
 - Never perform delivery (docs, CHANGELOG, version bumps) — delivery is DM's job. PM holds DM accountable but does not replace DM.
 - After any status change, use `python references/scripts/tracker.py transition` — never construct `gh issue edit` label commands manually.

--- a/tests/test_stale_tracker_files_ref.py
+++ b/tests/test_stale_tracker_files_ref.py
@@ -1,0 +1,38 @@
+"""Regression test for #7794: prohibitions must not reference stale 'tracker files' concept.
+
+GitHub Issues is the single source of truth. The prohibition 'Never delete entries
+from tracker files' is stale — it must name actual artifacts instead.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PROHIBITIONS_DIR = REPO_ROOT / "references" / "sub-skills" / "roles"
+
+
+class TestNoStaleTrackerFilesRef:
+    """Prohibitions must not reference the obsolete 'tracker files' concept."""
+
+    @pytest.mark.parametrize("role", ["pm", "dm"])
+    def test_prohibitions_no_stale_tracker_files(self, role):
+        """Prohibition 'Never delete entries from tracker files' must not exist."""
+        path = PROHIBITIONS_DIR / role / "prohibitions.md"
+        content = path.read_text(encoding="utf-8")
+        assert "from tracker files" not in content
+
+    def test_pm_prohibitions_names_actual_files(self):
+        """PM prohibitions must name qa-log.md and enhancements.md."""
+        path = PROHIBITIONS_DIR / "pm" / "prohibitions.md"
+        content = path.read_text(encoding="utf-8")
+        assert "qa-log.md" in content
+        assert "enhancements.md" in content
+        assert "GitHub Issue comments" in content
+
+    def test_dm_prohibitions_names_actual_files(self):
+        """DM prohibitions must name actual append-only files."""
+        path = PROHIBITIONS_DIR / "dm" / "prohibitions.md"
+        content = path.read_text(encoding="utf-8")
+        assert "append-only" in content.lower() or "append only" in content.lower()
+        assert "GitHub Issue comments" in content


### PR DESCRIPTION
Closes #7794

### Summary
Replaces the stale prohibition "Never delete entries from tracker files" in PM and DM prohibitions sub-skills. GitHub Issues is now the tracker — there are no internal markdown tracker files. The updated prohibitions name actual append-only artifacts.

### Acceptance Criteria
- [x] PM prohibitions: references qa-log.md, enhancements.md, and GitHub Issue comments
- [x] DM prohibitions: references append-only files and GitHub Issue comments
- [x] Composed PM/DM CLAUDE.md updated (recomposed)
- [x] Installer template dm-agent.md updated
- [x] Regression tests prevent reintroduction

### Changes
- **references/sub-skills/roles/pm/prohibitions.md**: "tracker files" → "qa-log.md or enhancements.md — append only. Never delete GitHub Issue comments."
- **references/sub-skills/roles/dm/prohibitions.md**: "tracker files" → "append-only files (qa-log.md, enhancements.md, CHANGELOG.md). Never delete GitHub Issue comments."
- **.squidsquad/pm/CLAUDE.md**, **.squidsquad/dm/CLAUDE.md**: Recomposed
- **.squidsquad/templates/dm-agent.md**: Updated installer template
- **tests/test_stale_tracker_files_ref.py**: 4 regression tests

### QA Status
- [x] All 4 new tests passing
- [x] Full test suite: same 2 pre-existing failures, zero new failures