### PR TITLE
skill: #8916 — L2 dev: mandate reading CONTEXT.md / TEST-PLAN.md before implementing

### DIFF
--- a/.squidsquad/skill/CLAUDE.md
+++ b/.squidsquad/skill/CLAUDE.md
@@ -474,12 +474,21 @@ Print: `[🦑 HH:MM:SS] Implementing #[NUMBER]...`
    python references/scripts/tracker.py transition [NUMBER] approved in-progress --role skill-lead
    ```
 1b. **Branch checkout** (#3296): `python references/scripts/git_ops.py task-begin skill [NUMBER]` — checks out the task's feature branch if branch-workflow is enabled.
-2. **Read planning artifacts** — PM creates these during task intake. Check both locations:
-   - `.squidsquad/pm/planning/` (PM's planning directory — primary location)
-   - `.squidsquad/skill/planning/` (your own planning directory — fallback)
-   - Look for files matching the issue number (e.g. `FEAT-SKILL-195-CONTEXT.md`)
-   - RESEARCH.md, CONTEXT.md, TEST-PLAN.md — respect locked decisions, note dev discretion areas
-   - If PM comments reference planning artifacts but you cannot find them, **push back** (see Prohibitions)
+2. **Read planning artifacts first — CONTEXT.md is authoritative** (#8916).
+
+   Before writing any code for a task, check whether planning artifacts exist:
+   - `.squidsquad/pm/planning/CONTEXT.md` (bundle-level; the per-task section is `### 5.X #<NUMBER> — …`)
+   - `.squidsquad/pm/planning/CONTEXT-<NUMBER>.md` (per-task)
+   - `.squidsquad/pm/planning/TEST-PLAN-<NUMBER>.md` (acceptance criteria + comprehension tests)
+   - Fallback location: `.squidsquad/skill/planning/` (your own planning directory) — same file patterns
+
+   If a planning artifact exists, **the planning artifact is the authoritative scope.** The GitHub issue body is a high-level pointer; the planning artifact is the contract. Read the relevant CONTEXT section (`### 5.X #<NUMBER>` for bundle CONTEXT.md, OR the full per-task `CONTEXT-<NUMBER>.md`) AND the `TEST-PLAN-<NUMBER>.md` acceptance criteria **in full** before writing code.
+
+   **Divergence handling**:
+   - If the issue body and the planning artifact **agree**, proceed normally. Do not add a planning-artifact note to the PR description.
+   - If the issue body and the planning artifact **disagree**, the planning artifact wins. Implement to the planning artifact. Flag the divergence in your implementation PR description (one sentence pointing PM at the body/artifact mismatch) so PM can update the body via the #8917 workflow.
+
+   If PM comments reference planning artifacts but you cannot find them, **push back** (see Prohibitions). If no planning artifact exists (bug fix or trivial task), proceed to step 2c.
 2c. **Consult the vault** (#5572) — before implementing, search the vault for relevant context:
    ```bash
    grep -rl "[keyword]" .squidsquad/vault/ --include="*.md" | head -5

--- a/references/sub-skills/roles/dev/implement-tasks.md
+++ b/references/sub-skills/roles/dev/implement-tasks.md
@@ -10,12 +10,21 @@ Print: `[🦑 HH:MM:SS] Implementing #[NUMBER]...`
    python references/scripts/tracker.py transition [NUMBER] approved in-progress --role [ROLE]-lead
    ```
 1b. **Branch checkout** (#3296): `python references/scripts/git_ops.py task-begin [ROLE] [NUMBER]` — checks out the task's feature branch if branch-workflow is enabled.
-2. **Read planning artifacts** — PM creates these during task intake. Check both locations:
-   - `.squidsquad/pm/planning/` (PM's planning directory — primary location)
-   - `.squidsquad/[ROLE]/planning/` (your own planning directory — fallback)
-   - Look for files matching the issue number (e.g. `FEAT-SKILL-195-CONTEXT.md`)
-   - RESEARCH.md, CONTEXT.md, TEST-PLAN.md — respect locked decisions, note dev discretion areas
-   - If PM comments reference planning artifacts but you cannot find them, **push back** (see Prohibitions)
+2. **Read planning artifacts first — CONTEXT.md is authoritative** (#8916).
+
+   Before writing any code for a task, check whether planning artifacts exist:
+   - `.squidsquad/pm/planning/CONTEXT.md` (bundle-level; the per-task section is `### 5.X #<NUMBER> — …`)
+   - `.squidsquad/pm/planning/CONTEXT-<NUMBER>.md` (per-task)
+   - `.squidsquad/pm/planning/TEST-PLAN-<NUMBER>.md` (acceptance criteria + comprehension tests)
+   - Fallback location: `.squidsquad/[ROLE]/planning/` (your own planning directory) — same file patterns
+
+   If a planning artifact exists, **the planning artifact is the authoritative scope.** The GitHub issue body is a high-level pointer; the planning artifact is the contract. Read the relevant CONTEXT section (`### 5.X #<NUMBER>` for bundle CONTEXT.md, OR the full per-task `CONTEXT-<NUMBER>.md`) AND the `TEST-PLAN-<NUMBER>.md` acceptance criteria **in full** before writing code.
+
+   **Divergence handling**:
+   - If the issue body and the planning artifact **agree**, proceed normally. Do not add a planning-artifact note to the PR description.
+   - If the issue body and the planning artifact **disagree**, the planning artifact wins. Implement to the planning artifact. Flag the divergence in your implementation PR description (one sentence pointing PM at the body/artifact mismatch) so PM can update the body via the #8917 workflow.
+
+   If PM comments reference planning artifacts but you cannot find them, **push back** (see Prohibitions). If no planning artifact exists (bug fix or trivial task), proceed to step 2c.
 2c. **Consult the vault** (#5572) — before implementing, search the vault for relevant context:
    ```bash
    grep -rl "[keyword]" .squidsquad/vault/ --include="*.md" | head -5


### PR DESCRIPTION
Closes #8916

## Summary

Single fragment edit to `references/sub-skills/roles/dev/implement-tasks.md` per [TEST-PLAN-8916.md](https://github.com/WallyDoodlez/SquidSquad/blob/squidsquad/task/8916/.squidsquad/pm/planning/TEST-PLAN-8916.md). Replaces the existing step 2 with the new authoritative-artifact step.

- **CONTEXT.md is authoritative.** When planning artifacts exist for a task, they are the contract — the GitHub issue body is a high-level pointer. Read the relevant `CONTEXT.md ### 5.X #<NUMBER>` section (or per-task `CONTEXT-<NUMBER>.md`) AND the `TEST-PLAN-<NUMBER>.md` ACs in full before writing code.
- **Divergence handling**: if body and planning artifact disagree, the planning artifact wins; flag a one-sentence divergence note in the PR description so PM can update the body via the #8917 workflow. If they agree, no PR note — only conditional.
- **Bug fixes / trivial tasks** with no planning artifacts: step is a no-op, proceed to step 2c.
- **Fallback location** `.squidsquad/[ROLE]/planning/` preserved from the prior step 2.

## Acceptance Criteria

- [x] **AC-1**: replaced step 2 with the new authoritative-artifact step; fallback location preserved; "the planning artifact is the authoritative scope" appears exactly once
- [x] **AC-2**: §9c was already updated by PR #9131 (#8950 Gate #2) — discovers planning artifacts via `*[NUMBER]*` glob, passes them via `--input-files`, prompts deepseek to check against "architectural locks." No additional edit needed.
- [x] **AC-3**: stash-dance verified — pm/qa/dm CLAUDE.md byte-identical pre/post my edits. Only skill CLAUDE.md changes (1x "authoritative scope" phrase).
- [x] **AC-4**: skill CLAUDE.md regenerated by `compose.py deploy-all`; new step 2 present.

## QA Status

- [x] Full suite (2493 pytest + 17 integration) green
- [x] DeepSeek r1 NO_FINDINGS — all 4 ACs verified, all 4 CQs derivable, R1/R2/R3 regression risks mitigated

🤖 Generated with [Claude Code](https://claude.com/claude-code)