### PR TITLE
refactor: #8891 extract is_process_alive to process_utils

### DIFF
--- a/references/scripts/boot_remote.py
+++ b/references/scripts/boot_remote.py
@@ -37,6 +37,9 @@ SQUIDSQUAD_DIR = REPO_ROOT / ".squidsquad"
 LOCAL_CONFIG = SQUIDSQUAD_DIR / ".local-config"
 CONFIG_MD = SQUIDSQUAD_DIR / "config.md"
 
+sys.path.insert(0, str(SCRIPT_DIR))
+from process_utils import is_process_alive as _is_process_alive  # noqa: E402  (#8891)
+
 # Removed: BOOT_LOG, BOOT_LOCK, COOLDOWN_SECONDS, LOCK_TTL_SECONDS (#2183)
 
 
@@ -158,24 +161,6 @@ def _read_pid_file(clone_path, role):
         return int(content) if content else None
     except (ValueError, OSError):
         return None
-
-
-def _is_process_alive(pid):
-    """Check if a process with the given PID is still running."""
-    if pid is None:
-        return False
-    try:
-        if platform.system().lower() == "windows":
-            result = subprocess.run(
-                ["tasklist", "/FI", f"PID eq {pid}", "/NH"],
-                capture_output=True, text=True, check=False,
-            )
-            return str(pid) in result.stdout
-        else:
-            os.kill(pid, 0)
-            return True
-    except (OSError, ProcessLookupError, PermissionError):
-        return False
 
 
 # _has_stop_sentinel was removed in #4792. Agent lifecycle is now controlled

--- a/references/scripts/health_check.py
+++ b/references/scripts/health_check.py
@@ -44,6 +44,9 @@ SQUIDSQUAD_DIR = REPO_ROOT / ".squidsquad"
 LOCAL_CONFIG = SQUIDSQUAD_DIR / ".local-config"
 CONFIG_MD = SQUIDSQUAD_DIR / "config.md"
 
+sys.path.insert(0, str(SCRIPT_DIR))
+from process_utils import is_process_alive as _is_process_alive  # noqa: E402  (#8891)
+
 # Health categories
 HEALTHY = "healthy"
 STALLED = "stalled"
@@ -206,24 +209,6 @@ def _read_any_pid(squid_dir):
     if pid is not None:
         return pid
     return _read_pid_file(squid_dir)
-
-
-def _is_process_alive(pid):
-    """Check if a process with the given PID is still running."""
-    if pid is None:
-        return False
-    try:
-        if platform.system().lower() == "windows":
-            result = subprocess.run(
-                ["tasklist", "/FI", f"PID eq {pid}", "/NH"],
-                capture_output=True, text=True, check=False,
-            )
-            return str(pid) in result.stdout
-        else:
-            os.kill(pid, 0)
-            return True
-    except (OSError, ProcessLookupError, PermissionError):
-        return False
 
 
 def _parse_health_file(text):

--- a/references/scripts/process_utils.py
+++ b/references/scripts/process_utils.py
@@ -1,0 +1,41 @@
+"""Shared OS-process helpers (#8891).
+
+Cross-platform process liveness used by boot_remote, health_check, and
+reboot_agent. thin_launcher.py keeps its own copy of this logic to avoid
+importing this module (and indirectly any heavier deps) at boot — see
+the comment there. If you change the semantics here, mirror the change
+in thin_launcher.py:_is_process_alive.
+"""
+
+import os
+import platform
+import subprocess
+
+
+def is_process_alive(pid):
+    """Return True if a process with this PID is currently running.
+
+    Cross-platform. On Windows we shell out to ``tasklist`` because
+    ``os.kill(pid, 0)`` doesn't exist there. On POSIX we use signal 0,
+    which only does the permission/existence check without delivering a
+    signal.
+
+    Rejects ``None`` and any non-positive PID: ``os.kill(0, 0)`` would
+    target the calling process group, and negative PIDs mean process
+    groups too — both unsafe to treat as "is this specific process
+    alive?". Stay strict so callers can't accidentally probe the wrong
+    thing.
+    """
+    if pid is None or pid <= 0:
+        return False
+    try:
+        if platform.system().lower() == "windows":
+            result = subprocess.run(
+                ["tasklist", "/FI", f"PID eq {pid}", "/NH"],
+                capture_output=True, text=True, check=False,
+            )
+            return str(pid) in result.stdout
+        os.kill(pid, 0)
+        return True
+    except (OSError, ProcessLookupError, PermissionError):
+        return False

--- a/references/scripts/reboot_agent.py
+++ b/references/scripts/reboot_agent.py
@@ -35,16 +35,12 @@ POLL_INTERVAL = 2  # seconds
 # Import boot_remote for unified clone-path resolution and spawn logic
 sys.path.insert(0, str(SCRIPT_DIR))
 import boot_remote
+from process_utils import is_process_alive as _is_process_alive  # (#8891)
 
 
 def _get_clone_path(role):
     """Get the clone path for a role. Uses boot_remote's unified resolution."""
     return boot_remote._get_clone_path(role)
-
-
-def _is_process_alive(pid):
-    """Check if a process is alive."""
-    return boot_remote._is_process_alive(pid)
 
 
 def _kill_process(pid):

--- a/references/scripts/thin_launcher.py
+++ b/references/scripts/thin_launcher.py
@@ -45,8 +45,9 @@ def _get_effort_level(role):
 def _is_process_alive(pid):
     """Check if a process with the given PID is still running. Cross-platform.
 
-    Mirrors boot_remote._is_process_alive — kept local to avoid importing
-    the much larger boot_remote module at launcher startup.
+    Canonical version lives in ``process_utils.is_process_alive`` — kept
+    local here to avoid importing extra modules at launcher startup
+    (#8891). If you change the semantics there, mirror the change here.
     """
     if pid is None or pid <= 0:
         return False

--- a/tests/test_process_utils.py
+++ b/tests/test_process_utils.py
@@ -1,0 +1,82 @@
+"""Tests for references/scripts/process_utils.py (#8891)."""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import process_utils
+
+
+class TestIsProcessAlive:
+    """Cross-platform PID liveness — canonical implementation (#8891)."""
+
+    def test_none_is_not_alive(self):
+        assert process_utils.is_process_alive(None) is False
+
+    def test_zero_is_not_alive(self):
+        # os.kill(0, ...) targets the calling process group on POSIX —
+        # we never want a 0 to be treated as "alive". Stay strict.
+        assert process_utils.is_process_alive(0) is False
+
+    def test_negative_is_not_alive(self):
+        # Negative PIDs are process groups on POSIX; reject them.
+        assert process_utils.is_process_alive(-1) is False
+        assert process_utils.is_process_alive(-12345) is False
+
+    def test_own_pid_is_alive(self):
+        # The test runner's own PID is obviously alive.
+        assert process_utils.is_process_alive(os.getpid()) is True
+
+    def test_unlikely_pid_is_not_alive(self):
+        # 2**31 - 2 is well above any plausible PID; tasklist / os.kill
+        # both report not-found.
+        assert process_utils.is_process_alive(2_147_483_646) is False
+
+    def test_oserror_returns_false(self):
+        """Implementation defensively swallows OSError and returns False."""
+        with patch("process_utils.platform.system", return_value="Linux"), \
+             patch("process_utils.os.kill", side_effect=OSError("boom")):
+            assert process_utils.is_process_alive(12345) is False
+
+    def test_permission_error_returns_false(self):
+        """PermissionError (process exists but not ours on some OSes) → False."""
+        with patch("process_utils.platform.system", return_value="Linux"), \
+             patch("process_utils.os.kill", side_effect=PermissionError):
+            assert process_utils.is_process_alive(12345) is False
+
+    def test_windows_branch_parses_tasklist(self):
+        """Windows branch checks for the PID string in tasklist stdout."""
+        fake_proc = MagicMock(stdout="some preamble PID:12345 more\n")
+        with patch("process_utils.platform.system", return_value="Windows"), \
+             patch("process_utils.subprocess.run", return_value=fake_proc) as run:
+            assert process_utils.is_process_alive(12345) is True
+            # Sanity-check we called tasklist with the right PID filter.
+            args = run.call_args[0][0]
+            assert args[0] == "tasklist"
+            assert "PID eq 12345" in args
+
+    def test_windows_branch_returns_false_when_pid_absent(self):
+        fake_proc = MagicMock(stdout="INFO: No tasks matching\n")
+        with patch("process_utils.platform.system", return_value="Windows"), \
+             patch("process_utils.subprocess.run", return_value=fake_proc):
+            assert process_utils.is_process_alive(99999999) is False
+
+
+class TestModuleReexports:
+    """Importers should be able to alias via `as _is_process_alive`."""
+
+    def test_boot_remote_alias_points_at_process_utils(self):
+        import boot_remote
+        assert boot_remote._is_process_alive is process_utils.is_process_alive
+
+    def test_health_check_alias_points_at_process_utils(self):
+        import health_check
+        assert health_check._is_process_alive is process_utils.is_process_alive
+
+    def test_reboot_agent_alias_points_at_process_utils(self):
+        import reboot_agent
+        assert reboot_agent._is_process_alive is process_utils.is_process_alive


### PR DESCRIPTION
Closes #8891

## Summary
Cross-platform PID-liveness logic was reimplemented in four scripts (`boot_remote`, `health_check`, `reboot_agent`, `thin_launcher`). This consolidates three of them into `references/scripts/process_utils.py`. `thin_launcher` keeps its local copy intentionally (boot-startup cost) but the comment now points at `process_utils` as canonical so future editors mirror semantic changes.

Found via improvement-scan on cycle 1128.

## Changes
- **NEW `references/scripts/process_utils.py`** — canonical `is_process_alive(pid)`. Now also rejects `pid <= 0` (`os.kill(0, ...)` targets the calling process group on POSIX — unsafe to treat as "is this specific process alive?"). Matches `thin_launcher`'s existing defensiveness; the old `boot_remote`/`health_check` copies only rejected `None`.
- **`boot_remote.py`, `health_check.py`**: removed local body, kept module-level alias `from process_utils import is_process_alive as _is_process_alive` so existing `@patch("boot_remote._is_process_alive", ...)` patches in the test suite continue to work unchanged.
- **`reboot_agent.py`**: was already delegating via `boot_remote._is_process_alive`; now delegates directly to `process_utils` for less indirection.
- **`thin_launcher.py`**: docstring updated to point at `process_utils` as canonical. Function body unchanged.
- **NEW `tests/test_process_utils.py`** — `TestIsProcessAlive` (8 cases: None / 0 / negative / own PID / unlikely PID / OSError swallowed / PermissionError swallowed / Windows tasklist branch present + absent) + `TestModuleReexports` (3 cases asserting each consumer's alias `is process_utils.is_process_alive`).

## Code Review (Sonnet)
- 1 iteration. No blockers. Two informational warnings, both by-design and pre-existing (harness.py uses `boot_remote._is_process_alive` via module ref — still patched transitively; alias-identity test can't catch all subtle shadowing — inherent to the pattern, well-mitigated by the passing test suite).

## Test plan
- [x] 167 affected tests pass across `test_process_utils.py` + `test_boot_remote.py` + `test_health_check.py` + `test_reboot_agent.py` + `test_thin_launcher.py`
- [x] Full `python tests/run_tests.py` passes — zero failures
- [x] Verified no existing caller passes `0` or negative PID (all sources read from `_read_pid_file`/`_read_any_pid`, which return `None` on failure)
- [x] Self-review: regression, integration, philosophy, personas — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)