### PR TITLE
skill: #8350 — remove unused import os from state_bus.py

### DIFF
--- a/references/scripts/state_bus.py
+++ b/references/scripts/state_bus.py
@@ -19,7 +19,6 @@ Exit codes:
 """
 
 import json
-import os
 import re
 import subprocess
 import sys


### PR DESCRIPTION
Closes #8350

### Summary
Remove unused `import os` from `state_bus.py`. All path operations use `pathlib.Path` and subprocess calls use `subprocess` directly — `os` is never referenced.

### Acceptance Criteria
- [x] `import os` removed
- [x] No references to `os` module remain

### Changes
- **Files**: `references/scripts/state_bus.py`
- **What**: Removed unused `import os` (line 22)
- **Why**: Dead import found by improvement scan

### QA Status
- [x] Unit tests passing (33/33 in test_state_bus)
- [x] Acceptance criteria met