### PR TITLE
skill: fix #8653 — task_begin auto-resolves state file conflicts

### DIFF
--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -402,6 +402,43 @@ def _is_state_file(path):
     return any(path.startswith(p) for p in STATE_PREFIXES)
 
 
+def _auto_resolve_state_conflicts():
+    """Auto-resolve unmerged state files (#8653).
+
+    cycle_pre's pull can leave unresolved conflicts in ephemeral state files
+    (e.g. .squidsquad/.backlog-cache, .squidsquad/.event-state.json). Those
+    files are runtime state — the next cycle rewrites them — so picking either
+    side is safe. We use --theirs (the incoming branch's version) so the
+    resolution matches what's already on the remote.
+
+    Code files outside .squidsquad/ and .claude/ are left untouched and
+    reported as unresolved so the caller can fail fast.
+
+    Returns (resolved_paths, unresolved_paths).
+    """
+    result = _run_list(["git", "ls-files", "--unmerged"], check=False)
+    if result.returncode != 0 or not result.stdout.strip():
+        return [], []
+    paths = set()
+    for line in result.stdout.splitlines():
+        if "\t" not in line:
+            continue
+        paths.add(line.split("\t", 1)[1].strip())
+    resolved = []
+    unresolved = []
+    for path in sorted(paths):
+        if _is_state_file(path):
+            r1 = _run_list(["git", "checkout", "--theirs", "--", path], check=False)
+            r2 = _run_list(["git", "add", "--", path], check=False)
+            if r1.returncode == 0 and r2.returncode == 0:
+                resolved.append(path)
+            else:
+                unresolved.append(path)
+        else:
+            unresolved.append(path)
+    return resolved, unresolved
+
+
 def _safe_checkout(target_branch):
     """Switch to target branch, stashing unstaged changes if needed.
 
@@ -621,6 +658,21 @@ def task_begin(role, number):
             return
     except Exception:
         return  # Can't read config — treat as disabled
+
+    # Auto-resolve unmerged state files from pull conflicts (#8653). Code
+    # conflicts still require manual resolution — fail fast in that case so
+    # the agent surfaces the real problem instead of an opaque checkout error.
+    resolved, unresolved = _auto_resolve_state_conflicts()
+    if resolved:
+        print(f"task-begin: auto-resolved state file conflict(s): {', '.join(resolved)}")
+    if unresolved:
+        print(
+            "ERROR: task-begin found unresolved conflicts in non-state files:\n  "
+            + "\n  ".join(unresolved),
+            file=sys.stderr,
+        )
+        print("Resolve manually (e.g. `git checkout --ours/theirs <file> && git add <file>`) before retrying task-begin.", file=sys.stderr)
+        sys.exit(1)
 
     branch = get_branch_name(role, number)
     working = _get_working_branch()

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -947,10 +947,11 @@ def _task_begin_config(field):
 class TestTaskBegin:
     """task_begin should create branch if missing, not error out."""
 
+    @patch("git_ops._auto_resolve_state_conflicts", return_value=([], []))
     @patch("git_ops._get_working_branch", return_value="main")
     @patch("git_ops._safe_checkout", return_value=True)
     @patch("git_ops._run_list")
-    def test_checks_out_existing_local_branch(self, mock_run_list, mock_checkout, mock_gwb):
+    def test_checks_out_existing_local_branch(self, mock_run_list, mock_checkout, mock_gwb, mock_resolve):
         """Existing local branch is checked out normally."""
         # rev-parse succeeds (branch exists locally)
         mock_run_list.return_value = _mock_result(returncode=0)
@@ -959,9 +960,10 @@ class TestTaskBegin:
             git_ops.task_begin("skill", "100")
         mock_checkout.assert_called_once_with("squidsquad/skill/100")
 
+    @patch("git_ops._auto_resolve_state_conflicts", return_value=([], []))
     @patch("git_ops._get_working_branch", return_value="main")
     @patch("git_ops._run_list")
-    def test_creates_branch_when_missing(self, mock_run_list, mock_gwb):
+    def test_creates_branch_when_missing(self, mock_run_list, mock_gwb, mock_resolve):
         """Branch not found locally or on remote — creates from origin/main (#5444)."""
         mock_run_list.side_effect = [
             _mock_result(returncode=1),  # rev-parse local — not found
@@ -978,9 +980,10 @@ class TestTaskBegin:
         create_call = mock_run_list.call_args_list[5]
         assert create_call[0][0] == ["git", "checkout", "-b", "squidsquad/skill/200", "origin/main"]
 
+    @patch("git_ops._auto_resolve_state_conflicts", return_value=([], []))
     @patch("git_ops._get_working_branch", return_value="main")
     @patch("git_ops._run_list")
-    def test_checks_out_remote_branch(self, mock_run_list, mock_gwb):
+    def test_checks_out_remote_branch(self, mock_run_list, mock_gwb, mock_resolve):
         """Branch exists on remote only — checks out and tracks."""
         mock_run_list.side_effect = [
             _mock_result(returncode=1),  # rev-parse local — not found
@@ -994,9 +997,10 @@ class TestTaskBegin:
         checkout_call = mock_run_list.call_args_list[3]
         assert "origin/squidsquad/skill/300" in checkout_call[0][0]
 
+    @patch("git_ops._auto_resolve_state_conflicts", return_value=([], []))
     @patch("git_ops._get_working_branch", return_value="main")
     @patch("git_ops._run_list")
-    def test_fetches_before_remote_check(self, mock_run_list, mock_gwb):
+    def test_fetches_before_remote_check(self, mock_run_list, mock_gwb, mock_resolve):
         """Regression #5013: task-begin must fetch before checking remote refs."""
         mock_run_list.side_effect = [
             _mock_result(returncode=1),  # rev-parse local — not found
@@ -1021,10 +1025,11 @@ class TestTaskBegin:
             git_ops.task_begin("skill", "400")
         mock_run_list.assert_not_called()
 
+    @patch("git_ops._auto_resolve_state_conflicts", return_value=([], []))
     @patch("git_ops._get_working_branch", return_value="main")
     @patch("git_ops._safe_checkout", return_value=True)
     @patch("git_ops._run_list")
-    def test_uses_configured_branch_pattern(self, mock_run_list, mock_checkout, mock_gwb):
+    def test_uses_configured_branch_pattern(self, mock_run_list, mock_checkout, mock_gwb, mock_resolve):
         """Regression #5040: task-begin uses branch-pattern from config."""
         mock_run_list.return_value = _mock_result(returncode=0)
 
@@ -1039,6 +1044,156 @@ class TestTaskBegin:
              patch("config.get_field", side_effect=custom_config):
             git_ops.task_begin("skill", "5040")
         mock_checkout.assert_called_once_with("squidsquad/task/5040")
+
+
+# ---------------------------------------------------------------------------
+# _auto_resolve_state_conflicts() — #8653
+# ---------------------------------------------------------------------------
+
+
+def _ls_files_output(*paths):
+    """Build mock `git ls-files --unmerged` output with one stage line per path."""
+    return "\n".join(f"100644 0000000000000000000000000000000000000000 2\t{p}" for p in paths)
+
+
+class TestAutoResolveStateConflicts:
+    """#8653: auto-resolve unmerged state files; bail on code conflicts."""
+
+    @patch("git_ops._run_list")
+    def test_no_unmerged_returns_empty(self, mock_run_list):
+        """Clean index — both lists are empty, no checkout/add calls."""
+        mock_run_list.return_value = _mock_result(returncode=0, stdout="")
+        resolved, unresolved = git_ops._auto_resolve_state_conflicts()
+        assert resolved == []
+        assert unresolved == []
+        assert mock_run_list.call_count == 1  # only ls-files
+
+    @patch("git_ops._run_list")
+    def test_state_file_resolved_with_theirs(self, mock_run_list):
+        """A .squidsquad/ state file is resolved via checkout --theirs + add."""
+        mock_run_list.side_effect = [
+            _mock_result(returncode=0, stdout=_ls_files_output(".squidsquad/.backlog-cache")),
+            _mock_result(returncode=0),  # checkout --theirs
+            _mock_result(returncode=0),  # git add
+        ]
+        resolved, unresolved = git_ops._auto_resolve_state_conflicts()
+        assert resolved == [".squidsquad/.backlog-cache"]
+        assert unresolved == []
+        # Verify --theirs is used and `--` separator is present (avoids ambiguity)
+        checkout_args = mock_run_list.call_args_list[1][0][0]
+        assert "--theirs" in checkout_args
+        assert "--" in checkout_args
+        assert checkout_args[-1] == ".squidsquad/.backlog-cache"
+
+    @patch("git_ops._run_list")
+    def test_claude_state_file_resolved(self, mock_run_list):
+        """A .claude/ state file is also treated as state and resolved."""
+        mock_run_list.side_effect = [
+            _mock_result(returncode=0, stdout=_ls_files_output(".claude/scheduled_tasks.lock")),
+            _mock_result(returncode=0),
+            _mock_result(returncode=0),
+        ]
+        resolved, unresolved = git_ops._auto_resolve_state_conflicts()
+        assert resolved == [".claude/scheduled_tasks.lock"]
+        assert unresolved == []
+
+    @patch("git_ops._run_list")
+    def test_code_file_left_unresolved(self, mock_run_list):
+        """Non-state code files are reported as unresolved, never auto-resolved."""
+        mock_run_list.return_value = _mock_result(
+            returncode=0, stdout=_ls_files_output("references/scripts/git_ops.py")
+        )
+        resolved, unresolved = git_ops._auto_resolve_state_conflicts()
+        assert resolved == []
+        assert unresolved == ["references/scripts/git_ops.py"]
+        # Only ls-files should have been called — no checkout/add attempt
+        assert mock_run_list.call_count == 1
+
+    @patch("git_ops._run_list")
+    def test_mixed_state_and_code(self, mock_run_list):
+        """State files resolve; code file is reported separately."""
+        mock_run_list.side_effect = [
+            _mock_result(returncode=0, stdout=_ls_files_output(
+                ".squidsquad/.event-state.json",
+                "references/scripts/harness.py",
+            )),
+            _mock_result(returncode=0),  # checkout --theirs state
+            _mock_result(returncode=0),  # git add state
+        ]
+        resolved, unresolved = git_ops._auto_resolve_state_conflicts()
+        assert resolved == [".squidsquad/.event-state.json"]
+        assert unresolved == ["references/scripts/harness.py"]
+
+    @patch("git_ops._run_list")
+    def test_deduplicates_multi_stage_entries(self, mock_run_list):
+        """ls-files emits one line per stage; we resolve each path once."""
+        # Two stages (2 + 3) for the same path
+        stages = "\n".join([
+            "100644 aaa 2\t.squidsquad/.backlog-cache",
+            "100644 bbb 3\t.squidsquad/.backlog-cache",
+        ])
+        mock_run_list.side_effect = [
+            _mock_result(returncode=0, stdout=stages),
+            _mock_result(returncode=0),
+            _mock_result(returncode=0),
+        ]
+        resolved, unresolved = git_ops._auto_resolve_state_conflicts()
+        assert resolved == [".squidsquad/.backlog-cache"]
+        # ls-files + 1 checkout + 1 add — not 2 of each
+        assert mock_run_list.call_count == 3
+
+    @patch("git_ops._run_list")
+    def test_checkout_failure_falls_to_unresolved(self, mock_run_list):
+        """If checkout --theirs fails, the path lands in unresolved (no silent loss)."""
+        mock_run_list.side_effect = [
+            _mock_result(returncode=0, stdout=_ls_files_output(".squidsquad/state.json")),
+            _mock_result(returncode=1),  # checkout failed
+            _mock_result(returncode=0),  # add (irrelevant after checkout failure, but called)
+        ]
+        resolved, unresolved = git_ops._auto_resolve_state_conflicts()
+        assert resolved == []
+        assert unresolved == [".squidsquad/state.json"]
+
+
+class TestTaskBeginConflictHandling:
+    """#8653: task_begin auto-resolves state conflicts and bails on code conflicts."""
+
+    @patch("git_ops._get_working_branch", return_value="main")
+    @patch("git_ops._safe_checkout", return_value=True)
+    @patch("git_ops._run_list")
+    @patch("git_ops._auto_resolve_state_conflicts")
+    def test_auto_resolves_state_then_proceeds(
+        self, mock_resolve, mock_run_list, mock_checkout, mock_gwb, capsys
+    ):
+        """State files were unmerged; task_begin reports and continues."""
+        mock_resolve.return_value = ([".squidsquad/.backlog-cache"], [])
+        mock_run_list.return_value = _mock_result(returncode=0)  # local rev-parse ok
+        with patch.dict("sys.modules", {"config": MagicMock()}), \
+             patch("config.get_field", side_effect=_task_begin_config):
+            git_ops.task_begin("skill", "100")
+        out = capsys.readouterr().out
+        assert "auto-resolved" in out
+        assert ".squidsquad/.backlog-cache" in out
+        mock_checkout.assert_called_once()
+
+    @patch("git_ops._get_working_branch", return_value="main")
+    @patch("git_ops._run_list")
+    @patch("git_ops._auto_resolve_state_conflicts")
+    def test_bails_when_code_conflict_present(
+        self, mock_resolve, mock_run_list, mock_gwb, capsys
+    ):
+        """Code conflicts cause task_begin to exit(1) with a clear message."""
+        mock_resolve.return_value = ([], ["references/scripts/harness.py"])
+        with patch.dict("sys.modules", {"config": MagicMock()}), \
+             patch("config.get_field", side_effect=_task_begin_config):
+            with pytest.raises(SystemExit) as exc:
+                git_ops.task_begin("skill", "100")
+            assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "unresolved conflicts" in err
+        assert "references/scripts/harness.py" in err
+        # Should not have attempted any git operations beyond the resolve probe
+        mock_run_list.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `_auto_resolve_state_conflicts()` to `git_ops.py` (#8653 (https://github.com/WallyDoodlez/SquidSquad/issues/8653))
- Called at start of `task_begin`: unmerged files under `.squidsquad/` or `.claude/` are auto-resolved with `git checkout --theirs` + `git add` (runtime state — next cycle rewrites them)
- Non-state code conflicts cause `task_begin` to exit(1) with a clear message instead of falling into an opaque `git checkout` failure

## Background
When `cycle_pre.py`'s pull leaves unresolved conflicts in ephemeral state files (commonly `.squidsquad/.backlog-cache`, `.squidsquad/.event-state.json`), `task_begin`'s downstream `git checkout` fails. The agent then hits a wall every cycle until a human intervenes. This change handles the common case (state file conflicts) silently and surfaces the rare case (real code conflicts) clearly.

## Test plan
- [x] `TestAutoResolveStateConflicts` (7 tests): no-unmerged, .squidsquad/ resolution, .claude/ resolution, code-file-left-alone, mixed state+code, multi-stage dedup, checkout-failure-falls-to-unresolved
- [x] `TestTaskBeginConflictHandling` (2 tests): state auto-resolved + task_begin proceeds; code conflict fails fast with exit(1)
- [x] Existing `TestTaskBegin` (6 tests) updated to patch the new helper
- [x] All 93 non-pre-existing tests in `test_git_ops.py` pass