### PR TITLE
skill: #8200 — strip pipe-alias from wikilinks in vault_check

### DIFF
--- a/references/scripts/vault_check.py
+++ b/references/scripts/vault_check.py
@@ -55,8 +55,12 @@ def _get_all_notes():
 
 
 def _extract_wikilinks(text):
-    """Extract all [[wikilink]] references from text body."""
-    return re.findall(r'\[\[([^\]]+)\]\]', text)
+    """Extract all [[wikilink]] references from text body.
+
+    Strips pipe-alias syntax: [[note|alias]] → note (#8200).
+    """
+    raw = re.findall(r'\[\[([^\]]+)\]\]', text)
+    return [link.split("|")[0].strip() for link in raw]
 
 
 def check_structure():

--- a/tests/test_vault_check.py
+++ b/tests/test_vault_check.py
@@ -50,6 +50,24 @@ class TestExtractWikilinks:
         links = vault_check._extract_wikilinks(text)
         assert links == ["valid-link"]
 
+    def test_pipe_alias_stripped(self):
+        """#8200 regression: [[note|alias]] must return 'note', not 'note|alias'."""
+        text = "See [[decision-foo|Foo Decision]] for context."
+        links = vault_check._extract_wikilinks(text)
+        assert links == ["decision-foo"]
+
+    def test_pipe_alias_with_spaces(self):
+        """Pipe alias with whitespace around the pipe."""
+        text = "[[note-name | Display Name]]"
+        links = vault_check._extract_wikilinks(text)
+        assert links == ["note-name"]
+
+    def test_mixed_bare_and_aliased(self):
+        """Mix of bare wikilinks and aliased ones."""
+        text = "[[bare-link]] and [[aliased|Pretty Name]]"
+        links = vault_check._extract_wikilinks(text)
+        assert links == ["bare-link", "aliased"]
+
 
 class TestCheckStructure:
     def test_valid_structure(self, tmp_path):


### PR DESCRIPTION
Closes #8200

### Summary
`_extract_wikilinks` now strips pipe-alias syntax from wikilinks before returning. `[[note|alias]]` returns `"note"` instead of `"note|alias"`, preventing false broken-link reports when aliased wikilinks are used (vault protocol prohibits aliases but no enforcement existed).

### Changes
- **references/scripts/vault_check.py**: Updated `_extract_wikilinks` to split on `|` and strip
- **tests/test_vault_check.py**: Added 3 tests: pipe-alias stripped, spaces around pipe, mixed bare+aliased

### QA Status
- [x] All 6 TestExtractWikilinks tests passing (3 existing + 3 new)
- [x] Full test suite: same 2 pre-existing failures, zero new failures