### PR TITLE
skill: #8234 — narrow except clause in start_team kill block

### DIFF
--- a/references/scripts/start_team.py
+++ b/references/scripts/start_team.py
@@ -149,7 +149,7 @@ def cmd_reboot(roles, force=False):
                 if alive and claude_pid:
                     reboot_agent._kill_process(claude_pid)
                     print(f"  [{role}] Killed PID {claude_pid}")
-            except (ImportError, Exception) as e:
+            except (ImportError, OSError, ProcessLookupError) as e:
                 print(f"  [{role}] Kill failed: {e}")
             time.sleep(2)
             r = boot_remote.boot_agent(role)

--- a/tests/test_start_team.py
+++ b/tests/test_start_team.py
@@ -137,3 +137,9 @@ class TestHarnessAPI:
              patch.object(start_team.boot_remote, "_needs_boot", return_value=(False, "running", "/path")):
             start_team.cmd_reboot(["skill"])
             mock_api.assert_called_once_with("POST", "/agents/skill/restart")
+
+    def test_no_bare_exception_in_kill_block(self):
+        """#8234 regression: kill block must not catch bare Exception."""
+        import inspect
+        source = inspect.getsource(start_team.cmd_reboot)
+        assert "(ImportError, Exception)" not in source


### PR DESCRIPTION
Closes #8234

### Summary
Replaces `except (ImportError, Exception)` with `except (ImportError, OSError, ProcessLookupError)` in `cmd_reboot`'s kill block. Previously, all exceptions were silently caught — genuine failures (permission errors, corrupted state) were swallowed and boot proceeded as if kill succeeded.

### Changes
- **references/scripts/start_team.py**: Narrowed except clause (line 152)
- **tests/test_start_team.py**: Added regression test asserting no bare `Exception` in kill block

### QA Status
- [x] New test passing
- [x] Full test suite: same 2 pre-existing failures, zero new failures