### PR TITLE
skill: #8159 — remove redundant imports in compose.py agent_compose

### DIFF
--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -729,9 +729,6 @@ def agent_compose(deterministic_output: str, role_name: str,
         return deterministic_output
 
     try:
-        import subprocess
-        import json
-
         # Extract code blocks and markers for preservation verification
         original_markers = _extract_markers(deterministic_output)
         original_code_blocks = _extract_code_blocks(deterministic_output)

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -874,3 +874,10 @@ class TestNoRedundantReImport:
         import inspect
         source = inspect.getsource(compose._generate_cqs_from_sources)
         assert "import re" not in source
+
+    def test_no_local_import_in_agent_compose(self):
+        """#8159 regression: agent_compose must not re-import subprocess/json."""
+        import inspect
+        source = inspect.getsource(compose.agent_compose)
+        assert "import subprocess" not in source
+        assert "import json" not in source


### PR DESCRIPTION
Closes #8159

### Summary
Removes redundant `import subprocess` and `import json` from inside `agent_compose()`. Both are already imported at module level (lines 15, 17). The local imports were dead code shadowing the module-level names.

### Acceptance Criteria
- [x] Local `import subprocess` and `import json` removed from `agent_compose`
- [x] No remaining local re-imports of module-level imports
- [x] Regression test prevents reintroduction

### Changes
- **references/scripts/compose.py**: Removed 2 lines (local imports)
- **tests/test_compose.py**: Added `test_no_local_import_in_agent_compose` to TestNoRedundantReImport

### QA Status
- [x] All 81 compose tests passing
- [x] Full test suite: same 2 pre-existing failures, zero new failures