### PR TITLE
skill: #8917 — PM: sync issue body when planning rewrites scope

### DIFF
--- a/.squidsquad/pm/CLAUDE.md
+++ b/.squidsquad/pm/CLAUDE.md
@@ -1312,6 +1312,16 @@ Continue until all questions are resolved. Capture decisions in `.squidsquad/pm/
 
 **Open in editor**: After CONTEXT.md is created, offer to open it (see "Open Artifacts in Editor" below).
 
+**Sync issue body when CONTEXT scope is (re)written** (#8917 Change 1): When Phase 2 (deepseek review, discussion locks, scope discussion) rewrites scope on `CONTEXT.md` (or per-task `CONTEXT-<NUMBER>.md`), the corresponding GitHub Issue body MUST be updated in the same PM step. Use `gh issue edit <N> --body-file <new-body>`. The issue body and CONTEXT.md must always agree at the time of the `planned → approved` transition.
+
+Every issue body that has a planning artifact MUST lead with an **AUTHORITATIVE SCOPE banner** pointing at the locked planning file:
+
+```
+> **AUTHORITATIVE SCOPE: `.squidsquad/pm/planning/CONTEXT.md §5.X` (or `CONTEXT-<NUMBER>.md`). Read that artifact in full. The bullets below are a summary; the planning artifact is the contract.**
+```
+
+The banner is required on every issue with a CONTEXT file — at issue creation time (Phase 3 §A below), and on every Phase 2 scope rewrite thereafter.
+
 **Design routing**: If a `designer` agent is configured (check `config.md` Dev Agents list for `designer`), ask the human if this task needs design work using `AskUserQuestion`:
 
 ```
@@ -1388,6 +1398,11 @@ If any answer is unclear, the AC is incomplete — refine before filing.
 - Acceptance criteria include edge case handling and side effect mitigations
 - Acceptance criteria verified against the AC Integration Check above
 - References RESEARCH.md and CONTEXT.md
+- **AUTHORITATIVE SCOPE banner at the start of the body** (#8917 Change 3): when the task has a `CONTEXT.md` (bundle `§5.X #<NUMBER>`) or `CONTEXT-<NUMBER>.md`, the body passed to `create-task` MUST start with the banner pointing at that locked planning file. Format:
+  ```
+  > **AUTHORITATIVE SCOPE: `.squidsquad/pm/planning/CONTEXT-<NUMBER>.md` (or `CONTEXT.md §5.X`). Read that artifact in full. The bullets below are a summary; the planning artifact is the contract.**
+  ```
+  Phase 2 (above) keeps the banner + body bullets in sync on every later scope rewrite; this rule places the banner from the start.
 
 **B) Test plan** — route to the configured model for test plan drafting:
 
@@ -1530,11 +1545,16 @@ To approve a task for planning:
 3. Update status to `Planning` (NOT `Approved`) and begin the Task Intake Process.
 4. After all planning phases complete (RESEARCH.md, CONTEXT.md, TEST-PLAN.md created), update status to `Planned` (NOT `Approved`).
 5. Present the completed plan to the human. Wait for explicit execution approval ("approved", "go", "build it", etc.).
-6. Only after human explicitly approves execution, update status to `Approved`.
+6. **Pre-approval body-vs-CONTEXT sync check** (#8917 Change 2): Before transitioning any task `planned → approved`:
+   1. Read the corresponding CONTEXT section: bundle `CONTEXT.md` `### 5.X #<NUMBER>` heading OR the full `CONTEXT-<NUMBER>.md`. Focus on `## Scope`, `## Locked Decisions`, and `## Out of Scope`.
+   2. Read the GitHub issue body: `gh issue view <N> --json body`.
+   3. Compare the body's scope bullets against those three CONTEXT sections (structured comparison, NOT a raw text diff — the body and CONTEXT intentionally have different formats). If any **locked decision** or **scope boundary** is missing, outdated, or contradicted in the body, update the body via `gh issue edit <N> --body-file <new-body>` BEFORE the transition.
+   4. Confirmation: re-read `gh issue view <N> --json body`; the AUTHORITATIVE SCOPE banner is present AND the body bullets are consistent with the CONTEXT sections.
+7. Only after human explicitly approves execution AND the pre-approval body-vs-CONTEXT check is clean, update status to `Approved`.
 
 Light mode (trivial tasks): PM can fast-track through planning with abbreviated research, but status still transitions through `Planning` → `Planned` → `Approved`.
 
-Do not set status to `Approved` without human explicitly approving execution. Do not skip the `Planned` state — it is the human's review gate between planning and execution.
+Do not set status to `Approved` without human explicitly approving execution. Do not skip the `Planned` state — it is the human's review gate between planning and execution. Do not skip the pre-approval body-vs-CONTEXT sync — the body is what skill reads on pickup; if it disagrees with the locked CONTEXT, the task will be implemented to a stale contract.
 <!-- /sub-skill: task-approval -->
 
 ---

--- a/references/sub-skills/roles/pm/task-approval.md
+++ b/references/sub-skills/roles/pm/task-approval.md
@@ -16,8 +16,13 @@ To approve a task for planning:
 3. Update status to `Planning` (NOT `Approved`) and begin the Task Intake Process.
 4. After all planning phases complete (RESEARCH.md, CONTEXT.md, TEST-PLAN.md created), update status to `Planned` (NOT `Approved`).
 5. Present the completed plan to the human. Wait for explicit execution approval ("approved", "go", "build it", etc.).
-6. Only after human explicitly approves execution, update status to `Approved`.
+6. **Pre-approval body-vs-CONTEXT sync check** (#8917 Change 2): Before transitioning any task `planned → approved`:
+   1. Read the corresponding CONTEXT section: bundle `CONTEXT.md` `### 5.X #<NUMBER>` heading OR the full `CONTEXT-<NUMBER>.md`. Focus on `## Scope`, `## Locked Decisions`, and `## Out of Scope`.
+   2. Read the GitHub issue body: `gh issue view <N> --json body`.
+   3. Compare the body's scope bullets against those three CONTEXT sections (structured comparison, NOT a raw text diff — the body and CONTEXT intentionally have different formats). If any **locked decision** or **scope boundary** is missing, outdated, or contradicted in the body, update the body via `gh issue edit <N> --body-file <new-body>` BEFORE the transition.
+   4. Confirmation: re-read `gh issue view <N> --json body`; the AUTHORITATIVE SCOPE banner is present AND the body bullets are consistent with the CONTEXT sections.
+7. Only after human explicitly approves execution AND the pre-approval body-vs-CONTEXT check is clean, update status to `Approved`.
 
 Light mode (trivial tasks): PM can fast-track through planning with abbreviated research, but status still transitions through `Planning` → `Planned` → `Approved`.
 
-Do not set status to `Approved` without human explicitly approving execution. Do not skip the `Planned` state — it is the human's review gate between planning and execution.
+Do not set status to `Approved` without human explicitly approving execution. Do not skip the `Planned` state — it is the human's review gate between planning and execution. Do not skip the pre-approval body-vs-CONTEXT sync — the body is what skill reads on pickup; if it disagrees with the locked CONTEXT, the task will be implemented to a stale contract.

--- a/references/sub-skills/roles/pm/task-intake.md
+++ b/references/sub-skills/roles/pm/task-intake.md
@@ -207,6 +207,16 @@ Continue until all questions are resolved. Capture decisions in `.squidsquad/[RO
 
 **Open in editor**: After CONTEXT.md is created, offer to open it (see "Open Artifacts in Editor" below).
 
+**Sync issue body when CONTEXT scope is (re)written** (#8917 Change 1): When Phase 2 (deepseek review, discussion locks, scope discussion) rewrites scope on `CONTEXT.md` (or per-task `CONTEXT-<NUMBER>.md`), the corresponding GitHub Issue body MUST be updated in the same PM step. Use `gh issue edit <N> --body-file <new-body>`. The issue body and CONTEXT.md must always agree at the time of the `planned → approved` transition.
+
+Every issue body that has a planning artifact MUST lead with an **AUTHORITATIVE SCOPE banner** pointing at the locked planning file:
+
+```
+> **AUTHORITATIVE SCOPE: `.squidsquad/pm/planning/CONTEXT.md §5.X` (or `CONTEXT-<NUMBER>.md`). Read that artifact in full. The bullets below are a summary; the planning artifact is the contract.**
+```
+
+The banner is required on every issue with a CONTEXT file — at issue creation time (Phase 3 §A below), and on every Phase 2 scope rewrite thereafter.
+
 **Design routing**: If a `designer` agent is configured (check `config.md` Dev Agents list for `designer`), ask the human if this task needs design work using `AskUserQuestion`:
 
 ```
@@ -283,6 +293,11 @@ If any answer is unclear, the AC is incomplete — refine before filing.
 - Acceptance criteria include edge case handling and side effect mitigations
 - Acceptance criteria verified against the AC Integration Check above
 - References RESEARCH.md and CONTEXT.md
+- **AUTHORITATIVE SCOPE banner at the start of the body** (#8917 Change 3): when the task has a `CONTEXT.md` (bundle `§5.X #<NUMBER>`) or `CONTEXT-<NUMBER>.md`, the body passed to `create-task` MUST start with the banner pointing at that locked planning file. Format:
+  ```
+  > **AUTHORITATIVE SCOPE: `.squidsquad/pm/planning/CONTEXT-<NUMBER>.md` (or `CONTEXT.md §5.X`). Read that artifact in full. The bullets below are a summary; the planning artifact is the contract.**
+  ```
+  Phase 2 (above) keeps the banner + body bullets in sync on every later scope rewrite; this rule places the banner from the start.
 
 **B) Test plan** — route to the configured model for test plan drafting:
 


### PR DESCRIPTION
Closes #8917

## Summary

Three PM-side fragment edits per [TEST-PLAN-8917.md](https://github.com/WallyDoodlez/SquidSquad/blob/squidsquad/task/8917/.squidsquad/pm/planning/TEST-PLAN-8917.md). All changes confined to `references/sub-skills/roles/pm/` so only PM CLAUDE.md is affected.

- **Change 1 (`task-intake.md` Phase 2)** — When Phase 2 rewrites scope on CONTEXT.md (or CONTEXT-<NUMBER>.md), the corresponding GitHub Issue body MUST be updated in the same PM step (`gh issue edit <N> --body-file <new-body>`). Defines the AUTHORITATIVE SCOPE banner format that must lead every issue body with a planning artifact.
- **Change 2 (`task-approval.md`)** — Inserted a 4-step pre-approval body-vs-CONTEXT sync check between human execution approval and the `planned → approved` transition. Structured comparison (NOT raw diff) against `## Scope` + `## Locked Decisions` + `## Out of Scope` sections; update body via `gh issue edit` if any locked decision or scope boundary is missing/outdated/contradicted; re-read confirmation. Documents that the sync gate must not be skipped.
- **Change 3 (`task-intake.md` Phase 3 §A)** — When a task has CONTEXT.md or CONTEXT-<NUMBER>.md, the body passed to `tracker.py create-task` MUST start with the AUTHORITATIVE SCOPE banner. Change 3 covers initial placement; Change 1 keeps it in sync on later rewrites.

## Acceptance Criteria

- [x] **AC-1**: scope-rewrite + banner fragment present (Phase 2 + Phase 3 §A both contain the banner per Change 3)
- [x] **AC-2**: pre-approval body-vs-CONTEXT 4-step check in `task-approval.md` step 6; transition gated on the check (step 7)
- [x] **AC-3**: issue creation places banner — Phase 3 §A `create-task` instruction explicit
- [x] **AC-4**: stash-dance verified — qa/dm/skill CLAUDE.md byte-identical pre/post my edits; PM CLAUDE.md has the new fragment content (3 banner mentions)
- [x] **AC-5**: backfill clean — #8917/#8916 already have AUTHORITATIVE SCOPE banners pointing at TEST-PLAN-N.md; #8999/#8998 have no CONTEXT artifact so banner not required by Change 3 wording

## QA Status

- [x] Full suite (2493 pytest + 17 integration) green
- [x] DeepSeek r1 NO_FINDINGS — all 5 ACs verified, all 4 CQs derivable from composed fragments, R1/R2/R3 regression risks mitigated

🤖 Generated with [Claude Code](https://claude.com/claude-code)