### PR TITLE
skill: #8547 — fix duplicate check=False kwarg crash in wizard.py

### DIFF
--- a/references/scripts/wizard.py
+++ b/references/scripts/wizard.py
@@ -2257,7 +2257,7 @@ def cmd_setup_yes(args):
 
     # 2. Load repo info
     repo_info = {}
-    result = _run(["gh", "repo", "view", "--json", "name,url"], check=False)
+    result = _run(["gh", "repo", "view", "--json", "name,url"])
     if result.returncode == 0:
         try:
             data = json.loads(result.stdout)

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -2314,3 +2314,43 @@ class TestPreflight:
             result = wizard.preflight(tmp_path)
         assert result["ok"] is True
         assert len(result["checks"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# cmd_setup_yes — #8547 regression
+# ---------------------------------------------------------------------------
+
+class TestCmdSetupYes:
+    """#8547: _run() must not receive duplicate check=False kwarg."""
+
+    def test_no_duplicate_check_kwarg(self, tmp_path):
+        """Regression: _run call in cmd_setup_yes must not pass check=False."""
+        from unittest.mock import patch, MagicMock
+        import inspect
+        source = inspect.getsource(wizard.cmd_setup_yes)
+        assert "check=False" not in source, (
+            "_run() already hardcodes check=False — passing it again "
+            "causes TypeError: got multiple values for keyword argument 'check'"
+        )
+
+    def test_run_not_called_with_check_kwarg(self, tmp_path):
+        """_run() is never called with check= kwarg from cmd_setup_yes."""
+        from unittest.mock import patch, MagicMock, call
+        calls = []
+
+        def tracking_run(cmd, **kwargs):
+            calls.append(kwargs)
+            return MagicMock(returncode=1, stdout="", stderr="")
+
+        # Patch enough to get past the gh repo view call without full execution
+        with patch.object(wizard, "_run", side_effect=tracking_run):
+            try:
+                wizard.cmd_setup_yes([str(tmp_path)])
+            except (SystemExit, Exception):
+                pass  # May fail later in setup — we only care about the _run call
+
+        # Verify no call passed check= kwarg
+        for kw in calls:
+            assert "check" not in kw, (
+                f"_run called with check={kw['check']} — this causes TypeError"
+            )


### PR DESCRIPTION
Closes #8547

### Summary
Removed redundant `check=False` kwarg from `_run()` call at line 2260 in `cmd_setup_yes`. The `_run()` helper already hardcodes `check=False` internally — passing it again caused `TypeError: got multiple values for keyword argument 'check'`, crashing the entire `setup-yes` command before it could call `gh repo view`.

### Acceptance Criteria
- [x] _run() call no longer passes check=False
- [x] Regression tests verify source + runtime behavior

### Changes
- **Files**: `references/scripts/wizard.py`, `tests/test_wizard.py`
- **What**: Removed redundant kwarg, added 2 regression tests
- **Why**: TypeError crash prevented non-interactive setup from running

### QA Status
- [x] Unit tests passing (2/2 new + all existing)
- [x] Full suite passing (17/17 run_tests.py)