### PR TITLE
skill: retro DeepSeek-review fixes for 6 already-merged PRs (#8653 #8664 #8689 #8691 #8699)

### DIFF
--- a/references/roles/dev/includes.yml
+++ b/references/roles/dev/includes.yml
@@ -3,8 +3,6 @@
 includes:
   - common/cycle-runner
   - common/event-driven-workflow
-  - common/event-reactions
-  - common/event-driven-workflow
   - common/context-pressure
   - common/resume-working-state
   - common/interval-sync

--- a/references/roles/dm/includes.yml
+++ b/references/roles/dm/includes.yml
@@ -5,8 +5,6 @@ includes:
   - common/capability-check
   - common/cycle-runner
   - common/event-driven-workflow
-  - common/event-reactions
-  - common/event-driven-workflow
   - common/context-pressure
   - roles/dm/task-pickup
   - roles/dm/issue-triage

--- a/references/roles/pm/includes.yml
+++ b/references/roles/pm/includes.yml
@@ -3,8 +3,6 @@
 includes:
   - common/cycle-runner
   - common/event-driven-workflow
-  - common/event-reactions
-  - common/event-driven-workflow
   - common/context-pressure
   - common/task-pickup
   - roles/pm/checkin

--- a/references/roles/qa/includes.yml
+++ b/references/roles/qa/includes.yml
@@ -4,8 +4,6 @@
 includes:
   - common/cycle-runner
   - common/event-driven-workflow
-  - common/event-reactions
-  - common/event-driven-workflow
   - common/context-pressure
   - common/task-pickup
   - roles/qa/verification

--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -403,8 +403,17 @@ def _do_commit_push(data, role):
         _run_script("git_ops.py", "commit-role-scoped", role, commit_msg)
         print(f"  Committed and pushed (QA → main)")
 
+    elif role == "skill":
+        # #8691 retro-review R1: when branch_workflow is OFF (or code_commit is
+        # missing) skill falls here. Skill's code lives outside the role's
+        # commit-role-scoped allowlist (which is intentionally state-only), so
+        # using it here would silently drop skill code changes. Fall back to
+        # commit-push for full coverage in that legacy single-branch flow.
+        _run_script("git_ops.py", "commit-push", role, commit_msg)
+        print(f"  Committed and pushed")
+
     else:
-        # #8691: PM/DM/other roles also commit only their own domain.
+        # #8691: PM/DM/other roles commit only their own domain.
         _run_script("git_ops.py", "commit-role-scoped", role, commit_msg)
         print(f"  Committed and pushed")
 

--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -417,7 +417,17 @@ def _auto_resolve_state_conflicts():
     Returns (resolved_paths, unresolved_paths).
     """
     result = _run_list(["git", "ls-files", "--unmerged"], check=False)
-    if result.returncode != 0 or not result.stdout.strip():
+    # #8653 retro-review R1: distinguish "git failed" from "no unmerged files"
+    # — silently treating the former as the latter would let task_begin
+    # proceed past real corruption.
+    if result.returncode != 0:
+        print(
+            f"WARNING: git ls-files --unmerged failed (rc={result.returncode}): "
+            f"{(result.stderr or '').strip()[:200]}",
+            file=sys.stderr,
+        )
+        return [], []
+    if not result.stdout.strip():
         return [], []
     paths = set()
     for line in result.stdout.splitlines():
@@ -428,11 +438,24 @@ def _auto_resolve_state_conflicts():
     unresolved = []
     for path in sorted(paths):
         if _is_state_file(path):
+            # #8653 retro-review R2: only `git add` after checkout succeeds —
+            # otherwise we could stage raw conflict markers into the index.
             r1 = _run_list(["git", "checkout", "--theirs", "--", path], check=False)
+            if r1.returncode != 0:
+                unresolved.append(path)
+                continue
             r2 = _run_list(["git", "add", "--", path], check=False)
-            if r1.returncode == 0 and r2.returncode == 0:
+            if r2.returncode == 0:
                 resolved.append(path)
             else:
+                # #8653 retro-review R3: checkout wrote --theirs to the working
+                # tree but add failed — surface explicitly so the caller's
+                # follow-up message can guide the user to just `git add`.
+                print(
+                    f"WARNING: {path} content resolved (--theirs in working tree) "
+                    f"but `git add` failed — index still holds the conflict.",
+                    file=sys.stderr,
+                )
                 unresolved.append(path)
         else:
             unresolved.append(path)
@@ -613,8 +636,12 @@ def commit_role_scoped(role, message):
     lines = [l for l in result.stdout.splitlines() if l.strip()]
     own_files = []
     foreign_files = []
+    foreign_staged = []  # subset of foreign_files that are already in the index
     patterns = _role_owned_patterns(role)
     for line in lines:
+        # git status --porcelain: XY<space>filename
+        # X = index status, Y = worktree status. A non-space X means staged.
+        index_status = line[0] if line else " "
         path = line[3:].strip().strip('"')
         if " -> " in path:
             path = path.split(" -> ")[1]
@@ -622,6 +649,17 @@ def commit_role_scoped(role, message):
             own_files.append(path)
         else:
             foreign_files.append(path)
+            # #8691 retro-review R2: if a foreign file is already STAGED, it
+            # would be silently included by the upcoming `git commit`. Track
+            # them so we can unstage before committing.
+            if index_status not in (" ", "?"):
+                foreign_staged.append(path)
+
+    if foreign_staged:
+        # Unstage so the commit doesn't pick them up. Working-tree content is
+        # untouched, matching the function's "left in working tree" contract.
+        for f in foreign_staged:
+            _run_list(["git", "reset", "HEAD", "--", f], check=False)
 
     if foreign_files:
         print(
@@ -633,6 +671,11 @@ def commit_role_scoped(role, message):
             print(f"  {f}", file=sys.stderr)
         if len(foreign_files) > 20:
             print(f"  ... and {len(foreign_files) - 20} more", file=sys.stderr)
+        if foreign_staged:
+            print(
+                f"  ({len(foreign_staged)} were pre-staged — unstaged before commit)",
+                file=sys.stderr,
+            )
 
     if not own_files:
         print("No role-domain changes to commit")

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -1377,7 +1377,19 @@ async def restart_agent(role: str):
             _log(f"  {role}: idle — killing PID {claude_pid} for immediate reboot")
             try:
                 reboot_agent._kill_process(claude_pid)
-                killed_pid = claude_pid
+                # #8689 retro-review R2: SIGINT on Unix is catchable — verify
+                # the process actually died before claiming immediate=True.
+                # Mirror the pattern in reboot_agent._kill_and_respawn (10 *
+                # 0.5s = 5s budget).
+                for _ in range(10):
+                    if not reboot_agent._is_process_alive(claude_pid):
+                        break
+                    time.sleep(0.5)
+                if reboot_agent._is_process_alive(claude_pid):
+                    _log(f"  {role}: WARNING — PID {claude_pid} still alive after kill; falling back to queued restart")
+                    immediate = False
+                else:
+                    killed_pid = claude_pid
             except Exception as e:
                 _log(f"  {role}: WARNING — kill failed: {e}")
                 immediate = False
@@ -1402,6 +1414,9 @@ async def restart_agent(role: str):
         "action": "restart",
         "success": True,
         "immediate": False,
+        # #8689 retro-review R1: keep response shape consistent across both
+        # paths so clients don't get a KeyError on `killed_pid`.
+        "killed_pid": None,
         "message": "Restart requested — agent will exit after current cycle and reboot",
     }
 

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1069,12 +1069,20 @@ class TestGitignoreVolatileFiles:
             capture_output=True, text=True, encoding="utf-8",
             cwd=str(Path(__file__).resolve().parent.parent),
         )
+        # #8664 retro-review R1: fail loud if git itself failed — otherwise the
+        # test silently passes on an empty `tracked` list.
+        assert result.returncode == 0, (
+            f"git ls-files failed (rc={result.returncode}): "
+            f"{(result.stderr or '').strip()}"
+        )
         tracked = result.stdout.strip().splitlines()
-        volatile_names = [".backlog-cache", ".event-state.json",
-                          ".claude-pid", ".health", ".booting",
-                          "scan-index.db", "scheduled_tasks.lock"]
+        # #8664 retro-review R3: derive basenames from VOLATILE_PATTERNS so the
+        # two tests cannot drift out of sync.
+        volatile_names = [p.rsplit("/", 1)[-1] for p in self.VOLATILE_PATTERNS]
+        # #8664 retro-review R2: anchor match to path end so `.health-check` or
+        # `.claude-pid-old` aren't false-positive flagged as the volatile files.
         for name in volatile_names:
-            matches = [f for f in tracked if name in f]
+            matches = [f for f in tracked if f.endswith("/" + name) or f == name]
             assert matches == [], (
                 f"Volatile file(s) still tracked in git index: {matches}"
             )


### PR DESCRIPTION
## Summary
Per user feedback in cycle 1116: 6 of my session's PRs (#8693 #8705 #8706 #8722 #8743 #8749) had been merged without DeepSeek code review. Ran retro reviews on all 6 (#8694 + #8695 already had reviews folded into #8801). Total: **2 errors + 10 warnings** across 5 PRs; #8692 (PR #8706 singleton enforcement) returned NO_FINDINGS.

This PR applies all 12 findings. After merge, the original 6 tickets should be re-verified by QA.

## Findings → fixes

### #8653 — `_auto_resolve_state_conflicts` robustness (3 warnings)
- `git ls-files --unmerged` failure no longer silently treated as "no conflicts" — now logs a warning.
- `git add` only runs when `git checkout --theirs` succeeds — previously could stage raw conflict markers.
- Surface the split state when checkout succeeds but add fails (working tree resolved, index still conflicting).

### #8664 — `test_volatile_files_not_tracked` robustness (1 error + 2 warnings)
- **ERROR** Assert `git ls-files` returncode == 0 — without this the test silently passed if git itself failed.
- Anchor name match to path-end: `f.endswith('/' + name) or f == name` — no more false positives like `.health-check` matching `.health`.
- Derive `volatile_names` from `VOLATILE_PATTERNS` so the two lists cannot drift.

### #8689 — restart endpoint (2 warnings)
- Queued response now includes `killed_pid: None` for shape consistency with the immediate path.
- Poll `_is_process_alive` for up to 5s after `_kill_process` before claiming `immediate=True` — SIGINT is catchable on Unix; falls back to queued restart if the process survives.

### #8691 — `cycle_post` commit scoping (1 error + 1 warning)
- **ERROR** Skill role with `branch_workflow=OFF` was falling into the `commit_role_scoped` else branch — but skill's code lives outside the allowlist, so skill code was silently dropped. Added explicit `elif role == 'skill'` → `commit-push` fallback for the legacy single-branch flow.
- `commit_role_scoped` now detects pre-staged foreign files (X column non-space in porcelain) and `git reset HEAD --` unstages them before committing, matching the function's "left in working tree" contract.

### #8699 — manifest cleanup (2 warnings)
- Removed duplicate `common/event-driven-workflow` from all four role manifests (dev, pm, qa, dm). `compose.py` was dedup'ing via `set()` so no output bug, but the source was misleading.
- Removed orphan `common/event-reactions` from all four manifests — no `instructions.md` template references it, so it was dead weight.

### #8692 — NO_FINDINGS
Singleton enforcement (`thin_launcher.py`) was clean as reviewed.

## Verification
- `pytest tests/test_git_ops.py tests/test_compose.py` — 189 passed.
- `compose.py deploy <role>` on all four roles produces no further diff (idempotent).

## QA re-verification request
After merge, QA should re-verify the original 6 tickets (#8653, #8664, #8689, #8691, #8692, #8699) against this consolidated fix bundle. The #8692 ticket is included for completeness (no fixes needed but it went through the review loop now).

## Test plan
- [x] Test suite: 189 passed
- [x] Idempotent recompose: zero diff after running deploy
- [ ] QA to re-verify the 6 original tickets against the updated harness/git_ops/test code