### PR TITLE
skill: #8381 — update LAYERS.md to reference start_team.py

### DIFF
--- a/references/roles/LAYERS.md
+++ b/references/roles/LAYERS.md
@@ -68,6 +68,6 @@ PM can push behavioral sub-skills to ALL agents without a dev cycle:
 
 1. Write sub-skills to `references/sub-skills/project/*.md` (standard sub-skill format with `<!-- sub-skill: name -->` markers)
 2. Run `python references/scripts/compose.py deploy-all`
-3. Reboot affected agents (`python references/scripts/reboot_agent.py --all`)
+3. Reboot affected agents (`python references/scripts/start_team.py --reboot --all`)
 
 Project sub-skills are auto-included in every agent's CLAUDE.md during assembly — same composition mechanism as all other sub-skills. PM owns this directory directly — no task filing, no QA verification needed. Use for project-wide rules, constraints, or behavioral adjustments that apply to the entire team.


### PR DESCRIPTION
Closes #8381

### Summary
Updated LAYERS.md to reference the canonical agent lifecycle interface (`start_team.py --reboot --all`) instead of the deprecated `reboot_agent.py --all`. The old script still exists as an internal dependency but `start_team.py` is the documented interface per #4966.

### Acceptance Criteria
- [x] LAYERS.md line 71 references `start_team.py --reboot --all`

### Changes
- **Files**: `references/roles/LAYERS.md`
- **What**: Changed reboot command reference from `reboot_agent.py --all` to `start_team.py --reboot --all`
- **Why**: Documentation should reference the canonical lifecycle interface

### QA Status
- [x] Unit tests passing (17/17)
- [x] Smoke tests passing
- [x] Acceptance criteria met