### PR TITLE
skill: #8160 — warn on corrupt .claude-pid instead of silent fallthrough

### DIFF
--- a/references/scripts/boot_remote.py
+++ b/references/scripts/boot_remote.py
@@ -314,8 +314,8 @@ def _needs_boot(role):
                 return False, f"alive (PID {pid})", str(clone_path)
             else:
                 return True, f"dead (PID {pid})", str(clone_path)
-        except (ValueError, OSError):
-            pass
+        except (ValueError, OSError) as e:
+            print(f"WARNING: corrupt .claude-pid for {role}: {e}", file=sys.stderr)
 
     # Fallback: legacy .pid file
     pid = _read_pid_file(clone_path, role)

--- a/tests/test_boot_remote.py
+++ b/tests/test_boot_remote.py
@@ -182,6 +182,21 @@ class TestNeedsBoot:
         assert "dead" in reason
 
 
+    @patch("boot_remote._get_clone_path")
+    def test_corrupt_claude_pid_warns_stderr(self, mock_clone, tmp_path, capsys):
+        """#8160 regression: corrupt .claude-pid must warn, not silently pass."""
+        mock_clone.return_value = tmp_path
+        pid_dir = tmp_path / ".squidsquad" / "skill"
+        pid_dir.mkdir(parents=True)
+        (pid_dir / ".claude-pid").write_text("not-a-number", encoding="utf-8")
+        needs, reason, _ = boot_remote._needs_boot("skill")
+        # Should fall through to "no PID file" (legacy .pid also missing)
+        assert needs is True
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "corrupt" in captured.err or ".claude-pid" in captured.err
+
+
 class TestBootAgentSkip:
     @patch("boot_remote._needs_boot", return_value=(False, "alive (PID 123)", "/tmp"))
     def test_alive_agent_skipped(self, mock_needs):


### PR DESCRIPTION
Closes #8160

### Summary
Adds a stderr warning when `.claude-pid` contains non-integer content (corrupt file, partial write). Previously the `except (ValueError, OSError)` silently passed, causing `_needs_boot` to fall through to the legacy `.pid` check and potentially trigger unnecessary reboots with no diagnostic output.

### Acceptance Criteria
- [x] Warning printed to stderr on corrupt `.claude-pid`
- [x] Fallthrough to legacy `.pid` check preserved (behavior unchanged)
- [x] Regression test verifies warning is emitted

### Changes
- **references/scripts/boot_remote.py**: Added `print(f"WARNING: corrupt .claude-pid for {role}: {e}", file=sys.stderr)` in except block
- **tests/test_boot_remote.py**: Added `test_corrupt_claude_pid_warns_stderr`

### QA Status
- [x] New test passing
- [x] Full test suite: same 2 pre-existing failures, zero new failures