### PR TITLE
skill: #8569 #8568 — fix empty eval results + remove unused tempfile import

### DIFF
--- a/references/scripts/run_comprehension_test.py
+++ b/references/scripts/run_comprehension_test.py
@@ -23,7 +23,6 @@ import os
 import shutil
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -265,6 +264,11 @@ Write ONLY the JSON array to the results file. No other text.
         print(f"  Content: {raw[:500]}", file=sys.stderr)
         sys.exit(1)
 
+    if not results:
+        print("ERROR: eval agent produced empty results — treating as failure",
+              file=sys.stderr)
+        return [], output_dir
+
     # Summary
     passed = sum(1 for r in results if r.get("pass"))
     total = len(results)
@@ -302,8 +306,8 @@ def main():
     if results is None:
         sys.exit(0)
 
-    # Exit code based on results
-    all_pass = all(r.get("pass") for r in results)
+    # Exit code based on results — empty results = failure
+    all_pass = results and all(r.get("pass") for r in results)
     if not all_pass:
         sys.exit(1)
 

--- a/tests/test_run_comprehension_test.py
+++ b/tests/test_run_comprehension_test.py
@@ -168,3 +168,71 @@ class TestRunTestCacheSkip:
             results, out_dir = rct.run_test(str(spec))
         assert results is None
         assert out_dir is None
+
+
+# ---------------------------------------------------------------------------
+# Empty results guard — #8569
+# ---------------------------------------------------------------------------
+
+class TestEmptyResultsGuard:
+    """#8569: Empty eval results must be treated as failure, not vacuous pass."""
+
+    def test_empty_results_returns_empty_list(self, tmp_path):
+        """run_test returns empty list (not None) when eval produces no results."""
+        from unittest.mock import MagicMock
+
+        spec = tmp_path / "spec.json"
+        spec.write_text(json.dumps({
+            "files": [],
+            "questions": [{"id": "Q1", "question": "test?", "expected": "yes"}],
+        }), encoding="utf-8")
+
+        # Mock agents: test agent writes answers, eval agent writes empty []
+        out_dir = tmp_path / "output"
+        out_dir.mkdir()
+        answers = out_dir / "answers.md"
+        answers.write_text("### Q-Q1\nsome answer\n", encoding="utf-8")
+        results_file = out_dir / "results.json"
+        results_file.write_text("[]", encoding="utf-8")
+
+        fake_result = MagicMock(returncode=0, stdout="", stderr="")
+        with patch.object(rct, "_check_cache", return_value=False), \
+             patch.object(rct, "_find_claude", return_value="/usr/bin/claude"), \
+             patch.object(rct, "_run_agent", return_value=fake_result), \
+             patch.object(rct, "REPO_ROOT", tmp_path):
+            results, _ = rct.run_test(str(spec), output_dir=str(out_dir))
+
+        assert results == []
+
+    def test_empty_results_not_cached(self, tmp_path):
+        """Empty results must NOT update the cache (would mask broken eval)."""
+        from unittest.mock import MagicMock
+
+        spec = tmp_path / "spec.json"
+        spec.write_text(json.dumps({
+            "files": [],
+            "questions": [{"id": "Q1", "question": "test?", "expected": "yes"}],
+        }), encoding="utf-8")
+
+        out_dir = tmp_path / "output"
+        out_dir.mkdir()
+        (out_dir / "answers.md").write_text("### Q-Q1\nanswer\n", encoding="utf-8")
+        (out_dir / "results.json").write_text("[]", encoding="utf-8")
+
+        cache_dir = tmp_path / ".cache"
+        fake_result = MagicMock(returncode=0, stdout="", stderr="")
+        with patch.object(rct, "_check_cache", return_value=False), \
+             patch.object(rct, "_find_claude", return_value="/usr/bin/claude"), \
+             patch.object(rct, "_run_agent", return_value=fake_result), \
+             patch.object(rct, "CACHE_DIR", cache_dir), \
+             patch.object(rct, "REPO_ROOT", tmp_path):
+            rct.run_test(str(spec), output_dir=str(out_dir))
+
+        # Cache should NOT have been written
+        assert not (cache_dir / "spec.hash").exists()
+
+    def test_no_unused_tempfile_import(self):
+        """#8568: tempfile import must be removed."""
+        import inspect
+        source = inspect.getsource(rct)
+        assert "import tempfile" not in source


### PR DESCRIPTION
Closes #8569
Closes #8568

### Summary
Two fixes in `run_comprehension_test.py`:
1. **Empty results guard** (#8569): Added check after parsing results.json — empty `[]` now returns early as failure instead of passing vacuously via `all([]) == True`. Also fixed `main()` to treat empty results as exit code 1.
2. **Unused import** (#8568): Removed `import tempfile` (never used).

### Changes
- **Files**: `references/scripts/run_comprehension_test.py`, `tests/test_run_comprehension_test.py`
- **What**: Empty results guard + dead import removal + 3 regression tests
- **Why**: Broken eval agent could silently pass and update cache, masking failures

### QA Status
- [x] Unit tests passing (3/3 new + all existing)
- [x] Full suite passing (17/17 run_tests.py; 1 pre-existing failure unrelated)