### PR TITLE
skill: #8548 — fix load_install_spec uncaught JSONDecodeError

### DIFF
--- a/references/scripts/wizard.py
+++ b/references/scripts/wizard.py
@@ -872,7 +872,10 @@ def load_install_spec(target_root):
     if not spec_path.exists():
         return None
     raw = spec_path.read_text(encoding="utf-8")
-    return json.loads(raw)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"invalid JSON in {spec_path}: {e}") from e
 
 
 def _write_l4_project_files(spec, project_dir, summary):

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -2057,6 +2057,14 @@ class TestInstallSpec:
         loaded = wizard.load_install_spec(tmp_path)
         assert loaded["squidsquad_version"] == "0.26.0"
 
+    def test_load_invalid_json_raises_valueerror(self, tmp_path):
+        """#8548: Corrupt JSON raises ValueError, not JSONDecodeError."""
+        spec_dir = tmp_path / ".squidsquad"
+        spec_dir.mkdir(parents=True)
+        (spec_dir / ".install-spec.json").write_text("not valid json{{", encoding="utf-8")
+        with pytest.raises(ValueError, match="invalid JSON"):
+            wizard.load_install_spec(tmp_path)
+
 
 # ---------------------------------------------------------------------------
 # Scan Summary (#13)


### PR DESCRIPTION
Closes #8548

### Summary
Wrapped `json.loads()` in `load_install_spec()` with try/except to convert `JSONDecodeError` to `ValueError` as documented in the docstring. Previously, a corrupt `.install-spec.json` would produce an unformatted traceback instead of the expected exception type.

### Changes
- **Files**: `references/scripts/wizard.py`, `tests/test_wizard.py`
- **What**: Added try/except converting JSONDecodeError to ValueError, plus 1 regression test
- **Why**: Docstring promises ValueError but JSONDecodeError escaped uncaught

### QA Status
- [x] Unit tests passing (1/1 new + all existing)
- [x] Full suite passing (17/17 run_tests.py)