### PR TITLE
skill: #8082 — fix record_decision silent no-op on missing file_coverage

### DIFF
--- a/references/scripts/scan_index.py
+++ b/references/scripts/scan_index.py
@@ -394,15 +394,26 @@ def record_decision(issue_number, accepted, db_path=None):
     # Update file_coverage counters
     fp = row["file_path"]
     if accepted:
-        conn.execute(
+        cur = conn.execute(
             "UPDATE file_coverage SET accepted_finding_count = accepted_finding_count + 1 WHERE file_path=?",
             (fp,),
         )
+        if cur.rowcount == 0:
+            conn.execute(
+                "INSERT INTO file_coverage (file_path, accepted_finding_count) VALUES (?, 1)",
+                (fp,),
+            )
     else:
-        conn.execute(
+        cur = conn.execute(
             "UPDATE file_coverage SET rejected_finding_count = rejected_finding_count + 1 WHERE file_path=?",
             (fp,),
         )
+        if cur.rowcount == 0:
+            conn.execute(
+                "INSERT INTO file_coverage (file_path, rejected_finding_count) VALUES (?, 1)",
+                (fp,),
+            )
+
         # Also record in rejections table
         finding = conn.execute(
             "SELECT description FROM findings WHERE github_issue_number=?",

--- a/tests/test_scan_index.py
+++ b/tests/test_scan_index.py
@@ -341,6 +341,58 @@ class TestRecordDecision:
         result = scan_index.record_decision(9999, True, db_path=db)
         assert result is False
 
+    def test_accept_creates_coverage_row_if_missing(self, db):
+        """#8082 regression: accepted decision inserts file_coverage if no row exists."""
+        conn = scan_index._get_db(db)
+        sid = conn.execute(
+            "INSERT INTO scans (role, scanned_at, file_path) VALUES ('skill', '2026-01-01 00:00:00', 'orphan.py')"
+        ).lastrowid
+        conn.execute(
+            "INSERT INTO findings (scan_id, file_path, finding_type, description, github_issue_number) VALUES (?, 'orphan.py', 'issue', 'no coverage row', 300)",
+            (sid,),
+        )
+        # Intentionally no file_coverage row for orphan.py
+        conn.commit()
+        conn.close()
+
+        result = scan_index.record_decision(300, True, db_path=db)
+        assert result is True
+
+        conn = scan_index._get_db(db)
+        cov = conn.execute(
+            "SELECT accepted_finding_count, rejected_finding_count FROM file_coverage WHERE file_path='orphan.py'"
+        ).fetchone()
+        assert cov is not None, "file_coverage row should be created on accept"
+        assert cov["accepted_finding_count"] == 1
+        assert cov["rejected_finding_count"] == 0
+        conn.close()
+
+    def test_reject_creates_coverage_row_if_missing(self, db):
+        """#8082 regression: rejected decision inserts file_coverage if no row exists."""
+        conn = scan_index._get_db(db)
+        sid = conn.execute(
+            "INSERT INTO scans (role, scanned_at, file_path) VALUES ('skill', '2026-01-01 00:00:00', 'orphan2.py')"
+        ).lastrowid
+        conn.execute(
+            "INSERT INTO findings (scan_id, file_path, finding_type, description, github_issue_number) VALUES (?, 'orphan2.py', 'issue', 'no coverage row', 400)",
+            (sid,),
+        )
+        # Intentionally no file_coverage row for orphan2.py
+        conn.commit()
+        conn.close()
+
+        result = scan_index.record_decision(400, False, db_path=db)
+        assert result is True
+
+        conn = scan_index._get_db(db)
+        cov = conn.execute(
+            "SELECT accepted_finding_count, rejected_finding_count FROM file_coverage WHERE file_path='orphan2.py'"
+        ).fetchone()
+        assert cov is not None, "file_coverage row should be created on reject"
+        assert cov["rejected_finding_count"] == 1
+        assert cov["accepted_finding_count"] == 0
+        conn.close()
+
 
 # ---------------------------------------------------------------------------
 # refresh-churn


### PR DESCRIPTION
Closes #8082

### Summary
`record_decision` in scan_index.py now inserts a new `file_coverage` row when the UPDATE affects 0 rows (missing row). Previously, acceptance/rejection counters silently failed to update for files imported via `rebuild` that lacked a coverage entry, causing stale acceptance rate scores.

### Acceptance Criteria
- [x] `cursor.rowcount` checked after UPDATE
- [x] Missing row → INSERT with initial counter (1 for the relevant field, 0 for the other)
- [x] Regression tests for both accept and reject paths

### Changes
- **references/scripts/scan_index.py**: Added rowcount check + INSERT fallback in `record_decision`
- **tests/test_scan_index.py**: Added `test_accept_creates_coverage_row_if_missing` and `test_reject_creates_coverage_row_if_missing`

### QA Status
- [x] All 5 TestRecordDecision tests passing
- [x] Full test suite: same 2 pre-existing failures, zero new failures