### PR TITLE
skill: #8484 — fix set_counter upsert for missing quiet cycle counter field

### DIFF
--- a/references/scripts/cycle.py
+++ b/references/scripts/cycle.py
@@ -97,16 +97,19 @@ def get_counter(role):
 
 
 def set_counter(role, value):
-    """Set quiet cycle counter in working-state.md."""
+    """Set quiet cycle counter in working-state.md (upserts if field absent)."""
     ws_path = _get_working_state_path(role)
     if not ws_path.exists():
         return
     text = ws_path.read_text(encoding="utf-8")
-    new_text = re.sub(
-        r'(Quiet Cycle Counter\*\*:\s*)\d+',
-        rf'\g<1>{value}',
-        text,
-    )
+    if re.search(r'Quiet Cycle Counter\*\*:\s*\d+', text):
+        new_text = re.sub(
+            r'(Quiet Cycle Counter\*\*:\s*)\d+',
+            rf'\g<1>{value}',
+            text,
+        )
+    else:
+        new_text = text.rstrip("\n") + f"\n- **Quiet Cycle Counter**: {value}\n"
     ws_path.write_text(new_text, encoding="utf-8")
     return value
 

--- a/tests/test_cycle.py
+++ b/tests/test_cycle.py
@@ -98,6 +98,31 @@ class TestCounters:
         text = ws.read_text()
         assert "Quiet Cycle Counter**: 5" in text
 
+    def test_set_counter_upserts_when_field_absent(self, tmp_path):
+        """#8484: set_counter creates the field if it doesn't exist."""
+        role_dir = tmp_path / "skill"
+        role_dir.mkdir(parents=True, exist_ok=True)
+        ws = role_dir / "working-state.md"
+        ws.write_text("# Working State\n\n- **Task**: none\n- **Status**: none\n")
+        with self._patch(tmp_path):
+            cycle.set_counter("skill", 3)
+        text = ws.read_text()
+        assert "- **Quiet Cycle Counter**: 3\n" in text
+        assert text.count("Quiet Cycle Counter") == 1
+
+    def test_inc_counter_upserts_when_field_absent(self, tmp_path, capsys):
+        """#8484: inc_counter persists when field starts absent."""
+        role_dir = tmp_path / "skill"
+        role_dir.mkdir(parents=True, exist_ok=True)
+        ws = role_dir / "working-state.md"
+        ws.write_text("# Working State\n\n- **Task**: none\n- **Status**: none\n")
+        with self._patch(tmp_path):
+            result = cycle.inc_counter("skill")
+        assert result == 1
+        text = ws.read_text()
+        assert "- **Quiet Cycle Counter**: 1\n" in text
+        assert capsys.readouterr().out.strip() == "1"
+
     def test_inc_counter(self, tmp_path, capsys):
         self._setup_working_state(tmp_path, "skill", counter=2)
         with self._patch(tmp_path):


### PR DESCRIPTION
Closes #8484

### Summary
Fixed `set_counter()` in `cycle.py` to create the `Quiet Cycle Counter` field when absent from working-state.md, rather than silently failing. Previously, if the field was missing (as was the case for the skill agent), the regex substitution found no match and the counter never persisted.

### Acceptance Criteria
- [x] set_counter creates Quiet Cycle Counter field if absent
- [x] inc_counter persists correctly when field starts absent
- [x] Regression tests cover both upsert and existing behavior

### Changes
- **Files**: `references/scripts/cycle.py`, `tests/test_cycle.py`
- **What**: Added upsert branch to `set_counter()` — appends field when regex finds no match. Added 2 regression tests for the upsert path.
- **Why**: Follows established pattern from `vault_remember.py _upsert_vault_writes()`. Makes the counter self-healing regardless of working-state.md initialization state.

### QA Status
- [x] Unit tests passing (19/19 in test_cycle.py)
- [x] Full suite passing (17/17 run_tests.py)
- [x] External code review passed (4 minor/nitpick findings — 2 fixed, 2 justified-ignore for pre-existing issues out of scope)
- [x] Acceptance criteria met