### PR TITLE
skill: #8269 — remove unused import os

### DIFF
--- a/references/scripts/squidsquad_cli.py
+++ b/references/scripts/squidsquad_cli.py
@@ -20,7 +20,6 @@ Exit codes:
 
 import io
 import json
-import os
 import platform
 import shutil
 import subprocess


### PR DESCRIPTION
Closes #8269

### Summary
Remove unused `import os` from `squidsquad_cli.py`. All path operations use `pathlib.Path` and subprocess calls use `subprocess` directly — `os` was never referenced.

### Acceptance Criteria
- [x] `import os` removed from squidsquad_cli.py
- [x] No references to `os` module remain in the file

### Changes
- **Files**: `references/scripts/squidsquad_cli.py`
- **What**: Removed unused `import os` (line 23)
- **Why**: Dead import found by improvement scan

### QA Status
- [x] Unit tests passing (2204/2206 — 2 pre-existing failures in unrelated files)
- [x] No smoke tests applicable (import removal only)
- [x] Acceptance criteria met