### PR TITLE
skill: #8561 — fix .local-config regex to accept hyphenated role names

### DIFF
--- a/references/scripts/add_role.py
+++ b/references/scripts/add_role.py
@@ -88,7 +88,7 @@ def _parse_local_config(config_path=None):
         return {}
     result = {}
     for line in path.read_text(encoding="utf-8").splitlines():
-        m = re.match(r"-\s*\*\*(\w+)\*\*:\s*(.+)", line)
+        m = re.match(r"-\s*\*\*([\w-]+)\*\*:\s*(.+)", line)
         if m:
             result[m.group(1).strip()] = m.group(2).strip()
     return result

--- a/references/scripts/boot_remote.py
+++ b/references/scripts/boot_remote.py
@@ -70,7 +70,7 @@ def _parse_local_config():
     try:
         text = LOCAL_CONFIG.read_text(encoding="utf-8")
         for line in text.splitlines():
-            m = re.match(r"-\s*\*\*(\w+)\*\*:\s*(.+)", line)
+            m = re.match(r"-\s*\*\*([\w-]+)\*\*:\s*(.+)", line)
             if m:
                 role = m.group(1).strip()
                 raw_path = Path(m.group(2).strip())

--- a/references/scripts/health_check.py
+++ b/references/scripts/health_check.py
@@ -104,7 +104,7 @@ def _parse_local_config():
     try:
         text = LOCAL_CONFIG.read_text(encoding="utf-8")
         for line in text.splitlines():
-            m = re.match(r"-\s*\*\*(\w+)\*\*:\s*(.+)", line)
+            m = re.match(r"-\s*\*\*([\w-]+)\*\*:\s*(.+)", line)
             if m:
                 role = m.group(1).strip()
                 raw_path = Path(m.group(2).strip())

--- a/tests/test_boot_remote.py
+++ b/tests/test_boot_remote.py
@@ -99,6 +99,21 @@ class TestParseLocalConfigMandatory:
         assert "pm" not in result
         assert "dm" not in result
 
+    def test_hyphenated_role_names(self, tmp_path):
+        """#8561: Hyphenated role names like dev-ios must be parsed correctly."""
+        config = tmp_path / ".local-config"
+        config.write_text(
+            "- **dev-ios**: ../project-dev-ios\n"
+            "- **pm-skill**: ../project-pm-skill\n"
+            "- **skill**: .\n"
+        )
+        with patch.object(boot_remote, "LOCAL_CONFIG", config), \
+             patch.object(boot_remote, "REPO_ROOT", tmp_path):
+            result = boot_remote._parse_local_config()
+        assert "dev-ios" in result
+        assert "pm-skill" in result
+        assert "skill" in result
+
 
 class TestGetClonePath:
     """Regression tests for _get_clone_path() JSON serialization (#5915)."""


### PR DESCRIPTION
Closes #8561

### Summary
Changed `\w+` to `[\w-]+` in .local-config parsing regex across 3 scripts (`boot_remote.py`, `add_role.py`, `health_check.py`), aligning them with `compose.py` which already used the correct pattern. Hyphenated role names like `dev-ios` were silently rejected.

### Changes
- **Files**: `references/scripts/boot_remote.py`, `references/scripts/add_role.py`, `references/scripts/health_check.py`, `tests/test_boot_remote.py`
- **What**: Regex fix in 3 files + 1 regression test
- **Why**: Consistent with compose.py; unblocks variant-style agent names

### QA Status
- [x] Unit tests passing (1/1 new + all existing)
- [x] Full suite passing (17/17 run_tests.py)