### PR TITLE
skill: #8235 — add missing redaction keywords to diagnostics

### DIFF
--- a/references/scripts/diagnostics.py
+++ b/references/scripts/diagnostics.py
@@ -110,7 +110,7 @@ def _sanitize_config():
     lines = []
     for line in text.splitlines():
         lower = line.lower()
-        if any(k in lower for k in ["repo", "path", "email", "token", "secret", "key"]):
+        if any(k in lower for k in ["repo", "path", "email", "token", "secret", "key", "url", "clone", "webhook", "password"]):
             if ":" in line:
                 field = line.split(":", 1)[0]
                 lines.append(f"{field}: [REDACTED]")

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -161,6 +161,32 @@ class TestSanitizeConfig:
         assert "[REDACTED]" in result
         assert "0.37.0" in result
 
+    def test_redacts_url_field(self):
+        """#8235 regression: url fields must be redacted."""
+        config_text = "clone-url: https://github.com/user/private\nversion: 0.38.0\n"
+        with patch.object(diagnostics, "_read_config", return_value=config_text):
+            result = diagnostics._sanitize_config()
+        assert "private" not in result
+        assert "[REDACTED]" in result
+        assert "0.38.0" in result
+
+    def test_redacts_webhook_field(self):
+        """#8235 regression: webhook fields must be redacted."""
+        config_text = "webhook: https://hooks.slack.com/secret123\nname: app\n"
+        with patch.object(diagnostics, "_read_config", return_value=config_text):
+            result = diagnostics._sanitize_config()
+        assert "secret123" not in result
+        assert "[REDACTED]" in result
+
+    def test_redacts_password_field(self):
+        """#8235 regression: password fields must be redacted."""
+        config_text = "password: hunter2\ninterval: 30\n"
+        with patch.object(diagnostics, "_read_config", return_value=config_text):
+            result = diagnostics._sanitize_config()
+        assert "hunter2" not in result
+        assert "[REDACTED]" in result
+        assert "30" in result
+
 
 class TestIsPublicRepo:
     def test_public_repo(self, capsys):


### PR DESCRIPTION
Closes #8235

### Summary
Adds `url`, `clone`, `webhook`, and `password` to the `_sanitize_config` redaction keyword list. Previously, fields like `clone-url: https://github.com/user/private-repo` or `webhook: https://hooks.slack.com/secret` passed through unredacted in diagnostic reports — a security concern when reports are posted to public trackers.

### Acceptance Criteria
- [x] `url`, `clone`, `webhook`, `password` added to keyword list
- [x] Existing redaction behavior preserved (repo, path, email, token, secret, key)
- [x] Regression tests for each new keyword

### Changes
- **references/scripts/diagnostics.py**: Added 4 keywords to redaction list (line 113)
- **tests/test_diagnostics.py**: Added 3 regression tests (url, webhook, password)

### QA Status
- [x] All 7 TestSanitizeConfig tests passing (4 existing + 3 new)
- [x] Full test suite: same 2 pre-existing failures, zero new failures