### PR TITLE
skill: #8081 — parse timestamps before comparing in qa-rejected

### DIFF
--- a/references/scripts/triage.py
+++ b/references/scripts/triage.py
@@ -21,12 +21,33 @@ Exit codes:
 import json
 import subprocess
 import sys
+from datetime import datetime
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 # Roles whose comments count as "QA feedback" that needs rework
 QA_FEEDBACK_ROLES = {"pm", "qa"}
+
+
+def _parse_timestamp(ts):
+    """Parse a GitHub ISO 8601 timestamp to a datetime for safe comparison.
+
+    Handles both 'Z' suffix and '+00:00' offset formats.
+    Returns None if parsing fails.
+    """
+    if not ts:
+        return None
+    try:
+        # Python 3.11+ fromisoformat handles 'Z' directly
+        return datetime.fromisoformat(ts)
+    except ValueError:
+        pass
+    # Fallback: strip Z and parse as naive UTC
+    try:
+        return datetime.strptime(ts.rstrip("Z"), "%Y-%m-%dT%H:%M:%S")
+    except (ValueError, AttributeError):
+        return None
 
 
 def _gh(*args: str) -> str:
@@ -131,7 +152,9 @@ def find_qa_rejected(role: str) -> list[dict]:
 
         # Check if feedback is newer than our last comment
         feedback_at = last_feedback["createdAt"]
-        if last_own_at and feedback_at <= last_own_at:
+        feedback_dt = _parse_timestamp(feedback_at)
+        own_dt = _parse_timestamp(last_own_at)
+        if own_dt and feedback_dt and feedback_dt <= own_dt:
             continue  # We already responded
 
         # Extract a summary (first 200 chars of the feedback body)

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -134,3 +134,51 @@ class TestFindQaRejectedErrorIsolation:
         assert isinstance(result, list)
         # 9992 had no feedback, so result is empty — but crucially no crash
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _parse_timestamp (#8081)
+# ---------------------------------------------------------------------------
+
+class TestParseTimestamp:
+    """Tests for _parse_timestamp — safe ISO 8601 comparison."""
+
+    def test_z_suffix(self):
+        dt = triage._parse_timestamp("2026-05-15T08:00:00Z")
+        assert dt is not None
+        assert dt.hour == 8
+
+    def test_offset_format(self):
+        dt = triage._parse_timestamp("2026-05-15T08:00:00+00:00")
+        assert dt is not None
+        assert dt.hour == 8
+
+    def test_no_timezone(self):
+        dt = triage._parse_timestamp("2026-05-15T08:00:00")
+        assert dt is not None
+        assert dt.hour == 8
+
+    def test_none_returns_none(self):
+        assert triage._parse_timestamp(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert triage._parse_timestamp("") is None
+
+    def test_garbage_returns_none(self):
+        assert triage._parse_timestamp("not-a-date") is None
+
+    def test_z_and_offset_compare_equal(self):
+        """#8081 regression: Z and +00:00 must compare as same time."""
+        dt_z = triage._parse_timestamp("2026-05-15T08:00:00Z")
+        dt_offset = triage._parse_timestamp("2026-05-15T08:00:00+00:00")
+        # Both should be non-None and represent the same point in time
+        assert dt_z is not None
+        assert dt_offset is not None
+        # Strip tzinfo for naive comparison (both are UTC)
+        assert dt_z.replace(tzinfo=None) == dt_offset.replace(tzinfo=None)
+
+    def test_ordering_works(self):
+        """Parsed timestamps support < > comparison."""
+        earlier = triage._parse_timestamp("2026-05-15T07:00:00Z")
+        later = triage._parse_timestamp("2026-05-15T09:00:00Z")
+        assert earlier < later


### PR DESCRIPTION
Closes #8081

### Summary
Replaces fragile string-based ISO 8601 timestamp comparison in `find_qa_rejected` with proper `datetime` parsing via `_parse_timestamp()`. Handles `Z`, `+00:00`, and bare formats. Prevents false QA-rejection loops if GitHub ever returns mixed timezone offset formats.

### Acceptance Criteria
- [x] Timestamps parsed with `datetime.fromisoformat()` before comparison
- [x] Handles Z suffix, +00:00 offset, and bare timestamps
- [x] Graceful None return on invalid/empty input
- [x] Regression tests for Z vs +00:00 equivalence

### Changes
- **references/scripts/triage.py**: Added `_parse_timestamp()` helper, `datetime` import, replaced string comparison with parsed comparison
- **tests/test_triage.py**: Added TestParseTimestamp class (8 tests)

### QA Status
- [x] All 8 new tests passing
- [x] Full test suite: same 2 pre-existing failures, zero new failures