### PR TITLE
fix: #8914 strip dispatch + gating from harness — restore thin-broadcast lock

### DIFF
--- a/references/scripts/event_bus.py
+++ b/references/scripts/event_bus.py
@@ -102,13 +102,13 @@ def ack(event_id, role):
 
 
 def bootup_complete(role):
-    """Signal that the agent has finished initial boot (#8695).
+    """Signal that the agent has finished initial boot (#8695 / #8914).
 
     Event-driven agents call this after: L1 init done, working-state.md read,
-    initial backlog scan complete, Monitor subscription active. Until the
-    harness sees this event, it returns no events from /events/for/<role> for
-    this role — preventing the race where an `assigned-to` arrives during boot
-    and is dropped because the agent isn't subscribed yet.
+    initial backlog scan complete, Monitor subscription active. The harness
+    records the signal on `AgentState.bootup_complete` and exposes it via
+    `GET /agents/{role}` for operator / TUI consumption. Informational only —
+    no per-role gating, queuing, or dispatch (CONTEXT.md §5.2).
 
     Fire-and-forget like emit(). Safe to call multiple times.
     """

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -98,11 +98,11 @@ class AgentState:
         self.last_cycle_start = None
         self.last_cycle_end = None
         self.last_cycle_type = None
-        # #8695: bootup-complete gating. False until the agent emits
-        # `bootup-complete`. While False, get_events_for_role returns no events
-        # so the harness never dispatches assigned-to / status-transition into
-        # a still-booting agent (events accumulate in the stream and drain on
-        # the agent's first poll after bootup-complete).
+        # #8695 / #8914: bootup_complete is informational only. False until
+        # the agent emits `bootup-complete`; exposed via GET /agents/{role} so
+        # operators / the TUI can see whether a role has finished its boot
+        # sequence. The harness does NOT gate, queue, or hold events on this
+        # flag — CONTEXT.md §2 + §5.2 lock the harness as a pure broadcast pipe.
         self.bootup_complete = False
 
     def to_dict(self):
@@ -1088,16 +1088,10 @@ async def receive_event(request: Request):
     # Store in stream (with disk persistence via lifecycle manager)
     event_lifecycle.append(body)
 
-    # Tracker handoff dispatch (#8694): when an agent transitions a tracker
-    # item, re-evaluate affected role queues and emit assigned-to for the new
-    # top item — no /loop polling delay between consecutive work items.
-    if event_type == "status-transition":
-        handoff_dispatcher.on_transition(body.get("payload", {}), role)
-
-    # Bootup gating (#8695): agent signals it's ready to receive dispatches.
-    # Until this fires, get_events_for_role returns nothing for this role —
-    # events accumulate in the stream and drain on the agent's first poll
-    # after bootup-complete, so nothing is lost.
+    # Bootup-complete is informational only (#8914). The harness records the
+    # flag on AgentState and exposes it via GET /agents/{role}; it does NOT
+    # gate or queue events per-role. CONTEXT.md §2 + §5.2 lock the harness as
+    # a pure broadcast pipe — no tracker observation, no dispatch logic.
     if event_type == "bootup-complete" and role:
         # Mutate under state._lock to avoid racing with the health poller's
         # auto-reboot path (which sets bootup_complete=False under the same
@@ -1184,17 +1178,9 @@ async def get_events_for_role(
     """
     _validate_role(role)
 
-    # #8695: Bootup-complete gating. While the agent has not yet emitted
-    # `bootup-complete`, return an empty list so the harness never dispatches
-    # work into a still-booting agent. Events remain in the stream and will be
-    # delivered on the next poll after bootup-complete arrives.
-    agent_for_gate = state.get_agent(role)
-    if agent_for_gate is not None and not agent_for_gate.bootup_complete:
-        return {
-            "events": [],
-            "total": 0,
-            "gated": "bootup-incomplete",
-        }
+    # No per-role gating here (#8914). The harness is a pure broadcast pipe;
+    # `bootup_complete` is informational only, exposed via GET /agents/{role}
+    # but never consulted for event delivery. CONTEXT.md §5.2.
 
     # Get relevant event types for this role from config
     try:
@@ -1960,9 +1946,11 @@ class ExternalActivityDetector:
         self._thread = None
         self._last_check_epoch = 0.0  # epoch seconds — avoids ISO string comparison
         self._emitted_issues: dict[int, None] = {}  # ordered dedup: issues already emitted
-        # #8694: shared lock for _emitted_issues — TrackerHandoffDispatcher
-        # writes here from a separate thread (cross-dedup); without this the
-        # compound eviction (next(iter) + del) can race with concurrent writes.
+        # Lock guards _emitted_issues against concurrent mutation. The
+        # detector's own poller thread is the only writer now that #8914
+        # removed TrackerHandoffDispatcher, but the lock stays — the
+        # compound eviction (next(iter) + del) still needs serialization
+        # if another thread is ever added.
         self._emitted_lock = threading.Lock()
 
     def is_emitted(self, issue_num):
@@ -2087,139 +2075,11 @@ class ExternalActivityDetector:
 activity_detector = ExternalActivityDetector()
 
 
-class TrackerHandoffDispatcher:
-    """Dispatches assigned-to events on tracker transitions (#8694).
-
-    Hook: `POST /events` calls `on_transition()` for every `status-transition`
-    event received. We re-evaluate the affected role queue(s) and emit an
-    `assigned-to` event for the new top item, with per-role dedup so the same
-    queue-head isn't re-emitted repeatedly.
-
-    No /complete API — the transition IS the completion signal.
-    """
-
-    AGENT_ROLES = ExternalActivityDetector.AGENT_ROLES
-
-    def __init__(self):
-        # Per-role last-emitted top issue number (None = no item known)
-        self._last_top: dict[str, int | None] = {}
-        self._lock = threading.Lock()
-        # Per-role serialization lock: only one dispatch runs per role at a
-        # time, so rapid-fire transitions on the same issue don't spawn N
-        # concurrent `gh issue list` subprocesses (#8694 follow-up).
-        self._role_locks: dict[str, threading.Lock] = {}
-        self._role_locks_guard = threading.Lock()
-
-    def _role_lock(self, role):
-        with self._role_locks_guard:
-            lock = self._role_locks.get(role)
-            if lock is None:
-                lock = threading.Lock()
-                self._role_locks[role] = lock
-            return lock
-
-    def on_transition(self, payload, actor_role):
-        """Called from POST /events for each status-transition event.
-
-        Runs the actual GitHub-poking work in a background thread so the
-        HTTP handler doesn't block on `gh` subprocess calls.
-        """
-        # #8694 follow-up: defensive — a truthy non-dict payload (string, int,
-        # bool) would `AttributeError` inside `_do_dispatch`. The `or {}` only
-        # caught falsy non-dicts; switch to isinstance.
-        safe_payload = payload if isinstance(payload, dict) else {}
-        thread = threading.Thread(
-            target=self._do_dispatch,
-            args=(safe_payload, actor_role),
-            daemon=True,
-            name="handoff-dispatch",
-        )
-        thread.start()
-
-    def _do_dispatch(self, payload, actor_role):
-        try:
-            roles_to_check = set()
-            if actor_role and actor_role in self.AGENT_ROLES:
-                roles_to_check.add(actor_role)
-            issue_num = payload.get("issue_number")
-            if issue_num:
-                issue_role = self._get_issue_role(issue_num)
-                if issue_role and issue_role in self.AGENT_ROLES:
-                    roles_to_check.add(issue_role)
-            for role in roles_to_check:
-                self._dispatch_next(role)
-        except Exception as e:
-            _log(f"Handoff dispatcher error: {e}")
-
-    def _dispatch_next(self, role):
-        """Compute role's current top item and emit assigned-to if it changed.
-
-        Serialized per-role: concurrent transitions for the same role queue
-        up rather than each running their own `gh issue list` subprocess.
-        """
-        with self._role_lock(role):
-            queue = self._get_work_queue(role)
-            if not queue:
-                with self._lock:
-                    self._last_top[role] = None
-                return
-            top = queue[0]
-            issue_num = top.get("number")
-            with self._lock:
-                if self._last_top.get(role) == issue_num:
-                    return  # queue head unchanged — no-op
-                self._last_top[role] = issue_num
-
-            # Bidirectional cross-dedup with the external poller: skip if the
-            # 60s poller already emitted this issue (#8694 follow-up).
-            if issue_num is not None and activity_detector.is_emitted(issue_num):
-                return
-
-            _emit_event("assigned-to", "harness", payload={
-                "issue_number": str(issue_num),
-                "title": top.get("title", ""),
-                "target_role": role,
-                "event_context": f"Next work for {role} after tracker handoff",
-            })
-            if issue_num is not None:
-                activity_detector.mark_emitted(issue_num)
-
-    def _get_work_queue(self, role):
-        """Return tracker.py work-queue output as a list of dicts."""
-        result = subprocess.run(
-            [sys.executable, str(SCRIPT_DIR / "tracker.py"), "work-queue", role],
-            capture_output=True, text=True, encoding="utf-8", errors="replace",
-            check=False, cwd=str(REPO_ROOT),
-        )
-        if result.returncode != 0:
-            return []
-        try:
-            return json.loads(result.stdout) or []
-        except json.JSONDecodeError:
-            return []
-
-    def _get_issue_role(self, issue_num):
-        """Return the role label on an issue (e.g. 'skill'), or None."""
-        result = subprocess.run(
-            ["gh", "issue", "view", str(issue_num), "--json", "labels"],
-            capture_output=True, text=True, encoding="utf-8", errors="replace",
-            check=False, cwd=str(REPO_ROOT),
-        )
-        if result.returncode != 0:
-            return None
-        try:
-            data = json.loads(result.stdout) or {}
-            for lbl in data.get("labels", []):
-                name = lbl.get("name", "")
-                if name.startswith("role:"):
-                    return name[len("role:"):]
-        except json.JSONDecodeError:
-            pass
-        return None
-
-
-# Global dispatcher instance
-handoff_dispatcher = TrackerHandoffDispatcher()
+# TrackerHandoffDispatcher was removed in #8914. CONTEXT.md §2 locks the
+# harness as a pure broadcast pipe with no tracker observation, no dispatch
+# logic, and no per-role queue knowledge. Tracker handoff handling lives in
+# the agents themselves — they consult the forge via tracker.py work-queue
+# when they wake.
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1359,117 +1359,39 @@ class TestCompleteEventEndpoint(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# TrackerHandoffDispatcher — #8694
+# Thin-harness invariants — #8914
 # ---------------------------------------------------------------------------
 
-class TestTrackerHandoffDispatcher(unittest.TestCase):
-    """#8694: harness emits assigned-to on tracker transitions, no /complete API."""
+class TestThinHarnessInvariants(unittest.TestCase):
+    """#8914: TrackerHandoffDispatcher + per-role event gating were removed.
 
-    def setUp(self):
-        from harness import TrackerHandoffDispatcher
-        self.dispatcher = TrackerHandoffDispatcher()
+    CONTEXT.md §2 locks the harness as a pure broadcast pipe with no tracker
+    observation, no dispatch logic, and no per-role queue knowledge. These
+    tests are negative guards — they fail loudly if the dispatcher or gating
+    is reintroduced.
+    """
 
-    def test_dispatches_for_actor_role(self):
-        """Actor role's transition → re-evaluates that role's queue."""
-        from harness import activity_detector
-        activity_detector._emitted_issues.clear()
-        with patch.object(self.dispatcher, "_get_work_queue",
-                          return_value=[{"number": 42, "title": "next task"}]), \
-             patch.object(self.dispatcher, "_get_issue_role", return_value=None), \
-             patch("harness._emit_event") as mock_emit:
-            self.dispatcher._do_dispatch(
-                {"issue_number": "10", "from": "in-progress", "to": "pending-test"},
-                actor_role="skill",
-            )
-        mock_emit.assert_called_once()
-        args, kwargs = mock_emit.call_args
-        self.assertEqual(args[0], "assigned-to")
-        self.assertEqual(args[1], "harness")
-        self.assertEqual(kwargs["payload"]["target_role"], "skill")
-        self.assertEqual(kwargs["payload"]["issue_number"], "42")
+    def test_tracker_handoff_dispatcher_class_is_absent(self):
+        import harness
+        self.assertNotIn(
+            "TrackerHandoffDispatcher", dir(harness),
+            "harness must remain a pure broadcast pipe — no dispatcher class",
+        )
 
-    def test_skips_non_agent_actor(self):
-        """Transition from a non-agent role (e.g. external) → no dispatch."""
-        with patch.object(self.dispatcher, "_get_work_queue") as mock_queue, \
-             patch.object(self.dispatcher, "_get_issue_role", return_value=None), \
-             patch("harness._emit_event") as mock_emit:
-            self.dispatcher._do_dispatch({"issue_number": "10"}, actor_role="external")
-        mock_queue.assert_not_called()
-        mock_emit.assert_not_called()
+    def test_handoff_dispatcher_instance_is_absent(self):
+        import harness
+        self.assertNotIn(
+            "handoff_dispatcher", dir(harness),
+            "no global handoff_dispatcher — harness has no per-role dispatch",
+        )
 
-    def test_dispatches_for_issue_role_if_different(self):
-        """Re-evaluate the queue for the issue's role label too, not just actor."""
-        with patch.object(self.dispatcher, "_get_work_queue",
-                          return_value=[{"number": 7, "title": "verify"}]) as mock_queue, \
-             patch.object(self.dispatcher, "_get_issue_role", return_value="qa"), \
-             patch("harness._emit_event"):
-            self.dispatcher._do_dispatch({"issue_number": "10"}, actor_role="pm")
-        called_roles = {c[0][0] for c in mock_queue.call_args_list}
-        self.assertEqual(called_roles, {"pm", "qa"})
-
-    def test_dedup_skips_same_top_twice(self):
-        """Same queue head on two consecutive transitions → emit once."""
-        from harness import activity_detector
-        activity_detector._emitted_issues.clear()
-        with patch.object(self.dispatcher, "_get_work_queue",
-                          return_value=[{"number": 42, "title": "same"}]), \
-             patch.object(self.dispatcher, "_get_issue_role", return_value=None), \
-             patch("harness._emit_event") as mock_emit:
-            self.dispatcher._do_dispatch({"issue_number": "10"}, actor_role="skill")
-            self.dispatcher._do_dispatch({"issue_number": "11"}, actor_role="skill")
-        self.assertEqual(mock_emit.call_count, 1)
-
-    def test_empty_queue_clears_last_top_and_emits_nothing(self):
-        """No items for role → no assigned-to event, last_top cleared."""
-        self.dispatcher._last_top["skill"] = 99
-        with patch.object(self.dispatcher, "_get_work_queue", return_value=[]), \
-             patch.object(self.dispatcher, "_get_issue_role", return_value=None), \
-             patch("harness._emit_event") as mock_emit:
-            self.dispatcher._do_dispatch({"issue_number": "10"}, actor_role="skill")
-        mock_emit.assert_not_called()
-        self.assertIsNone(self.dispatcher._last_top.get("skill"))
-
-    def test_different_top_after_dedup_re_emits(self):
-        """After top changes, the new top is emitted."""
-        from harness import activity_detector
-        activity_detector._emitted_issues.clear()
-        with patch.object(self.dispatcher, "_get_issue_role", return_value=None), \
-             patch("harness._emit_event") as mock_emit:
-            with patch.object(self.dispatcher, "_get_work_queue",
-                              return_value=[{"number": 42, "title": "A"}]):
-                self.dispatcher._do_dispatch({"issue_number": "1"}, actor_role="skill")
-            with patch.object(self.dispatcher, "_get_work_queue",
-                              return_value=[{"number": 43, "title": "B"}]):
-                self.dispatcher._do_dispatch({"issue_number": "2"}, actor_role="skill")
-        self.assertEqual(mock_emit.call_count, 2)
-        _, kwargs = mock_emit.call_args_list[1]
-        self.assertEqual(kwargs["payload"]["issue_number"], "43")
-
-    def test_emission_marks_external_detector_dedup(self):
-        """Emitted issue is added to ExternalActivityDetector dedup."""
-        from harness import activity_detector
-        activity_detector._emitted_issues.clear()
-        with patch.object(self.dispatcher, "_get_work_queue",
-                          return_value=[{"number": 99, "title": "X"}]), \
-             patch.object(self.dispatcher, "_get_issue_role", return_value=None), \
-             patch("harness._emit_event"):
-            self.dispatcher._do_dispatch({"issue_number": "1"}, actor_role="skill")
-        self.assertIn(99, activity_detector._emitted_issues)
-
-    def test_on_transition_runs_in_background_thread(self):
-        """on_transition spawns a daemon thread — handler is non-blocking."""
-        with patch.object(self.dispatcher, "_do_dispatch") as mock_dispatch:
-            self.dispatcher.on_transition({"issue_number": "1"}, "skill")
-            import time as _t
-            _t.sleep(0.05)
-        mock_dispatch.assert_called_once()
-
-    def test_post_events_status_transition_triggers_dispatcher(self):
-        """POST /events with status-transition calls dispatcher.on_transition."""
+    def test_status_transition_does_not_call_subprocess(self):
+        """A status-transition event must NOT trigger any gh/tracker work
+        on the harness side (no _get_work_queue, no `gh issue list`)."""
         from fastapi.testclient import TestClient
         from harness import app
         client = TestClient(app)
-        with patch("harness.handoff_dispatcher.on_transition") as mock_on:
+        with patch("harness.subprocess.run") as mock_run:
             resp = client.post("/events", json={
                 "event_type": "status-transition",
                 "role": "skill",
@@ -1477,32 +1399,19 @@ class TestTrackerHandoffDispatcher(unittest.TestCase):
                 "timestamp": "2026-05-18T00:00:00",
             })
         self.assertEqual(resp.status_code, 200)
-        mock_on.assert_called_once()
-        args, _ = mock_on.call_args
-        self.assertEqual(args[0]["issue_number"], "55")
-        self.assertEqual(args[1], "skill")
-
-    def test_post_events_non_transition_skips_dispatcher(self):
-        """Non-status-transition events do NOT trigger the dispatcher."""
-        from fastapi.testclient import TestClient
-        from harness import app
-        client = TestClient(app)
-        with patch("harness.handoff_dispatcher.on_transition") as mock_on:
-            client.post("/events", json={
-                "event_type": "cycle-start",
-                "role": "skill",
-                "payload": {"cycle_number": 1},
-                "timestamp": "2026-05-18T00:00:00",
-            })
-        mock_on.assert_not_called()
+        mock_run.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
-# Bootup-complete gating — #8695
+# Bootup-complete flag (informational only) — #8695 / #8914
 # ---------------------------------------------------------------------------
 
-class TestBootupCompleteGating(unittest.TestCase):
-    """#8695: harness gates event dispatch on per-agent bootup-complete."""
+class TestBootupCompleteFlag(unittest.TestCase):
+    """#8695 / #8914: bootup_complete is recorded and exposed but NEVER gates.
+
+    The flag remains on AgentState and rides through GET /agents/{role}.
+    GET /events/for/<role> ignores it — see CONTEXT.md §5.2.
+    """
 
     def setUp(self):
         from harness import state
@@ -1530,22 +1439,27 @@ class TestBootupCompleteGating(unittest.TestCase):
         agent.bootup_complete = True
         self.assertTrue(agent.to_dict()["bootup_complete"])
 
-    def test_events_for_role_gated_before_bootup(self):
-        """/events/for/<role> returns empty + 'gated' marker when not bootup-complete."""
-        from harness import AgentState, state
+    def test_events_for_role_never_gated_when_flag_false(self):
+        """#8914: gating was removed. Even with bootup_complete=False the
+        endpoint returns the normal event payload (never `gated`)."""
+        from harness import AgentState, state, event_stream
         agent = AgentState("skill")
         agent.bootup_complete = False
         state.set_agent("skill", agent)
+        event_stream.append({
+            "id": "e_nogate_a", "event_type": "assigned-to", "role": "harness",
+            "payload": {"target_role": "skill", "issue_number": "1"},
+        })
         with patch("harness._validate_role"):
             resp = self.client.get("/events/for/skill")
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
-        self.assertEqual(data["events"], [])
-        self.assertEqual(data["total"], 0)
-        self.assertEqual(data.get("gated"), "bootup-incomplete")
+        self.assertNotIn("gated", data)
+        self.assertGreaterEqual(data["total"], 1)
 
-    def test_events_for_role_flows_after_bootup(self):
-        """After bootup-complete, events flow normally."""
+    def test_events_for_role_flows_when_flag_true(self):
+        """Events flow regardless of the flag — confirms parity with the
+        flag=False case so we know flag state never gates."""
         from harness import AgentState, state, event_stream
         agent = AgentState("skill")
         agent.bootup_complete = True
@@ -1562,7 +1476,8 @@ class TestBootupCompleteGating(unittest.TestCase):
         self.assertGreaterEqual(data["total"], 1)
 
     def test_bootup_complete_event_sets_flag(self):
-        """POST /events with event_type=bootup-complete sets agent.bootup_complete=True."""
+        """POST /events with event_type=bootup-complete sets the flag on AgentState.
+        This is purely informational — the flag is exposed via /agents/{role}."""
         from harness import state
         resp = self.client.post("/events", json={
             "event_type": "bootup-complete",
@@ -1575,36 +1490,9 @@ class TestBootupCompleteGating(unittest.TestCase):
         self.assertIsNotNone(agent)
         self.assertTrue(agent.bootup_complete)
 
-    def test_bootup_complete_unlocks_dispatch(self):
-        """Events accumulate while gated; first poll after bootup-complete returns them."""
-        from harness import AgentState, state, event_stream
-        agent = AgentState("skill")
-        agent.bootup_complete = False
-        state.set_agent("skill", agent)
-
-        event_stream.append({
-            "id": "e_unlock_1", "event_type": "assigned-to", "role": "harness",
-            "payload": {"target_role": "skill", "issue_number": "1"},
-        })
-
-        with patch("harness._validate_role"):
-            r1 = self.client.get("/events/for/skill")
-        self.assertEqual(r1.json()["total"], 0)
-        self.assertEqual(r1.json().get("gated"), "bootup-incomplete")
-
-        self.client.post("/events", json={
-            "event_type": "bootup-complete", "role": "skill",
-            "payload": {}, "timestamp": "2026-05-18T00:00:00",
-        })
-
-        with patch("harness._validate_role"):
-            r2 = self.client.get("/events/for/skill")
-        self.assertEqual(r2.status_code, 200)
-        self.assertGreaterEqual(r2.json()["total"], 1)
-        self.assertNotIn("gated", r2.json())
-
-    def test_no_agent_state_does_not_gate(self):
-        """If no AgentState exists for a role, do not gate (backwards compat)."""
+    def test_no_agent_state_returns_normal_payload(self):
+        """If no AgentState exists for a role, /events/for/<role> still
+        returns the standard event list. (Was already true; #8914 keeps it.)"""
         from harness import event_stream
         event_stream.append({
             "id": "e_nogate_1", "event_type": "assigned-to", "role": "harness",
@@ -1778,93 +1666,9 @@ class TestReviewFixes(unittest.TestCase):
         # The newest entries are retained
         self.assertTrue(det.is_emitted(599))
 
-    def test_dispatcher_skips_when_external_detector_already_emitted(self):
-        """#8694 R2: bidirectional cross-dedup — dispatcher checks before emitting."""
-        from harness import TrackerHandoffDispatcher, activity_detector
-        activity_detector._emitted_issues.clear()
-        # External poller already emitted #77
-        activity_detector.mark_emitted(77)
-        d = TrackerHandoffDispatcher()
-        with patch.object(d, "_get_work_queue",
-                          return_value=[{"number": 77, "title": "dup"}]), \
-             patch.object(d, "_get_issue_role", return_value=None), \
-             patch("harness._emit_event") as mock_emit:
-            d._do_dispatch({"issue_number": "1"}, actor_role="skill")
-        mock_emit.assert_not_called()
-
-    def test_dispatcher_handles_non_dict_payload(self):
-        """#8694 R3: a malformed (non-dict) payload doesn't crash on_transition."""
-        from harness import TrackerHandoffDispatcher
-        d = TrackerHandoffDispatcher()
-        # Pass a string payload — would crash with `.get` if not guarded
-        with patch.object(d, "_do_dispatch") as mock_dispatch:
-            d.on_transition("not-a-dict", "skill")
-            import time as _t
-            _t.sleep(0.05)
-        # _do_dispatch should have been called with an empty dict, not the string
-        args, _ = mock_dispatch.call_args
-        self.assertEqual(args[0], {})
-        self.assertEqual(args[1], "skill")
-
-    def test_dispatcher_serializes_per_role(self):
-        """#8694 R4: per-role lock prevents concurrent `gh issue list` calls.
-
-        Two concurrent transitions for the same role: with the per-role lock,
-        the second `_get_work_queue` call cannot overlap the first.
-        """
-        from harness import TrackerHandoffDispatcher, activity_detector
-        activity_detector._emitted_issues.clear()
-        d = TrackerHandoffDispatcher()
-        overlap = {"max_concurrent": 0, "current": 0}
-        import threading as _th
-        counter_lock = _th.Lock()
-        import time as _t
-
-        def slow_queue(role):
-            with counter_lock:
-                overlap["current"] += 1
-                overlap["max_concurrent"] = max(overlap["max_concurrent"], overlap["current"])
-            _t.sleep(0.05)
-            with counter_lock:
-                overlap["current"] -= 1
-            return [{"number": 5, "title": "same"}]
-
-        with patch.object(d, "_get_work_queue", side_effect=slow_queue), \
-             patch.object(d, "_get_issue_role", return_value=None), \
-             patch("harness._emit_event"):
-            d.on_transition({"issue_number": "1"}, "skill")
-            d.on_transition({"issue_number": "2"}, "skill")
-            _t.sleep(0.25)
-        # Per-role lock means at most one _get_work_queue executes at a time.
-        self.assertEqual(overlap["max_concurrent"], 1)
-
-    def test_dispatcher_does_not_serialize_across_roles(self):
-        """#8694 R4: different roles dispatch concurrently — per-role lock only."""
-        from harness import TrackerHandoffDispatcher, activity_detector
-        activity_detector._emitted_issues.clear()
-        d = TrackerHandoffDispatcher()
-        overlap = {"max_concurrent": 0, "current": 0}
-        import threading as _th
-        counter_lock = _th.Lock()
-        import time as _t
-
-        def slow_queue(role):
-            with counter_lock:
-                overlap["current"] += 1
-                overlap["max_concurrent"] = max(overlap["max_concurrent"], overlap["current"])
-            _t.sleep(0.05)
-            with counter_lock:
-                overlap["current"] -= 1
-            return [{"number": 5, "title": role}]
-
-        with patch.object(d, "_get_work_queue", side_effect=slow_queue), \
-             patch.object(d, "_get_issue_role", return_value=None), \
-             patch("harness._emit_event"):
-            d.on_transition({"issue_number": "1"}, "skill")
-            d.on_transition({"issue_number": "2"}, "pm")
-            _t.sleep(0.25)
-        # Different roles should be allowed to overlap.
-        self.assertGreaterEqual(overlap["max_concurrent"], 2)
+    # TrackerHandoffDispatcher tests removed in #8914 — the class no longer
+    # exists, so its review-fix tests have nothing to assert against. The
+    # ExternalActivityDetector lock/eviction tests above still apply.
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #8914

## Summary
PR #8790 (#8694) and PR #8801 (#8695) shipped harness code that violates the locked Phase 5 architecture (.squidsquad/pm/planning/CONTEXT.md §2 + §5.2): the harness is a pure broadcast pipe — no tracker observation, no dispatch logic, no per-role queue knowledge, and \`bootup_complete\` is informational only.

## Removed (the violations)
- **\`TrackerHandoffDispatcher\` class + global instance** (~133 lines) and the \`receive_event\` hook that called \`on_transition\` on every \`status-transition\` event. The class read the forge via \`gh issue list\` per role and emitted per-role \`assigned-to\` events — the dispatch intelligence CONTEXT.md §2 forbids.
- **The \`get_events_for_role\` gating branch** that returned \`{events: [], total: 0, gated: 'bootup-incomplete'}\` while \`AgentState.bootup_complete == False\`. CONTEXT.md §5.2 explicitly bans per-role event holding on this flag.

## Kept (CONTEXT.md §5.2 permits — informational only)
- \`AgentState.bootup_complete\` field, reset on every spawn / auto-reboot
- POST \`/events\` handler that sets the flag when \`event_type=bootup-complete\`
- Exposure via GET \`/agents/{role}\`

## Tests
- Removed \`TestTrackerHandoffDispatcher\` (9 tests) and the four dispatcher tests inside \`TestReviewFixes\`.
- Renamed \`TestBootupCompleteGating\` → \`TestBootupCompleteFlag\`. Removed the two gating tests; added \`test_events_for_role_never_gated_when_flag_false\` asserting the inverse — gating is gone even when flag is False.
- **NEW negative-guard class \`TestThinHarnessInvariants\`** (per the issue's acceptance criteria):
  - \`TrackerHandoffDispatcher not in dir(harness)\`
  - \`handoff_dispatcher not in dir(harness)\`
  - POST /events with status-transition does NOT call any subprocess (no \`gh issue list\`, no per-role tracker work on the harness side)

## /loop byte-identical regression
Verified no /loop fragment consumes \`/events/for/<role>\` or the removed \`assigned-to\` dispatches; /loop agents poll the tracker directly via \`tracker.py work-queue\`. Dispatcher removal cannot affect /loop agents.

## Docstring cleanup
Also updated stale docstrings on \`AgentState.bootup_complete\` init, \`get_events_for_role\`, \`receive_event\`, \`ExternalActivityDetector\` lock, and \`event_bus.bootup_complete()\` to describe the informational-only behavior and cite CONTEXT.md §5.2.

## Code Review (Sonnet)
- Iteration 1: 2 warnings — stale docstrings still describing gating. Both fixed.
- Iteration 2: CLEAN — ready to merge.

## Acceptance checklist (from #8914)
- [x] \`TrackerHandoffDispatcher\` class removed from harness.py
- [x] \`receive_event\` no longer calls \`handoff_dispatcher.on_transition\`
- [x] GET \`/events/for/<role>\` returns events unconditionally
- [x] \`AgentState.bootup_complete\` preserved + exposed via GET \`/agents/{role}\`
- [x] Dispatcher / gating tests removed; informational-flag tests stay
- [x] Negative test added: \`TrackerHandoffDispatcher not in dir(harness)\`
- [x] /loop mode byte-identical regression check passes

## Test plan
- [x] 56 affected tests pass across changed-area classes
- [x] Full \`tests/run_tests.py\` integration suite green
- [x] \`grep\` confirms no live code references to \`TrackerHandoffDispatcher\` / \`handoff_dispatcher\` / \`bootup-incomplete\` outside comments and negative tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)