### PR TITLE
skill: feat #8704 — harness /human/queue endpoint for human-assigned work

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -1295,6 +1295,138 @@ async def get_in_flight_events(role: str):
     return {"role": role, "in_flight": event_lifecycle.get_in_flight(role)}
 
 
+# Status priority/severity rank for /human/queue ordering (high → low).
+_HUMAN_QUEUE_PRIORITY_RANK = {"high": 0, "medium": 1, "low": 2}
+
+
+def _parse_iso_to_epoch(iso_str):
+    """Parse an ISO timestamp returned by `gh` into epoch seconds.
+
+    Returns `float('inf')` on failure so items with unknown/unparseable
+    timestamps sort LAST in ascending order — they should not appear at the
+    head of "oldest first" rankings (#8704 review fix R2).
+    """
+    if not iso_str:
+        return float("inf")
+    try:
+        from datetime import datetime, timezone
+        # gh returns "2026-05-18T12:34:56Z" or with offset; normalize.
+        s = iso_str.rstrip("Z")
+        s = s.split(".")[0]
+        # Try parse without timezone first.
+        try:
+            dt = datetime.strptime(s, "%Y-%m-%dT%H:%M:%S").replace(tzinfo=timezone.utc)
+        except ValueError:
+            # Try with offset (e.g. "+00:00")
+            dt = datetime.fromisoformat(iso_str.rstrip("Z"))
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    except Exception:
+        return float("inf")
+
+
+def _gh_list_pending_human_issues():
+    """Query GitHub for issues in any pending-human-* status.
+
+    Returns a list of raw `gh issue list` JSON dicts. Empty list on any error
+    so the endpoint never crashes the harness.
+    """
+    statuses = ("status:pending-human-review", "status:pending-human-setup")
+    seen = {}
+    for status in statuses:
+        try:
+            result = subprocess.run(
+                ["gh", "issue", "list",
+                 "--label", f"squidsquad,{status}",
+                 "--state", "open",
+                 "--json", "number,title,labels,updatedAt,url",
+                 "--limit", "100"],
+                capture_output=True, text=True, encoding="utf-8",
+                errors="replace", check=False, cwd=str(REPO_ROOT),
+            )
+            if result.returncode != 0:
+                continue
+            try:
+                issues = json.loads(result.stdout) or []
+            except json.JSONDecodeError:
+                continue
+            for issue in issues:
+                num = issue.get("number")
+                if num is not None and num not in seen:
+                    seen[num] = issue
+        except Exception:
+            # Best-effort — never block the endpoint on `gh` failure.
+            continue
+    return list(seen.values())
+
+
+def _summarize_pending_human(issue):
+    """Compress a `gh issue list` row to the shape returned by /human/queue."""
+    labels = {l.get("name", "") for l in issue.get("labels", [])}
+    status = next(
+        (l[len("status:"):] for l in labels if l.startswith("status:pending-human-")),
+        "pending-human-unknown",
+    )
+    role = next(
+        (l[len("role:"):] for l in labels if l.startswith("role:")),
+        None,
+    )
+    severity = next(
+        (l[len("severity:"):] for l in labels if l.startswith("severity:")),
+        None,
+    )
+    priority = next(
+        (l[len("priority:"):] for l in labels if l.startswith("priority:")),
+        None,
+    )
+    return {
+        "number": issue.get("number"),
+        "title": issue.get("title", ""),
+        "status": status,
+        "role": role,
+        "priority": priority or severity,
+        "updated_at": issue.get("updatedAt", ""),
+        "url": issue.get("url", ""),
+    }
+
+
+@app.get("/human/queue")
+async def get_human_queue():
+    """Items awaiting human action (#8704).
+
+    Treats the human as another role assignee. Returns issues in any
+    `status:pending-human-*` (currently `pending-human-review` and
+    `pending-human-setup`) ordered by priority (high → low) then age
+    (oldest first — longest-waiting bubbles up).
+
+    Future TUIs / web UIs poll this on their own refresh loop (similar to
+    the status line refactor in #8700).
+    """
+    raw = _gh_list_pending_human_issues()
+    # #8704 review fix R1: defend against unexpected gh JSON shape (e.g.
+    # `labels` as a string instead of a list). Skip rows that fail to
+    # summarize rather than 500-ing the endpoint.
+    items = []
+    for issue in raw:
+        try:
+            items.append(_summarize_pending_human(issue))
+        except Exception:
+            continue
+
+    def _sort_key(item):
+        prio_rank = _HUMAN_QUEUE_PRIORITY_RANK.get(item.get("priority"), 99)
+        # Older items sort first → use updated_at ascending.
+        ts = _parse_iso_to_epoch(item.get("updated_at"))
+        return (prio_rank, ts)
+
+    items.sort(key=_sort_key)
+    return {
+        "count": len(items),
+        "items": items,
+    }
+
+
 @app.get("/events/lifecycle")
 async def get_event_lifecycle():
     """Event lifecycle overview — stream size, in-flight per role, persistence state (#7630 2-7)."""

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1867,5 +1867,186 @@ class TestReviewFixes(unittest.TestCase):
         self.assertGreaterEqual(overlap["max_concurrent"], 2)
 
 
+# ---------------------------------------------------------------------------
+# /human/queue endpoint — #8704
+# ---------------------------------------------------------------------------
+
+class TestHumanQueueEndpoint(unittest.TestCase):
+    """#8704: harness exposes items awaiting human action via /human/queue."""
+
+    def setUp(self):
+        from fastapi.testclient import TestClient
+        from harness import app
+        self.client = TestClient(app)
+
+    def _fake_subproc(self, issues_by_status):
+        """Build a side_effect for subprocess.run that returns different issues
+        per `status:pending-human-*` label filter.
+
+        `issues_by_status` is a dict like
+        `{"status:pending-human-review": [{...}, {...}], "status:pending-human-setup": []}`.
+        """
+        def _runner(cmd, **kwargs):
+            # The command always includes `--label "squidsquad,status:..."`.
+            label_arg = ""
+            for i, arg in enumerate(cmd):
+                if arg == "--label" and i + 1 < len(cmd):
+                    label_arg = cmd[i + 1]
+                    break
+            status = next(
+                (s for s in issues_by_status if s in label_arg), None
+            )
+            issues = issues_by_status.get(status, []) if status else []
+            return MagicMock(
+                returncode=0,
+                stdout=json.dumps(issues),
+                stderr="",
+            )
+        return _runner
+
+    def test_empty_queue_returns_zero(self):
+        with patch("harness.subprocess.run", side_effect=self._fake_subproc({})):
+            resp = self.client.get("/human/queue")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["count"], 0)
+        self.assertEqual(data["items"], [])
+
+    def test_returns_pending_human_review_items(self):
+        issues = {
+            "status:pending-human-review": [{
+                "number": 42,
+                "title": "Designer review needed",
+                "labels": [
+                    {"name": "status:pending-human-review"},
+                    {"name": "role:skill"},
+                    {"name": "priority:high"},
+                ],
+                "updatedAt": "2026-05-18T08:00:00Z",
+                "url": "https://example.com/42",
+            }],
+        }
+        with patch("harness.subprocess.run", side_effect=self._fake_subproc(issues)):
+            resp = self.client.get("/human/queue")
+        data = resp.json()
+        self.assertEqual(data["count"], 1)
+        item = data["items"][0]
+        self.assertEqual(item["number"], 42)
+        self.assertEqual(item["status"], "pending-human-review")
+        self.assertEqual(item["role"], "skill")
+        self.assertEqual(item["priority"], "high")
+
+    def test_dedups_across_both_pending_statuses(self):
+        """An item flagged with both labels (unlikely) should appear only once."""
+        same_issue = {
+            "number": 99,
+            "title": "Dual-labeled",
+            "labels": [
+                {"name": "status:pending-human-review"},
+                {"name": "status:pending-human-setup"},
+            ],
+            "updatedAt": "2026-05-18T08:00:00Z",
+            "url": "",
+        }
+        issues = {
+            "status:pending-human-review": [same_issue],
+            "status:pending-human-setup": [same_issue],
+        }
+        with patch("harness.subprocess.run", side_effect=self._fake_subproc(issues)):
+            resp = self.client.get("/human/queue")
+        data = resp.json()
+        self.assertEqual(data["count"], 1)
+
+    def test_sorts_by_priority_then_age(self):
+        issues = {
+            "status:pending-human-review": [
+                {"number": 1, "title": "low new",
+                 "labels": [{"name": "priority:low"},
+                            {"name": "status:pending-human-review"}],
+                 "updatedAt": "2026-05-18T09:00:00Z", "url": ""},
+                {"number": 2, "title": "high new",
+                 "labels": [{"name": "priority:high"},
+                            {"name": "status:pending-human-review"}],
+                 "updatedAt": "2026-05-18T09:00:00Z", "url": ""},
+                {"number": 3, "title": "high old",
+                 "labels": [{"name": "priority:high"},
+                            {"name": "status:pending-human-review"}],
+                 "updatedAt": "2026-05-17T09:00:00Z", "url": ""},
+            ],
+        }
+        with patch("harness.subprocess.run", side_effect=self._fake_subproc(issues)):
+            resp = self.client.get("/human/queue")
+        data = resp.json()
+        # high+old → high+new → low+new
+        self.assertEqual([i["number"] for i in data["items"]], [3, 2, 1])
+
+    def test_uses_severity_when_priority_missing(self):
+        """Issues (severity:*) and tasks (priority:*) should both sort."""
+        issues = {
+            "status:pending-human-review": [
+                {"number": 5, "title": "issue medium",
+                 "labels": [{"name": "severity:medium"},
+                            {"name": "status:pending-human-review"}],
+                 "updatedAt": "2026-05-18T09:00:00Z", "url": ""},
+            ],
+        }
+        with patch("harness.subprocess.run", side_effect=self._fake_subproc(issues)):
+            resp = self.client.get("/human/queue")
+        self.assertEqual(resp.json()["items"][0]["priority"], "medium")
+
+    def test_does_not_crash_on_gh_failure(self):
+        """A failing gh subprocess (rc != 0) returns an empty queue, not 500."""
+        with patch("harness.subprocess.run",
+                   return_value=MagicMock(returncode=1, stdout="", stderr="gh: command not found")):
+            resp = self.client.get("/human/queue")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["count"], 0)
+
+    def test_does_not_crash_on_malformed_json(self):
+        with patch("harness.subprocess.run",
+                   return_value=MagicMock(returncode=0, stdout="not json", stderr="")):
+            resp = self.client.get("/human/queue")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["count"], 0)
+
+    def test_does_not_crash_on_unexpected_label_shape(self):
+        """#8704 R1: malformed `labels` (not a list) skips the row, doesn't 500."""
+        issues = {
+            "status:pending-human-review": [
+                {"number": 1, "title": "good", "labels": [
+                    {"name": "status:pending-human-review"}
+                ], "updatedAt": "2026-05-18T09:00:00Z", "url": ""},
+                # Row with `labels` as a string instead of a list — should be skipped.
+                {"number": 2, "title": "broken", "labels": "not-a-list",
+                 "updatedAt": "2026-05-18T09:00:00Z", "url": ""},
+            ],
+        }
+        with patch("harness.subprocess.run", side_effect=self._fake_subproc(issues)):
+            resp = self.client.get("/human/queue")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual([i["number"] for i in data["items"]], [1])
+
+    def test_unknown_updated_at_sorts_last(self):
+        """#8704 R2: items with no/unparseable updated_at sort LAST in their
+        priority tier (not first, which the old `return 0` behavior produced)."""
+        issues = {
+            "status:pending-human-review": [
+                {"number": 1, "title": "unknown age",
+                 "labels": [{"name": "priority:high"},
+                            {"name": "status:pending-human-review"}],
+                 "updatedAt": "", "url": ""},
+                {"number": 2, "title": "known old",
+                 "labels": [{"name": "priority:high"},
+                            {"name": "status:pending-human-review"}],
+                 "updatedAt": "2026-05-17T09:00:00Z", "url": ""},
+            ],
+        }
+        with patch("harness.subprocess.run", side_effect=self._fake_subproc(issues)):
+            resp = self.client.get("/human/queue")
+        # Known-age item sorts before unknown-age within the same priority tier.
+        self.assertEqual([i["number"] for i in resp.json()["items"]], [2, 1])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Implements #8704 harness side. The human is treated as another role assignee — items in `status:pending-human-review` or `status:pending-human-setup` are work for the human. The planned TUI / web UI (#3963) needs an endpoint to poll on its own refresh loop and surface these prominently. This PR adds the endpoint; UI consumption lands when the UI exists.

## Endpoint
`GET /human/queue` → `{count, items: [{number, title, status, role, priority, updated_at, url}, ...]}`

- Aggregates both `pending-human-*` statuses (deduped if a single issue carries both labels).
- Sorted by priority (high → low), then age within tier (oldest first).
- Uses `severity:*` when `priority:*` is absent — works for both issues and tasks.

## Defensive behavior
- `gh` subprocess failure (rc != 0) → returns empty queue, not 500.
- Malformed JSON → empty queue.
- Malformed `labels` on a single row (e.g. string instead of list) → row skipped, others returned.
- Unparseable `updated_at` → sorts LAST in its priority tier (not first, which a naïve `return 0` fallback would produce).

## DeepSeek review (run BEFORE push)
2 warnings, both addressed inline:
- **R1**: `_summarize_pending_human` could `AttributeError` on unexpected `labels` shape. Wrapped per-row summarization in try/except — one bad row doesn't 500 the endpoint.
- **R2**: `_parse_iso_to_epoch` returned `0` on failure, which sorts before all valid timestamps. Now `float('inf')` so unknown-age items sort last in their priority tier.

## Verification
- 9 tests in `TestHumanQueueEndpoint`: empty / populated / dedup / sort-by-priority-then-age / severity-fallback / 3 error paths / unknown-age-sorts-last / malformed-label-shape.

## Out of scope
- The TUI / web UI itself (per the task body, deferred to the web UI work tracked in #3963 / harness architecture vision).
- Notification channels (Slack, email) — separate concern.

## Test plan
- [x] `pytest tests/test_harness.py::TestHumanQueueEndpoint` — 9 passed
- [x] DeepSeek-clean
- [ ] Manual: transition an issue to `pending-human-review`, hit `GET /human/queue`, see it in the response