### PR TITLE
feat: #8701 cycle_pre/post task-level refactor for event-driven mode

### DIFF
--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -221,10 +221,22 @@ def _do_tracker_comments(data, role):
 
 
 def _do_iteration_log(data, role):
-    """Create iteration log entry."""
+    """Create iteration log entry.
+
+    #8701: in event-driven task mode (when cycle-output.json contains a
+    `task` field), write a task-log entry keyed by task id + timestamp
+    instead of the monotonic iter-N.md. Mid-task crashes leave no entry —
+    that's correct semantics (the task didn't complete).
+    """
     cycle_number = data.get("cycle_number", 0)
     cycle_type = data.get("cycle_type", "quiet")
     summary = data.get("iteration_summary", "")
+    task_id = data.get("task")
+
+    if task_id:
+        # Task mode: write task-log/task-<id>-<timestamp>.md.
+        _write_task_log(role, task_id, cycle_type, summary, data)
+        return
 
     if cycle_type == "quiet":
         result = _run_script(
@@ -243,6 +255,85 @@ def _do_iteration_log(data, role):
 
     if result.returncode == 0:
         print(f"  Iteration log: iter-{cycle_number}.md")
+
+
+_TASK_LOG_RETENTION_PER_TASK = 5
+
+
+def _write_task_log(role, task_id, cycle_type, summary, data):
+    """Write a task-log entry under .squidsquad/<role>/task-log/ (#8701).
+
+    Format: `task-<id>-<YYYY-MM-DD-HHMMSS>.md`. Atomic write so a
+    mid-write crash leaves no entry (matches the design intent — only
+    completed task runs produce a log).
+
+    #8701 review fixes:
+    - R1: capture `now` once so filename + content timestamps agree.
+    - R2: reject `task_id` containing path-traversal characters before
+      constructing the filename.
+    - R3: prune older entries per-task to `_TASK_LOG_RETENTION_PER_TASK`
+      so the directory doesn't grow without bound.
+    """
+    # R2: refuse any task_id that could escape the task-log/ subdir.
+    sid = str(task_id)
+    if not sid or "/" in sid or "\\" in sid or ".." in sid:
+        print(f"WARNING: Invalid task_id {sid!r} — refusing to write task-log",
+              file=sys.stderr)
+        return
+
+    log_dir = SQUID_DIR / role / "task-log"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    # R1: single now() call drives both filename and content.
+    now = datetime.now()
+    ts = now.strftime("%Y-%m-%d-%H%M%S")
+    fname = f"task-{sid}-{ts}.md"
+
+    content_lines = [
+        f"# Task #{sid} — {role}",
+        "",
+        f"- **Cycle type**: {cycle_type}",
+        f"- **Timestamp**: {now.isoformat(timespec='seconds')}",
+        f"- **Cycle number (counter)**: {data.get('cycle_number', '?')}",
+        "",
+        "## Summary",
+        "",
+        summary or "(no summary)",
+    ]
+    transitions = data.get("status_transitions", [])
+    if transitions:
+        content_lines.extend(["", "## Status transitions"])
+        for t in transitions:
+            content_lines.append(
+                f"- #{t.get('number')}: {t.get('from')} → {t.get('to')}"
+            )
+    content = "\n".join(content_lines) + "\n"
+
+    final_path = log_dir / fname
+    tmp_path = log_dir / f".{fname}.tmp"
+    try:
+        tmp_path.write_text(content, encoding="utf-8")
+        tmp_path.replace(final_path)
+    except OSError as e:
+        print(f"WARNING: Could not write task-log {final_path}: {e}",
+              file=sys.stderr)
+        return
+    print(f"  Task log: {final_path.relative_to(REPO_ROOT)}")
+
+    # R3: prune older entries for this task. Keep newest N by mtime.
+    try:
+        existing = sorted(
+            log_dir.glob(f"task-{sid}-*.md"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        for stale in existing[_TASK_LOG_RETENTION_PER_TASK:]:
+            try:
+                stale.unlink()
+            except OSError:
+                pass
+    except OSError:
+        pass
 
 
 _AUTOCLOSE_RE = re.compile(

--- a/references/scripts/cycle_pre.py
+++ b/references/scripts/cycle_pre.py
@@ -5,11 +5,14 @@ Runs before the agent's creative phase. Handles git pull, context pressure,
 working state, triage, branch setup, and writes cycle-input.json.
 
 Usage:
-    python references/scripts/cycle_pre.py <role>
-    python references/scripts/cycle_pre.py skill
-    python references/scripts/cycle_pre.py pm
-    python references/scripts/cycle_pre.py qa
-    python references/scripts/cycle_pre.py dm
+    python references/scripts/cycle_pre.py <role>             # /loop mode
+    python references/scripts/cycle_pre.py <role> --task <n>  # event-driven, task-scoped (#8701)
+
+In task mode (#8701, used by event-driven agents), `cycle_pre` skips the
+work-queue scan and writes a `cycle-input.json` scoped to the single task
+passed via `--task`. `cycle_post.py` detects task mode by the presence of
+a `task` field in `cycle-output.json` and uses task-log files keyed by
+task id + timestamp rather than monotonic cycle numbers.
 
 Exit codes:
     0 — success (cycle-input.json written, possibly degraded)
@@ -970,19 +973,41 @@ ROLE_BUILDERS = {
 }
 
 
-def main():
-    if len(sys.argv) < 2:
-        print("Usage: cycle_pre.py <role>", file=sys.stderr)
-        sys.exit(1)
+def _parse_cli_args(argv):
+    """Parse `<role> [--task <number>]` from argv (post-script-name).
 
-    role = sys.argv[1]
+    Returns (role, task) where task is a string or None. Kept lightweight
+    so cycle_pre stays callable from tests without rebuilding argv.
+    """
+    if not argv:
+        return None, None
+    role = argv[0]
+    task = None
+    i = 1
+    while i < len(argv):
+        if argv[i] == "--task" and i + 1 < len(argv):
+            task = argv[i + 1]
+            i += 2
+        else:
+            i += 1
+    return role, task
+
+
+def main():
+    role, task_id = _parse_cli_args(sys.argv[1:])
+    if not role:
+        print("Usage: cycle_pre.py <role> [--task <number>]", file=sys.stderr)
+        sys.exit(1)
     if role not in ROLE_BUILDERS:
         print(f"ERROR: Unknown role '{role}'. Valid: {list(ROLE_BUILDERS.keys())}",
               file=sys.stderr)
         sys.exit(1)
 
     ts = _timestamp_short()
-    print(f"[🦑 {ts}] cycle_pre starting for {role}...")
+    if task_id:
+        print(f"[🦑 {ts}] cycle_pre starting for {role} (task #{task_id}, event-driven mode)...")
+    else:
+        print(f"[🦑 {ts}] cycle_pre starting for {role}...")
     _write_status_bar(role, "pulling", "pull-latest — Syncing with remote...")
 
     # 1a. Read working state early to determine correct branch (#4942)
@@ -1011,7 +1036,18 @@ def main():
     _write_status_bar(role, "triaging", "tracker-protocol — Building work queue...")
 
     # 7. Role-specific input
-    role_input = ROLE_BUILDERS[role](role)
+    # #8701: task mode skips the role-specific work-queue scan. The harness
+    # already chose this task; cycle_pre's only forge-side responsibility is
+    # to surface the task itself plus the standard branch/state context.
+    if task_id:
+        role_input = {
+            "task": task_id,
+            "task_mode": True,
+            # Cross-agent health checks intentionally omitted in event-driven
+            # mode (per #8701 design: the harness owns liveness).
+        }
+    else:
+        role_input = ROLE_BUILDERS[role](role)
 
     # 7b. Read event bus (#5622)
     recent_events = []
@@ -1028,6 +1064,10 @@ def main():
     mechanical_reactions = _run_mechanical_reactions(recent_events, role)
 
     # 8. Build and write cycle-input.json
+    # #8701: in task mode, cycle_number is replaced by `task` + `timestamp`
+    # as the unit of work identifier. The numeric counter is kept in the
+    # JSON for downstream consumers but flagged as task-mode so cycle_post
+    # branches correctly.
     cycle_input = {
         "role": role,
         "cycle_number": cycle_number,

--- a/tests/test_cycle_post.py
+++ b/tests/test_cycle_post.py
@@ -1319,3 +1319,158 @@ class TestStateCommitAfterCodeCommit:
 
         assert len(state_commit_calls) == 1
         assert "cycle 300 state" in state_commit_calls[0][0]
+
+
+# ---------------------------------------------------------------------------
+# Task-mode logging — #8701
+# ---------------------------------------------------------------------------
+
+
+class TestTaskModeLog:
+    """#8701: when cycle-output.json carries a `task` field, write a
+    task-log entry instead of the monotonic iter-N.md."""
+
+    def test_task_mode_writes_task_log(self, tmp_path):
+        with patch.object(cycle_post, "SQUID_DIR", tmp_path), \
+             patch.object(cycle_post, "REPO_ROOT", tmp_path), \
+             patch.object(cycle_post, "_run_script") as mock_script:
+            cycle_post._do_iteration_log(
+                {
+                    "task": "8701",
+                    "cycle_number": 1125,
+                    "cycle_type": "active",
+                    "iteration_summary": "task-mode refactor done",
+                    "status_transitions": [
+                        {"number": 8701, "from": "in-progress", "to": "pending-test"}
+                    ],
+                },
+                "skill",
+            )
+        # No iter-N.md path taken in task mode
+        mock_script.assert_not_called()
+        # A task-log file should exist
+        log_dir = tmp_path / "skill" / "task-log"
+        assert log_dir.is_dir()
+        logs = list(log_dir.glob("task-8701-*.md"))
+        assert len(logs) == 1
+        content = logs[0].read_text(encoding="utf-8")
+        assert "Task #8701" in content
+        assert "task-mode refactor done" in content
+        assert "#8701: in-progress → pending-test" in content
+
+    def test_task_mode_atomic_write(self, tmp_path):
+        """Task log uses .tmp + rename so partial writes leave no entry."""
+        with patch.object(cycle_post, "SQUID_DIR", tmp_path), \
+             patch.object(cycle_post, "REPO_ROOT", tmp_path), \
+             patch.object(cycle_post, "_run_script"):
+            cycle_post._do_iteration_log(
+                {"task": "1", "cycle_number": 1, "cycle_type": "quiet",
+                 "iteration_summary": "s"},
+                "pm",
+            )
+        log_dir = tmp_path / "pm" / "task-log"
+        # No `.tmp` residue after success
+        tmps = list(log_dir.glob(".task-*.tmp"))
+        assert tmps == []
+        # Final file is present
+        assert list(log_dir.glob("task-1-*.md"))
+
+    def test_non_task_mode_unchanged(self, tmp_path):
+        """When no `task` field, falls through to the existing iter-N.md path."""
+        with patch.object(cycle_post, "SQUID_DIR", tmp_path), \
+             patch.object(cycle_post, "REPO_ROOT", tmp_path), \
+             patch.object(cycle_post, "_run_script",
+                          return_value=MagicMock(returncode=0)) as mock_script:
+            cycle_post._do_iteration_log(
+                {"cycle_number": 500, "cycle_type": "active",
+                 "iteration_summary": "loop cycle"},
+                "skill",
+            )
+        # Should have invoked cycle.py log-iteration at some point (NOT task-log path)
+        assert mock_script.called
+        invocations = [c[0] for c in mock_script.call_args_list]
+        assert any(
+            inv[0] == "cycle.py" and inv[1] == "log-iteration"
+            for inv in invocations
+        ), f"expected log-iteration call in {invocations}"
+        # No task-log directory should be created
+        assert not (tmp_path / "skill" / "task-log").exists()
+
+    def test_filename_and_content_timestamp_match(self, tmp_path):
+        """R1: single datetime.now() drives both filename and content."""
+        with patch.object(cycle_post, "SQUID_DIR", tmp_path), \
+             patch.object(cycle_post, "REPO_ROOT", tmp_path):
+            cycle_post._write_task_log(
+                "skill", "8701", "active", "summary",
+                {"cycle_number": 1},
+            )
+        logs = list((tmp_path / "skill" / "task-log").glob("task-8701-*.md"))
+        assert len(logs) == 1
+        fname = logs[0].name  # task-8701-YYYY-MM-DD-HHMMSS.md
+        # Extract the YYYY-MM-DD-HHMMSS portion
+        stem = fname[len("task-8701-"):-len(".md")]
+        content = logs[0].read_text(encoding="utf-8")
+        # Content has ISO format `YYYY-MM-DDTHH:MM:SS`. Derive the same
+        # YYYY-MM-DD-HHMMSS form and check it matches the filename stem.
+        from datetime import datetime
+        # Find the Timestamp line
+        ts_line = next(l for l in content.splitlines() if "Timestamp" in l)
+        iso = ts_line.split("**: ", 1)[1].strip()
+        derived = datetime.fromisoformat(iso).strftime("%Y-%m-%d-%H%M%S")
+        assert derived == stem, f"filename {stem} != content {derived}"
+
+    def test_rejects_path_traversal_in_task_id(self, tmp_path, capsys):
+        """R2: task_id with `..`, `/`, or `\\` is refused, no file written."""
+        with patch.object(cycle_post, "SQUID_DIR", tmp_path), \
+             patch.object(cycle_post, "REPO_ROOT", tmp_path):
+            for bad in ["../escape", "a/b", "a\\b", "..", ""]:
+                cycle_post._write_task_log(
+                    "skill", bad, "active", "s", {"cycle_number": 1},
+                )
+        # No files were ever created under task-log/ (or anywhere outside)
+        log_dir = tmp_path / "skill" / "task-log"
+        if log_dir.exists():
+            assert list(log_dir.iterdir()) == []
+        # And nothing escaped the role dir
+        all_md = list(tmp_path.rglob("*.md"))
+        assert all_md == [], f"unexpected files written: {all_md}"
+
+    def test_retention_prunes_old_task_logs(self, tmp_path):
+        """R3: only the N newest entries per task are kept."""
+        import time
+        with patch.object(cycle_post, "SQUID_DIR", tmp_path), \
+             patch.object(cycle_post, "REPO_ROOT", tmp_path):
+            for i in range(cycle_post._TASK_LOG_RETENTION_PER_TASK + 3):
+                cycle_post._write_task_log(
+                    "skill", "8701", "active", f"run {i}",
+                    {"cycle_number": i},
+                )
+                # ensure distinct mtimes; filenames carry seconds so we
+                # also need a sub-second nudge between calls
+                time.sleep(1.05)
+        logs = list((tmp_path / "skill" / "task-log").glob("task-8701-*.md"))
+        assert len(logs) == cycle_post._TASK_LOG_RETENTION_PER_TASK
+
+    def test_retention_keeps_other_tasks(self, tmp_path):
+        """R3: pruning is scoped to the current task_id only."""
+        with patch.object(cycle_post, "SQUID_DIR", tmp_path), \
+             patch.object(cycle_post, "REPO_ROOT", tmp_path):
+            cycle_post._write_task_log(
+                "skill", "1234", "active", "other task",
+                {"cycle_number": 1},
+            )
+            import time
+            time.sleep(1.05)
+            for i in range(cycle_post._TASK_LOG_RETENTION_PER_TASK + 2):
+                cycle_post._write_task_log(
+                    "skill", "8701", "active", f"r{i}",
+                    {"cycle_number": i},
+                )
+                time.sleep(1.05)
+        log_dir = tmp_path / "skill" / "task-log"
+        # 1234 untouched
+        assert len(list(log_dir.glob("task-1234-*.md"))) == 1
+        # 8701 pruned
+        assert len(list(log_dir.glob("task-8701-*.md"))) == \
+            cycle_post._TASK_LOG_RETENTION_PER_TASK
+

--- a/tests/test_cycle_pre.py
+++ b/tests/test_cycle_pre.py
@@ -1551,3 +1551,37 @@ class TestRunMechanicalReactions:
         result = cycle_pre._run_mechanical_reactions(events, "pm")
         rework = [r for r in result if r["type"] == "rework-needed"]
         assert len(rework) == 0
+
+
+# ---------------------------------------------------------------------------
+# Task-mode CLI parsing — #8701
+# ---------------------------------------------------------------------------
+
+
+class TestParseCliArgs:
+    def test_role_only_no_task(self):
+        role, task = cycle_pre._parse_cli_args(["skill"])
+        assert role == "skill"
+        assert task is None
+
+    def test_role_with_task_flag(self):
+        role, task = cycle_pre._parse_cli_args(["skill", "--task", "42"])
+        assert role == "skill"
+        assert task == "42"
+
+    def test_task_flag_with_no_value_ignored(self):
+        """Trailing `--task` without a value should not crash."""
+        role, task = cycle_pre._parse_cli_args(["skill", "--task"])
+        assert role == "skill"
+        assert task is None
+
+    def test_empty_argv(self):
+        role, task = cycle_pre._parse_cli_args([])
+        assert role is None
+        assert task is None
+
+    def test_extra_args_after_task(self):
+        role, task = cycle_pre._parse_cli_args(["pm", "--task", "100", "--ignored"])
+        assert role == "pm"
+        assert task == "100"
+


### PR DESCRIPTION
## Summary
- `cycle_pre.py` accepts `--task <id>` and skips `ROLE_BUILDERS` in task mode (role_input carries `task` + `task_mode` only).
- `cycle_post.py` detects task mode via `cycle-output.json`'s `task` field and writes a per-task log to `.squidsquad/<role>/task-log/task-<id>-<ts>.md` instead of the monotonic `iter-N.md` path. Atomic write via `.tmp` + `replace`.
- This is the last remaining Phase 5 task on #7630 (event-driven architecture).

## DeepSeek review fixes (applied pre-push)
- **R1**: single `datetime.now()` drives both filename and content timestamps (was inconsistent across two calls).
- **R2**: reject `task_id` containing `/`, `\`, or `..` so a malformed value can't escape the `task-log/` subdir.
- **R3**: prune older entries per task to `_TASK_LOG_RETENTION_PER_TASK` (5) by mtime so the directory doesn't grow without bound.

## Test plan
- [x] `pytest tests/test_cycle_pre.py tests/test_cycle_post.py` — 180 pass
- [x] New: `TestParseCliArgs` (5 tests) covers `--task` parsing.
- [x] New: `TestTaskModeLog` (7 tests) covers task-log write, atomic write, non-task fallthrough, filename/content timestamp agreement, path-traversal rejection, retention pruning, and per-task pruning scope.

Closes #8701

🤖 Generated with [Claude Code](https://claude.com/claude-code)