### PR TITLE
skill: #8116 — use section-aware config for health_check interval

### DIFF
--- a/references/scripts/health_check.py
+++ b/references/scripts/health_check.py
@@ -62,16 +62,20 @@ HEALTH_EMOJI = {
 
 
 def _read_interval():
-    """Read the iteration interval from config.md. Default 30."""
-    if not CONFIG_MD.exists():
-        return 30
+    """Read the iteration interval from config.md. Default 30.
+
+    Uses config.py get_field (section-aware via FIELD_MAP) to avoid
+    matching unrelated 'Minutes' occurrences in other config sections.
+    """
     try:
-        text = CONFIG_MD.read_text(encoding="utf-8")
-        # Works for both v1 ("Minutes": N) and v2 ("Interval Minutes": N)
-        m = re.search(r"Minutes\b.*?(\d+)", text)
-        return int(m.group(1)) if m else 30
-    except Exception:
-        return 30
+        sys.path.insert(0, str(SCRIPT_DIR))
+        from config import get_field
+        val = get_field("interval")
+        if val:
+            return int(val)
+    except (ImportError, ValueError, TypeError):
+        pass
+    return 30
 
 
 def _parse_local_config():

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -87,20 +87,25 @@ class TestParseLocalConfigMandatory:
 
 
 class TestReadInterval:
-    def test_reads_from_config(self, tmp_path):
-        config = tmp_path / "config.md"
-        config.write_text("## Iteration Interval\n\n- **Minutes**: 45\n")
-        with patch.object(health_check, "CONFIG_MD", config):
+    def test_reads_from_config(self):
+        with patch("config.get_field", return_value="45"):
             assert health_check._read_interval() == 45
 
-    def test_missing_config_returns_default(self, tmp_path):
-        with patch.object(health_check, "CONFIG_MD", tmp_path / "missing"):
+    def test_missing_config_returns_default(self):
+        with patch("config.get_field", return_value=None):
             assert health_check._read_interval() == 30
 
-    def test_no_minutes_field_returns_default(self, tmp_path):
-        config = tmp_path / "config.md"
-        config.write_text("## Some Section\n\n- **Foo**: bar\n")
-        with patch.object(health_check, "CONFIG_MD", config):
+    def test_import_error_returns_default(self):
+        with patch("config.get_field", side_effect=ImportError):
+            assert health_check._read_interval() == 30
+
+    def test_non_numeric_returns_default(self):
+        """#8116 regression: malformed config value must not crash."""
+        with patch("config.get_field", return_value="10 items"):
+            assert health_check._read_interval() == 30
+
+    def test_empty_string_returns_default(self):
+        with patch("config.get_field", return_value=""):
             assert health_check._read_interval() == 30
 
 


### PR DESCRIPTION
Closes #8116

### Summary
Replaces the unscoped `re.search(r"Minutes\b.*?(\d+)", text)` in `_read_interval()` with `config.get_field("interval")` which is section-aware via FIELD_MAP. Prevents silently matching the wrong "Minutes" occurrence from an unrelated config section, which could corrupt all health stale-threshold calculations.

### Acceptance Criteria
- [x] `_read_interval` uses `config.get_field` (section-aware)
- [x] Graceful fallback to 30 on ImportError, ValueError, empty/None
- [x] Updated tests mock `config.get_field` instead of patching CONFIG_MD
- [x] Regression test for malformed non-numeric value

### Changes
- **references/scripts/health_check.py**: Rewrote `_read_interval` to use `config.get_field`
- **tests/test_health_check.py**: Updated TestReadInterval — 5 tests covering valid, None, ImportError, non-numeric, empty

### QA Status
- [x] All 5 TestReadInterval tests passing
- [x] Full test suite: same 2 pre-existing failures, zero new failures