### PR TITLE
skill: feat #8695 + #8694 review fixes — bootup-complete gating with DeepSeek findings addressed

### DIFF
--- a/references/scripts/event_bus.py
+++ b/references/scripts/event_bus.py
@@ -99,3 +99,19 @@ def ack(event_id, role):
     if not event_id:
         return
     emit("ack", role, payload={"event_id": event_id})
+
+
+def bootup_complete(role):
+    """Signal that the agent has finished initial boot (#8695).
+
+    Event-driven agents call this after: L1 init done, working-state.md read,
+    initial backlog scan complete, Monitor subscription active. Until the
+    harness sees this event, it returns no events from /events/for/<role> for
+    this role — preventing the race where an `assigned-to` arrives during boot
+    and is dropped because the agent isn't subscribed yet.
+
+    Fire-and-forget like emit(). Safe to call multiple times.
+    """
+    if not role:
+        return
+    emit("bootup-complete", role, payload={})

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -71,7 +71,7 @@ class AgentState:
     __slots__ = ("role", "status", "intent", "last_health_check", "boot_time",
                  "clone_path", "claude_pid", "terminal_pid",
                  "current_cycle", "current_phase", "last_cycle_start",
-                 "last_cycle_end", "last_cycle_type")
+                 "last_cycle_end", "last_cycle_type", "bootup_complete")
 
     # Intent values:
     #   "running"    — agent should be alive; auto-reboot on death (#4949)
@@ -98,6 +98,12 @@ class AgentState:
         self.last_cycle_start = None
         self.last_cycle_end = None
         self.last_cycle_type = None
+        # #8695: bootup-complete gating. False until the agent emits
+        # `bootup-complete`. While False, get_events_for_role returns no events
+        # so the harness never dispatches assigned-to / status-transition into
+        # a still-booting agent (events accumulate in the stream and drain on
+        # the agent's first poll after bootup-complete).
+        self.bootup_complete = False
 
     def to_dict(self):
         return {
@@ -114,6 +120,7 @@ class AgentState:
             "last_cycle_start": self.last_cycle_start,
             "last_cycle_end": self.last_cycle_end,
             "last_cycle_type": self.last_cycle_type,
+            "bootup_complete": self.bootup_complete,
         }
 
 
@@ -255,6 +262,9 @@ class HarnessState:
                     reboot_roles.append(role)
                     agent.status = "starting"
                     agent.claude_pid = None  # Clear stale PID
+                    # #8695: the replacement process needs to re-emit
+                    # bootup-complete before we'll dispatch events to it.
+                    agent.bootup_complete = False
                     state_changed = True
 
                 # Stopping intent fulfilled — agent died as requested (#4966)
@@ -322,6 +332,11 @@ class HarnessState:
                         "clone_path": a.clone_path,
                         "claude_pid": a.claude_pid,
                         "terminal_pid": a.terminal_pid,
+                        # #8695: must survive harness crash recovery — otherwise
+                        # already-running agents stay gated forever after a
+                        # harness restart, since boot_remote skips already-alive
+                        # agents and the agent has no way to know we restarted.
+                        "bootup_complete": a.bootup_complete,
                     }
                     for role, a in self.agents.items()
                 },
@@ -359,6 +374,9 @@ class HarnessState:
                 agent.boot_time = agent_data.get("boot_time")
                 agent.claude_pid = agent_data.get("claude_pid")
                 agent.terminal_pid = agent_data.get("terminal_pid")
+                # #8695: restore so already-running agents stay ungated after
+                # a harness restart. Defaults to False for older state files.
+                agent.bootup_complete = agent_data.get("bootup_complete", False)
 
         _log(f"Restored state for {len(state_data.get('agents', {}))} agents from state file")
 
@@ -899,6 +917,9 @@ async def start_agent(role: str):
         agent_state.intent = AgentState.INTENT_RUNNING
         agent_state.boot_time = time.time()
         agent_state.terminal_pid = result.get("terminal_pid")
+        # #8695: spawning a fresh agent → bootup-complete must be re-asserted
+        # by the new process before we'll dispatch any events to it.
+        agent_state.bootup_complete = False
         state.set_agent(role, agent_state)
         state.save_state()
 
@@ -1071,6 +1092,23 @@ async def receive_event(request: Request):
     if event_type == "status-transition":
         handoff_dispatcher.on_transition(body.get("payload", {}), role)
 
+    # Bootup gating (#8695): agent signals it's ready to receive dispatches.
+    # Until this fires, get_events_for_role returns nothing for this role —
+    # events accumulate in the stream and drain on the agent's first poll
+    # after bootup-complete, so nothing is lost.
+    if event_type == "bootup-complete" and role:
+        # Mutate under state._lock to avoid racing with the health poller's
+        # auto-reboot path (which sets bootup_complete=False under the same
+        # lock when it detects death).
+        with state._lock:
+            agent = state.agents.get(role)
+            if agent is None:
+                agent = AgentState(role)
+                state.agents[role] = agent
+            agent.bootup_complete = True
+        state.save_state()
+        _log(f"{role}: bootup-complete — event dispatch unlocked")
+
     # Ack processing (#7630 2-2): if event is an ack, process the lifecycle closure
     if event_type == "ack":
         ack_event_id = body.get("payload", {}).get("event_id")
@@ -1143,6 +1181,18 @@ async def get_events_for_role(
     This is the primary endpoint for event-driven agents using Monitor tool.
     """
     _validate_role(role)
+
+    # #8695: Bootup-complete gating. While the agent has not yet emitted
+    # `bootup-complete`, return an empty list so the harness never dispatches
+    # work into a still-booting agent. Events remain in the stream and will be
+    # delivered on the next poll after bootup-complete arrives.
+    agent_for_gate = state.get_agent(role)
+    if agent_for_gate is not None and not agent_for_gate.bootup_complete:
+        return {
+            "events": [],
+            "total": 0,
+            "gated": "bootup-incomplete",
+        }
 
     # Get relevant event types for this role from config
     try:
@@ -1292,6 +1342,9 @@ async def restart_agent(role: str):
     # cycle_post.py queries GET /agents/{role} and reads intent (#4966)
     agent_state = state.get_agent(role) or AgentState(role)
     agent_state.intent = AgentState.INTENT_RESTARTING
+    # #8695: restart will respawn the process → new boot must re-assert
+    # bootup-complete before events flow again.
+    agent_state.bootup_complete = False
     state.set_agent(role, agent_state)
     state.save_state()
 
@@ -1685,6 +1738,10 @@ def _reboot_affected_agents(pr_number, files_changed):
         agent = state.get_agent(role)
         if agent and agent.intent == AgentState.INTENT_RUNNING:
             agent.intent = AgentState.INTENT_RESTARTING
+            # #8695: match the other three restart paths — close the window
+            # where events would still dispatch after we've marked the agent
+            # for restart but before its process actually dies.
+            agent.bootup_complete = False
             state.set_agent(role, agent)
     state.save_state()
 
@@ -1774,6 +1831,23 @@ class ExternalActivityDetector:
         self._thread = None
         self._last_check_epoch = 0.0  # epoch seconds — avoids ISO string comparison
         self._emitted_issues: dict[int, None] = {}  # ordered dedup: issues already emitted
+        # #8694: shared lock for _emitted_issues — TrackerHandoffDispatcher
+        # writes here from a separate thread (cross-dedup); without this the
+        # compound eviction (next(iter) + del) can race with concurrent writes.
+        self._emitted_lock = threading.Lock()
+
+    def is_emitted(self, issue_num):
+        """Thread-safe membership check on _emitted_issues."""
+        with self._emitted_lock:
+            return issue_num in self._emitted_issues
+
+    def mark_emitted(self, issue_num):
+        """Thread-safe insert + bounded eviction on _emitted_issues (#8694)."""
+        with self._emitted_lock:
+            self._emitted_issues[issue_num] = None
+            while len(self._emitted_issues) > 500:
+                oldest = next(iter(self._emitted_issues))
+                del self._emitted_issues[oldest]
 
     def start(self):
         """Start the detector daemon thread."""
@@ -1842,8 +1916,8 @@ class ExternalActivityDetector:
         for issue in issues:
             issue_num = issue.get("number", 0)
 
-            # Dedup: skip issues already emitted
-            if issue_num in self._emitted_issues:  # O(1) dict lookup
+            # Dedup: skip issues already emitted (thread-safe via #8694)
+            if self.is_emitted(issue_num):
                 continue
 
             # Skip agent-filed issues to prevent self-triggering loops
@@ -1874,14 +1948,10 @@ class ExternalActivityDetector:
                 "target_role": target_role,
                 "event_context": f"Issue #{issue_num} updated",
             })
-            self._emitted_issues[issue_num] = None
+            self.mark_emitted(issue_num)
 
         self._last_check_epoch = check_time
-
-        # Bound the dedup dict to prevent unbounded growth — evict oldest first
-        while len(self._emitted_issues) > 500:
-            oldest = next(iter(self._emitted_issues))
-            del self._emitted_issues[oldest]
+        # Eviction now happens inside mark_emitted() under _emitted_lock.
 
 
 # Global detector instance
@@ -1905,6 +1975,19 @@ class TrackerHandoffDispatcher:
         # Per-role last-emitted top issue number (None = no item known)
         self._last_top: dict[str, int | None] = {}
         self._lock = threading.Lock()
+        # Per-role serialization lock: only one dispatch runs per role at a
+        # time, so rapid-fire transitions on the same issue don't spawn N
+        # concurrent `gh issue list` subprocesses (#8694 follow-up).
+        self._role_locks: dict[str, threading.Lock] = {}
+        self._role_locks_guard = threading.Lock()
+
+    def _role_lock(self, role):
+        with self._role_locks_guard:
+            lock = self._role_locks.get(role)
+            if lock is None:
+                lock = threading.Lock()
+                self._role_locks[role] = lock
+            return lock
 
     def on_transition(self, payload, actor_role):
         """Called from POST /events for each status-transition event.
@@ -1912,9 +1995,13 @@ class TrackerHandoffDispatcher:
         Runs the actual GitHub-poking work in a background thread so the
         HTTP handler doesn't block on `gh` subprocess calls.
         """
+        # #8694 follow-up: defensive — a truthy non-dict payload (string, int,
+        # bool) would `AttributeError` inside `_do_dispatch`. The `or {}` only
+        # caught falsy non-dicts; switch to isinstance.
+        safe_payload = payload if isinstance(payload, dict) else {}
         thread = threading.Thread(
             target=self._do_dispatch,
-            args=(payload or {}, actor_role),
+            args=(safe_payload, actor_role),
             daemon=True,
             name="handoff-dispatch",
         )
@@ -1936,27 +2023,37 @@ class TrackerHandoffDispatcher:
             _log(f"Handoff dispatcher error: {e}")
 
     def _dispatch_next(self, role):
-        """Compute role's current top item and emit assigned-to if it changed."""
-        queue = self._get_work_queue(role)
-        if not queue:
-            with self._lock:
-                self._last_top[role] = None
-            return
-        top = queue[0]
-        issue_num = top.get("number")
-        with self._lock:
-            if self._last_top.get(role) == issue_num:
-                return  # queue head unchanged — no-op
-            self._last_top[role] = issue_num
+        """Compute role's current top item and emit assigned-to if it changed.
 
-        _emit_event("assigned-to", "harness", payload={
-            "issue_number": str(issue_num),
-            "title": top.get("title", ""),
-            "target_role": role,
-            "event_context": f"Next work for {role} after tracker handoff",
-        })
-        # Also tell the external poller it doesn't need to re-emit this one.
-        activity_detector._emitted_issues[issue_num] = None
+        Serialized per-role: concurrent transitions for the same role queue
+        up rather than each running their own `gh issue list` subprocess.
+        """
+        with self._role_lock(role):
+            queue = self._get_work_queue(role)
+            if not queue:
+                with self._lock:
+                    self._last_top[role] = None
+                return
+            top = queue[0]
+            issue_num = top.get("number")
+            with self._lock:
+                if self._last_top.get(role) == issue_num:
+                    return  # queue head unchanged — no-op
+                self._last_top[role] = issue_num
+
+            # Bidirectional cross-dedup with the external poller: skip if the
+            # 60s poller already emitted this issue (#8694 follow-up).
+            if issue_num is not None and activity_detector.is_emitted(issue_num):
+                return
+
+            _emit_event("assigned-to", "harness", payload={
+                "issue_number": str(issue_num),
+                "title": top.get("title", ""),
+                "target_role": role,
+                "event_context": f"Next work for {role} after tracker handoff",
+            })
+            if issue_num is not None:
+                activity_detector.mark_emitted(issue_num)
 
     def _get_work_queue(self, role):
         """Return tracker.py work-queue output as a list of dicts."""

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1497,5 +1497,375 @@ class TestTrackerHandoffDispatcher(unittest.TestCase):
         mock_on.assert_not_called()
 
 
+# ---------------------------------------------------------------------------
+# Bootup-complete gating — #8695
+# ---------------------------------------------------------------------------
+
+class TestBootupCompleteGating(unittest.TestCase):
+    """#8695: harness gates event dispatch on per-agent bootup-complete."""
+
+    def setUp(self):
+        from harness import state
+        # Snapshot then clear agents in-place so other modules that captured
+        # `state` at import time still see the same object.
+        self._restore_agents = dict(state.agents)
+        state.agents.clear()
+        from fastapi.testclient import TestClient
+        from harness import app
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        from harness import state
+        state.agents.clear()
+        state.agents.update(self._restore_agents)
+
+    def test_default_bootup_complete_is_false(self):
+        from harness import AgentState
+        agent = AgentState("skill")
+        self.assertFalse(agent.bootup_complete)
+
+    def test_to_dict_includes_bootup_complete(self):
+        from harness import AgentState
+        agent = AgentState("skill")
+        agent.bootup_complete = True
+        self.assertTrue(agent.to_dict()["bootup_complete"])
+
+    def test_events_for_role_gated_before_bootup(self):
+        """/events/for/<role> returns empty + 'gated' marker when not bootup-complete."""
+        from harness import AgentState, state
+        agent = AgentState("skill")
+        agent.bootup_complete = False
+        state.set_agent("skill", agent)
+        with patch("harness._validate_role"):
+            resp = self.client.get("/events/for/skill")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["events"], [])
+        self.assertEqual(data["total"], 0)
+        self.assertEqual(data.get("gated"), "bootup-incomplete")
+
+    def test_events_for_role_flows_after_bootup(self):
+        """After bootup-complete, events flow normally."""
+        from harness import AgentState, state, event_stream
+        agent = AgentState("skill")
+        agent.bootup_complete = True
+        state.set_agent("skill", agent)
+        event_stream.append({
+            "id": "e_unique_1", "event_type": "assigned-to", "role": "harness",
+            "payload": {"target_role": "skill", "issue_number": "1"},
+        })
+        with patch("harness._validate_role"):
+            resp = self.client.get("/events/for/skill")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertNotIn("gated", data)
+        self.assertGreaterEqual(data["total"], 1)
+
+    def test_bootup_complete_event_sets_flag(self):
+        """POST /events with event_type=bootup-complete sets agent.bootup_complete=True."""
+        from harness import state
+        resp = self.client.post("/events", json={
+            "event_type": "bootup-complete",
+            "role": "skill",
+            "payload": {},
+            "timestamp": "2026-05-18T00:00:00",
+        })
+        self.assertEqual(resp.status_code, 200)
+        agent = state.get_agent("skill")
+        self.assertIsNotNone(agent)
+        self.assertTrue(agent.bootup_complete)
+
+    def test_bootup_complete_unlocks_dispatch(self):
+        """Events accumulate while gated; first poll after bootup-complete returns them."""
+        from harness import AgentState, state, event_stream
+        agent = AgentState("skill")
+        agent.bootup_complete = False
+        state.set_agent("skill", agent)
+
+        event_stream.append({
+            "id": "e_unlock_1", "event_type": "assigned-to", "role": "harness",
+            "payload": {"target_role": "skill", "issue_number": "1"},
+        })
+
+        with patch("harness._validate_role"):
+            r1 = self.client.get("/events/for/skill")
+        self.assertEqual(r1.json()["total"], 0)
+        self.assertEqual(r1.json().get("gated"), "bootup-incomplete")
+
+        self.client.post("/events", json={
+            "event_type": "bootup-complete", "role": "skill",
+            "payload": {}, "timestamp": "2026-05-18T00:00:00",
+        })
+
+        with patch("harness._validate_role"):
+            r2 = self.client.get("/events/for/skill")
+        self.assertEqual(r2.status_code, 200)
+        self.assertGreaterEqual(r2.json()["total"], 1)
+        self.assertNotIn("gated", r2.json())
+
+    def test_no_agent_state_does_not_gate(self):
+        """If no AgentState exists for a role, do not gate (backwards compat)."""
+        from harness import event_stream
+        event_stream.append({
+            "id": "e_nogate_1", "event_type": "assigned-to", "role": "harness",
+            "payload": {"target_role": "skill", "issue_number": "1"},
+        })
+        with patch("harness._validate_role"):
+            resp = self.client.get("/events/for/skill")
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotIn("gated", resp.json())
+
+    def test_start_clears_bootup_complete(self):
+        """POST /agents/<role>/start resets bootup_complete=False on fresh spawn."""
+        from harness import AgentState, state
+        prev = AgentState("skill")
+        prev.bootup_complete = True
+        prev.status = "stopped"
+        state.set_agent("skill", prev)
+        with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+             patch("harness.boot_remote.boot_agent",
+                   return_value={"role": "skill", "action": "spawn", "success": True,
+                                  "message": "ok", "terminal_pid": 1}):
+            self.client.post("/agents/skill/start")
+        self.assertFalse(state.get_agent("skill").bootup_complete)
+
+    def test_restart_clears_bootup_complete(self):
+        """POST /agents/<role>/restart resets bootup_complete=False."""
+        import tempfile
+        from harness import AgentState, state
+        prev = AgentState("skill")
+        prev.bootup_complete = True
+        state.set_agent("skill", prev)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / ".squidsquad" / "skill").mkdir(parents=True)
+            with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+                 patch("harness.boot_remote._get_clone_path", return_value=tmpdir):
+                self.client.post("/agents/skill/restart")
+        self.assertFalse(state.get_agent("skill").bootup_complete)
+
+
+class TestEventBusBootupComplete(unittest.TestCase):
+    """#8695: event_bus.bootup_complete() helper."""
+
+    def test_emits_bootup_complete_event(self):
+        import event_bus
+        with patch.object(event_bus, "emit") as mock_emit:
+            event_bus.bootup_complete("skill")
+        mock_emit.assert_called_once_with("bootup-complete", "skill", payload={})
+
+    def test_no_op_without_role(self):
+        import event_bus
+        with patch.object(event_bus, "emit") as mock_emit:
+            event_bus.bootup_complete("")
+            event_bus.bootup_complete(None)
+        mock_emit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Review fixes — #8695 + #8694 post-DeepSeek
+# ---------------------------------------------------------------------------
+
+class TestReviewFixes(unittest.TestCase):
+    """DeepSeek review fixes for #8694 and #8695."""
+
+    # ---- #8695 review fixes ------------------------------------------------
+
+    def test_save_state_persists_bootup_complete(self):
+        """#8695 R1: save_state writes bootup_complete to the state file."""
+        import tempfile
+        from harness import HarnessState, AgentState
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_file = Path(tmpdir) / ".harness-state.json"
+            with patch("harness.HARNESS_STATE_FILE", state_file):
+                hs = HarnessState()
+                agent = AgentState("skill")
+                agent.bootup_complete = True
+                hs.set_agent("skill", agent)
+                hs.save_state()
+                data = json.loads(state_file.read_text(encoding="utf-8"))
+                self.assertTrue(data["agents"]["skill"]["bootup_complete"])
+
+    def test_load_state_restores_bootup_complete(self):
+        """#8695 R1: load_state restores bootup_complete so already-running
+        agents don't get gated forever after a harness restart."""
+        import tempfile
+        from harness import HarnessState, AgentState
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_file = Path(tmpdir) / ".harness-state.json"
+            state_file.write_text(json.dumps({
+                "agents": {"skill": {
+                    "intent": "running", "clone_path": "",
+                    "bootup_complete": True,
+                }}
+            }), encoding="utf-8")
+            with patch("harness.HARNESS_STATE_FILE", state_file):
+                hs = HarnessState()
+                with patch("harness._log"):
+                    hs.load_state()
+                self.assertTrue(hs.get_agent("skill").bootup_complete)
+
+    def test_load_state_defaults_bootup_complete_false_for_old_files(self):
+        """#8695 R1: state files predating this change → bootup_complete=False."""
+        import tempfile
+        from harness import HarnessState
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_file = Path(tmpdir) / ".harness-state.json"
+            state_file.write_text(json.dumps({
+                "agents": {"skill": {"intent": "running", "clone_path": ""}}
+            }), encoding="utf-8")
+            with patch("harness.HARNESS_STATE_FILE", state_file):
+                hs = HarnessState()
+                with patch("harness._log"):
+                    hs.load_state()
+                self.assertFalse(hs.get_agent("skill").bootup_complete)
+
+    def test_reboot_affected_agents_clears_bootup_complete(self):
+        """#8695 R2: compose-driven restart resets bootup_complete=False."""
+        from harness import HarnessState, AgentState
+        hs = HarnessState()
+        agent = AgentState("skill")
+        agent.intent = AgentState.INTENT_RUNNING
+        agent.bootup_complete = True
+        hs.set_agent("skill", agent)
+        import harness
+        prev_state = harness.state
+        harness.state = hs
+        # Fake git-diff output so the function decides skill's CLAUDE.md changed
+        fake_git_diff = MagicMock()
+        fake_git_diff.returncode = 0
+        fake_git_diff.stdout = ".squidsquad/skill/CLAUDE.md\n"
+        try:
+            with patch("harness._log"), \
+                 patch("harness.subprocess.run", return_value=fake_git_diff), \
+                 patch.object(hs, "save_state"):
+                harness._reboot_affected_agents(123, ["references/sub-skills/common/x.md"])
+        finally:
+            harness.state = prev_state
+        self.assertFalse(hs.get_agent("skill").bootup_complete)
+
+    # ---- #8694 review fixes ------------------------------------------------
+
+    def test_external_detector_mark_emitted_is_thread_safe(self):
+        """#8694 R1: mark_emitted holds _emitted_lock; concurrent writes don't crash."""
+        from harness import ExternalActivityDetector
+        det = ExternalActivityDetector()
+        import threading as _t
+        errors = []
+
+        def hammer(start):
+            try:
+                for i in range(200):
+                    det.mark_emitted(start + i)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [_t.Thread(target=hammer, args=(i * 1000,)) for i in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(errors, [])
+        # Bounded at 500 entries
+        self.assertLessEqual(len(det._emitted_issues), 500)
+
+    def test_external_detector_eviction_bounds_at_500(self):
+        """#8694 R1: oldest entries evict when count exceeds 500."""
+        from harness import ExternalActivityDetector
+        det = ExternalActivityDetector()
+        for n in range(600):
+            det.mark_emitted(n)
+        self.assertLessEqual(len(det._emitted_issues), 500)
+        # The newest entries are retained
+        self.assertTrue(det.is_emitted(599))
+
+    def test_dispatcher_skips_when_external_detector_already_emitted(self):
+        """#8694 R2: bidirectional cross-dedup — dispatcher checks before emitting."""
+        from harness import TrackerHandoffDispatcher, activity_detector
+        activity_detector._emitted_issues.clear()
+        # External poller already emitted #77
+        activity_detector.mark_emitted(77)
+        d = TrackerHandoffDispatcher()
+        with patch.object(d, "_get_work_queue",
+                          return_value=[{"number": 77, "title": "dup"}]), \
+             patch.object(d, "_get_issue_role", return_value=None), \
+             patch("harness._emit_event") as mock_emit:
+            d._do_dispatch({"issue_number": "1"}, actor_role="skill")
+        mock_emit.assert_not_called()
+
+    def test_dispatcher_handles_non_dict_payload(self):
+        """#8694 R3: a malformed (non-dict) payload doesn't crash on_transition."""
+        from harness import TrackerHandoffDispatcher
+        d = TrackerHandoffDispatcher()
+        # Pass a string payload — would crash with `.get` if not guarded
+        with patch.object(d, "_do_dispatch") as mock_dispatch:
+            d.on_transition("not-a-dict", "skill")
+            import time as _t
+            _t.sleep(0.05)
+        # _do_dispatch should have been called with an empty dict, not the string
+        args, _ = mock_dispatch.call_args
+        self.assertEqual(args[0], {})
+        self.assertEqual(args[1], "skill")
+
+    def test_dispatcher_serializes_per_role(self):
+        """#8694 R4: per-role lock prevents concurrent `gh issue list` calls.
+
+        Two concurrent transitions for the same role: with the per-role lock,
+        the second `_get_work_queue` call cannot overlap the first.
+        """
+        from harness import TrackerHandoffDispatcher, activity_detector
+        activity_detector._emitted_issues.clear()
+        d = TrackerHandoffDispatcher()
+        overlap = {"max_concurrent": 0, "current": 0}
+        import threading as _th
+        counter_lock = _th.Lock()
+        import time as _t
+
+        def slow_queue(role):
+            with counter_lock:
+                overlap["current"] += 1
+                overlap["max_concurrent"] = max(overlap["max_concurrent"], overlap["current"])
+            _t.sleep(0.05)
+            with counter_lock:
+                overlap["current"] -= 1
+            return [{"number": 5, "title": "same"}]
+
+        with patch.object(d, "_get_work_queue", side_effect=slow_queue), \
+             patch.object(d, "_get_issue_role", return_value=None), \
+             patch("harness._emit_event"):
+            d.on_transition({"issue_number": "1"}, "skill")
+            d.on_transition({"issue_number": "2"}, "skill")
+            _t.sleep(0.25)
+        # Per-role lock means at most one _get_work_queue executes at a time.
+        self.assertEqual(overlap["max_concurrent"], 1)
+
+    def test_dispatcher_does_not_serialize_across_roles(self):
+        """#8694 R4: different roles dispatch concurrently — per-role lock only."""
+        from harness import TrackerHandoffDispatcher, activity_detector
+        activity_detector._emitted_issues.clear()
+        d = TrackerHandoffDispatcher()
+        overlap = {"max_concurrent": 0, "current": 0}
+        import threading as _th
+        counter_lock = _th.Lock()
+        import time as _t
+
+        def slow_queue(role):
+            with counter_lock:
+                overlap["current"] += 1
+                overlap["max_concurrent"] = max(overlap["max_concurrent"], overlap["current"])
+            _t.sleep(0.05)
+            with counter_lock:
+                overlap["current"] -= 1
+            return [{"number": 5, "title": role}]
+
+        with patch.object(d, "_get_work_queue", side_effect=slow_queue), \
+             patch.object(d, "_get_issue_role", return_value=None), \
+             patch("harness._emit_event"):
+            d.on_transition({"issue_number": "1"}, "skill")
+            d.on_transition({"issue_number": "2"}, "pm")
+            _t.sleep(0.25)
+        # Different roles should be allowed to overlap.
+        self.assertGreaterEqual(overlap["max_concurrent"], 2)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Implements #8695 (https://github.com/WallyDoodlez/SquidSquad/issues/8695) (bootup-complete gating) and folds in DeepSeek-review fixes for #8694 (https://github.com/WallyDoodlez/SquidSquad/issues/8694) (already-merged tracker-handoff dispatcher) since they touch the same module.

## #8695 implementation
- `AgentState`: new `bootup_complete: bool` field (default `False`); in `__slots__`, `to_dict()`, `save_state()`, `load_state()`.
- `POST /events`: `event_type='bootup-complete'` sets the agent's flag to True under `state._lock` (avoids race with the health poller's auto-reboot path).
- `GET /events/for/<role>`: returns `{events: [], total: 0, gated: 'bootup-incomplete'}` while the role's `AgentState.bootup_complete` is False.
- Reset to False on **four** boot/respawn paths: `POST /agents/<role>/start`, `POST /agents/<role>/restart`, auto-reboot in `update_health`, and compose-driven restart in `_reboot_affected_agents`.
- `event_bus.bootup_complete(role)` convenience function for event-driven agents.
- Backwards compat: if no `AgentState` exists for a role, no gating.

## #8695 DeepSeek findings addressed
- **R1 (error) — Persistence**: `save_state` now writes `bootup_complete`; `load_state` restores it. Without this, agents already-running before a harness restart would be permanently gated.
- **R2 (warning) — `_reboot_affected_agents` reset**: now matches the other three restart paths and resets `bootup_complete=False` alongside `intent=RESTARTING`.
- **R3 (warning) — Lock for bootup-complete mutation**: the flag is now flipped inside `state._lock`, eliminating the race with the health poller setting it back to False during auto-reboot.

## #8694 DeepSeek findings addressed (retro)
- **R1 (warning) — `_emitted_issues` thread safety**: added `_emitted_lock` on `ExternalActivityDetector` plus thread-safe `is_emitted()` and `mark_emitted()` methods (the latter also handles bounded eviction). Both the detector and the dispatcher now go through these helpers.
- **R2 (warning) — Bidirectional cross-dedup**: dispatcher now checks `activity_detector.is_emitted(issue_num)` before emitting (previously it only marked-after-emitting, which left a window where both the 60s poller and the dispatcher could each emit the same issue).
- **R3 (warning) — Payload defensive check**: replaced `payload or {}` with `payload if isinstance(payload, dict) else {}` so a malformed truthy non-dict payload no longer crashes the dispatcher thread.
- **R4 (warning) — Per-role coalescing**: added per-role lock so concurrent transitions for the same role no longer spawn N concurrent `gh issue list` subprocesses. Different roles still dispatch concurrently.

## Verification
- 21 new tests in `TestBootupCompleteGating` (9), `TestEventBusBootupComplete` (2), `TestReviewFixes` (10).
- 46 tests pass together across `TestReviewFixes + TestTrackerHandoffDispatcher + TestBootupCompleteGating + TestEventBusBootupComplete + tests/test_event_bus.py` — no regressions.

## Notes
Agent-side wiring to actually CALL `event_bus.bootup_complete(role)` lands in #8697 (compose dual-mode CLAUDE.md generation), which composes the event-driven instructions. This PR is the harness side + the helper function.

## Test plan
- [x] `pytest tests/test_harness.py::TestBootupCompleteGating tests/test_harness.py::TestEventBusBootupComplete tests/test_harness.py::TestReviewFixes` — 21 passed
- [x] `pytest tests/test_harness.py::TestTrackerHandoffDispatcher` (existing #8694 tests) — still pass with the cross-dedup + per-role-lock changes