### PR TITLE
skill: #8201 — handle unreadable --file in vault_entity.py

### DIFF
--- a/references/scripts/vault_entity.py
+++ b/references/scripts/vault_entity.py
@@ -188,7 +188,11 @@ def main():
             if not path.exists():
                 print(f"File not found: {path}", file=sys.stderr)
                 return 2
-            text = path.read_text(encoding="utf-8")
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as e:
+                print(f"Cannot read {path}: {e}", file=sys.stderr)
+                return 2
     else:
         # Remaining args after "extract" are the text
         text = " ".join(args[1:])

--- a/tests/test_vault_entity.py
+++ b/tests/test_vault_entity.py
@@ -187,3 +187,29 @@ class TestProperNameClassification:
             assert red_hat[0]["type"] == "unknown", \
                 f"Ambiguous name should be 'unknown', got '{red_hat[0]['type']}'"
             assert red_hat[0]["confidence"] == "low"
+
+
+class TestMainFileArg:
+    """Tests for --file argument handling in main()."""
+
+    def test_unreadable_file_returns_2(self, tmp_path, monkeypatch):
+        """#8201 regression: unreadable file must return 2, not crash."""
+        bad_file = tmp_path / "bad.bin"
+        bad_file.write_bytes(b'\x80\x81\x82\xff\xfe' * 100)
+        monkeypatch.setattr(sys, "argv", ["vault_entity.py", "extract", "--file", str(bad_file)])
+        result = vault_entity.main()
+        assert result == 2
+
+    def test_missing_file_returns_2(self, monkeypatch):
+        """Missing file returns 2."""
+        monkeypatch.setattr(sys, "argv", ["vault_entity.py", "extract", "--file", "/nonexistent/path.md"])
+        result = vault_entity.main()
+        assert result == 2
+
+    def test_valid_file_succeeds(self, tmp_path, monkeypatch):
+        """Valid file with extractable content returns 0."""
+        good_file = tmp_path / "test.md"
+        good_file.write_text("Check out https://example.com for details.", encoding="utf-8")
+        monkeypatch.setattr(sys, "argv", ["vault_entity.py", "extract", "--file", str(good_file)])
+        result = vault_entity.main()
+        assert result == 0


### PR DESCRIPTION
Closes #8201

### Summary
Wraps `path.read_text()` in vault_entity.py's `--file` handler with try/except for `OSError` and `UnicodeDecodeError`. Previously, an unreadable file (permissions, encoding) would crash with a raw traceback. Now returns exit code 2 with a clean error message.

### Changes
- **references/scripts/vault_entity.py**: Added try/except around `path.read_text()` at line 191
- **tests/test_vault_entity.py**: Added TestMainFileArg (3 tests: unreadable, missing, valid)

### QA Status
- [x] All 3 new tests passing
- [x] Full test suite: same 2 pre-existing failures, zero new failures