### PR TITLE
skill: #8336 — remove redundant import re in cycle_post.py

### DIFF
--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -430,7 +430,6 @@ def _do_version_bump(data, role):
     skill_md = REPO_ROOT / "SKILL.md"
     if skill_md.exists():
         content = skill_md.read_text(encoding="utf-8")
-        import re
         content = re.sub(r'version:\s*[\d.]+', f'version: {new_version}', content, count=1)
         skill_md.write_text(content, encoding="utf-8")
 
@@ -621,7 +620,6 @@ def _advance_event_cursor(data, role):
     # Replace existing cursor line or add it
     cursor_line = f"- **Last Processed Event ID**: {last_event_id}"
     if "- **Last Processed Event ID**:" in content:
-        import re
         content = re.sub(
             r"- \*\*Last Processed Event ID\*\*:.*",
             cursor_line,


### PR DESCRIPTION
Closes #8336

### Summary
Remove two redundant `import re` statements inside `_do_version_bump()` (line 434) and `_advance_event_cursor()` (line 624). The `re` module is already imported at module scope (line 16).

### Acceptance Criteria
- [x] Redundant local `import re` removed from `_do_version_bump`
- [x] Redundant local `import re` removed from `_advance_event_cursor`
- [x] Module-scope `import re` (line 16) remains

### Changes
- **Files**: `references/scripts/cycle_post.py`
- **What**: Removed 2 local `import re` statements
- **Why**: Dead code — `re` already imported at module scope

### QA Status
- [x] Unit tests passing (65/65 in test_cycle_post)
- [x] Acceptance criteria met