### PR TITLE
skill: #8308 — suppress MCP plugins in agent sessions

### DIFF
--- a/references/scripts/thin_launcher.py
+++ b/references/scripts/thin_launcher.py
@@ -83,6 +83,10 @@ def main():
                 "--name", f"squidsquad-{role}",
                 "--effort", effort,
                 "--dangerously-skip-permissions",
+                # #8308: suppress user/account MCP plugins so built-in deferred
+                # tools (Monitor, etc.) aren't crowded out. If an agent needs an
+                # MCP server, add --mcp-config <file> alongside this flag.
+                "--strict-mcp-config",
                 "Boot. Begin your first Ralph Loop cycle now.",
             ],
             cwd=clone_path,

--- a/tests/test_thin_launcher.py
+++ b/tests/test_thin_launcher.py
@@ -69,6 +69,57 @@ class TestEffortLevel:
             assert result == "high"
 
 
+class TestClaudeInvocation:
+    """Verify claude CLI flags passed by thin launcher."""
+
+    def test_strict_mcp_config_flag(self, tmp_path):
+        """#8308: --strict-mcp-config prevents MCP plugins from crowding out built-in tools."""
+        sqdir = tmp_path / ".squidsquad" / "skill"
+        sqdir.mkdir(parents=True)
+        captured_cmd = []
+
+        def mock_popen(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            proc = MagicMock()
+            proc.pid = 99999
+            proc.wait.return_value = 0
+            return proc
+
+        with patch("thin_launcher.subprocess.Popen", side_effect=mock_popen), \
+             patch("thin_launcher.os.getcwd", return_value=str(tmp_path)), \
+             patch("thin_launcher._get_effort_level", return_value="high"), \
+             patch("sys.argv", ["thin_launcher.py", "skill"]):
+            thin_launcher.main()
+
+        assert "--strict-mcp-config" in captured_cmd
+        # Flag must appear before the prompt argument (positional)
+        prompt_idx = captured_cmd.index("Boot. Begin your first Ralph Loop cycle now.")
+        flag_idx = captured_cmd.index("--strict-mcp-config")
+        assert flag_idx < prompt_idx
+
+    def test_append_system_prompt_includes_role(self, tmp_path):
+        """Agent role is passed via --append-system-prompt."""
+        sqdir = tmp_path / ".squidsquad" / "skill"
+        sqdir.mkdir(parents=True)
+        captured_cmd = []
+
+        def mock_popen(cmd, **kwargs):
+            captured_cmd.extend(cmd)
+            proc = MagicMock()
+            proc.pid = 99999
+            proc.wait.return_value = 0
+            return proc
+
+        with patch("thin_launcher.subprocess.Popen", side_effect=mock_popen), \
+             patch("thin_launcher.os.getcwd", return_value=str(tmp_path)), \
+             patch("thin_launcher._get_effort_level", return_value="high"), \
+             patch("sys.argv", ["thin_launcher.py", "skill"]):
+            thin_launcher.main()
+
+        idx = captured_cmd.index("--append-system-prompt")
+        assert captured_cmd[idx + 1] == "SQUIDSQUAD_ROLE=skill"
+
+
 class TestThinLauncherBoot:
     """Thin launcher boot_remote integration."""
 


### PR DESCRIPTION
Closes #8308

### Summary
Add `--strict-mcp-config` to the Claude CLI invocation in `thin_launcher.py`. Agent sessions were loading ~85+ MCP plugin tools (Playwright, Meta Ads, Google Drive, etc.) which filled the deferred tool budget and caused built-in tools (Monitor, PowerShell, PushNotification, ScheduleWakeup) to be dropped. This blocks #7630 Phase 4 (event-driven architecture) which requires Monitor.

`--strict-mcp-config` tells Claude to only use MCP servers explicitly passed via `--mcp-config`, ignoring all user/account-level configurations. Since no `--mcp-config` is passed, agent sessions load zero MCP plugins, freeing the budget for built-in deferred tools.

### Acceptance Criteria
- [x] Agent sessions launched via thin_launcher no longer load user/account MCP plugins
- [x] Built-in deferred tools (Monitor, etc.) should be available in agent sessions
- [x] Human sessions (run via `claude` directly) are unaffected

### Changes
- **Files**: `references/scripts/thin_launcher.py`, `tests/test_thin_launcher.py`
- **What**: Added `--strict-mcp-config` flag to claude Popen command
- **Why**: ~85+ MCP tools crowded out 6 built-in deferred tools including Monitor

### Future Escape Hatch
If an agent role needs an MCP server, add `--mcp-config <file>` alongside `--strict-mcp-config` to selectively enable specific servers.

### QA Status
- [x] Unit tests passing (10/10 in test_thin_launcher, full suite green minus 2 pre-existing)
- [x] Flag ordering verified — appears before positional prompt argument
- [x] Acceptance criteria met