### PR TITLE
skill: #8268 — fix get_state returning OPEN for missing state

### DIFF
--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -1116,9 +1116,7 @@ def get_state(number):
     adapter = _get_forge_adapter()
     if adapter:
         data = adapter.view_issue(number)
-        state = "OPEN" if data else "UNKNOWN"
-        if data and data.get("state"):
-            state = data["state"]
+        state = (data or {}).get("state") or "UNKNOWN"
         print(state)
         return state
     result = _run_list(["gh", "issue", "view", str(number), "--json", "state"])

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -289,6 +289,36 @@ class TestGetState:
         state = tracker.get_state(42)
         assert state == "CLOSED"
 
+    def test_adapter_returns_state(self, monkeypatch):
+        adapter = MagicMock()
+        adapter.view_issue.return_value = {"state": "CLOSED"}
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: adapter)
+        state = tracker.get_state(42)
+        assert state == "CLOSED"
+
+    def test_adapter_missing_state_returns_unknown(self, monkeypatch):
+        """Regression: #8268 — missing state field should return UNKNOWN, not OPEN."""
+        adapter = MagicMock()
+        adapter.view_issue.return_value = {"title": "some issue"}
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: adapter)
+        state = tracker.get_state(42)
+        assert state == "UNKNOWN"
+
+    def test_adapter_empty_state_returns_unknown(self, monkeypatch):
+        """Empty string state treated as UNKNOWN (#8268)."""
+        adapter = MagicMock()
+        adapter.view_issue.return_value = {"state": ""}
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: adapter)
+        state = tracker.get_state(42)
+        assert state == "UNKNOWN"
+
+    def test_adapter_no_data_returns_unknown(self, monkeypatch):
+        adapter = MagicMock()
+        adapter.view_issue.return_value = None
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: adapter)
+        state = tracker.get_state(42)
+        assert state == "UNKNOWN"
+
 
 class TestCloseIssue:
     def test_calls_close(self, monkeypatch):


### PR DESCRIPTION
Closes #8268

### Summary
Fix `get_state()` adapter path returning `OPEN` when the `state` field is missing from adapter data. A closed issue with a missing state field was incorrectly reported as OPEN. Now returns `UNKNOWN` for any ambiguous data.

### Acceptance Criteria
- [x] Missing state field returns UNKNOWN, not OPEN
- [x] Empty state string returns UNKNOWN
- [x] Null/None data returns UNKNOWN
- [x] Valid state values still returned correctly

### Changes
- **Files**: `references/scripts/tracker.py`, `tests/test_tracker.py`
- **What**: Simplified adapter branch from 3-line guard to `(data or {}).get("state") or "UNKNOWN"`
- **Why**: Previous code defaulted to OPEN when data existed but lacked a state field — incorrect for closed issues

### QA Status
- [x] Unit tests passing (6/6 in TestGetState, full suite green minus 2 pre-existing)
- [x] Regression test covers the exact bug scenario
- [x] Acceptance criteria met