### PR TITLE
fix: #8879 thin_launcher _write_pid failure orphans claude

### DIFF
--- a/references/scripts/thin_launcher.py
+++ b/references/scripts/thin_launcher.py
@@ -171,8 +171,17 @@ def main():
         print(f"[thin-launcher] ERROR: failed to execute '{claude_exe}'", file=sys.stderr)
         return 1
 
-    # Write PID for harness monitoring
-    _write_pid(clone_path, role, proc.pid)
+    # Write PID for harness monitoring. If the write fails (disk full,
+    # permission denied, antivirus locking the .tmp), warn and continue —
+    # claude is already running and we still need to reach proc.wait()
+    # below. Otherwise the exception would unwind past the wait, leaving
+    # claude as an orphan child without a pid file for the harness (#8879).
+    try:
+        _write_pid(clone_path, role, proc.pid)
+    except OSError as e:
+        pid_path = Path(clone_path) / ".squidsquad" / role / ".claude-pid"
+        print(f"[thin-launcher] WARNING: could not write pid file "
+              f"({pid_path}): {e}", file=sys.stderr)
     print(f"[thin-launcher] claude PID: {proc.pid}")
 
     # Wait for claude to exit — keeps terminal open

--- a/tests/test_thin_launcher.py
+++ b/tests/test_thin_launcher.py
@@ -275,3 +275,37 @@ class TestSingletonEnforcement:
             rc = thin_launcher.main()
 
         assert rc == 0
+
+
+class TestWritePidFailure:
+    """#8879: if _write_pid raises after Popen, claude must still be waited on."""
+
+    @pytest.mark.parametrize("wait_code", [0, 42])
+    def test_oserror_in_write_pid_does_not_orphan_child(
+        self, tmp_path, capsys, wait_code,
+    ):
+        """_write_pid OSError is caught; proc.wait() still runs and exit code propagates."""
+        (tmp_path / ".squidsquad" / "skill").mkdir(parents=True)
+
+        proc = MagicMock()
+        proc.pid = 99999
+        proc.wait.return_value = wait_code
+        proc.kill = MagicMock()
+
+        with patch("thin_launcher.os.getcwd", return_value=str(tmp_path)), \
+             patch("thin_launcher.subprocess.Popen", return_value=proc), \
+             patch("thin_launcher._get_effort_level", return_value="high"), \
+             patch("thin_launcher._write_pid",
+                   side_effect=OSError("disk full")), \
+             patch("sys.argv", ["thin_launcher.py", "skill"]):
+            rc = thin_launcher.main()
+
+        # Exit code reflects proc.wait(), not the OSError — both happy
+        # path (0) and context-pressure exit (42) must propagate.
+        assert rc == wait_code
+        # We actually waited on the child instead of unwinding past it.
+        proc.wait.assert_called_once()
+        # Warning surfaced on stderr with the pid file path for operator triage.
+        err = capsys.readouterr().err
+        assert "WARNING" in err and "pid file" in err
+        assert str(tmp_path / ".squidsquad" / "skill" / ".claude-pid") in err


### PR DESCRIPTION
Closes #8879

## Summary
When `_write_pid` raises after `Popen` (disk full, permission denied, AV locking `.tmp`), the exception unwinds past `proc.wait()`, leaving the spawned `claude` process orphaned without a pid file for the harness to track.

This wraps `_write_pid` in `try/except OSError` so the launcher still reaches `proc.wait()` and exits with claude's actual exit code. A WARNING is logged to stderr with the pid file path so an operator can investigate.

Found via improvement-scan on cycle 1126.

## Changes
- **`references/scripts/thin_launcher.py`**: `try/except OSError` around `_write_pid`; WARNING includes the pid file path.
- **`tests/test_thin_launcher.py`**: new `TestWritePidFailure` class with parametrized test (`wait_code` ∈ {0, 42}) asserting `proc.wait()` runs, exit code propagates, and the pid path appears in stderr.

## Code Review (Sonnet)
- Iteration 1: 2 warnings — (a) WARNING omitted pid file path, (b) test didn't cover non-zero exit propagation. Both fixed.
- Iteration 2: CLEAN — no findings, ready to merge.

## QA Status
- [x] Unit tests passing (24/24 in test_thin_launcher.py)
- [x] Self-review: regression, integration, philosophy, personas — all clean
- [x] Code review iterations clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)