### PR TITLE
skill: #8401 #8400 — fix /nonexistent path in tests

### DIFF
--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -251,18 +251,20 @@ class TestGenerateReport:
         assert "Recent Diagnostics" in report
         assert '"warning"' in report
 
-    def test_report_no_log_file(self, capsys):
+    def test_report_no_log_file(self, tmp_path, capsys):
+        no_log = tmp_path / "no_such_log.jsonl"
         with patch.object(diagnostics, "get_field", return_value="1.0.0"), \
              patch.object(diagnostics, "_sanitize_config", return_value="cfg"), \
-             patch.object(diagnostics, "LOG_FILE", Path("/nonexistent")):
+             patch.object(diagnostics, "LOG_FILE", no_log):
             report = diagnostics.generate_report()
         assert "Recent Diagnostics" not in report
         assert "Issue Report" in report
 
-    def test_report_version_unknown_on_error(self, capsys):
+    def test_report_version_unknown_on_error(self, tmp_path, capsys):
+        no_log = tmp_path / "no_such_log.jsonl"
         with patch.object(diagnostics, "get_field", side_effect=SystemExit(1)), \
              patch.object(diagnostics, "_sanitize_config", return_value="cfg"), \
-             patch.object(diagnostics, "LOG_FILE", Path("/nonexistent")):
+             patch.object(diagnostics, "LOG_FILE", no_log):
             report = diagnostics.generate_report()
         assert "unknown" in report
 

--- a/tests/test_forgejo_setup.py
+++ b/tests/test_forgejo_setup.py
@@ -215,8 +215,9 @@ class TestCreateRepo:
 
 class TestTeardown:
     @patch("subprocess.run")
-    def test_teardown_no_deployment(self, mock_run):
-        with patch.object(forgejo_setup, "DEPLOY_DIR", Path("/nonexistent")):
+    def test_teardown_no_deployment(self, mock_run, tmp_path):
+        no_deploy = tmp_path / "no_such_deploy_dir"
+        with patch.object(forgejo_setup, "DEPLOY_DIR", no_deploy):
             result = forgejo_setup.teardown()
         assert result["ok"] is True
         assert "no" in result["message"].lower()


### PR DESCRIPTION
Closes ​#8401
Closes ​#8400

### Summary
Both test failures had the same root cause: `Path('/nonexistent')` on Windows resolves to `D:\nonexistent`, which actually exists as a file on this machine. Tests assumed the path wouldn't exist, but it does.

### Changes
- **test_forgejo_setup.py**: `test_teardown_no_deployment` — replaced `Path('/nonexistent')` with `tmp_path / 'no_such_deploy_dir'`
- **test_diagnostics.py**: `test_report_no_log_file` and `test_report_version_unknown_on_error` — replaced `Path('/nonexistent')` with `tmp_path / 'no_such_log.jsonl'`

### QA Status
- [x] All 24 forgejo_setup tests passing
- [x] All 29 diagnostics tests passing
- [x] No regressions