### PR TITLE
skill: fix #8691 — cycle_post commit scoped to role-owned files, foreign files left behind with warning

### DIFF
--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -398,12 +398,14 @@ def _do_commit_push(data, role):
         if current_branch != working:
             _run(["git", "checkout", working], check=False)
 
-        _run_script("git_ops.py", "commit-push", role, commit_msg)
+        # #8691: scope commit to QA's domain so foreign uncommitted files
+        # (other agents' work in the same clone) don't get bundled in.
+        _run_script("git_ops.py", "commit-role-scoped", role, commit_msg)
         print(f"  Committed and pushed (QA → main)")
 
     else:
-        # Default: commit-push on current branch (main)
-        _run_script("git_ops.py", "commit-push", role, commit_msg)
+        # #8691: PM/DM/other roles also commit only their own domain.
+        _run_script("git_ops.py", "commit-role-scoped", role, commit_msg)
         print(f"  Committed and pushed")
 
     # Commit state files to state branch if worktree exists (#3664)

--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -520,6 +520,95 @@ def commit_code(role, branch, message):
     return True
 
 
+def _role_owned_patterns(role):
+    """Path patterns this role is allowed to stage in its cycle commit (#8691).
+
+    Patterns ending in '/' match by prefix; bare paths match exactly. The
+    skill role is intentionally absent — skill's code/tests go through the
+    branch+PR workflow via commit_code, and its state files go through
+    commit_state (which is broader, allowing cross-role CLAUDE.md updates
+    from compose.py deploy).
+    """
+    common = [
+        f".squidsquad/{role}/",
+        ".squidsquad/.backlog-cache",
+        ".squidsquad/.event-state.json",
+        ".squidsquad/vault/",
+    ]
+    role_specific = {
+        "pm": [".squidsquad/config.md", ".squidsquad/project/"],
+        "dm": ["README.md", "CHANGELOG.md", "docs/"],
+        # qa: nothing beyond common
+    }
+    return common + role_specific.get(role, [])
+
+
+def _path_matches(path, patterns):
+    """True if `path` matches any pattern. '/' suffix → prefix match; else exact."""
+    for pat in patterns:
+        if pat.endswith("/"):
+            if path.startswith(pat):
+                return True
+        elif path == pat:
+            return True
+    return False
+
+
+def commit_role_scoped(role, message):
+    """Stage and commit only files in the role's commit domain (#8691).
+
+    A single clone can have multiple agents and parallel processes writing
+    files. A naive `git add -A` (the old commit_push path) bundles whatever
+    happens to be uncommitted into the role's commit — even foreign code
+    files or other roles' state. This pollutes the audit trail.
+
+    This function uses an explicit per-role allowlist (see
+    `_role_owned_patterns`). Foreign files are left in the working tree and
+    surfaced as a stderr warning so the investigator can route them.
+
+    Returns True if a commit (and push) succeeded, False otherwise.
+    """
+    result = _run("git status --porcelain", check=False)
+    if not result.stdout.strip():
+        print("Nothing to commit")
+        return False
+
+    lines = [l for l in result.stdout.splitlines() if l.strip()]
+    own_files = []
+    foreign_files = []
+    patterns = _role_owned_patterns(role)
+    for line in lines:
+        path = line[3:].strip().strip('"')
+        if " -> " in path:
+            path = path.split(" -> ")[1]
+        if _path_matches(path, patterns):
+            own_files.append(path)
+        else:
+            foreign_files.append(path)
+
+    if foreign_files:
+        print(
+            f"WARNING: cycle commit skipped {len(foreign_files)} file(s) outside "
+            f"'{role}' domain (left in working tree for the owning role to handle):",
+            file=sys.stderr,
+        )
+        for f in foreign_files[:20]:
+            print(f"  {f}", file=sys.stderr)
+        if len(foreign_files) > 20:
+            print(f"  ... and {len(foreign_files) - 20} more", file=sys.stderr)
+
+    if not own_files:
+        print("No role-domain changes to commit")
+        return False
+
+    for f in own_files:
+        _run_list(["git", "add", "--", f], check=False)
+
+    if not commit(role, message):
+        return False
+    return push(role=role)
+
+
 def commit_state(role, message):
     """Stage and commit only .squidsquad/ files to the working branch.
 
@@ -789,6 +878,11 @@ def main():
             print("Usage: git_ops.py commit-state <role> <message>", file=sys.stderr)
             sys.exit(1)
         commit_state(rest[0], " ".join(rest[1:]))
+    elif cmd == "commit-role-scoped":
+        if len(rest) < 2:
+            print("Usage: git_ops.py commit-role-scoped <role> <message>", file=sys.stderr)
+            sys.exit(1)
+        commit_role_scoped(rest[0], " ".join(rest[1:]))
     elif cmd == "branch-exists":
         if not rest:
             print("Usage: git_ops.py branch-exists <name>", file=sys.stderr)

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -621,6 +621,183 @@ class TestCommitState:
 
 
 # ---------------------------------------------------------------------------
+# commit_role_scoped() — #8691
+# ---------------------------------------------------------------------------
+
+
+class TestRoleOwnedPatterns:
+    """Per-role commit-domain allowlists."""
+
+    def test_common_patterns_present_for_every_role(self):
+        for role in ("pm", "qa", "dm", "skill"):
+            pats = git_ops._role_owned_patterns(role)
+            assert f".squidsquad/{role}/" in pats
+            assert ".squidsquad/.backlog-cache" in pats
+            assert ".squidsquad/.event-state.json" in pats
+            assert ".squidsquad/vault/" in pats
+
+    def test_pm_extras(self):
+        pats = git_ops._role_owned_patterns("pm")
+        assert ".squidsquad/config.md" in pats
+        assert ".squidsquad/project/" in pats
+
+    def test_dm_extras(self):
+        pats = git_ops._role_owned_patterns("dm")
+        assert "README.md" in pats
+        assert "CHANGELOG.md" in pats
+        assert "docs/" in pats
+
+    def test_qa_has_no_extras_beyond_common(self):
+        pats = git_ops._role_owned_patterns("qa")
+        # QA must NOT pick up config or delivery docs
+        assert ".squidsquad/config.md" not in pats
+        assert "README.md" not in pats
+
+
+class TestPathMatches:
+    def test_prefix_match(self):
+        assert git_ops._path_matches(".squidsquad/pm/working-state.md", [".squidsquad/pm/"])
+        assert git_ops._path_matches("docs/foo/bar.md", ["docs/"])
+
+    def test_exact_match(self):
+        assert git_ops._path_matches("README.md", ["README.md"])
+        assert not git_ops._path_matches("README.md.bak", ["README.md"])
+
+    def test_no_match(self):
+        assert not git_ops._path_matches("references/scripts/foo.py", [".squidsquad/pm/"])
+
+
+class TestCommitRoleScoped:
+    """#8691: cycle commits must not bundle foreign files."""
+
+    @patch("git_ops.push", return_value=True)
+    @patch("git_ops.commit", return_value=True)
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_pm_stages_only_own_files_skips_foreign(
+        self, mock_run, mock_run_list, mock_commit, mock_push, capsys
+    ):
+        """The exact scenario from the bug report: PM commit + foreign code/tests."""
+        mock_run.return_value = _mock_result(stdout=(
+            " M .squidsquad/pm/working-state.md\n"
+            " M .squidsquad/.backlog-cache\n"
+            " M .squidsquad/skill/CLAUDE.md\n"
+            " M references/scripts/thin_launcher.py\n"
+            " M tests/test_thin_launcher.py\n"
+        ))
+        mock_run_list.return_value = _mock_result()
+
+        result = git_ops.commit_role_scoped("pm", "cycle 1494")
+        assert result is True
+
+        add_calls = [c for c in mock_run_list.call_args_list
+                     if c[0][0][:2] == ["git", "add"]]
+        staged = [c[0][0][-1] for c in add_calls]
+        assert ".squidsquad/pm/working-state.md" in staged
+        assert ".squidsquad/.backlog-cache" in staged
+        assert ".squidsquad/skill/CLAUDE.md" not in staged
+        assert "references/scripts/thin_launcher.py" not in staged
+        assert "tests/test_thin_launcher.py" not in staged
+
+        err = capsys.readouterr().err
+        assert "outside 'pm' domain" in err
+        assert "references/scripts/thin_launcher.py" in err
+        assert ".squidsquad/skill/CLAUDE.md" in err
+
+    @patch("git_ops.push", return_value=True)
+    @patch("git_ops.commit", return_value=True)
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_dm_can_stage_readme_and_changelog(
+        self, mock_run, mock_run_list, mock_commit, mock_push
+    ):
+        mock_run.return_value = _mock_result(stdout=(
+            " M README.md\n"
+            " M CHANGELOG.md\n"
+            " M docs/release-notes.md\n"
+            " M .squidsquad/dm/working-state.md\n"
+        ))
+        mock_run_list.return_value = _mock_result()
+
+        result = git_ops.commit_role_scoped("dm", "delivery cycle")
+        assert result is True
+
+        staged = [c[0][0][-1] for c in mock_run_list.call_args_list
+                  if c[0][0][:2] == ["git", "add"]]
+        assert "README.md" in staged
+        assert "CHANGELOG.md" in staged
+        assert "docs/release-notes.md" in staged
+        assert ".squidsquad/dm/working-state.md" in staged
+
+    @patch("git_ops.commit", return_value=True)
+    @patch("git_ops.push", return_value=True)
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_qa_cannot_stage_config_md(
+        self, mock_run, mock_run_list, mock_push, mock_commit, capsys
+    ):
+        """QA must not pick up PM-domain config.md changes."""
+        mock_run.return_value = _mock_result(stdout=(
+            " M .squidsquad/qa/working-state.md\n"
+            " M .squidsquad/config.md\n"
+        ))
+        mock_run_list.return_value = _mock_result()
+
+        git_ops.commit_role_scoped("qa", "qa cycle")
+
+        staged = [c[0][0][-1] for c in mock_run_list.call_args_list
+                  if c[0][0][:2] == ["git", "add"]]
+        assert ".squidsquad/qa/working-state.md" in staged
+        assert ".squidsquad/config.md" not in staged
+        assert ".squidsquad/config.md" in capsys.readouterr().err
+
+    @patch("git_ops._run")
+    def test_returns_false_when_no_own_files(self, mock_run, capsys):
+        """Only foreign files → nothing to commit, push not attempted."""
+        mock_run.return_value = _mock_result(stdout=" M references/scripts/foo.py\n")
+        with patch("git_ops.commit") as mock_commit, \
+             patch("git_ops.push") as mock_push:
+            result = git_ops.commit_role_scoped("pm", "msg")
+        assert result is False
+        mock_commit.assert_not_called()
+        mock_push.assert_not_called()
+
+    @patch("git_ops._run")
+    def test_empty_status_returns_false(self, mock_run):
+        mock_run.return_value = _mock_result(stdout="")
+        assert git_ops.commit_role_scoped("pm", "msg") is False
+
+    @patch("git_ops.push", return_value=True)
+    @patch("git_ops.commit", return_value=False)
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_commit_failure_short_circuits_push(
+        self, mock_run, mock_run_list, mock_commit, mock_push
+    ):
+        mock_run.return_value = _mock_result(stdout=" M .squidsquad/pm/foo.md\n")
+        mock_run_list.return_value = _mock_result()
+        assert git_ops.commit_role_scoped("pm", "msg") is False
+        mock_push.assert_not_called()
+
+    @patch("git_ops.push", return_value=True)
+    @patch("git_ops.commit", return_value=True)
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_warning_truncates_long_foreign_list(
+        self, mock_run, mock_run_list, mock_commit, mock_push, capsys
+    ):
+        # 25 foreign files; warning should mention "... and 5 more"
+        lines = [" M .squidsquad/pm/own.md"]
+        lines += [f" M references/scripts/foreign_{i}.py" for i in range(25)]
+        mock_run.return_value = _mock_result(stdout="\n".join(lines) + "\n")
+        mock_run_list.return_value = _mock_result()
+
+        git_ops.commit_role_scoped("pm", "msg")
+        err = capsys.readouterr().err
+        assert "and 5 more" in err
+
+
+# ---------------------------------------------------------------------------
 # branch_exists() / branch_delete() / current_branch()
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Fixes ​#8691 (https://github.com/WallyDoodlez/SquidSquad/issues/8691). When two agents (or a parallel script like `compose.py`) run in the same clone, the first one to reach `cycle_post` was bundling everyone else's uncommitted work into its commit via the broad `git add -A` path in `commit_push`. The bug report cites a PM cycle commit that included 4 role CLAUDE.md files and a code change to `thin_launcher.py` — none of which were PM's work.

## Changes
- `references/scripts/git_ops.py`:
  - New `_role_owned_patterns(role)` — per-role commit-domain allowlist:
    - common: `.squidsquad/<role>/`, `.squidsquad/.backlog-cache`, `.squidsquad/.event-state.json`, `.squidsquad/vault/`
    - PM extras: `.squidsquad/config.md`, `.squidsquad/project/`
    - DM extras: `README.md`, `CHANGELOG.md`, `docs/`
    - QA: common only (cannot stage config or delivery docs)
  - New `_path_matches(path, patterns)` — prefix/exact match helper
  - New `commit_role_scoped(role, message)` — stages only role-domain files, leaves foreign files in working tree, prints a stderr WARNING listing them (truncated at 20 with `... and N more`). Returns False if no role-domain changes (push not attempted).
  - New CLI subcommand: `git_ops.py commit-role-scoped <role> <message>`
- `references/scripts/cycle_post.py`:
  - QA and the default (PM/DM/other) branches now invoke `commit-role-scoped` instead of `commit-push`. Skill's flow (commit-code + commit-state) is unchanged — skill still uses the broader `commit_state` because compose.py legitimately produces cross-role state.

## Verification
- 14 new tests (`TestRoleOwnedPatterns` x4, `TestPathMatches` x3, `TestCommitRoleScoped` x7), including a direct simulation of the bug-report scenario (PM commit with foreign skill CLAUDE.md + thin_launcher.py + tests). All 14 pass.
- Full git_ops + cycle_post suite: 175 passed (1 pre-existing volatile-file tracking failure, unrelated)

## Test plan
- [x] `python -m pytest tests/test_git_ops.py::TestCommitRoleScoped` — 7 passed
- [x] `python -m pytest tests/test_git_ops.py::TestRoleOwnedPatterns tests/test_git_ops.py::TestPathMatches` — 7 passed
- [x] `python -m pytest tests/test_git_ops.py tests/test_cycle_post.py` — 175 passed
- [x] Bug-report scenario directly tested: PM commit with foreign skill state + foreign code → only PM's own files staged, foreign files surfaced as stderr warning