### PR TITLE
skill: #8526 #8525 — fix type mismatch and redundant import in harness.py

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -466,7 +466,7 @@ async def lifespan(app: FastAPI):
             clone_paths = boot_remote._parse_local_config()
             for role, clone_root in clone_paths.items():
                 clone_squid = Path(clone_root) / ".squidsquad"
-                if clone_squid.is_dir() and clone_root != REPO_ROOT:
+                if clone_squid.is_dir() and Path(clone_root).resolve() != REPO_ROOT.resolve():
                     clone_port_file = clone_squid / ".harness-port"
                     try:
                         clone_tmp = clone_port_file.with_suffix(".tmp")
@@ -839,8 +839,7 @@ async def receive_event(request: Request):
         raise HTTPException(status_code=400, detail="event_type and role are required")
 
     # Stamp received_at for ordering (#5622)
-    import time as _time
-    body["received_at"] = _time.time()
+    body["received_at"] = time.time()
 
     # Store in stream
     event_stream.append(body)


### PR DESCRIPTION
Closes #8526
Closes #8525

### Summary
Two fixes in `harness.py`:
1. **Type mismatch** (line 469): `clone_root` (str) compared with `REPO_ROOT` (Path) was always True. Fixed with `Path(clone_root).resolve() != REPO_ROOT.resolve()`.
2. **Redundant import** (line 842): Removed `import time as _time` inside `receive_event()` — `time` is already imported at module level.

### Changes
- **Files**: `references/scripts/harness.py`
- **What**: Fixed Path/str comparison, removed redundant local import
- **Why**: Skip-primary-repo guard was bypassed (benign duplicate write); dead import added noise

### QA Status
- [x] Full suite passing (17/17 run_tests.py)
- [x] Module imports cleanly (`import harness` succeeds)