### PR TITLE
skill: #8115 — guard cycle_pre int() calls against malformed config

### DIFF
--- a/references/scripts/cycle_pre.py
+++ b/references/scripts/cycle_pre.py
@@ -76,6 +76,17 @@ def _config_get(field):
     return result.stdout.strip()
 
 
+def _config_get_int(field, default=0):
+    """Get a config field as int with safe fallback on malformed values (#8115)."""
+    raw = _config_get(field)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        return default
+
+
 def _write_status_bar(role, phase, description):
     """Write status bar state atomically."""
     state_file = SQUID_DIR / role / "current-state"
@@ -658,8 +669,8 @@ def _build_pm_input(role):
                 merged_branches.append(line.strip())
 
     config = _read_config_flags()
-    config["ship_threshold"] = int(_config_get("ship-threshold") or "10")
-    config["shipped_since_bump"] = int(_config_get("shipped-since-bump") or "0")
+    config["ship_threshold"] = _config_get_int("ship-threshold", 10)
+    config["shipped_since_bump"] = _config_get_int("shipped-since-bump", 0)
     # Boot detection — DEPRECATED (#3807). PM no longer auto-boots agents.
     # Wrapper handles all respawning via .stop-after-cycle sentinel.
     # Field kept as empty list for backward compat until all agents redeployed.
@@ -711,7 +722,7 @@ def _build_pm_input(role):
                         now = datetime.now(updated_dt.tzinfo) if updated_dt.tzinfo else datetime.now()
                         delta = (now - updated_dt).total_seconds()
                         # Items updated within 2x iteration interval (default 60 min)
-                        interval = int(_config_get("interval") or "30")
+                        interval = _config_get_int("interval", 30)
                         if delta <= interval * 2 * 60:
                             recently_commented.append(item)
                     except (ValueError, TypeError):
@@ -827,7 +838,7 @@ def _build_qa_input(role):
         pass
 
     config = _read_config_flags()
-    config["iteration_interval"] = int(_config_get("interval") or "30")
+    config["iteration_interval"] = _config_get_int("interval", 30)
 
     # E2E test result (run if configured)
     e2e_result = {"result": "skipped", "tests_run": 0, "failures": []}
@@ -905,8 +916,8 @@ def _build_dm_input(role):
     _enrich_with_comments(bugs)
 
     # Version bump info
-    ship_threshold = int(_config_get("ship-threshold") or "10")
-    shipped_since_bump = int(_config_get("shipped-since-bump") or "0")
+    ship_threshold = _config_get_int("ship-threshold", 10)
+    shipped_since_bump = _config_get_int("shipped-since-bump", 0)
     current_version = _config_get("version") or "0.0.0"
 
     # Count open issues across all roles

--- a/tests/test_cycle_pre.py
+++ b/tests/test_cycle_pre.py
@@ -1317,3 +1317,46 @@ class TestConfigVersionValidation:
         monkeypatch.setattr(cycle_pre, "_config_get", lambda f: "")
 
         cycle_pre._validate_config_version()  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# _config_get_int (#8115)
+# ---------------------------------------------------------------------------
+
+class TestConfigGetInt:
+    """Tests for _config_get_int — safe int parsing from config values."""
+
+    def test_valid_integer(self, monkeypatch):
+        monkeypatch.setattr(cycle_pre, "_config_get", lambda f: "42")
+        assert cycle_pre._config_get_int("ship-threshold", 10) == 42
+
+    def test_empty_returns_default(self, monkeypatch):
+        monkeypatch.setattr(cycle_pre, "_config_get", lambda f: "")
+        assert cycle_pre._config_get_int("ship-threshold", 10) == 10
+
+    def test_none_like_returns_default(self, monkeypatch):
+        """_config_get returns '' on failure, never None, but guard anyway."""
+        monkeypatch.setattr(cycle_pre, "_config_get", lambda f: "")
+        assert cycle_pre._config_get_int("interval", 30) == 30
+
+    def test_non_numeric_returns_default(self, monkeypatch):
+        """#8115 regression: '10 items' must not crash."""
+        monkeypatch.setattr(cycle_pre, "_config_get", lambda f: "10 items")
+        assert cycle_pre._config_get_int("ship-threshold", 10) == 10
+
+    def test_float_string_returns_default(self, monkeypatch):
+        monkeypatch.setattr(cycle_pre, "_config_get", lambda f: "10.5")
+        assert cycle_pre._config_get_int("interval", 30) == 30
+
+    def test_whitespace_only_returns_default(self, monkeypatch):
+        monkeypatch.setattr(cycle_pre, "_config_get", lambda f: "   ")
+        assert cycle_pre._config_get_int("shipped-since-bump", 0) == 0
+
+    def test_zero_is_valid(self, monkeypatch):
+        monkeypatch.setattr(cycle_pre, "_config_get", lambda f: "0")
+        assert cycle_pre._config_get_int("shipped-since-bump", 5) == 0
+
+    def test_negative_is_valid(self, monkeypatch):
+        """Negative values are technically valid integers."""
+        monkeypatch.setattr(cycle_pre, "_config_get", lambda f: "-1")
+        assert cycle_pre._config_get_int("ship-threshold", 10) == -1


### PR DESCRIPTION
Closes #8115

### Summary
Adds `_config_get_int(field, default)` helper to cycle_pre.py that wraps `int()` parsing with `try/except (ValueError, TypeError)`. Replaces all 6 unguarded `int(_config_get(...))` call sites. Prevents `ValueError` crash on malformed config values (e.g., "10 items" instead of "10").

### Acceptance Criteria
- [x] `_config_get_int` helper with safe fallback
- [x] All 6 unguarded `int(_config_get(...))` calls replaced
- [x] No remaining `int(_config_get` patterns in cycle_pre.py
- [x] Regression tests for valid, empty, non-numeric, float, whitespace, zero, negative

### Changes
- **references/scripts/cycle_pre.py**: Added `_config_get_int`, replaced 6 call sites
- **tests/test_cycle_pre.py**: Added TestConfigGetInt (8 tests)

### QA Status
- [x] All 8 new tests passing
- [x] Full test suite: same 2 pre-existing failures, zero new failures