### PR TITLE
skill: #8913 add timeout to wizard._run

### DIFF
--- a/references/scripts/wizard.py
+++ b/references/scripts/wizard.py
@@ -121,17 +121,37 @@ PROJECT_TYPE_LABELS = {
 # ---------------------------------------------------------------------------
 
 
-def _run(cmd, **kwargs):
-    """Thin subprocess.run wrapper — list form only, captures output."""
-    return subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        check=False,
-        **kwargs,
-    )
+def _run(cmd, *, timeout=30, **kwargs):
+    """Thin subprocess.run wrapper — list form only, captures output.
+
+    A default ``timeout`` of 30 seconds guards the wizard against hangs in
+    ``gh`` and ``git`` (slow OAuth, captive-portal proxy, firewall drop without
+    RST, GitHub Enterprise rate-limit delay). On timeout, returns a
+    ``CompletedProcess`` with ``returncode=124`` so existing callers that
+    inspect ``.returncode`` / ``.stdout`` / ``.stderr`` keep working without
+    branching on exception types.
+
+    Pass ``timeout=None`` (or a larger value) for call sites that legitimately
+    take longer than 30 seconds.
+    """
+    try:
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            timeout=timeout,
+            **kwargs,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=124,
+            stdout="",
+            stderr=f"timeout after {timeout}s: {' '.join(str(c) for c in cmd[:2])}\n",
+        )
 
 
 def check_gh():
@@ -1118,9 +1138,10 @@ def scaffold_install(spec, target_root, overwrite_existing=False):
                     summary.setdefault("existing_clones", []).append(str(clone_dir))
                 else:
                     try:
-                        result = _run([
-                            "git", "clone", remote_url, str(clone_dir),
-                        ])
+                        result = _run(
+                            ["git", "clone", remote_url, str(clone_dir)],
+                            timeout=None,
+                        )
                         if result.returncode != 0:
                             print(
                                 f"  WARNING: Failed to clone for {agent_id}: "

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -57,6 +57,83 @@ def _install_fake_run(monkeypatch, mapping):
 
 
 # ===========================================================================
+# _run subprocess wrapper — timeout behavior (#8913)
+# ===========================================================================
+
+
+class TestRunWrapper:
+    def test_passes_default_timeout_to_subprocess_run(self, monkeypatch):
+        captured = {}
+
+        def _spy(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(wizard.subprocess, "run", _spy)
+        wizard._run(["gh", "auth", "status"])
+        assert captured["kwargs"].get("timeout") == 30
+
+    def test_custom_timeout_forwarded(self, monkeypatch):
+        captured = {}
+
+        def _spy(cmd, **kwargs):
+            captured["kwargs"] = kwargs
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(wizard.subprocess, "run", _spy)
+        wizard._run(["gh", "auth", "status"], timeout=120)
+        assert captured["kwargs"]["timeout"] == 120
+
+    def test_none_timeout_forwarded(self, monkeypatch):
+        captured = {}
+
+        def _spy(cmd, **kwargs):
+            captured["kwargs"] = kwargs
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(wizard.subprocess, "run", _spy)
+        wizard._run(["gh", "auth", "status"], timeout=None)
+        assert captured["kwargs"]["timeout"] is None
+
+    def test_timeout_returns_completed_process_with_124(self, monkeypatch):
+        import subprocess as _sp
+
+        def _boom(cmd, **kwargs):
+            raise _sp.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout", 30))
+
+        monkeypatch.setattr(wizard.subprocess, "run", _boom)
+        result = wizard._run(["gh", "auth", "status"])
+        assert isinstance(result, _sp.CompletedProcess)
+        assert result.returncode == 124
+        assert result.stdout == ""
+        assert "timeout after 30s" in result.stderr
+        assert "gh auth" in result.stderr
+
+    def test_timeout_message_reflects_custom_timeout(self, monkeypatch):
+        import subprocess as _sp
+
+        def _boom(cmd, **kwargs):
+            raise _sp.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout", 30))
+
+        monkeypatch.setattr(wizard.subprocess, "run", _boom)
+        result = wizard._run(["git", "remote", "-v"], timeout=5)
+        assert "timeout after 5s" in result.stderr
+
+    def test_timeout_handles_non_string_cmd_elements(self, monkeypatch):
+        """Coerce non-string cmd elements (e.g. PosixPath) when building stderr."""
+        import subprocess as _sp
+
+        def _boom(cmd, **kwargs):
+            raise _sp.TimeoutExpired(cmd=cmd, timeout=30)
+
+        monkeypatch.setattr(wizard.subprocess, "run", _boom)
+        result = wizard._run([Path("gh"), "auth", "status"])
+        assert result.returncode == 124
+        assert "auth" in result.stderr
+
+
+# ===========================================================================
 # Step 0 — check_gh
 # ===========================================================================
 


### PR DESCRIPTION
Fixes #8913.

## Summary

`wizard._run` wraps `subprocess.run` for all `gh` and `git` invocations in the install wizard (14 call sites). With no timeout, a stalled `gh` (slow OAuth, captive-portal proxy redirect, firewall drop without RST, GitHub Enterprise rate-limit delay) hangs the wizard indefinitely with no progress signal — a poor first impression for a v1.0 public installer.

## Change

- `_run` now defaults to `timeout=30`. On `TimeoutExpired`, returns a `CompletedProcess(returncode=124, stderr="timeout after 30s: <cmd>\n")` so existing callers that branch on `result.returncode != 0` surface the timeout as a normal failure with a useful message — no `try/except TimeoutExpired` needed at every call site.
- The one legitimately long-running call site (`git clone` inside `scaffold_install`) opts out with `timeout=None`. Audited the other 12 call sites (single short `gh` API calls / local `git` ops) — 30s is generously sufficient.

## Tests

`TestRunWrapper` adds six tests covering:
- Default `timeout=30` forwarded to `subprocess.run`
- Custom `timeout` forwarded
- `timeout=None` forwarded
- `TimeoutExpired` → `CompletedProcess(returncode=124)`
- Stderr message reflects the actual timeout value
- Non-string cmd elements (PosixPath) coerced when formatting stderr

Full wizard suite: 261 passed.

## Code review

External code-review loop ran 2 iterations:
- Iteration 1: flagged the `git clone` site as needing `timeout=None` — applied.
- Iteration 2: clean (zero findings) via Claude fallback after the external model returned below-threshold output.