### PR TITLE
skill: feat #8694 — harness dispatches next work on tracker handoff (no /complete API)

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -1065,6 +1065,12 @@ async def receive_event(request: Request):
     # Store in stream (with disk persistence via lifecycle manager)
     event_lifecycle.append(body)
 
+    # Tracker handoff dispatch (#8694): when an agent transitions a tracker
+    # item, re-evaluate affected role queues and emit assigned-to for the new
+    # top item — no /loop polling delay between consecutive work items.
+    if event_type == "status-transition":
+        handoff_dispatcher.on_transition(body.get("payload", {}), role)
+
     # Ack processing (#7630 2-2): if event is an ack, process the lifecycle closure
     if event_type == "ack":
         ack_event_id = body.get("payload", {}).get("event_id")
@@ -1880,6 +1886,114 @@ class ExternalActivityDetector:
 
 # Global detector instance
 activity_detector = ExternalActivityDetector()
+
+
+class TrackerHandoffDispatcher:
+    """Dispatches assigned-to events on tracker transitions (#8694).
+
+    Hook: `POST /events` calls `on_transition()` for every `status-transition`
+    event received. We re-evaluate the affected role queue(s) and emit an
+    `assigned-to` event for the new top item, with per-role dedup so the same
+    queue-head isn't re-emitted repeatedly.
+
+    No /complete API — the transition IS the completion signal.
+    """
+
+    AGENT_ROLES = ExternalActivityDetector.AGENT_ROLES
+
+    def __init__(self):
+        # Per-role last-emitted top issue number (None = no item known)
+        self._last_top: dict[str, int | None] = {}
+        self._lock = threading.Lock()
+
+    def on_transition(self, payload, actor_role):
+        """Called from POST /events for each status-transition event.
+
+        Runs the actual GitHub-poking work in a background thread so the
+        HTTP handler doesn't block on `gh` subprocess calls.
+        """
+        thread = threading.Thread(
+            target=self._do_dispatch,
+            args=(payload or {}, actor_role),
+            daemon=True,
+            name="handoff-dispatch",
+        )
+        thread.start()
+
+    def _do_dispatch(self, payload, actor_role):
+        try:
+            roles_to_check = set()
+            if actor_role and actor_role in self.AGENT_ROLES:
+                roles_to_check.add(actor_role)
+            issue_num = payload.get("issue_number")
+            if issue_num:
+                issue_role = self._get_issue_role(issue_num)
+                if issue_role and issue_role in self.AGENT_ROLES:
+                    roles_to_check.add(issue_role)
+            for role in roles_to_check:
+                self._dispatch_next(role)
+        except Exception as e:
+            _log(f"Handoff dispatcher error: {e}")
+
+    def _dispatch_next(self, role):
+        """Compute role's current top item and emit assigned-to if it changed."""
+        queue = self._get_work_queue(role)
+        if not queue:
+            with self._lock:
+                self._last_top[role] = None
+            return
+        top = queue[0]
+        issue_num = top.get("number")
+        with self._lock:
+            if self._last_top.get(role) == issue_num:
+                return  # queue head unchanged — no-op
+            self._last_top[role] = issue_num
+
+        _emit_event("assigned-to", "harness", payload={
+            "issue_number": str(issue_num),
+            "title": top.get("title", ""),
+            "target_role": role,
+            "event_context": f"Next work for {role} after tracker handoff",
+        })
+        # Also tell the external poller it doesn't need to re-emit this one.
+        activity_detector._emitted_issues[issue_num] = None
+
+    def _get_work_queue(self, role):
+        """Return tracker.py work-queue output as a list of dicts."""
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_DIR / "tracker.py"), "work-queue", role],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            check=False, cwd=str(REPO_ROOT),
+        )
+        if result.returncode != 0:
+            return []
+        try:
+            return json.loads(result.stdout) or []
+        except json.JSONDecodeError:
+            return []
+
+    def _get_issue_role(self, issue_num):
+        """Return the role label on an issue (e.g. 'skill'), or None."""
+        result = subprocess.run(
+            ["gh", "issue", "view", str(issue_num), "--json", "labels"],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            check=False, cwd=str(REPO_ROOT),
+        )
+        if result.returncode != 0:
+            return None
+        try:
+            data = json.loads(result.stdout) or {}
+            for lbl in data.get("labels", []):
+                name = lbl.get("name", "")
+                if name.startswith("role:"):
+                    return name[len("role:"):]
+        except json.JSONDecodeError:
+            pass
+        return None
+
+
+# Global dispatcher instance
+handoff_dispatcher = TrackerHandoffDispatcher()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1358,5 +1358,144 @@ class TestCompleteEventEndpoint(unittest.TestCase):
         self.assertEqual(resp.status_code, 400)
 
 
+# ---------------------------------------------------------------------------
+# TrackerHandoffDispatcher — #8694
+# ---------------------------------------------------------------------------
+
+class TestTrackerHandoffDispatcher(unittest.TestCase):
+    """#8694: harness emits assigned-to on tracker transitions, no /complete API."""
+
+    def setUp(self):
+        from harness import TrackerHandoffDispatcher
+        self.dispatcher = TrackerHandoffDispatcher()
+
+    def test_dispatches_for_actor_role(self):
+        """Actor role's transition → re-evaluates that role's queue."""
+        from harness import activity_detector
+        activity_detector._emitted_issues.clear()
+        with patch.object(self.dispatcher, "_get_work_queue",
+                          return_value=[{"number": 42, "title": "next task"}]), \
+             patch.object(self.dispatcher, "_get_issue_role", return_value=None), \
+             patch("harness._emit_event") as mock_emit:
+            self.dispatcher._do_dispatch(
+                {"issue_number": "10", "from": "in-progress", "to": "pending-test"},
+                actor_role="skill",
+            )
+        mock_emit.assert_called_once()
+        args, kwargs = mock_emit.call_args
+        self.assertEqual(args[0], "assigned-to")
+        self.assertEqual(args[1], "harness")
+        self.assertEqual(kwargs["payload"]["target_role"], "skill")
+        self.assertEqual(kwargs["payload"]["issue_number"], "42")
+
+    def test_skips_non_agent_actor(self):
+        """Transition from a non-agent role (e.g. external) → no dispatch."""
+        with patch.object(self.dispatcher, "_get_work_queue") as mock_queue, \
+             patch.object(self.dispatcher, "_get_issue_role", return_value=None), \
+             patch("harness._emit_event") as mock_emit:
+            self.dispatcher._do_dispatch({"issue_number": "10"}, actor_role="external")
+        mock_queue.assert_not_called()
+        mock_emit.assert_not_called()
+
+    def test_dispatches_for_issue_role_if_different(self):
+        """Re-evaluate the queue for the issue's role label too, not just actor."""
+        with patch.object(self.dispatcher, "_get_work_queue",
+                          return_value=[{"number": 7, "title": "verify"}]) as mock_queue, \
+             patch.object(self.dispatcher, "_get_issue_role", return_value="qa"), \
+             patch("harness._emit_event"):
+            self.dispatcher._do_dispatch({"issue_number": "10"}, actor_role="pm")
+        called_roles = {c[0][0] for c in mock_queue.call_args_list}
+        self.assertEqual(called_roles, {"pm", "qa"})
+
+    def test_dedup_skips_same_top_twice(self):
+        """Same queue head on two consecutive transitions → emit once."""
+        from harness import activity_detector
+        activity_detector._emitted_issues.clear()
+        with patch.object(self.dispatcher, "_get_work_queue",
+                          return_value=[{"number": 42, "title": "same"}]), \
+             patch.object(self.dispatcher, "_get_issue_role", return_value=None), \
+             patch("harness._emit_event") as mock_emit:
+            self.dispatcher._do_dispatch({"issue_number": "10"}, actor_role="skill")
+            self.dispatcher._do_dispatch({"issue_number": "11"}, actor_role="skill")
+        self.assertEqual(mock_emit.call_count, 1)
+
+    def test_empty_queue_clears_last_top_and_emits_nothing(self):
+        """No items for role → no assigned-to event, last_top cleared."""
+        self.dispatcher._last_top["skill"] = 99
+        with patch.object(self.dispatcher, "_get_work_queue", return_value=[]), \
+             patch.object(self.dispatcher, "_get_issue_role", return_value=None), \
+             patch("harness._emit_event") as mock_emit:
+            self.dispatcher._do_dispatch({"issue_number": "10"}, actor_role="skill")
+        mock_emit.assert_not_called()
+        self.assertIsNone(self.dispatcher._last_top.get("skill"))
+
+    def test_different_top_after_dedup_re_emits(self):
+        """After top changes, the new top is emitted."""
+        from harness import activity_detector
+        activity_detector._emitted_issues.clear()
+        with patch.object(self.dispatcher, "_get_issue_role", return_value=None), \
+             patch("harness._emit_event") as mock_emit:
+            with patch.object(self.dispatcher, "_get_work_queue",
+                              return_value=[{"number": 42, "title": "A"}]):
+                self.dispatcher._do_dispatch({"issue_number": "1"}, actor_role="skill")
+            with patch.object(self.dispatcher, "_get_work_queue",
+                              return_value=[{"number": 43, "title": "B"}]):
+                self.dispatcher._do_dispatch({"issue_number": "2"}, actor_role="skill")
+        self.assertEqual(mock_emit.call_count, 2)
+        _, kwargs = mock_emit.call_args_list[1]
+        self.assertEqual(kwargs["payload"]["issue_number"], "43")
+
+    def test_emission_marks_external_detector_dedup(self):
+        """Emitted issue is added to ExternalActivityDetector dedup."""
+        from harness import activity_detector
+        activity_detector._emitted_issues.clear()
+        with patch.object(self.dispatcher, "_get_work_queue",
+                          return_value=[{"number": 99, "title": "X"}]), \
+             patch.object(self.dispatcher, "_get_issue_role", return_value=None), \
+             patch("harness._emit_event"):
+            self.dispatcher._do_dispatch({"issue_number": "1"}, actor_role="skill")
+        self.assertIn(99, activity_detector._emitted_issues)
+
+    def test_on_transition_runs_in_background_thread(self):
+        """on_transition spawns a daemon thread — handler is non-blocking."""
+        with patch.object(self.dispatcher, "_do_dispatch") as mock_dispatch:
+            self.dispatcher.on_transition({"issue_number": "1"}, "skill")
+            import time as _t
+            _t.sleep(0.05)
+        mock_dispatch.assert_called_once()
+
+    def test_post_events_status_transition_triggers_dispatcher(self):
+        """POST /events with status-transition calls dispatcher.on_transition."""
+        from fastapi.testclient import TestClient
+        from harness import app
+        client = TestClient(app)
+        with patch("harness.handoff_dispatcher.on_transition") as mock_on:
+            resp = client.post("/events", json={
+                "event_type": "status-transition",
+                "role": "skill",
+                "payload": {"issue_number": "55", "from": "in-progress", "to": "pending-test"},
+                "timestamp": "2026-05-18T00:00:00",
+            })
+        self.assertEqual(resp.status_code, 200)
+        mock_on.assert_called_once()
+        args, _ = mock_on.call_args
+        self.assertEqual(args[0]["issue_number"], "55")
+        self.assertEqual(args[1], "skill")
+
+    def test_post_events_non_transition_skips_dispatcher(self):
+        """Non-status-transition events do NOT trigger the dispatcher."""
+        from fastapi.testclient import TestClient
+        from harness import app
+        client = TestClient(app)
+        with patch("harness.handoff_dispatcher.on_transition") as mock_on:
+            client.post("/events", json={
+                "event_type": "cycle-start",
+                "role": "skill",
+                "payload": {"cycle_number": 1},
+                "timestamp": "2026-05-18T00:00:00",
+            })
+        mock_on.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Implements #8694 (https://github.com/WallyDoodlez/SquidSquad/issues/8694). Phase 5 of event-driven architecture (#7630 (https://github.com/WallyDoodlez/SquidSquad/issues/7630)). The harness now observes `status-transition` events posted by agents and immediately re-evaluates affected role queues, emitting `assigned-to` for any new queue head. No /complete round-trip — the transition IS the completion signal.

## Changes
- `references/scripts/harness.py`:
  - New `TrackerHandoffDispatcher` class. On every `status-transition` event:
    - Re-evaluates the actor role's queue, and the queue of the issue's `role:` label if different.
    - Calls `tracker.py work-queue <role>` and emits `assigned-to` for the new top item.
    - Per-role dedup via `_last_top` — same queue head won't fire twice.
    - Cross-dedup with `ExternalActivityDetector._emitted_issues` to prevent the 60s poller from double-emitting an item the dispatcher already sent.
    - Runs in a daemon thread so the `POST /events` HTTP handler stays non-blocking.
  - `receive_event` calls `handoff_dispatcher.on_transition(payload, actor_role)` for `status-transition` events.

## How the acceptance criteria is met
> end-to-end: role X picks up A, transitions it, receives assigned-to for B within seconds (no /loop tick required)

When role X transitions issue A (in-progress → pending-test), its `cycle_post` already emits a `status-transition` event to `POST /events`. The new dispatcher hook reads role X's current work queue via `tracker.py work-queue skill`, finds the new top item B, and emits `assigned-to` immediately. Total latency: one `gh issue list` round-trip (~1–2s) vs. the previous 30-min /loop interval.

## Verification
- 10 new tests in `TestTrackerHandoffDispatcher` covering: actor-role dispatch, non-agent actor skip, dual dispatch when issue role ≠ actor, dedup of same head, empty-queue last_top reset, re-emit on changed head, cross-dedup with external detector, background-thread non-blocking, POST /events trigger, non-transition no-op.
- Existing endpoint and event-bus tests unchanged: `TestEndpointsViaTestClient` (17), `TestEventLifecycleManager` (6), `TestEventDrivenPhase4` (10) — all 33 pass.

## Test plan
- [x] `python -m pytest tests/test_harness.py::TestTrackerHandoffDispatcher` — 10 passed
- [x] `python -m pytest tests/test_harness.py::TestEndpointsViaTestClient tests/test_harness.py::TestEventLifecycleManager tests/test_harness.py::TestEventDrivenPhase4` — 33 passed (no regressions)
- [ ] End-to-end on a live harness: an agent transition produces a follow-on `assigned-to` event within seconds (recommended for QA)