### PR TITLE
skill: #8307 — remove dead code in find_qa_rejected

### DIFF
--- a/references/scripts/triage.py
+++ b/references/scripts/triage.py
@@ -137,7 +137,7 @@ def find_qa_rejected(role: str) -> list[dict]:
         last_own_at = None
         for c in comments:
             cr = _parse_comment_role(c["body"])
-            if cr and (cr == role or cr == f"{role}-lead"):
+            if cr and cr == role:
                 last_own_at = c["createdAt"]
 
         # Find the latest QA/PM feedback comment

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -101,6 +101,30 @@ class TestTriageLiveSmoke:
         assert result == []
 
 
+class TestOwnCommentDetection:
+    """#8307: own-comment matching uses normalized role from _parse_comment_role."""
+
+    def test_lead_suffix_comment_recognized_as_own(self):
+        """A '**skill-lead**:' comment is recognized as role 'skill' own comment."""
+        from unittest.mock import patch
+
+        def mock_gh(*args):
+            if args[0] == "issue" and args[1] == "list":
+                return json.dumps([{"number": 100, "title": "Test"}])
+            if args[0] == "issue" and args[1] == "view":
+                return json.dumps({"comments": [
+                    {"body": "**qa**: Needs rework.", "createdAt": "2026-05-15T08:00:00Z"},
+                    {"body": "**skill-lead**: Fixed.", "createdAt": "2026-05-15T09:00:00Z"},
+                ]})
+            return ""
+
+        with patch.object(triage, "_gh", side_effect=mock_gh):
+            result = triage.find_qa_rejected("skill")
+
+        # skill-lead comment is newer than qa comment — feedback is addressed
+        assert result == []
+
+
 class TestFindQaRejectedErrorIsolation:
     """#4051 regression: single-issue gh failure must not abort the scan."""
 


### PR DESCRIPTION
Closes #8307

### Summary
Remove dead `cr == f"{role}-lead"` branch in `find_qa_rejected()`. `_parse_comment_role()` already strips the `-lead` suffix (lines 84-85), so `cr` is always the base role name — the second condition can never be True.

### Acceptance Criteria
- [x] Dead branch removed
- [x] Own-comment detection still works for `-lead` suffixed comments (regression test added)

### Changes
- **Files**: `references/scripts/triage.py`, `tests/test_triage.py`
- **What**: Simplified `if cr and (cr == role or cr == f"{role}-lead")` to `if cr and cr == role`
- **Why**: Dead code — `_parse_comment_role` normalizes `-lead` before returning

### QA Status
- [x] Unit tests passing (28/28 in test_triage)
- [x] Regression test confirms `-lead` comments are correctly matched
- [x] Acceptance criteria met