### PR TITLE
skill: #8483 — remove unused imports io and json from cycle.py

### DIFF
--- a/references/scripts/cycle.py
+++ b/references/scripts/cycle.py
@@ -16,8 +16,6 @@ Usage:
     python scripts/cycle.py --help
 """
 
-import io
-import json
 import re
 import sys
 from datetime import datetime


### PR DESCRIPTION
Closes #8483

### Summary
Removed unused `import io` and `import json` from `references/scripts/cycle.py`. Neither module is referenced anywhere in the file.

### Changes
- **Files**: `references/scripts/cycle.py`
- **What**: Removed 2 dead import lines
- **Why**: Dead code cleanup — neither `io` nor `json` is used in this module

### QA Status
- [x] Unit tests passing (19/19 in test_cycle.py)
- [x] Full suite passing (17/17 run_tests.py)