### PR TITLE
skill: fix #8689 — harness restart kills idle agents immediately instead of waiting for next /loop tick

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -1275,7 +1275,9 @@ async def stop_agent(role: str):
 
 @app.post("/agents/{role}/restart")
 async def restart_agent(role: str):
-    """Graceful restart — set intent=restarting (#4966). Harness reboots on death."""
+    """Restart agent. If idle, kill immediately and let auto-reboot fire (#8689).
+    If mid-cycle, just set intent=restarting and let the agent exit cleanly at
+    its next cycle boundary (#4966 graceful-restart behavior preserved)."""
     _validate_role(role)
 
     _log(f"Restarting {role}...")
@@ -1289,18 +1291,58 @@ async def restart_agent(role: str):
 
     # Remove .stop sentinel if present (allow re-start after previous stop)
     clone_path = boot_remote._get_clone_path(role)
-    stop_file = Path(clone_path) / ".squidsquad" / role / ".stop"
+    clone_path_p = Path(clone_path)
+    stop_file = clone_path_p / ".squidsquad" / role / ".stop"
     try:
         stop_file.unlink(missing_ok=True)
     except OSError:
         pass
 
-    _log(f"  {role}: restart requested (intent=restarting)")
+    # #8689: if the agent is idle between cycles, kill the claude process
+    # right now so the auto-reboot path (running periodic health-poll already
+    # watches for is_dead + intent=restarting) fires within seconds instead
+    # of waiting up to a full /loop interval (e.g. 30 minutes). For active
+    # cycles, fall back to the graceful queued behavior.
+    current_state = ""
+    state_file = clone_path_p / ".squidsquad" / role / "current-state"
+    try:
+        current_state = state_file.read_text(encoding="utf-8").strip()
+    except (FileNotFoundError, OSError):
+        pass
 
+    immediate = current_state.startswith("idle")
+    killed_pid = None
+    if immediate:
+        claude_pid, alive = reboot_agent._read_claude_pid(clone_path_p, role)
+        if alive and claude_pid:
+            _log(f"  {role}: idle — killing PID {claude_pid} for immediate reboot")
+            try:
+                reboot_agent._kill_process(claude_pid)
+                killed_pid = claude_pid
+            except Exception as e:
+                _log(f"  {role}: WARNING — kill failed: {e}")
+                immediate = False
+        else:
+            # Already dead — the auto-reboot loop will pick it up next tick.
+            immediate = False
+
+    if immediate:
+        _log(f"  {role}: restart requested (idle path — killed PID {killed_pid})")
+        return {
+            "role": role,
+            "action": "restart",
+            "success": True,
+            "immediate": True,
+            "killed_pid": killed_pid,
+            "message": "Restart requested — agent was idle, killed and will be auto-rebooted",
+        }
+
+    _log(f"  {role}: restart requested (intent=restarting)")
     return {
         "role": role,
         "action": "restart",
         "success": True,
+        "immediate": False,
         "message": "Restart requested — agent will exit after current cycle and reboot",
     }
 

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -495,6 +495,114 @@ class TestEndpointsViaTestClient(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertIn("results", resp.json())
 
+    # #8689 — idle agents should be killed immediately on restart, not wait for
+    # the next /loop tick (potentially 30+ minutes).
+    def test_restart_kills_immediately_when_idle(self):
+        """Idle current-state → restart kills the claude PID and reports immediate=True."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            role_dir = Path(tmpdir) / ".squidsquad" / "skill"
+            role_dir.mkdir(parents=True)
+            (role_dir / "current-state").write_text("idle|", encoding="utf-8")
+            killed = []
+
+            def _fake_kill(pid):
+                killed.append(pid)
+
+            with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+                 patch("harness.boot_remote._get_clone_path", return_value=tmpdir), \
+                 patch("harness.reboot_agent._read_claude_pid", return_value=(12345, True)), \
+                 patch("harness.reboot_agent._kill_process", side_effect=_fake_kill):
+                resp = self.client.post("/agents/skill/restart")
+            self.assertEqual(resp.status_code, 200)
+            data = resp.json()
+            self.assertTrue(data["success"])
+            self.assertTrue(data["immediate"])
+            self.assertEqual(data["killed_pid"], 12345)
+            self.assertEqual(killed, [12345])
+
+    def test_restart_falls_back_to_queued_when_busy(self):
+        """Non-idle current-state → restart only sets intent, no kill."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            role_dir = Path(tmpdir) / ".squidsquad" / "skill"
+            role_dir.mkdir(parents=True)
+            (role_dir / "current-state").write_text(
+                "implementing|dev-agent — 🔨 #999...", encoding="utf-8"
+            )
+            with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+                 patch("harness.boot_remote._get_clone_path", return_value=tmpdir), \
+                 patch("harness.reboot_agent._read_claude_pid", return_value=(12345, True)), \
+                 patch("harness.reboot_agent._kill_process") as mock_kill:
+                resp = self.client.post("/agents/skill/restart")
+            self.assertEqual(resp.status_code, 200)
+            data = resp.json()
+            self.assertTrue(data["success"])
+            self.assertFalse(data["immediate"])
+            mock_kill.assert_not_called()
+
+    def test_restart_queued_when_idle_but_no_claude_pid(self):
+        """Idle but no live claude PID → fall back to queued (auto-reboot loop handles it)."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            role_dir = Path(tmpdir) / ".squidsquad" / "skill"
+            role_dir.mkdir(parents=True)
+            (role_dir / "current-state").write_text("idle|", encoding="utf-8")
+            with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+                 patch("harness.boot_remote._get_clone_path", return_value=tmpdir), \
+                 patch("harness.reboot_agent._read_claude_pid", return_value=(None, False)), \
+                 patch("harness.reboot_agent._kill_process") as mock_kill:
+                resp = self.client.post("/agents/skill/restart")
+            self.assertEqual(resp.status_code, 200)
+            self.assertFalse(resp.json()["immediate"])
+            mock_kill.assert_not_called()
+
+    def test_restart_queued_when_no_current_state_file(self):
+        """Missing current-state file → safe default is queued restart."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            role_dir = Path(tmpdir) / ".squidsquad" / "skill"
+            role_dir.mkdir(parents=True)
+            with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+                 patch("harness.boot_remote._get_clone_path", return_value=tmpdir), \
+                 patch("harness.reboot_agent._kill_process") as mock_kill:
+                resp = self.client.post("/agents/skill/restart")
+            self.assertEqual(resp.status_code, 200)
+            self.assertFalse(resp.json()["immediate"])
+            mock_kill.assert_not_called()
+
+    def test_restart_still_sets_intent_on_immediate_path(self):
+        """Immediate kill path must still set intent=restarting so auto-reboot fires."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            role_dir = Path(tmpdir) / ".squidsquad" / "skill"
+            role_dir.mkdir(parents=True)
+            (role_dir / "current-state").write_text("idle|", encoding="utf-8")
+            with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+                 patch("harness.boot_remote._get_clone_path", return_value=tmpdir), \
+                 patch("harness.reboot_agent._read_claude_pid", return_value=(12345, True)), \
+                 patch("harness.reboot_agent._kill_process"):
+                resp = self.client.post("/agents/skill/restart")
+            self.assertEqual(resp.status_code, 200)
+            from harness import state as harness_state, AgentState
+            agent = harness_state.get_agent("skill")
+            self.assertEqual(agent.intent, AgentState.INTENT_RESTARTING)
+
+    def test_restart_kill_failure_falls_back_to_queued(self):
+        """If kill raises, response reports immediate=False (queued fallback)."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            role_dir = Path(tmpdir) / ".squidsquad" / "skill"
+            role_dir.mkdir(parents=True)
+            (role_dir / "current-state").write_text("idle|", encoding="utf-8")
+            with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+                 patch("harness.boot_remote._get_clone_path", return_value=tmpdir), \
+                 patch("harness.reboot_agent._read_claude_pid", return_value=(12345, True)), \
+                 patch("harness.reboot_agent._kill_process", side_effect=OSError("denied")):
+                resp = self.client.post("/agents/skill/restart")
+            self.assertEqual(resp.status_code, 200)
+            self.assertFalse(resp.json()["immediate"])
+
 
 # ---------------------------------------------------------------------------
 # Intent-based lifecycle — regression #4949


### PR DESCRIPTION
## Summary
Fixes ​#8689 (https://github.com/WallyDoodlez/SquidSquad/issues/8689). `POST /agents/{role}/restart` previously only set `intent=restarting` and waited for the agent to read it at its next `cycle_post`. If the agent was idle between cycles (sleeping on /loop), the operator-visible latency to actually reboot could be up to a full /loop interval — typically 30 minutes — which contradicts the endpoint name.

## Changes
- `references/scripts/harness.py` `restart_agent` endpoint:
  - Still sets `intent=restarting` first (preserves the existing graceful path; the auto-reboot watcher at `harness.py:247–258` already triggers reboots on `is_dead + intent ∈ {RUNNING, RESTARTING}`).
  - Reads `.squidsquad/<role>/current-state`. If it starts with `idle`, calls `reboot_agent._kill_process(claude_pid)` immediately. The existing health-poll loop then detects the death within seconds and respawns via the standard auto-reboot path.
  - If the agent is mid-cycle (state is `triaging|`, `implementing|`, etc.), or the file is missing, or the PID is already dead, or the kill raises — falls back to the original queued behavior. No mid-cycle work is interrupted.
  - Response now includes `immediate: bool` and (on the kill path) `killed_pid` so operators can see which path was taken.

## Verification
- 6 new endpoint tests covering: idle-kill happy path; busy → queued; idle but no claude PID → queued; missing current-state → queued; intent still set on kill path; kill-failure → graceful fallback. All pass alongside the 2 pre-existing restart tests (17/17 in `TestEndpointsViaTestClient`).
- No behavior change for mid-cycle agents.

## Test plan
- [x] `python -m pytest tests/test_harness.py::TestEndpointsViaTestClient` — 17 passed
- [x] Manual: write `idle|` to `current-state`, hit `POST /agents/skill/restart` → response has `immediate: true, killed_pid: <pid>`; agent gets auto-rebooted within a few seconds rather than waiting for /loop