### PR TITLE
skill: #8343 — normalize boolean config parsing in cycle_pre.py

### DIFF
--- a/references/scripts/cycle_pre.py
+++ b/references/scripts/cycle_pre.py
@@ -436,12 +436,13 @@ def _run_mechanical_reactions(events, role):
 
 def _read_config_flags():
     """Read common config flags."""
+    _YES = ("yes", "true", "1")
     return {
-        "branch_workflow": _config_get("branch-workflow").lower() == "yes",
-        "pr_flow": _config_get("pr-flow").lower() == "yes",
-        "improvement_scanning": _config_get("improvement-scanning").lower() == "yes",
-        "vault_remember": _config_get("vault-remember").lower() == "yes",
-        "vault_optimize": _config_get("vault-optimize").lower() == "yes",
+        "branch_workflow": _config_get("branch-workflow").lower() in _YES,
+        "pr_flow": _config_get("pr-flow").lower() in _YES,
+        "improvement_scanning": _config_get("improvement-scanning").lower() in _YES,
+        "vault_remember": _config_get("vault-remember").lower() in _YES,
+        "vault_optimize": _config_get("vault-optimize").lower() in _YES,
     }
 
 

--- a/tests/test_cycle_pre.py
+++ b/tests/test_cycle_pre.py
@@ -277,6 +277,23 @@ class TestReadConfigFlags:
         assert result["vault_remember"] is False
         assert result["vault_optimize"] is True
 
+    def test_accepts_true_and_1_as_truthy(self, monkeypatch):
+        """#8343 regression: 'true' and '1' must be accepted, not just 'yes'."""
+        flags = {
+            "branch-workflow": "true",
+            "pr-flow": "1",
+            "improvement-scanning": "True",
+            "vault-remember": "YES",
+            "vault-optimize": "no",
+        }
+        monkeypatch.setattr(cycle_pre, "_config_get", lambda f: flags.get(f, ""))
+        result = cycle_pre._read_config_flags()
+        assert result["branch_workflow"] is True
+        assert result["pr_flow"] is True
+        assert result["improvement_scanning"] is True
+        assert result["vault_remember"] is True
+        assert result["vault_optimize"] is False
+
 
 # ---------------------------------------------------------------------------
 # Skill Input Builder


### PR DESCRIPTION
Closes #8343

### Summary
Normalize `_read_config_flags()` to accept `yes`, `true`, and `1` as truthy values — matching `_enforce_branch()` (same file) and `cycle_post.py`. Previously only `yes` was accepted, causing inconsistent behavior if config values were set to `true` or `1`.

### Acceptance Criteria
- [x] All 5 flags in `_read_config_flags` accept `yes`/`true`/`1` (case-insensitive)
- [x] Consistent with `_enforce_branch` and `cycle_post.py` parsing
- [x] Regression test covers `true`, `1`, `True`, `YES` variants

### Changes
- **Files**: `references/scripts/cycle_pre.py`, `tests/test_cycle_pre.py`
- **What**: Changed `.lower() == "yes"` to `.lower() in _YES` where `_YES = ("yes", "true", "1")`
- **Why**: Inconsistent parsing between functions in same file and across cycle scripts

### QA Status
- [x] Unit tests passing (2/2 in TestReadConfigFlags)
- [x] Regression test added for `true`/`1` acceptance
- [x] Acceptance criteria met