### PR TITLE
skill: #8576 — fix article and iOS capitalization in variant templates

### DIFF
--- a/references/roles/dev/android/instructions.md
+++ b/references/roles/dev/android/instructions.md
@@ -2,6 +2,6 @@
 
 # SquidSquad — [ROLE] Lead (Android Specialization)
 
-You are a android-specialized [ROLE] agent. You inherit all standard [ROLE] responsibilities and add domain expertise in **Android app development (Kotlin/Jetpack)**.
+You are an Android-specialized [ROLE] agent. You inherit all standard [ROLE] responsibilities and add domain expertise in **Android app development (Kotlin/Jetpack)**.
 
 {{include: roles/dev/android/domain-context}}

--- a/references/roles/dev/ios/instructions.md
+++ b/references/roles/dev/ios/instructions.md
@@ -1,7 +1,7 @@
 {{runtime: souls/dev-ios}}
 
-# SquidSquad — [ROLE] Lead (Ios Specialization)
+# SquidSquad — [ROLE] Lead (iOS Specialization)
 
-You are a ios-specialized [ROLE] agent. You inherit all standard [ROLE] responsibilities and add domain expertise in **iOS app development (Swift/SwiftUI)**.
+You are an iOS-specialized [ROLE] agent. You inherit all standard [ROLE] responsibilities and add domain expertise in **iOS app development (Swift/SwiftUI)**.
 
 {{include: roles/dev/ios/domain-context}}

--- a/references/roles/dm/android/instructions.md
+++ b/references/roles/dm/android/instructions.md
@@ -2,6 +2,6 @@
 
 # SquidSquad — [ROLE] Lead (Android Specialization)
 
-You are a android-specialized [ROLE] agent. You inherit all standard [ROLE] responsibilities and add domain expertise in **Android app development (Kotlin/Jetpack)**.
+You are an Android-specialized [ROLE] agent. You inherit all standard [ROLE] responsibilities and add domain expertise in **Android app development (Kotlin/Jetpack)**.
 
 {{include: roles/dm/android/domain-context}}

--- a/references/roles/dm/ios/instructions.md
+++ b/references/roles/dm/ios/instructions.md
@@ -1,7 +1,7 @@
 {{runtime: souls/dm-ios}}
 
-# SquidSquad — [ROLE] Lead (Ios Specialization)
+# SquidSquad — [ROLE] Lead (iOS Specialization)
 
-You are a ios-specialized [ROLE] agent. You inherit all standard [ROLE] responsibilities and add domain expertise in **iOS app development (Swift/SwiftUI)**.
+You are an iOS-specialized [ROLE] agent. You inherit all standard [ROLE] responsibilities and add domain expertise in **iOS app development (Swift/SwiftUI)**.
 
 {{include: roles/dm/ios/domain-context}}

--- a/references/roles/pm/android/instructions.md
+++ b/references/roles/pm/android/instructions.md
@@ -2,6 +2,6 @@
 
 # SquidSquad — [ROLE] Lead (Android Specialization)
 
-You are a android-specialized [ROLE] agent. You inherit all standard [ROLE] responsibilities and add domain expertise in **Android app development (Kotlin/Jetpack)**.
+You are an Android-specialized [ROLE] agent. You inherit all standard [ROLE] responsibilities and add domain expertise in **Android app development (Kotlin/Jetpack)**.
 
 {{include: roles/pm/android/domain-context}}

--- a/references/roles/pm/ios/instructions.md
+++ b/references/roles/pm/ios/instructions.md
@@ -1,7 +1,7 @@
 {{runtime: souls/pm-ios}}
 
-# SquidSquad — [ROLE] Lead (Ios Specialization)
+# SquidSquad — [ROLE] Lead (iOS Specialization)
 
-You are a ios-specialized [ROLE] agent. You inherit all standard [ROLE] responsibilities and add domain expertise in **iOS app development (Swift/SwiftUI)**.
+You are an iOS-specialized [ROLE] agent. You inherit all standard [ROLE] responsibilities and add domain expertise in **iOS app development (Swift/SwiftUI)**.
 
 {{include: roles/pm/ios/domain-context}}

--- a/references/roles/qa/android/instructions.md
+++ b/references/roles/qa/android/instructions.md
@@ -2,6 +2,6 @@
 
 # SquidSquad — [ROLE] Lead (Android Specialization)
 
-You are a android-specialized [ROLE] agent. You inherit all standard [ROLE] responsibilities and add domain expertise in **Android app development (Kotlin/Jetpack)**.
+You are an Android-specialized [ROLE] agent. You inherit all standard [ROLE] responsibilities and add domain expertise in **Android app development (Kotlin/Jetpack)**.
 
 {{include: roles/qa/android/domain-context}}

--- a/references/roles/qa/ios/instructions.md
+++ b/references/roles/qa/ios/instructions.md
@@ -1,7 +1,7 @@
 {{runtime: souls/qa-ios}}
 
-# SquidSquad — [ROLE] Lead (Ios Specialization)
+# SquidSquad — [ROLE] Lead (iOS Specialization)
 
-You are a ios-specialized [ROLE] agent. You inherit all standard [ROLE] responsibilities and add domain expertise in **iOS app development (Swift/SwiftUI)**.
+You are an iOS-specialized [ROLE] agent. You inherit all standard [ROLE] responsibilities and add domain expertise in **iOS app development (Swift/SwiftUI)**.
 
 {{include: roles/qa/ios/domain-context}}


### PR DESCRIPTION
Closes #8576

### Summary
Fixed grammar and capitalization in 8 role variant template files:
- **iOS** (4 files): "Ios Specialization" → "iOS Specialization", "a ios-specialized" → "an iOS-specialized"
- **Android** (4 files): "a android-specialized" → "an Android-specialized"

### Changes
- **Files**: 8 `instructions.md` files across dev/pm/qa/dm for ios and android variants
- **What**: Article correction (a→an) and iOS brand capitalization
- **Why**: User-facing text in composed CLAUDE.md — polish for v1.0.0

### QA Status
- [x] Full suite passing (17/17 run_tests.py)
- [x] Template structure unchanged (only prose content)