### PR TITLE
skill: #8193 — remove unused sys import from event bus modules

### DIFF
--- a/references/scripts/event_bus.py
+++ b/references/scripts/event_bus.py
@@ -11,7 +11,6 @@ Usage (from mechanical scripts only):
 
 import hashlib
 import json
-import sys
 import urllib.request
 import urllib.error
 from datetime import datetime

--- a/references/scripts/event_bus_reader.py
+++ b/references/scripts/event_bus_reader.py
@@ -10,7 +10,6 @@ Usage:
 """
 
 import json
-import sys
 import urllib.request
 import urllib.error
 from pathlib import Path

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -12,6 +12,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "references" / "scripts"))
 import event_bus
+import event_bus_reader
 
 
 class _EventCollector(BaseHTTPRequestHandler):
@@ -164,3 +165,17 @@ class TestGenerateId:
         a = event_bus._generate_id("cycle-start", "skill", "2026-05-01T18:00:00", {})
         b = event_bus._generate_id("cycle-end", "skill", "2026-05-01T18:00:00", {})
         assert a != b
+
+
+class TestNoUnusedImports:
+    """#8193 regression: event bus modules must not have unused imports."""
+
+    def test_event_bus_no_unused_sys(self):
+        import inspect
+        source = inspect.getsource(event_bus)
+        assert "import sys" not in source
+
+    def test_event_bus_reader_no_unused_sys(self):
+        import inspect
+        source = inspect.getsource(event_bus_reader)
+        assert "import sys" not in source


### PR DESCRIPTION
Closes #8193

### Summary
Removes unused `import sys` from both `event_bus.py` and `event_bus_reader.py`. Neither file references any `sys` attribute.

### Changes
- **references/scripts/event_bus.py**: Removed `import sys` (line 14)
- **references/scripts/event_bus_reader.py**: Removed `import sys` (line 13)
- **tests/test_event_bus.py**: Added TestNoUnusedImports (2 regression tests), imported event_bus_reader

### QA Status
- [x] 2 new tests passing
- [x] Full test suite: same 2 pre-existing failures, zero new failures