### PR TITLE
skill: #8998 — regenerate 8697 fixtures + spec.json for event-mode L1 base content

### DIFF
--- a/tests/comprehension/8697_fixtures/dm_events_CLAUDE.md
+++ b/tests/comprehension/8697_fixtures/dm_events_CLAUDE.md
@@ -218,87 +218,300 @@ python references/scripts/capability_check.py [ROLE]
 
 
 <!-- sub-skill: event-driven-workflow -->
-## Event-Driven Workflow (#7630)
+## Event-Driven Workflow
 
-You are a persistent agent session that reacts to events dispatched by the harness. You sit idle until the Monitor tool detects an event, then execute exactly one creative task and close the event via the completion API.
+You are a persistent agent session driven by events from the harness. You react to one event at a time, consult the forge as the source of truth, and let `event_poll.py` advance your cursor automatically.
 
-### Config Gate
+This fragment is a brief orientation. The full agent contract lives in the companion event-mode fragments — read them in this order:
 
-This mode is active ONLY when `event-driven: yes` in config.md. If `event-driven: no`, use the standard /loop + cycle_pre/cycle_post flow instead.
+1. **[[l1-base]]** — boot sequence (Case A), event reactions (Cases B–E), case-precedence rule, working-state ownership discipline, degraded-mode operation.
+2. **[[cursor-management]]** — atomic `.tmp` + `mv` protocol, per-event advance, gap handling (in-stream, long lag, eviction).
+3. **[[forge-read-pattern]]** — why the forge is the source of truth and how to read it before acting.
+4. **[[idle-cooldown-loop]]** — what an event-mode agent does when `work_queue()` is empty.
+5. **[[comment-handling]]** — comments are NOT event triggers; DM end-of-task exception; transition-on-handoff rule.
 
-### How You Wake
+### Quick reference
 
-At boot, invoke the Monitor tool to watch for events:
+- **Wake mechanism** — Monitor tool streaming `python references/scripts/event_poll.py <role> --wait 5 --target`. Each line of stdout is one JSON event.
+- **Atomic unit of work** — one event at a time. Process to completion before reading the next.
+- **Source of truth** — the forge (`tracker.py` queries). Event payloads are hints; always forge-read before acting.
+- **Cursor** — `event_poll.py` persists it to `working-state.md` automatically (see [[cursor-management]]).
+- **Idle** — improvement-scan cool-down loop (see [[idle-cooldown-loop]]).
+- **Handoff** — status transitions and label changes wake the stream; bare comments do not (see [[comment-handling]]).
+
+### Error handling
+
+If the harness becomes unreachable, the agent does NOT pivot to forge-direct work mid-session — that path exists only at boot (degraded mode, see [[l1-base]]). Mid-session unreachable is a **manual-recovery scenario**: keep retrying at the 5-minute-capped backoff; the operator restarts the harness; the agent resumes via the event stream on reconnect.
+
+`event_poll.py` handles transient HTTP errors (5xx, `ConnectionError`, `Timeout`, `IncompleteRead`) automatically with exponential backoff. 4xx responses are treated as caller faults and exit non-zero.
+
+### Context pressure
+
+The harness monitors agent context pressure files and emits `stop-requested` when a restart is needed. Honor `stop-requested` at the next task boundary (see Case E in [[l1-base]]); the harness handles the respawn.
+<!-- /sub-skill: event-driven-workflow -->
+
+<!-- sub-skill: l1-base -->
+## Event-Mode L1 Base — Agent Definition
+
+You are a persistent agent session that reacts to events on the harness event stream. The forge (GitHub Issues) is your source of truth; the stream is a wake-up signal that tells you when forge state may have changed.
+
+This fragment is the entire event-mode agent contract: boot sequence, event reactions, and the always-on rules that bind the two together.
+
+---
+
+### Boot Sequence (Case A — L1 failsafe)
+
+The boot sequence MUST work even when the harness is unreachable. Forge access is the only hard prerequisite.
+
+1. **Read working-state.** Open `.squidsquad/<role>/working-state.md`. Extract three fields:
+   - **Cursor** — line `- **Last Processed Event ID**: <event-id>` (see [[cursor-management]]). Missing or empty → start from the beginning of the stream with a stderr warning.
+   - **In-progress task** — line `- **Task**: <issue-number>` (or `- **Task**: none` if idle).
+   - **Improvement-scan status** — `Status:` field under `## Improvement Scan` (see [[idle-cooldown-loop]]). If the section is absent (first boot), treat `Status` as `idle`.
+
+2. **Branch on what working-state shows:**
+   - **In-progress tracker task** → verify against the forge: still my role? still `status:in-progress`? Yes → resume. No → clear the task field (`- **Task**: none` in working-state) and drop the task locally — **no forge transition is needed** because the forge already reflects the change (that is why verification failed). Fall through to a fresh `work_queue()` scan.
+   - **Improvement-scan `Status: running`** (not a tracker item) → skip forge verification; restart the scan. Improvement scans are idempotent — a fresh scan subsumes a partial one. See [[idle-cooldown-loop]]. **When the scan completes, run `work_queue()`** before re-entering the cool-down loop, in case a task arrived during the outage.
+   - **Idle / nothing in progress** → run `work_queue()` against the forge. If work is returned: **pick up the top item** — transition it to `status:in-progress`, write the issue number to the Task field in `working-state.md`, and begin work. If `work_queue()` is empty, defer to step 3 for the empty-queue path (cool-down loop if harness reachable; degraded-mode sleep loop if not).
+
+3. **Check harness reachability** (before any event-stream call or cool-down entry):
+   - **Unreachable** → skip steps 4–5 (nothing to skim, cursor unchanged) and proceed to degraded-mode operation: continue working directly from the forge via `work_queue()`. While in degraded mode, if `work_queue()` returns empty, sleep a short fixed interval (e.g. 60s) and retry `work_queue()`; if `work_queue()` returns work, pick up the top item directly (transition to `in-progress`, update the Task field, begin work) and on completion follow Case C (transition, clear Task field, re-run `work_queue()`) — then continue applying the same degraded-mode rules (empty → 60s sleep, non-empty → pick up). **Do NOT enter the improvement-scan cool-down loop in degraded mode**, because the Monitor (`event_poll.py`) requires the harness. **Before each `work_queue()` call** (including after each 60s sleep), attempt to POST `bootup-complete` using exponential backoff capped at **5 minutes**. A successful POST indicates the harness is reachable — **exit degraded mode** by skimming events from the current cursor forward (step 4), advancing the cursor (step 5 cursor write), and entering the listening loop. `bootup-complete` is **best-effort, not blocking** — the agent never hangs waiting for the harness.
+   - **Reachable** → continue to step 4. (If you got here from step 2's empty idle branch, after step 5 enter the improvement-scan cool-down loop — see [[idle-cooldown-loop]].)
+
+4. **Skim events from cursor forward.** Informational only — the forge already has current state. Skim-then-advance; never jump-to-latest. Handle gap scenarios per [[cursor-management]] (in-stream gap, long lag, eviction gap). In an eviction gap specifically, the cursor advances to the *oldest available* id, not the latest observed.
+
+5. **Advance cursor and announce.** Persist the cursor atomically (see [[cursor-management]]); emit `bootup-complete` (POST `/events` with `event_type=bootup-complete`, `role=<role>`, payload `{"listener_active": true}`); enter the event-listening loop via `event_poll.py`.
+
+After boot, processing is dictated by Cases B through E below.
+
+---
+
+### How You Listen (Event Poll)
+
+Invoke the Monitor tool to stream events from `event_poll.py`:
 
 ```
 Monitor tool invocation:
   command: python references/scripts/event_poll.py <role> --wait 5 --target
-  description: Watch harness event bus for work events
+  description: Watch harness event bus for relevant events
   persistent: true
 ```
 
-The Monitor tool streams `event_poll.py` stdout. Each line is a JSON event object. When the Monitor delivers a line, you wake and process it.
+`event_poll.py` writes one JSON object per line to stdout. Each line wakes you to process exactly one event.
 
-### Event Types You Receive
+---
 
-| Event Type | When | What To Do |
-|---|---|---|
-| `assigned-to` | Work item needs your attention | Read the issue from payload, do your creative work |
-| `stop-requested` | Harness wants you to exit | Checkpoint working-state.md, then exit cleanly |
-| `status-transition` | A relevant item changed status | React per your role's logic |
+> **Cursor advancement is automatic.** `event_poll.py` persists the cursor to `working-state.md` as each event line is emitted to stdout. Cases B–E below describe the agent's reaction to each delivered event; the cursor write happens on the agent's behalf — there is no separate "advance cursor" step for the agent to perform. See [[cursor-management]].
 
-> **Future event types** (not yet emitted by harness — planned for Phase 5+):
-> - `scan-needed` — idle timeout reached → run improvement scan
-> - `vault-reflect` — active work completed → run vault reflection
+> **Case precedence.** When an event arrives, **evaluate Case E (special events) first**, regardless of your current state. Only if the event type is not special, fall through to the state-based case (B if idle, D if mid-task; Case C is reached implicitly when work completes).
 
-### Processing Flow
+### Case B — Idle, event arrives
 
-For each event:
+1. Read the event delivered by the Monitor.
+2. **Forge-read** the referenced item (if any) via `tracker.py`. The forge is the source of truth — see [[forge-read-pattern]].
+3. Run `work_queue(<role>)` against the forge — pick up the top item if available, else stay idle (re-enter the improvement-scan cool-down loop — see [[idle-cooldown-loop]]).
 
-1. **Read**: Parse the JSON event. Extract `id`, `event_type`, and `payload`.
-2. **Act**: Do your creative work — implement, verify, plan, deliver (per your role).
-3. **Complete**: When done, call the completion endpoint:
-   ```bash
-   curl -s -X POST http://127.0.0.1:$(cat .squidsquad/.harness-port)/events/<event_id>/complete \
-     -H "Content-Type: application/json" \
-     -d '{"role": "<role>", "status": "success", "summary": "<brief description>"}'
+---
+
+### Case C — After completing work
+
+1. You just transitioned a tracker item via `tracker.py transition`.
+2. Update `working-state.md` → `- **Task**: none`.
+3. **Immediately run `work_queue()`** against the forge. Do NOT wait for your own transition event to come back through the stream.
+4. Pick up the next item, or — if `work_queue()` is empty — enter idle (improvement-scan cool-down). **Degraded-mode exception**: if the harness is currently unreachable, do NOT enter the cool-down loop; apply the degraded-mode rules instead (60s sleep + retry `work_queue()`).
+
+---
+
+### Case D — Mid-task, event arrives
+
+1. Read the event delivered by the Monitor.
+2. **Note but do NOT act.** The current task runs atomically to completion.
+3. On task completion, fall through to **Case C** (transition the item, clear the Task field, run `work_queue()`). Case C's forge-read absorbs all mid-task events that arrived during the task.
+
+---
+
+### Case E — Special events
+
+- **`stop-requested`** — honored ONLY at a task boundary. Mid-task: read the event, ignore. At a boundary: checkpoint `working-state.md` (preserve the cursor), then exit cleanly.
+- **`bootup-complete` from another agent** — informational. No action required.
+- **Unknown event type** — log a warning to stderr. Do not block.
+
+---
+
+### Always-On Rules
+
+- **Forge-read before acting.** Every decision consults the forge. Event payloads are hints, not state. See [[forge-read-pattern]].
+- **One event at a time.** Process atomically. Never start a second event before the first is complete.
+- **Cursor advance is atomic and per-event.** Write `.tmp` then `mv` — never leave a partial cursor. See [[cursor-management]].
+- **`working-state.md` writes follow an ownership discipline.** During the event-listening loop, `event_poll.py` is the sole writer of the cursor line (`- **Last Processed Event ID**: …`); the agent is the sole writer of every other field (`- **Task**: …`, the `## Improvement Scan` block, etc.). During boot (before the listening loop starts) the agent may also write the cursor line — see step 5 of the boot sequence and [[cursor-management]] for crash-recovery / gap-handling writes. Both writers use the `.tmp` + `mv` protocol so readers never see a half-written file, and each writer's read-modify-write cycle preserves the other writer's lines verbatim. `.tmp` + `mv` prevents partial writes but does NOT prevent lost updates across concurrent R-M-W cycles — the ownership rule is what makes the file safe to share. If a future writer ever needs to update both classes of field together while the listening loop is active, switch to an explicit file lock before doing so.
+- **Bare comments do not wake anyone.** Urgent agent-to-agent signaling must ride a status transition or label change. See [[comment-handling]].
+- **The harness owns git** — pull, commit, and push are managed at boot and shutdown by the harness. You do not run mechanical pre/post steps in event mode. Event IDs are the tracking unit; there is no per-iteration counter.
+- **Context pressure is managed by the harness.** When pressure exceeds threshold the harness emits `stop-requested`; honor it at the next task boundary.
+
+---
+
+### Degraded-Mode Glossary
+
+**Degraded mode** = harness unreachable at boot. The agent works directly from the forge via `work_queue()` and retries `bootup-complete` emission with the 5-minute capped backoff.
+
+**Manual-recovery scenario** = harness becomes unreachable AFTER `bootup-complete` has been emitted. The agent keeps retrying at the capped backoff but does **NOT** pivot to forge-direct work. The operator manually restarts the harness; the agent resumes via the event stream on reconnect.
+
+Rationale: agents log everything to the forge, so state is recoverable; adding a runtime degraded-mode adds complexity the failsafe boot path already handles after a restart.
+<!-- /sub-skill: l1-base -->
+
+<!-- sub-skill: cursor-management -->
+## Cursor Management
+
+Your event cursor is the last event id you have processed. It lives in `.squidsquad/<role>/working-state.md` under the line:
+
+```
+- **Last Processed Event ID**: <event-id>
+```
+
+`event_poll.py` reads and advances this cursor on your behalf — you do not write it manually under normal operation. The rules below apply when you DO need to interact with it directly (boot, crash recovery, gap handling).
+
+### Atomic Update Protocol
+
+When advancing the cursor, write the new value to `<path>.tmp` then `os.replace` (or `mv`) it onto `working-state.md`. **Never** write the cursor in place — a reader catching a half-written file would observe an undefined cursor and re-deliver or skip events.
+
+`event_poll.py` handles this for the event-listening loop. If you advance the cursor by hand (e.g. on boot after skimming events), follow the same protocol.
+
+### Per-Event Advance, Not Per-Batch
+
+When a poll returns a batch of events, the cursor advances **after each event is durably persisted**, not after the whole batch. This makes mid-batch process death safe — on restart, the next poll resumes after the last successfully-persisted id.
+
+### Gap Scenarios
+
+Three kinds of cursor gap exist (CONTEXT.md §2):
+
+- **In-stream gap.** You received events `[10, 11, 13]` — no event `12`. Log a warning naming the gap; advance to the highest observed id and forge-read affected items.
+- **Long lag.** Your cursor is hundreds or thousands of events behind. Skim-then-advance through the stream; do not jump to latest. The forge already has current state — the stream is just informational.
+- **Eviction gap.** Your cursor predates the oldest retained event in the harness deque. `GET /events?since=<old>` returns the oldest available id and an eviction-count hint. Log an eviction warning naming the oldest available id and the count of evicted events; advance the cursor to that oldest available id; proceed to a forge-read for current state. Do NOT crash.
+
+### Crash Recovery
+
+On restart, `event_poll.py` reads the cursor from `working-state.md` and resumes polling from `cursor+1`. Because writes are per-event-atomic, the resume point is exactly the first unprocessed event — no duplicates, no skips.
+
+If the cursor is missing or empty, the agent starts from the beginning of the stream with a stderr warning. Use `event_poll.py --since <id>` to bootstrap a specific cursor at first run.
+<!-- /sub-skill: cursor-management -->
+
+<!-- sub-skill: forge-read-pattern -->
+## Forge-Read Pattern
+
+**The forge is the source of truth. The event stream is a wake-up signal, not state.**
+
+Every decision consults the forge before acting. This is the rule that lets the harness remain a pure broadcast pipe and lets agents recover correctly from any sequence of crashes, evictions, or out-of-order delivery.
+
+### When You Receive An Event
+
+1. **Wake.** `event_poll.py` delivered one JSON event to stdout.
+2. **Read the event payload.** Treat it as a hint about what may have changed on the forge.
+3. **Forge-read.** Query the forge via `tracker.py` for the referenced item (and/or `work_queue(<role>)` for your role's queue). The forge tells you the actual current state.
+4. **Act on what the forge says**, not on what the event payload said. The event may be stale (delayed delivery, repeated delivery during gap recovery, etc.).
+
+The cursor advances automatically as `event_poll.py` emits each event line — there is no separate step you take to advance it (see [[cursor-management]]).
+
+### Why
+
+- Events can be **stale, duplicated, or out-of-order**. The forge is consistent.
+- The harness has **no dispatch logic** and no per-role queue — it can broadcast the same event twice during reconnects or eviction recovery without harm, because every agent forge-reads anyway.
+- **Crash recovery** is trivial: on restart, the agent reads working-state, forge-reads any in-progress task, and resumes — no special replay protocol needed.
+- **Mid-task events** (Case D in [[l1-base]]) are absorbed by the next forge-read at task completion. The agent never needs an in-memory event queue.
+
+### `work_queue()` Semantics
+
+`tracker.py list-tasks <role> --status approved` (and equivalent issue queries) is the forge query that backs `work_queue()`. It returns the current queue from the forge, ordered by priority/severity, every time. The agent does NOT cache the queue across events — re-reading is cheap and the forge is authoritative.
+
+### `tracker.py get-state <number>`
+
+Use this whenever you need to confirm an item's current status, role assignment, or labels before acting. Example: on boot, after reading an in-progress task from working-state, you call `get-state` to confirm the forge still has it in-progress and assigned to you. If the forge says otherwise, drop the task and fall through to `work_queue()`.
+<!-- /sub-skill: forge-read-pattern -->
+
+<!-- sub-skill: idle-cooldown-loop -->
+## Idle = Improvement-Scan Cool-Down Loop
+
+When `work_queue(<role>)` returns empty, you are **not** finished — you enter the improvement-scan cool-down loop. Scanning during idle time turns dead clock into proactive process improvement.
+
+### Working-State Schema
+
+The cool-down state lives under a `## Improvement Scan` section in `.squidsquad/<role>/working-state.md`:
+
+```
+## Improvement Scan
+Status: idle | running
+Last completed: YYYY-MM-DD HH:MM
+Next scan after: YYYY-MM-DD HH:MM
+```
+
+Three fields, three values:
+
+- **`Status`** — `running` while a scan is in flight; `idle` between scans.
+- **`Last completed`** — wall-clock timestamp of the last successful scan completion.
+- **`Next scan after`** — when the next scan is eligible to run. Computed at completion as `Last completed + <cool-down>`.
+
+### Lifecycle
+
+1. **Entering idle.** `work_queue()` returned empty. If `Status: running` was already set (from a previous boot interrupted mid-scan), restart the scan — improvement scans are idempotent, a fresh scan subsumes a partial one.
+2. **Eligibility check.** If `Next scan after` is missing (no prior scan) or in the past, the agent is eligible — proceed to step 3. If `Next scan after` is in the future, you are NOT eligible yet — proceed to step 5 (wait).
+3. **Start scan.** Write `Status: running` to working-state (atomic). Run your role's scanning sub-skill.
+4. **Complete scan.** Read the cool-down value from `config.md`. Compute `Next scan after = now + cooldown`. Write under `## Improvement Scan`:
    ```
-   Or via Python:
-   ```python
-   import json, urllib.request
-   port = open(".squidsquad/.harness-port").read().strip()
-   data = json.dumps({"role": "<role>", "status": "success", "summary": "<brief>"}).encode()
-   req = urllib.request.Request(f"http://127.0.0.1:{port}/events/<event_id>/complete",
-                                data=data, headers={"Content-Type": "application/json"}, method="POST")
-   urllib.request.urlopen(req, timeout=5)
+   Status: idle
+   Last completed: <YYYY-MM-DD HH:MM>
+   Next scan after: <YYYY-MM-DD HH:MM>
    ```
-
-### What You Do NOT Do
-
-- **No /loop** — the Monitor tool + event_poll.py delivers events; you don't schedule cron
-- **No cycle_pre.py / cycle_post.py** — the harness handles git pull, commit, push
-- **No git operations** — the harness owns git pull (before event delivery) and commit/push (after completion)
-- **No cycle counting** — event IDs are the tracking unit, not cycles
-- **No conditional step branching** — you react to ONE event at a time
+   Note: `Next scan after` is **stored**, not derived on the fly — this is the only place the cool-down value is read.
+4a. **Re-check the queue.** Run `work_queue()` immediately after writing the scan-completion fields. A task may have arrived during the scan (or during the crashed-out window if this was a crash-recovery restart). If `work_queue()` returns work, **exit the cool-down loop** — transition the top item to `in-progress`, update the Task field in `working-state.md`, and begin work directly (no need to wait for an event, since you already have the item). Only if `work_queue()` is empty proceed to step 5.
+5. **Wait via the Monitor.** The persistent Monitor (see [[l1-base]] "How You Listen") delivers events at a short fixed cadence; you do not perform a long blocking sleep. After each empty poll interval:
+   - If `now >= Next scan after` → run the next improvement scan (back to step 3).
+   - If a task-relevant event arrives in the meantime → the Monitor wakes Case B in [[l1-base]] (forge-read, possibly pick up new work). The cool-down timer keeps running in the background; when work completes (Case C) and the queue is empty again, return here for the eligibility check.
 
 ### Atomicity
 
-Process one event at a time. Do not start a second event before completing the first. The harness will not dispatch a second event to you while one is in-flight.
+- **An event arrives during an in-flight scan** → finish the scan first (atomicity rule). Process the event when the scan completes.
+- **Crash mid-scan** → on boot, working-state shows `Status: running`. Skip forge verification for the scan, restart it from scratch. Scans are idempotent. After the restarted scan completes, run `work_queue()` (step 4a above) before re-entering the cool-down loop — a task may have arrived during the outage.
 
-### Error Handling
+### Cool-Down Configuration
 
-If the harness is unreachable (event_poll.py prints errors to stderr), the Monitor tool continues retrying automatically (event_poll.py has built-in retry with --wait). You remain idle until connection is restored.
+`config.md` carries the default:
 
-If processing fails, complete the event with `"status": "failure"` and include the error in `summary`. The harness may re-emit the work via a new event.
+```
+- **Improvement Scan Cool-Down**: 30m
+```
 
-### Context Pressure
+Per-role overrides may be added (e.g. `Improvement Scan Cool-Down (qa)`) but are NOT shipped initially. All roles share the same default cool-down (defined in `config.md`) unless config says otherwise.
+<!-- /sub-skill: idle-cooldown-loop -->
 
-The harness monitors your context pressure file and triggers restarts when exceeded. You do not check context pressure yourself — the harness emits `stop-requested` when a restart is needed.
+<!-- sub-skill: comment-handling -->
+## Comment Handling
 
-### Working State
+**Comments are NOT standalone event triggers.** A bare comment on an issue does NOT wake any agent. Comments are absorbed by the next agent that picks up the issue.
 
-Maintain `.squidsquad/<role>/working-state.md` between events for crash recovery. Update after each event completion so the harness can resume you after a restart.
-<!-- /sub-skill: event-driven-workflow -->
+This rule is the single most important consequence of the thin-broadcast harness: any wake-up signal must ride a status transition or label change, because those are the only things the harness emits onto the event stream.
+
+### The Rule
+
+When you forge-read an issue (Case B in [[l1-base]], or at task pickup), you read **all comments since you last touched the item**. New information from comments is absorbed as part of that read. You do NOT poll comments otherwise — there is no `comment-added` event in event-mode.
+
+### DM Exception — End-Of-Task Re-Read
+
+DM is the one role that has a sub-task that **spans waiting**: the PR-merge wait. While DM is waiting on a PR to merge, the task is still in flight. Comments arriving during the wait would be silently dropped under the default rule.
+
+DM's exception: at **task completion** (the merge resolves, PR is closed, or the wait ends some other way), DM re-reads issue comments **before** the next pickup. Comments are honored once the wait ends.
+
+**No sub-loop during the wait.** DM does not poll comments while waiting. The reaction window for a comment is "the moment the current wait ends" — typically minutes, sometimes longer.
+
+### Practical Consequences for Senders
+
+- **Urgent agent-to-agent signaling MUST ride a status transition or label change.** A comment alone will not wake anyone. If you need a fast reaction:
+  - Transition the issue (e.g. `in-progress → planning`) — this emits a `status-transition` event.
+  - Add or remove a label (e.g. `pending-human-review`) — this emits a label-change event.
+- **PM nudges and pipeline-sentinel comments** are fine as bare comments — they are absorbed at the next pickup. They are advisory, not blocking.
+- **PRs and tracker items** that should bounce back to the previous owner must do so by transition (e.g. QA reject → `pending-test → in-progress`), not by comment.
+
+### Transition-On-Handoff Rule
+
+When you assign work to a different role (including humans), the assignment MUST be a status transition so it appears on the event stream. Bare comments do not constitute a handoff in event mode. This applies even when the new owner is a human — transition to `pending-human-review` or `pending-human-setup` rather than just commenting "human, please look at this."
+<!-- /sub-skill: comment-handling -->
 
 <!-- sub-skill: context-pressure -->
 ### Step 1b — Context Pressure Check
@@ -416,9 +629,23 @@ For each Pending Ship task that is NOT skipped:
 
 0b. **PR merge gate**: If Branch Workflow is enabled (`python references/scripts/config.py get branch-workflow` → `yes`), check for an associated PR:
    ```bash
-   gh pr list --search "squidsquad/" --state open --json number,headRefName --limit 20
+   gh pr list --search "squidsquad/" --state open --json number,headRefName,body --limit 20
    ```
-   Find the PR matching this issue number. If found, request merge via harness before shipping:
+   Find the PR matching this issue number. If found, **first** apply the contract-citation soft gate (#8950 Gate #4):
+
+   ```bash
+   ARTIFACTS=$(ls .squidsquad/pm/planning/*[NUMBER]* 2>/dev/null)
+   ```
+
+   - **If `$ARTIFACTS` is empty** (bug fix or trivial task with no planning artifacts): the citation gate does not apply — proceed with the merge request below.
+   - **If `$ARTIFACTS` is non-empty**: scan the PR description (`body` field above) for a substring reference to any planning filename returned (e.g. `CONTEXT-[NUMBER].md`, `TEST-PLAN-[NUMBER].md`, `FEAT-*-[NUMBER]-TEST-PLAN.md`) OR a `### 5.X #[NUMBER]` bundle-CONTEXT section pointer. If **no** such reference is present, do **not** merge — route back to QA:
+     ```bash
+     python references/scripts/tracker.py transition [NUMBER] pending-ship pending-test --role dm-lead
+     python references/scripts/tracker.py comment [NUMBER] --role dm-lead --message "PR does not cite the planning contract; cannot verify architectural conformance. QA: confirm AC walk completed against the planning artifacts listed in .squidsquad/pm/planning/*[NUMBER]*."
+     ```
+     Skip this item and move to the next.
+
+   If the citation gate passes (or did not apply), request merge via harness before shipping:
      ```bash
      curl -s -X POST http://localhost:7373/merge -H "Content-Type: application/json" -d '{"pr_number": [PR_NUMBER], "branch": "[BRANCH]", "role": "dm"}'
      ```
@@ -447,6 +674,81 @@ For each Pending Ship task that is NOT skipped:
 6. Increment shipped count: `python references/scripts/config.py set shipped-since-bump [N+1]`
 7. Clear working state.
 <!-- /sub-skill: delivery-packaging -->
+
+<!-- sub-skill: pr-merge-wait -->
+## DM — PR-Merge Wait (Event Mode)
+
+DM is the one role whose work routinely spans **waiting on an external system**: a feature PR must merge before DM can transition the corresponding tracker item to `shipped` and run delivery packaging. Event mode makes this wait a single atomic task that DM holds open until the merge resolves (or DM rolls it back).
+
+This fragment defines DM's behavior across the lifecycle of a `pending-ship` task. It builds on [[l1-base]] (Cases A–E), [[forge-read-pattern]], and [[comment-handling]] — read those first.
+
+### The Task IS The Wait
+
+A `pending-ship` item assigned to DM is an active task even though DM is "just" waiting on a PR merge. From the agent's point of view this is a single atomic task per [[l1-base]] Case D: DM holds the Task field set to the issue number for the full wait, and the task only completes when DM has confirmed (via forge-read) that the PR has reached a terminal state — merged, closed without merge, or blocked by an unresolvable merge conflict.
+
+### Pickup-Time Readiness Check
+
+When DM picks up a `pending-ship` item via `work_queue()`, before entering the wait, DM forge-reads the PR (`gh pr view <number>` or equivalent) and inspects three signals:
+
+- **CI status** — green / red / pending
+- **Review state** — approved / changes-requested / blocked
+- **Mergeable state** — `MERGEABLE` / `CONFLICTING` / `UNKNOWN` (transient)
+
+The five resulting pickup branches:
+
+1. **Already merged** (the PR state is `merged` at pickup — a human merged manually, or a prior DM execution merged but crashed before transitioning) → skip the wait entirely and fall through directly to End-Of-Task Re-Read.
+2. **Ready to merge** (open, CI green, no blocking reviews, `MERGEABLE`) → if auto-merge is configured for the project, merge directly, **then verify via forge-read that the PR state is now `merged`**, then fall through to End-Of-Task Re-Read below. If the merge attempt did not produce `merged` state (network blip, server-side race, permissions), fall back to the begin-the-wait path — do NOT pretend the merge succeeded. If auto-merge is NOT configured, begin the wait described below: in this configuration the merge is performed by a human (the project policy), and the wait exits when that human action lands as PR `merged`. The stalled-PR ceiling is the safety net if the human never acts.
+3. **CI red OR review blocking** → comment a one-line summary of the cause on the issue, transition `pending-ship → in-progress` so the assigned dev role can fix the underlying problem, clear the Task field, fall through to Case C.
+4. **`CONFLICTING`** → same rollback as branch 3: comment, transition back to `in-progress`, clear Task, fall through.
+5. **`UNKNOWN`** → GitHub is computing the mergeable state; treat as the wait case (branch 2's begin-the-wait path) and recheck on next forge-read.
+
+Branches 3 and 4 do NOT transition to `shipped` (they actively roll back). Branch 5 enters the wait and may eventually ship via outcome (d) once GitHub finishes computing the mergeable state. Running delivery before a PR has merged would commit to a release of code that may never reach `main`.
+
+### No Sub-Loop During The Wait
+
+Per [[comment-handling]] DM exception: comments arriving on the issue during the wait are NOT polled in real time. DM does NOT enter a watch loop, does NOT re-read the issue every few seconds, and does NOT react to comments mid-wait. Doing so would violate the atomicity rule in [[l1-base]] Case D — events arriving mid-task are noted but not acted upon, and their information is absorbed by DM's final forge-read at task completion.
+
+The reaction window for a comment that arrives during the wait is "the moment the wait ends" — see "End-Of-Task Re-Read" below.
+
+### How DM Detects The Merge
+
+The wait is implemented as a **bounded periodic forge-read**, NOT as event-driven action. Events arriving on the stream during the wait are handled per [[l1-base]] Case D (noted, not acted on) — they are NOT what triggers DM to recheck the PR.
+
+On each Monitor wake (the persistent `event_poll.py` heartbeat at the role's wait cadence), DM forge-reads the PR exactly once and inspects:
+
+- **PR state == merged** → the wait ends, fall through to End-Of-Task Re-Read.
+- **PR state == closed and not merged** → the wait ends with a rollback; fall through to End-Of-Task Re-Read.
+- **PR state == open but `CONFLICTING`** → conflict developed mid-wait; the wait ends with a rollback. Fall through to End-Of-Task Re-Read.
+- **PR state == open and (`MERGEABLE` or `UNKNOWN`) BUT the wait has exceeded the project's configured stalled-PR ceiling** (a per-project policy setting; default unbounded) → the wait ends with a rollback (stalled-PR ceiling exceeded); fall through to End-Of-Task Re-Read.
+- **PR state == open and (`MERGEABLE` or `UNKNOWN`) and wait has not exceeded the ceiling** → wait is not over; return to wait.
+
+Event payloads about the PR are hints; the forge is authoritative ([[forge-read-pattern]]).
+
+### End-Of-Task Re-Read
+
+When the wait ends, DM performs a **single, complete re-read** of both the issue and the PR before deciding the outcome:
+
+1. **Re-read the PR** (`gh pr view <number>` or equivalent) so outcomes (c) and (d) compare against the freshest PR state, not the stale detection-phase snapshot. The TOCTOU qualifier in outcome (c) depends on this read.
+2. **Re-read issue comments** since DM last touched the item. Comments accumulated during the wait are honored here — never mid-wait.
+3. **Re-check the issue's current labels and status** for any operator changes that should redirect DM (e.g. a human flipped the item to `pending-human-review`, or transitioned it back to `planning`).
+4. **Pick exactly one outcome, evaluated in this precedence order** — earlier rules take priority because operator redirection is more authoritative than the PR's terminal state:
+   - **(a)** **A `pending-human-*` label appeared during the wait** → leave the item where the operator put it; do NOT transition. The human handoff wins regardless of PR state.
+   - **(b)** **The issue is no longer at `pending-ship`** (operator transitioned it to another status during the wait) → leave it where the operator put it; do NOT transition further. Comments on the new owner are honored at their next pickup.
+   - **(c)** **PR is not merged AND (closed without merge, OR open-but-conflicted, OR stalled-PR ceiling exceeded)** (rollback) → comment a one-line summary of the cause, transition `pending-ship → in-progress` so the assigned dev role can address it. Do NOT run delivery. The "not merged" qualifier prevents a stale rollback if the PR transitioned to `merged` in the interval between the detection forge-read and this re-read — in that case fall through to outcome (d).
+   - **(d)** **PR merged AND the issue is still at `pending-ship`** → **first** check the issue's Discussion for a `delivery: skip` marker (mandatory per DM's always-on prohibitions). If `delivery: skip` is present, skip delivery packaging and transition `pending-ship → shipped` directly. Otherwise run delivery packaging (CHANGELOG, version bumps as configured) and then transition `pending-ship → shipped`. Either way the transition auto-closes the issue.
+5. **Update working-state** → `- **Task**: none` (atomic write per [[l1-base]] ownership discipline). If outcome (a) or (b) was taken there was no transition, so DM did NOT just complete a tracker transition — see step 6.
+6. Run `work_queue()` for the next DM item. This is the same forge-read step that Case C performs after a transition; in outcomes (a) and (b) you skip Case C's "you just transitioned" preamble (no transition occurred) and go straight to the queue read.
+
+### Comment Examples (For Future Reference)
+
+| When the comment arrives | When DM acts on it |
+|--------------------------|-------------------|
+| Before DM picks up the item | At pickup (forge-read absorbs all prior comments) |
+| During the PR-merge wait | At task end (End-Of-Task Re-Read above) |
+| After DM ships the item | Never — the issue is closed; new work must come as a new tracker item |
+
+Senders who need DM to react faster than "end of current wait" must ride a status transition or label change ([[comment-handling]] transition-on-handoff rule). A comment alone is not enough.
+<!-- /sub-skill: pr-merge-wait -->
 
 <!-- sub-skill: version-bumps -->
 ### Step 3 — Version Bump Check
@@ -603,12 +905,24 @@ After completing **4 full rotations**, assess if accessibility improvements are 
 
 Agents can signal a restart only when their own context pressure exceeds the threshold. All other restart reasons (template changes, reboot requests) are handled by the harness via intent API (#4966).
 
-**Context pressure restart flow**:
+**Context pressure restart flow** (#4792 Phase 1):
+
 1. Step 1b detects context pressure exceeds threshold.
 2. Checkpoint working state to `.squidsquad/[ROLE]/working-state.md`.
 3. Complete the current cycle normally.
-4. At cycle end, `cycle_post.py` checks context pressure from `cycle-input.json`. If exceeded, exits with code 42.
-5. The harness detects the exit, sees intent=running, and respawns the agent.
+4. At cycle end, `cycle_post.py` checks the `context_pressure` field of your `cycle-output.json` (falling back to `cycle-input.json` if you did not pass it through). If exceeded, it POSTs `/agents/[ROLE]/restart` to the harness so intent flips to `restarting` (recording `intent_set_at` for the 60s force-kill safety net), then exits with code 42.
+5. **You then invoke `/quit`** — see "Graceful Stop — Self-Quit Protocol" below.
+6. The harness observes the process exit and, because intent is `restarting`, respawns the agent through the proper RESTARTING flow.
+
+### Graceful Stop — Self-Quit Protocol
+
+**After `cycle_post.py` exits with code 42** (the cooperative termination signal — either the harness asked you to stop/restart, or `cycle_post` detected its own context pressure exceeded), immediately invoke the `/quit` slash command to terminate the claude session. The harness will then observe the process exit and either mark you stopped or respawn you per its intent state machine.
+
+- Do NOT continue working after a 42 exit — the harness is waiting for you to terminate.
+- Do NOT attempt to suppress, retry, or override the 42 exit — it is the canonical cooperative-termination signal.
+- The exit-42 conditions are owned by `cycle_post.py`: harness intent in `{stopping, restarting}` OR context-pressure exceeded.
+
+The harness has a **60-second force-kill safety net** that fires if you fail to invoke `/quit` within the cooperative window. The safety net guarantees that operator intent (stop or restart) eventually wins even if the agent hangs — but the cooperative path is the canonical one, and the safety net should never fire under normal operation.
 
 **You do NOT**:
 - Set `restart_needed` in cycle-output.json (deprecated).
@@ -617,7 +931,7 @@ Agents can signal a restart only when their own context pressure exceeds the thr
 - Kill or manage other agents (harness handles this).
 - Implement any restart loop logic (harness handles respawn).
 
-Write `idle|` to `current-state` at cycle end so health monitoring works.
+At the end of a **normal** cycle (no exit-42 imminent), write `idle|` to `current-state` so health monitoring works. Do NOT overwrite it on the restart path — `cycle_post.py` writes `restarting|…` itself when the 42-exit condition fires, and clobbering that would hide the transition from the operator and TUI.
 <!-- /sub-skill: self-restart -->
 
 <!-- sub-skill: agent-lifecycle -->
@@ -630,7 +944,7 @@ Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). A
 2. **Graceful stop**: Harness sets intent=stopping via API. `cycle_post.py` queries `GET /agents/{role}` at cycle end, sees the intent, and exits with code 42.
 3. **Start correctly**: Harness spawns agents via thin launcher (`thin_launcher.py`) in visible terminal windows. `cycle_pre.py` handles git pull/branch per cycle.
 
-**Health monitoring**: Harness monitors agent liveness via direct PID checks (primary) and `.claude-pid` file (fallback). No heartbeat files needed — the harness polls every 5 seconds.
+**Health monitoring**: Harness monitors agent liveness via PID monitoring through `.claude-pid` (sole liveness signal). The harness polls every 5 seconds.
 
 **Intent state machine** (per-agent, in harness memory + `.harness-state.json`):
 - `running` — agent should be alive; auto-reboot on death
@@ -638,25 +952,25 @@ Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). A
 - `restarting` — graceful restart; reboot after death
 - `stopped` — agent died as requested
 
-**Lifecycle interface**:
+**Lifecycle interface** (`squidsquad_cli.py` is canonical; `start_team.py <args>` remains as a backward-compatible shim):
 ```bash
-# Start all agents
-python references/scripts/start_team.py --all
+# Start harness + all agents
+python references/scripts/squidsquad_cli.py start
 
-# Start single agent
-python references/scripts/start_team.py --role <role>
+# Start a single agent (harness auto-spawns if needed)
+python references/scripts/squidsquad_cli.py start <role>
 
-# Graceful reboot — harness sets intent=restarting
-python references/scripts/start_team.py --reboot <role>
+# Graceful restart — harness sets intent=restarting
+python references/scripts/squidsquad_cli.py restart <role>
 
-# Reboot all agents
-python references/scripts/start_team.py --reboot --all
-
-# Stop agent — harness sets intent=stopping
-python references/scripts/start_team.py --stop <role>
+# Stop a single agent — harness sets intent=stopping
+python references/scripts/squidsquad_cli.py stop <role>
 
 # Stop all agents
-python references/scripts/start_team.py --stop --all
+python references/scripts/squidsquad_cli.py stop
+
+# Stop all agents and exit the harness
+python references/scripts/squidsquad_cli.py shutdown
 ```
 
 **Crash recovery**: Harness persists state to `.squidsquad/.harness-state.json`. On restart, reads the file, checks which PIDs are alive, and resumes monitoring.
@@ -937,8 +1251,8 @@ These instructions apply to ALL agents on this project.
 
 ### Agent Infrastructure
 
-- **Harness manages agent lifecycle**: PID monitoring (primary), `.health` file (legacy fallback). Intent state machine via REST API (#4966).
-- **Agent lifecycle via `start_team.py`**: Agents do not manage their own or other agents' processes.
+- **Harness manages agent lifecycle**: PID monitoring via `.claude-pid` (sole liveness signal). Intent state machine via REST API (#4966).
+- **Agent lifecycle via `squidsquad_cli.py`** (with `start_team.py` as a backward-compatible shim): Agents do not manage their own or other agents' processes.
 - **Context pressure restart via `cycle_post.py`**: Mechanical detection, agents don't set `restart_needed`.
 
 ### Planning & Verification

--- a/tests/comprehension/8697_fixtures/dm_polling_CLAUDE.md
+++ b/tests/comprehension/8697_fixtures/dm_polling_CLAUDE.md
@@ -358,6 +358,11 @@ The script handles: status transitions, tracker comments, iteration logging, git
 <!-- /sub-skill: cycle-runner -->
 
 
+
+
+
+
+
 <!-- sub-skill: context-pressure -->
 ### Step 1b — Context Pressure Check
 
@@ -474,9 +479,23 @@ For each Pending Ship task that is NOT skipped:
 
 0b. **PR merge gate**: If Branch Workflow is enabled (`python references/scripts/config.py get branch-workflow` → `yes`), check for an associated PR:
    ```bash
-   gh pr list --search "squidsquad/" --state open --json number,headRefName --limit 20
+   gh pr list --search "squidsquad/" --state open --json number,headRefName,body --limit 20
    ```
-   Find the PR matching this issue number. If found, request merge via harness before shipping:
+   Find the PR matching this issue number. If found, **first** apply the contract-citation soft gate (#8950 Gate #4):
+
+   ```bash
+   ARTIFACTS=$(ls .squidsquad/pm/planning/*[NUMBER]* 2>/dev/null)
+   ```
+
+   - **If `$ARTIFACTS` is empty** (bug fix or trivial task with no planning artifacts): the citation gate does not apply — proceed with the merge request below.
+   - **If `$ARTIFACTS` is non-empty**: scan the PR description (`body` field above) for a substring reference to any planning filename returned (e.g. `CONTEXT-[NUMBER].md`, `TEST-PLAN-[NUMBER].md`, `FEAT-*-[NUMBER]-TEST-PLAN.md`) OR a `### 5.X #[NUMBER]` bundle-CONTEXT section pointer. If **no** such reference is present, do **not** merge — route back to QA:
+     ```bash
+     python references/scripts/tracker.py transition [NUMBER] pending-ship pending-test --role dm-lead
+     python references/scripts/tracker.py comment [NUMBER] --role dm-lead --message "PR does not cite the planning contract; cannot verify architectural conformance. QA: confirm AC walk completed against the planning artifacts listed in .squidsquad/pm/planning/*[NUMBER]*."
+     ```
+     Skip this item and move to the next.
+
+   If the citation gate passes (or did not apply), request merge via harness before shipping:
      ```bash
      curl -s -X POST http://localhost:7373/merge -H "Content-Type: application/json" -d '{"pr_number": [PR_NUMBER], "branch": "[BRANCH]", "role": "dm"}'
      ```
@@ -505,6 +524,7 @@ For each Pending Ship task that is NOT skipped:
 6. Increment shipped count: `python references/scripts/config.py set shipped-since-bump [N+1]`
 7. Clear working state.
 <!-- /sub-skill: delivery-packaging -->
+
 
 <!-- sub-skill: version-bumps -->
 ### Step 3 — Version Bump Check
@@ -661,12 +681,24 @@ After completing **4 full rotations**, assess if accessibility improvements are 
 
 Agents can signal a restart only when their own context pressure exceeds the threshold. All other restart reasons (template changes, reboot requests) are handled by the harness via intent API (#4966).
 
-**Context pressure restart flow**:
+**Context pressure restart flow** (#4792 Phase 1):
+
 1. Step 1b detects context pressure exceeds threshold.
 2. Checkpoint working state to `.squidsquad/[ROLE]/working-state.md`.
 3. Complete the current cycle normally.
-4. At cycle end, `cycle_post.py` checks context pressure from `cycle-input.json`. If exceeded, exits with code 42.
-5. The harness detects the exit, sees intent=running, and respawns the agent.
+4. At cycle end, `cycle_post.py` checks the `context_pressure` field of your `cycle-output.json` (falling back to `cycle-input.json` if you did not pass it through). If exceeded, it POSTs `/agents/[ROLE]/restart` to the harness so intent flips to `restarting` (recording `intent_set_at` for the 60s force-kill safety net), then exits with code 42.
+5. **You then invoke `/quit`** — see "Graceful Stop — Self-Quit Protocol" below.
+6. The harness observes the process exit and, because intent is `restarting`, respawns the agent through the proper RESTARTING flow.
+
+### Graceful Stop — Self-Quit Protocol
+
+**After `cycle_post.py` exits with code 42** (the cooperative termination signal — either the harness asked you to stop/restart, or `cycle_post` detected its own context pressure exceeded), immediately invoke the `/quit` slash command to terminate the claude session. The harness will then observe the process exit and either mark you stopped or respawn you per its intent state machine.
+
+- Do NOT continue working after a 42 exit — the harness is waiting for you to terminate.
+- Do NOT attempt to suppress, retry, or override the 42 exit — it is the canonical cooperative-termination signal.
+- The exit-42 conditions are owned by `cycle_post.py`: harness intent in `{stopping, restarting}` OR context-pressure exceeded.
+
+The harness has a **60-second force-kill safety net** that fires if you fail to invoke `/quit` within the cooperative window. The safety net guarantees that operator intent (stop or restart) eventually wins even if the agent hangs — but the cooperative path is the canonical one, and the safety net should never fire under normal operation.
 
 **You do NOT**:
 - Set `restart_needed` in cycle-output.json (deprecated).
@@ -675,7 +707,7 @@ Agents can signal a restart only when their own context pressure exceeds the thr
 - Kill or manage other agents (harness handles this).
 - Implement any restart loop logic (harness handles respawn).
 
-Write `idle|` to `current-state` at cycle end so health monitoring works.
+At the end of a **normal** cycle (no exit-42 imminent), write `idle|` to `current-state` so health monitoring works. Do NOT overwrite it on the restart path — `cycle_post.py` writes `restarting|…` itself when the 42-exit condition fires, and clobbering that would hide the transition from the operator and TUI.
 <!-- /sub-skill: self-restart -->
 
 <!-- sub-skill: agent-lifecycle -->
@@ -688,7 +720,7 @@ Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). A
 2. **Graceful stop**: Harness sets intent=stopping via API. `cycle_post.py` queries `GET /agents/{role}` at cycle end, sees the intent, and exits with code 42.
 3. **Start correctly**: Harness spawns agents via thin launcher (`thin_launcher.py`) in visible terminal windows. `cycle_pre.py` handles git pull/branch per cycle.
 
-**Health monitoring**: Harness monitors agent liveness via direct PID checks (primary) and `.claude-pid` file (fallback). No heartbeat files needed — the harness polls every 5 seconds.
+**Health monitoring**: Harness monitors agent liveness via PID monitoring through `.claude-pid` (sole liveness signal). The harness polls every 5 seconds.
 
 **Intent state machine** (per-agent, in harness memory + `.harness-state.json`):
 - `running` — agent should be alive; auto-reboot on death
@@ -696,25 +728,25 @@ Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). A
 - `restarting` — graceful restart; reboot after death
 - `stopped` — agent died as requested
 
-**Lifecycle interface**:
+**Lifecycle interface** (`squidsquad_cli.py` is canonical; `start_team.py <args>` remains as a backward-compatible shim):
 ```bash
-# Start all agents
-python references/scripts/start_team.py --all
+# Start harness + all agents
+python references/scripts/squidsquad_cli.py start
 
-# Start single agent
-python references/scripts/start_team.py --role <role>
+# Start a single agent (harness auto-spawns if needed)
+python references/scripts/squidsquad_cli.py start <role>
 
-# Graceful reboot — harness sets intent=restarting
-python references/scripts/start_team.py --reboot <role>
+# Graceful restart — harness sets intent=restarting
+python references/scripts/squidsquad_cli.py restart <role>
 
-# Reboot all agents
-python references/scripts/start_team.py --reboot --all
-
-# Stop agent — harness sets intent=stopping
-python references/scripts/start_team.py --stop <role>
+# Stop a single agent — harness sets intent=stopping
+python references/scripts/squidsquad_cli.py stop <role>
 
 # Stop all agents
-python references/scripts/start_team.py --stop --all
+python references/scripts/squidsquad_cli.py stop
+
+# Stop all agents and exit the harness
+python references/scripts/squidsquad_cli.py shutdown
 ```
 
 **Crash recovery**: Harness persists state to `.squidsquad/.harness-state.json`. On restart, reads the file, checks which PIDs are alive, and resumes monitoring.
@@ -995,8 +1027,8 @@ These instructions apply to ALL agents on this project.
 
 ### Agent Infrastructure
 
-- **Harness manages agent lifecycle**: PID monitoring (primary), `.health` file (legacy fallback). Intent state machine via REST API (#4966).
-- **Agent lifecycle via `start_team.py`**: Agents do not manage their own or other agents' processes.
+- **Harness manages agent lifecycle**: PID monitoring via `.claude-pid` (sole liveness signal). Intent state machine via REST API (#4966).
+- **Agent lifecycle via `squidsquad_cli.py`** (with `start_team.py` as a backward-compatible shim): Agents do not manage their own or other agents' processes.
 - **Context pressure restart via `cycle_post.py`**: Mechanical detection, agents don't set `restart_needed`.
 
 ### Planning & Verification

--- a/tests/comprehension/8697_fixtures/pm_events_CLAUDE.md
+++ b/tests/comprehension/8697_fixtures/pm_events_CLAUDE.md
@@ -196,87 +196,300 @@ The active dev agents on this project are: **[ACTIVE_AGENTS]** (read from `.squi
 
 
 <!-- sub-skill: event-driven-workflow -->
-## Event-Driven Workflow (#7630)
+## Event-Driven Workflow
 
-You are a persistent agent session that reacts to events dispatched by the harness. You sit idle until the Monitor tool detects an event, then execute exactly one creative task and close the event via the completion API.
+You are a persistent agent session driven by events from the harness. You react to one event at a time, consult the forge as the source of truth, and let `event_poll.py` advance your cursor automatically.
 
-### Config Gate
+This fragment is a brief orientation. The full agent contract lives in the companion event-mode fragments — read them in this order:
 
-This mode is active ONLY when `event-driven: yes` in config.md. If `event-driven: no`, use the standard /loop + cycle_pre/cycle_post flow instead.
+1. **[[l1-base]]** — boot sequence (Case A), event reactions (Cases B–E), case-precedence rule, working-state ownership discipline, degraded-mode operation.
+2. **[[cursor-management]]** — atomic `.tmp` + `mv` protocol, per-event advance, gap handling (in-stream, long lag, eviction).
+3. **[[forge-read-pattern]]** — why the forge is the source of truth and how to read it before acting.
+4. **[[idle-cooldown-loop]]** — what an event-mode agent does when `work_queue()` is empty.
+5. **[[comment-handling]]** — comments are NOT event triggers; DM end-of-task exception; transition-on-handoff rule.
 
-### How You Wake
+### Quick reference
 
-At boot, invoke the Monitor tool to watch for events:
+- **Wake mechanism** — Monitor tool streaming `python references/scripts/event_poll.py <role> --wait 5 --target`. Each line of stdout is one JSON event.
+- **Atomic unit of work** — one event at a time. Process to completion before reading the next.
+- **Source of truth** — the forge (`tracker.py` queries). Event payloads are hints; always forge-read before acting.
+- **Cursor** — `event_poll.py` persists it to `working-state.md` automatically (see [[cursor-management]]).
+- **Idle** — improvement-scan cool-down loop (see [[idle-cooldown-loop]]).
+- **Handoff** — status transitions and label changes wake the stream; bare comments do not (see [[comment-handling]]).
+
+### Error handling
+
+If the harness becomes unreachable, the agent does NOT pivot to forge-direct work mid-session — that path exists only at boot (degraded mode, see [[l1-base]]). Mid-session unreachable is a **manual-recovery scenario**: keep retrying at the 5-minute-capped backoff; the operator restarts the harness; the agent resumes via the event stream on reconnect.
+
+`event_poll.py` handles transient HTTP errors (5xx, `ConnectionError`, `Timeout`, `IncompleteRead`) automatically with exponential backoff. 4xx responses are treated as caller faults and exit non-zero.
+
+### Context pressure
+
+The harness monitors agent context pressure files and emits `stop-requested` when a restart is needed. Honor `stop-requested` at the next task boundary (see Case E in [[l1-base]]); the harness handles the respawn.
+<!-- /sub-skill: event-driven-workflow -->
+
+<!-- sub-skill: l1-base -->
+## Event-Mode L1 Base — Agent Definition
+
+You are a persistent agent session that reacts to events on the harness event stream. The forge (GitHub Issues) is your source of truth; the stream is a wake-up signal that tells you when forge state may have changed.
+
+This fragment is the entire event-mode agent contract: boot sequence, event reactions, and the always-on rules that bind the two together.
+
+---
+
+### Boot Sequence (Case A — L1 failsafe)
+
+The boot sequence MUST work even when the harness is unreachable. Forge access is the only hard prerequisite.
+
+1. **Read working-state.** Open `.squidsquad/<role>/working-state.md`. Extract three fields:
+   - **Cursor** — line `- **Last Processed Event ID**: <event-id>` (see [[cursor-management]]). Missing or empty → start from the beginning of the stream with a stderr warning.
+   - **In-progress task** — line `- **Task**: <issue-number>` (or `- **Task**: none` if idle).
+   - **Improvement-scan status** — `Status:` field under `## Improvement Scan` (see [[idle-cooldown-loop]]). If the section is absent (first boot), treat `Status` as `idle`.
+
+2. **Branch on what working-state shows:**
+   - **In-progress tracker task** → verify against the forge: still my role? still `status:in-progress`? Yes → resume. No → clear the task field (`- **Task**: none` in working-state) and drop the task locally — **no forge transition is needed** because the forge already reflects the change (that is why verification failed). Fall through to a fresh `work_queue()` scan.
+   - **Improvement-scan `Status: running`** (not a tracker item) → skip forge verification; restart the scan. Improvement scans are idempotent — a fresh scan subsumes a partial one. See [[idle-cooldown-loop]]. **When the scan completes, run `work_queue()`** before re-entering the cool-down loop, in case a task arrived during the outage.
+   - **Idle / nothing in progress** → run `work_queue()` against the forge. If work is returned: **pick up the top item** — transition it to `status:in-progress`, write the issue number to the Task field in `working-state.md`, and begin work. If `work_queue()` is empty, defer to step 3 for the empty-queue path (cool-down loop if harness reachable; degraded-mode sleep loop if not).
+
+3. **Check harness reachability** (before any event-stream call or cool-down entry):
+   - **Unreachable** → skip steps 4–5 (nothing to skim, cursor unchanged) and proceed to degraded-mode operation: continue working directly from the forge via `work_queue()`. While in degraded mode, if `work_queue()` returns empty, sleep a short fixed interval (e.g. 60s) and retry `work_queue()`; if `work_queue()` returns work, pick up the top item directly (transition to `in-progress`, update the Task field, begin work) and on completion follow Case C (transition, clear Task field, re-run `work_queue()`) — then continue applying the same degraded-mode rules (empty → 60s sleep, non-empty → pick up). **Do NOT enter the improvement-scan cool-down loop in degraded mode**, because the Monitor (`event_poll.py`) requires the harness. **Before each `work_queue()` call** (including after each 60s sleep), attempt to POST `bootup-complete` using exponential backoff capped at **5 minutes**. A successful POST indicates the harness is reachable — **exit degraded mode** by skimming events from the current cursor forward (step 4), advancing the cursor (step 5 cursor write), and entering the listening loop. `bootup-complete` is **best-effort, not blocking** — the agent never hangs waiting for the harness.
+   - **Reachable** → continue to step 4. (If you got here from step 2's empty idle branch, after step 5 enter the improvement-scan cool-down loop — see [[idle-cooldown-loop]].)
+
+4. **Skim events from cursor forward.** Informational only — the forge already has current state. Skim-then-advance; never jump-to-latest. Handle gap scenarios per [[cursor-management]] (in-stream gap, long lag, eviction gap). In an eviction gap specifically, the cursor advances to the *oldest available* id, not the latest observed.
+
+5. **Advance cursor and announce.** Persist the cursor atomically (see [[cursor-management]]); emit `bootup-complete` (POST `/events` with `event_type=bootup-complete`, `role=<role>`, payload `{"listener_active": true}`); enter the event-listening loop via `event_poll.py`.
+
+After boot, processing is dictated by Cases B through E below.
+
+---
+
+### How You Listen (Event Poll)
+
+Invoke the Monitor tool to stream events from `event_poll.py`:
 
 ```
 Monitor tool invocation:
   command: python references/scripts/event_poll.py <role> --wait 5 --target
-  description: Watch harness event bus for work events
+  description: Watch harness event bus for relevant events
   persistent: true
 ```
 
-The Monitor tool streams `event_poll.py` stdout. Each line is a JSON event object. When the Monitor delivers a line, you wake and process it.
+`event_poll.py` writes one JSON object per line to stdout. Each line wakes you to process exactly one event.
 
-### Event Types You Receive
+---
 
-| Event Type | When | What To Do |
-|---|---|---|
-| `assigned-to` | Work item needs your attention | Read the issue from payload, do your creative work |
-| `stop-requested` | Harness wants you to exit | Checkpoint working-state.md, then exit cleanly |
-| `status-transition` | A relevant item changed status | React per your role's logic |
+> **Cursor advancement is automatic.** `event_poll.py` persists the cursor to `working-state.md` as each event line is emitted to stdout. Cases B–E below describe the agent's reaction to each delivered event; the cursor write happens on the agent's behalf — there is no separate "advance cursor" step for the agent to perform. See [[cursor-management]].
 
-> **Future event types** (not yet emitted by harness — planned for Phase 5+):
-> - `scan-needed` — idle timeout reached → run improvement scan
-> - `vault-reflect` — active work completed → run vault reflection
+> **Case precedence.** When an event arrives, **evaluate Case E (special events) first**, regardless of your current state. Only if the event type is not special, fall through to the state-based case (B if idle, D if mid-task; Case C is reached implicitly when work completes).
 
-### Processing Flow
+### Case B — Idle, event arrives
 
-For each event:
+1. Read the event delivered by the Monitor.
+2. **Forge-read** the referenced item (if any) via `tracker.py`. The forge is the source of truth — see [[forge-read-pattern]].
+3. Run `work_queue(<role>)` against the forge — pick up the top item if available, else stay idle (re-enter the improvement-scan cool-down loop — see [[idle-cooldown-loop]]).
 
-1. **Read**: Parse the JSON event. Extract `id`, `event_type`, and `payload`.
-2. **Act**: Do your creative work — implement, verify, plan, deliver (per your role).
-3. **Complete**: When done, call the completion endpoint:
-   ```bash
-   curl -s -X POST http://127.0.0.1:$(cat .squidsquad/.harness-port)/events/<event_id>/complete \
-     -H "Content-Type: application/json" \
-     -d '{"role": "<role>", "status": "success", "summary": "<brief description>"}'
+---
+
+### Case C — After completing work
+
+1. You just transitioned a tracker item via `tracker.py transition`.
+2. Update `working-state.md` → `- **Task**: none`.
+3. **Immediately run `work_queue()`** against the forge. Do NOT wait for your own transition event to come back through the stream.
+4. Pick up the next item, or — if `work_queue()` is empty — enter idle (improvement-scan cool-down). **Degraded-mode exception**: if the harness is currently unreachable, do NOT enter the cool-down loop; apply the degraded-mode rules instead (60s sleep + retry `work_queue()`).
+
+---
+
+### Case D — Mid-task, event arrives
+
+1. Read the event delivered by the Monitor.
+2. **Note but do NOT act.** The current task runs atomically to completion.
+3. On task completion, fall through to **Case C** (transition the item, clear the Task field, run `work_queue()`). Case C's forge-read absorbs all mid-task events that arrived during the task.
+
+---
+
+### Case E — Special events
+
+- **`stop-requested`** — honored ONLY at a task boundary. Mid-task: read the event, ignore. At a boundary: checkpoint `working-state.md` (preserve the cursor), then exit cleanly.
+- **`bootup-complete` from another agent** — informational. No action required.
+- **Unknown event type** — log a warning to stderr. Do not block.
+
+---
+
+### Always-On Rules
+
+- **Forge-read before acting.** Every decision consults the forge. Event payloads are hints, not state. See [[forge-read-pattern]].
+- **One event at a time.** Process atomically. Never start a second event before the first is complete.
+- **Cursor advance is atomic and per-event.** Write `.tmp` then `mv` — never leave a partial cursor. See [[cursor-management]].
+- **`working-state.md` writes follow an ownership discipline.** During the event-listening loop, `event_poll.py` is the sole writer of the cursor line (`- **Last Processed Event ID**: …`); the agent is the sole writer of every other field (`- **Task**: …`, the `## Improvement Scan` block, etc.). During boot (before the listening loop starts) the agent may also write the cursor line — see step 5 of the boot sequence and [[cursor-management]] for crash-recovery / gap-handling writes. Both writers use the `.tmp` + `mv` protocol so readers never see a half-written file, and each writer's read-modify-write cycle preserves the other writer's lines verbatim. `.tmp` + `mv` prevents partial writes but does NOT prevent lost updates across concurrent R-M-W cycles — the ownership rule is what makes the file safe to share. If a future writer ever needs to update both classes of field together while the listening loop is active, switch to an explicit file lock before doing so.
+- **Bare comments do not wake anyone.** Urgent agent-to-agent signaling must ride a status transition or label change. See [[comment-handling]].
+- **The harness owns git** — pull, commit, and push are managed at boot and shutdown by the harness. You do not run mechanical pre/post steps in event mode. Event IDs are the tracking unit; there is no per-iteration counter.
+- **Context pressure is managed by the harness.** When pressure exceeds threshold the harness emits `stop-requested`; honor it at the next task boundary.
+
+---
+
+### Degraded-Mode Glossary
+
+**Degraded mode** = harness unreachable at boot. The agent works directly from the forge via `work_queue()` and retries `bootup-complete` emission with the 5-minute capped backoff.
+
+**Manual-recovery scenario** = harness becomes unreachable AFTER `bootup-complete` has been emitted. The agent keeps retrying at the capped backoff but does **NOT** pivot to forge-direct work. The operator manually restarts the harness; the agent resumes via the event stream on reconnect.
+
+Rationale: agents log everything to the forge, so state is recoverable; adding a runtime degraded-mode adds complexity the failsafe boot path already handles after a restart.
+<!-- /sub-skill: l1-base -->
+
+<!-- sub-skill: cursor-management -->
+## Cursor Management
+
+Your event cursor is the last event id you have processed. It lives in `.squidsquad/<role>/working-state.md` under the line:
+
+```
+- **Last Processed Event ID**: <event-id>
+```
+
+`event_poll.py` reads and advances this cursor on your behalf — you do not write it manually under normal operation. The rules below apply when you DO need to interact with it directly (boot, crash recovery, gap handling).
+
+### Atomic Update Protocol
+
+When advancing the cursor, write the new value to `<path>.tmp` then `os.replace` (or `mv`) it onto `working-state.md`. **Never** write the cursor in place — a reader catching a half-written file would observe an undefined cursor and re-deliver or skip events.
+
+`event_poll.py` handles this for the event-listening loop. If you advance the cursor by hand (e.g. on boot after skimming events), follow the same protocol.
+
+### Per-Event Advance, Not Per-Batch
+
+When a poll returns a batch of events, the cursor advances **after each event is durably persisted**, not after the whole batch. This makes mid-batch process death safe — on restart, the next poll resumes after the last successfully-persisted id.
+
+### Gap Scenarios
+
+Three kinds of cursor gap exist (CONTEXT.md §2):
+
+- **In-stream gap.** You received events `[10, 11, 13]` — no event `12`. Log a warning naming the gap; advance to the highest observed id and forge-read affected items.
+- **Long lag.** Your cursor is hundreds or thousands of events behind. Skim-then-advance through the stream; do not jump to latest. The forge already has current state — the stream is just informational.
+- **Eviction gap.** Your cursor predates the oldest retained event in the harness deque. `GET /events?since=<old>` returns the oldest available id and an eviction-count hint. Log an eviction warning naming the oldest available id and the count of evicted events; advance the cursor to that oldest available id; proceed to a forge-read for current state. Do NOT crash.
+
+### Crash Recovery
+
+On restart, `event_poll.py` reads the cursor from `working-state.md` and resumes polling from `cursor+1`. Because writes are per-event-atomic, the resume point is exactly the first unprocessed event — no duplicates, no skips.
+
+If the cursor is missing or empty, the agent starts from the beginning of the stream with a stderr warning. Use `event_poll.py --since <id>` to bootstrap a specific cursor at first run.
+<!-- /sub-skill: cursor-management -->
+
+<!-- sub-skill: forge-read-pattern -->
+## Forge-Read Pattern
+
+**The forge is the source of truth. The event stream is a wake-up signal, not state.**
+
+Every decision consults the forge before acting. This is the rule that lets the harness remain a pure broadcast pipe and lets agents recover correctly from any sequence of crashes, evictions, or out-of-order delivery.
+
+### When You Receive An Event
+
+1. **Wake.** `event_poll.py` delivered one JSON event to stdout.
+2. **Read the event payload.** Treat it as a hint about what may have changed on the forge.
+3. **Forge-read.** Query the forge via `tracker.py` for the referenced item (and/or `work_queue(<role>)` for your role's queue). The forge tells you the actual current state.
+4. **Act on what the forge says**, not on what the event payload said. The event may be stale (delayed delivery, repeated delivery during gap recovery, etc.).
+
+The cursor advances automatically as `event_poll.py` emits each event line — there is no separate step you take to advance it (see [[cursor-management]]).
+
+### Why
+
+- Events can be **stale, duplicated, or out-of-order**. The forge is consistent.
+- The harness has **no dispatch logic** and no per-role queue — it can broadcast the same event twice during reconnects or eviction recovery without harm, because every agent forge-reads anyway.
+- **Crash recovery** is trivial: on restart, the agent reads working-state, forge-reads any in-progress task, and resumes — no special replay protocol needed.
+- **Mid-task events** (Case D in [[l1-base]]) are absorbed by the next forge-read at task completion. The agent never needs an in-memory event queue.
+
+### `work_queue()` Semantics
+
+`tracker.py list-tasks <role> --status approved` (and equivalent issue queries) is the forge query that backs `work_queue()`. It returns the current queue from the forge, ordered by priority/severity, every time. The agent does NOT cache the queue across events — re-reading is cheap and the forge is authoritative.
+
+### `tracker.py get-state <number>`
+
+Use this whenever you need to confirm an item's current status, role assignment, or labels before acting. Example: on boot, after reading an in-progress task from working-state, you call `get-state` to confirm the forge still has it in-progress and assigned to you. If the forge says otherwise, drop the task and fall through to `work_queue()`.
+<!-- /sub-skill: forge-read-pattern -->
+
+<!-- sub-skill: idle-cooldown-loop -->
+## Idle = Improvement-Scan Cool-Down Loop
+
+When `work_queue(<role>)` returns empty, you are **not** finished — you enter the improvement-scan cool-down loop. Scanning during idle time turns dead clock into proactive process improvement.
+
+### Working-State Schema
+
+The cool-down state lives under a `## Improvement Scan` section in `.squidsquad/<role>/working-state.md`:
+
+```
+## Improvement Scan
+Status: idle | running
+Last completed: YYYY-MM-DD HH:MM
+Next scan after: YYYY-MM-DD HH:MM
+```
+
+Three fields, three values:
+
+- **`Status`** — `running` while a scan is in flight; `idle` between scans.
+- **`Last completed`** — wall-clock timestamp of the last successful scan completion.
+- **`Next scan after`** — when the next scan is eligible to run. Computed at completion as `Last completed + <cool-down>`.
+
+### Lifecycle
+
+1. **Entering idle.** `work_queue()` returned empty. If `Status: running` was already set (from a previous boot interrupted mid-scan), restart the scan — improvement scans are idempotent, a fresh scan subsumes a partial one.
+2. **Eligibility check.** If `Next scan after` is missing (no prior scan) or in the past, the agent is eligible — proceed to step 3. If `Next scan after` is in the future, you are NOT eligible yet — proceed to step 5 (wait).
+3. **Start scan.** Write `Status: running` to working-state (atomic). Run your role's scanning sub-skill.
+4. **Complete scan.** Read the cool-down value from `config.md`. Compute `Next scan after = now + cooldown`. Write under `## Improvement Scan`:
    ```
-   Or via Python:
-   ```python
-   import json, urllib.request
-   port = open(".squidsquad/.harness-port").read().strip()
-   data = json.dumps({"role": "<role>", "status": "success", "summary": "<brief>"}).encode()
-   req = urllib.request.Request(f"http://127.0.0.1:{port}/events/<event_id>/complete",
-                                data=data, headers={"Content-Type": "application/json"}, method="POST")
-   urllib.request.urlopen(req, timeout=5)
+   Status: idle
+   Last completed: <YYYY-MM-DD HH:MM>
+   Next scan after: <YYYY-MM-DD HH:MM>
    ```
-
-### What You Do NOT Do
-
-- **No /loop** — the Monitor tool + event_poll.py delivers events; you don't schedule cron
-- **No cycle_pre.py / cycle_post.py** — the harness handles git pull, commit, push
-- **No git operations** — the harness owns git pull (before event delivery) and commit/push (after completion)
-- **No cycle counting** — event IDs are the tracking unit, not cycles
-- **No conditional step branching** — you react to ONE event at a time
+   Note: `Next scan after` is **stored**, not derived on the fly — this is the only place the cool-down value is read.
+4a. **Re-check the queue.** Run `work_queue()` immediately after writing the scan-completion fields. A task may have arrived during the scan (or during the crashed-out window if this was a crash-recovery restart). If `work_queue()` returns work, **exit the cool-down loop** — transition the top item to `in-progress`, update the Task field in `working-state.md`, and begin work directly (no need to wait for an event, since you already have the item). Only if `work_queue()` is empty proceed to step 5.
+5. **Wait via the Monitor.** The persistent Monitor (see [[l1-base]] "How You Listen") delivers events at a short fixed cadence; you do not perform a long blocking sleep. After each empty poll interval:
+   - If `now >= Next scan after` → run the next improvement scan (back to step 3).
+   - If a task-relevant event arrives in the meantime → the Monitor wakes Case B in [[l1-base]] (forge-read, possibly pick up new work). The cool-down timer keeps running in the background; when work completes (Case C) and the queue is empty again, return here for the eligibility check.
 
 ### Atomicity
 
-Process one event at a time. Do not start a second event before completing the first. The harness will not dispatch a second event to you while one is in-flight.
+- **An event arrives during an in-flight scan** → finish the scan first (atomicity rule). Process the event when the scan completes.
+- **Crash mid-scan** → on boot, working-state shows `Status: running`. Skip forge verification for the scan, restart it from scratch. Scans are idempotent. After the restarted scan completes, run `work_queue()` (step 4a above) before re-entering the cool-down loop — a task may have arrived during the outage.
 
-### Error Handling
+### Cool-Down Configuration
 
-If the harness is unreachable (event_poll.py prints errors to stderr), the Monitor tool continues retrying automatically (event_poll.py has built-in retry with --wait). You remain idle until connection is restored.
+`config.md` carries the default:
 
-If processing fails, complete the event with `"status": "failure"` and include the error in `summary`. The harness may re-emit the work via a new event.
+```
+- **Improvement Scan Cool-Down**: 30m
+```
 
-### Context Pressure
+Per-role overrides may be added (e.g. `Improvement Scan Cool-Down (qa)`) but are NOT shipped initially. All roles share the same default cool-down (defined in `config.md`) unless config says otherwise.
+<!-- /sub-skill: idle-cooldown-loop -->
 
-The harness monitors your context pressure file and triggers restarts when exceeded. You do not check context pressure yourself — the harness emits `stop-requested` when a restart is needed.
+<!-- sub-skill: comment-handling -->
+## Comment Handling
 
-### Working State
+**Comments are NOT standalone event triggers.** A bare comment on an issue does NOT wake any agent. Comments are absorbed by the next agent that picks up the issue.
 
-Maintain `.squidsquad/<role>/working-state.md` between events for crash recovery. Update after each event completion so the harness can resume you after a restart.
-<!-- /sub-skill: event-driven-workflow -->
+This rule is the single most important consequence of the thin-broadcast harness: any wake-up signal must ride a status transition or label change, because those are the only things the harness emits onto the event stream.
+
+### The Rule
+
+When you forge-read an issue (Case B in [[l1-base]], or at task pickup), you read **all comments since you last touched the item**. New information from comments is absorbed as part of that read. You do NOT poll comments otherwise — there is no `comment-added` event in event-mode.
+
+### DM Exception — End-Of-Task Re-Read
+
+DM is the one role that has a sub-task that **spans waiting**: the PR-merge wait. While DM is waiting on a PR to merge, the task is still in flight. Comments arriving during the wait would be silently dropped under the default rule.
+
+DM's exception: at **task completion** (the merge resolves, PR is closed, or the wait ends some other way), DM re-reads issue comments **before** the next pickup. Comments are honored once the wait ends.
+
+**No sub-loop during the wait.** DM does not poll comments while waiting. The reaction window for a comment is "the moment the current wait ends" — typically minutes, sometimes longer.
+
+### Practical Consequences for Senders
+
+- **Urgent agent-to-agent signaling MUST ride a status transition or label change.** A comment alone will not wake anyone. If you need a fast reaction:
+  - Transition the issue (e.g. `in-progress → planning`) — this emits a `status-transition` event.
+  - Add or remove a label (e.g. `pending-human-review`) — this emits a label-change event.
+- **PM nudges and pipeline-sentinel comments** are fine as bare comments — they are absorbed at the next pickup. They are advisory, not blocking.
+- **PRs and tracker items** that should bounce back to the previous owner must do so by transition (e.g. QA reject → `pending-test → in-progress`), not by comment.
+
+### Transition-On-Handoff Rule
+
+When you assign work to a different role (including humans), the assignment MUST be a status transition so it appears on the event stream. Bare comments do not constitute a handoff in event mode. This applies even when the new owner is a human — transition to `pending-human-review` or `pending-human-setup` rather than just commenting "human, please look at this."
+<!-- /sub-skill: comment-handling -->
 
 <!-- sub-skill: context-pressure -->
 ### Step 1b — Context Pressure Check
@@ -536,14 +749,14 @@ Run the deterministic health check script:
 python references/scripts/health_check.py
 ```
 
-The script checks agent liveness via PID monitoring (primary) and `.health` file (legacy fallback). The harness monitors PIDs directly every 5 seconds (#4966).
+The script reads each agent's `.claude-pid` (sole liveness signal) and `current-state` mtime for offline diagnostics. The harness monitors PIDs directly every 5 seconds (#4966); prefer `squidsquad_cli.py status` when the harness is reachable.
 
 Log the script's output in `pm/qa-log.md`. For any agent reporting stalled (👻) or unknown (❓):
 
 1. Append a Discussion note to that agent's latest open tracker item.
 2. If no open item exists, log in `qa-log.md` only.
 
-**Context pressure monitoring**: Check each agent's context pressure file. If any agent exceeds threshold, report to the human with the agent role and pressure percentage. **PM does not execute reboots directly** — agent lifecycle is managed by the harness and `start_team.py` (#4966).
+**Context pressure monitoring**: Check each agent's context pressure file. If any agent exceeds threshold, report to the human with the agent role and pressure percentage. **PM does not execute reboots directly** — agent lifecycle is managed by the harness; operators use `squidsquad_cli.py` (or the backward-compatible `start_team.py` shim) (#4966).
 
 For programmatic use, the script accepts `--json` for structured output.
 <!-- /sub-skill: health-check -->
@@ -955,12 +1168,24 @@ Log in iteration summary: `Vault synthesis: [N] recent notes reviewed, [M] postu
 
 Agents can signal a restart only when their own context pressure exceeds the threshold. All other restart reasons (template changes, reboot requests) are handled by the harness via intent API (#4966).
 
-**Context pressure restart flow**:
+**Context pressure restart flow** (#4792 Phase 1):
+
 1. Step 1b detects context pressure exceeds threshold.
 2. Checkpoint working state to `.squidsquad/[ROLE]/working-state.md`.
 3. Complete the current cycle normally.
-4. At cycle end, `cycle_post.py` checks context pressure from `cycle-input.json`. If exceeded, exits with code 42.
-5. The harness detects the exit, sees intent=running, and respawns the agent.
+4. At cycle end, `cycle_post.py` checks the `context_pressure` field of your `cycle-output.json` (falling back to `cycle-input.json` if you did not pass it through). If exceeded, it POSTs `/agents/[ROLE]/restart` to the harness so intent flips to `restarting` (recording `intent_set_at` for the 60s force-kill safety net), then exits with code 42.
+5. **You then invoke `/quit`** — see "Graceful Stop — Self-Quit Protocol" below.
+6. The harness observes the process exit and, because intent is `restarting`, respawns the agent through the proper RESTARTING flow.
+
+### Graceful Stop — Self-Quit Protocol
+
+**After `cycle_post.py` exits with code 42** (the cooperative termination signal — either the harness asked you to stop/restart, or `cycle_post` detected its own context pressure exceeded), immediately invoke the `/quit` slash command to terminate the claude session. The harness will then observe the process exit and either mark you stopped or respawn you per its intent state machine.
+
+- Do NOT continue working after a 42 exit — the harness is waiting for you to terminate.
+- Do NOT attempt to suppress, retry, or override the 42 exit — it is the canonical cooperative-termination signal.
+- The exit-42 conditions are owned by `cycle_post.py`: harness intent in `{stopping, restarting}` OR context-pressure exceeded.
+
+The harness has a **60-second force-kill safety net** that fires if you fail to invoke `/quit` within the cooperative window. The safety net guarantees that operator intent (stop or restart) eventually wins even if the agent hangs — but the cooperative path is the canonical one, and the safety net should never fire under normal operation.
 
 **You do NOT**:
 - Set `restart_needed` in cycle-output.json (deprecated).
@@ -969,7 +1194,7 @@ Agents can signal a restart only when their own context pressure exceeds the thr
 - Kill or manage other agents (harness handles this).
 - Implement any restart loop logic (harness handles respawn).
 
-Write `idle|` to `current-state` at cycle end so health monitoring works.
+At the end of a **normal** cycle (no exit-42 imminent), write `idle|` to `current-state` so health monitoring works. Do NOT overwrite it on the restart path — `cycle_post.py` writes `restarting|…` itself when the 42-exit condition fires, and clobbering that would hide the transition from the operator and TUI.
 <!-- /sub-skill: self-restart -->
 
 <!-- sub-skill: agent-lifecycle -->
@@ -982,7 +1207,7 @@ Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). A
 2. **Graceful stop**: Harness sets intent=stopping via API. `cycle_post.py` queries `GET /agents/{role}` at cycle end, sees the intent, and exits with code 42.
 3. **Start correctly**: Harness spawns agents via thin launcher (`thin_launcher.py`) in visible terminal windows. `cycle_pre.py` handles git pull/branch per cycle.
 
-**Health monitoring**: Harness monitors agent liveness via direct PID checks (primary) and `.claude-pid` file (fallback). No heartbeat files needed — the harness polls every 5 seconds.
+**Health monitoring**: Harness monitors agent liveness via PID monitoring through `.claude-pid` (sole liveness signal). The harness polls every 5 seconds.
 
 **Intent state machine** (per-agent, in harness memory + `.harness-state.json`):
 - `running` — agent should be alive; auto-reboot on death
@@ -990,25 +1215,25 @@ Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). A
 - `restarting` — graceful restart; reboot after death
 - `stopped` — agent died as requested
 
-**Lifecycle interface**:
+**Lifecycle interface** (`squidsquad_cli.py` is canonical; `start_team.py <args>` remains as a backward-compatible shim):
 ```bash
-# Start all agents
-python references/scripts/start_team.py --all
+# Start harness + all agents
+python references/scripts/squidsquad_cli.py start
 
-# Start single agent
-python references/scripts/start_team.py --role <role>
+# Start a single agent (harness auto-spawns if needed)
+python references/scripts/squidsquad_cli.py start <role>
 
-# Graceful reboot — harness sets intent=restarting
-python references/scripts/start_team.py --reboot <role>
+# Graceful restart — harness sets intent=restarting
+python references/scripts/squidsquad_cli.py restart <role>
 
-# Reboot all agents
-python references/scripts/start_team.py --reboot --all
-
-# Stop agent — harness sets intent=stopping
-python references/scripts/start_team.py --stop <role>
+# Stop a single agent — harness sets intent=stopping
+python references/scripts/squidsquad_cli.py stop <role>
 
 # Stop all agents
-python references/scripts/start_team.py --stop --all
+python references/scripts/squidsquad_cli.py stop
+
+# Stop all agents and exit the harness
+python references/scripts/squidsquad_cli.py shutdown
 ```
 
 **Crash recovery**: Harness persists state to `.squidsquad/.harness-state.json`. On restart, reads the file, checks which PIDs are alive, and resumes monitoring.
@@ -1241,6 +1466,16 @@ Continue until all questions are resolved. Capture decisions in `.squidsquad/[RO
 
 **Open in editor**: After CONTEXT.md is created, offer to open it (see "Open Artifacts in Editor" below).
 
+**Sync issue body when CONTEXT scope is (re)written** (#8917 Change 1): When Phase 2 (deepseek review, discussion locks, scope discussion) rewrites scope on `CONTEXT.md` (or per-task `CONTEXT-<NUMBER>.md`), the corresponding GitHub Issue body MUST be updated in the same PM step. Use `gh issue edit <N> --body-file <new-body>`. The issue body and CONTEXT.md must always agree at the time of the `planned → approved` transition.
+
+Every issue body that has a planning artifact MUST lead with an **AUTHORITATIVE SCOPE banner** pointing at the locked planning file:
+
+```
+> **AUTHORITATIVE SCOPE: `.squidsquad/pm/planning/CONTEXT.md §5.X` (or `CONTEXT-<NUMBER>.md`). Read that artifact in full. The bullets below are a summary; the planning artifact is the contract.**
+```
+
+The banner is required on every issue with a CONTEXT file — at issue creation time (Phase 3 §A below), and on every Phase 2 scope rewrite thereafter.
+
 **Design routing**: If a `designer` agent is configured (check `config.md` Dev Agents list for `designer`), ask the human if this task needs design work using `AskUserQuestion`:
 
 ```
@@ -1317,6 +1552,11 @@ If any answer is unclear, the AC is incomplete — refine before filing.
 - Acceptance criteria include edge case handling and side effect mitigations
 - Acceptance criteria verified against the AC Integration Check above
 - References RESEARCH.md and CONTEXT.md
+- **AUTHORITATIVE SCOPE banner at the start of the body** (#8917 Change 3): when the task has a `CONTEXT.md` (bundle `§5.X #<NUMBER>`) or `CONTEXT-<NUMBER>.md`, the body passed to `create-task` MUST start with the banner pointing at that locked planning file. Format:
+  ```
+  > **AUTHORITATIVE SCOPE: `.squidsquad/pm/planning/CONTEXT-<NUMBER>.md` (or `CONTEXT.md §5.X`). Read that artifact in full. The bullets below are a summary; the planning artifact is the contract.**
+  ```
+  Phase 2 (above) keeps the banner + body bullets in sync on every later scope rewrite; this rule places the banner from the start.
 
 **B) Test plan** — route to the configured model for test plan drafting:
 
@@ -1459,11 +1699,16 @@ To approve a task for planning:
 3. Update status to `Planning` (NOT `Approved`) and begin the Task Intake Process.
 4. After all planning phases complete (RESEARCH.md, CONTEXT.md, TEST-PLAN.md created), update status to `Planned` (NOT `Approved`).
 5. Present the completed plan to the human. Wait for explicit execution approval ("approved", "go", "build it", etc.).
-6. Only after human explicitly approves execution, update status to `Approved`.
+6. **Pre-approval body-vs-CONTEXT sync check** (#8917 Change 2): Before transitioning any task `planned → approved`:
+   1. Read the corresponding CONTEXT section: bundle `CONTEXT.md` `### 5.X #<NUMBER>` heading OR the full `CONTEXT-<NUMBER>.md`. Focus on `## Scope`, `## Locked Decisions`, and `## Out of Scope`.
+   2. Read the GitHub issue body: `gh issue view <N> --json body`.
+   3. Compare the body's scope bullets against those three CONTEXT sections (structured comparison, NOT a raw text diff — the body and CONTEXT intentionally have different formats). If any **locked decision** or **scope boundary** is missing, outdated, or contradicted in the body, update the body via `gh issue edit <N> --body-file <new-body>` BEFORE the transition.
+   4. Confirmation: re-read `gh issue view <N> --json body`; the AUTHORITATIVE SCOPE banner is present AND the body bullets are consistent with the CONTEXT sections.
+7. Only after human explicitly approves execution AND the pre-approval body-vs-CONTEXT check is clean, update status to `Approved`.
 
 Light mode (trivial tasks): PM can fast-track through planning with abbreviated research, but status still transitions through `Planning` → `Planned` → `Approved`.
 
-Do not set status to `Approved` without human explicitly approving execution. Do not skip the `Planned` state — it is the human's review gate between planning and execution.
+Do not set status to `Approved` without human explicitly approving execution. Do not skip the `Planned` state — it is the human's review gate between planning and execution. Do not skip the pre-approval body-vs-CONTEXT sync — the body is what skill reads on pickup; if it disagrees with the locked CONTEXT, the task will be implemented to a stale contract.
 <!-- /sub-skill: task-approval -->
 
 ---
@@ -1826,8 +2071,8 @@ These instructions apply to ALL agents on this project.
 
 ### Agent Infrastructure
 
-- **Harness manages agent lifecycle**: PID monitoring (primary), `.health` file (legacy fallback). Intent state machine via REST API (#4966).
-- **Agent lifecycle via `start_team.py`**: Agents do not manage their own or other agents' processes.
+- **Harness manages agent lifecycle**: PID monitoring via `.claude-pid` (sole liveness signal). Intent state machine via REST API (#4966).
+- **Agent lifecycle via `squidsquad_cli.py`** (with `start_team.py` as a backward-compatible shim): Agents do not manage their own or other agents' processes.
 - **Context pressure restart via `cycle_post.py`**: Mechanical detection, agents don't set `restart_needed`.
 
 ### Planning & Verification

--- a/tests/comprehension/8697_fixtures/pm_polling_CLAUDE.md
+++ b/tests/comprehension/8697_fixtures/pm_polling_CLAUDE.md
@@ -339,6 +339,11 @@ The script handles: status transitions, tracker comments, iteration logging, git
 <!-- /sub-skill: cycle-runner -->
 
 
+
+
+
+
+
 <!-- sub-skill: context-pressure -->
 ### Step 1b — Context Pressure Check
 
@@ -597,14 +602,14 @@ Run the deterministic health check script:
 python references/scripts/health_check.py
 ```
 
-The script checks agent liveness via PID monitoring (primary) and `.health` file (legacy fallback). The harness monitors PIDs directly every 5 seconds (#4966).
+The script reads each agent's `.claude-pid` (sole liveness signal) and `current-state` mtime for offline diagnostics. The harness monitors PIDs directly every 5 seconds (#4966); prefer `squidsquad_cli.py status` when the harness is reachable.
 
 Log the script's output in `pm/qa-log.md`. For any agent reporting stalled (👻) or unknown (❓):
 
 1. Append a Discussion note to that agent's latest open tracker item.
 2. If no open item exists, log in `qa-log.md` only.
 
-**Context pressure monitoring**: Check each agent's context pressure file. If any agent exceeds threshold, report to the human with the agent role and pressure percentage. **PM does not execute reboots directly** — agent lifecycle is managed by the harness and `start_team.py` (#4966).
+**Context pressure monitoring**: Check each agent's context pressure file. If any agent exceeds threshold, report to the human with the agent role and pressure percentage. **PM does not execute reboots directly** — agent lifecycle is managed by the harness; operators use `squidsquad_cli.py` (or the backward-compatible `start_team.py` shim) (#4966).
 
 For programmatic use, the script accepts `--json` for structured output.
 <!-- /sub-skill: health-check -->
@@ -1016,12 +1021,24 @@ Log in iteration summary: `Vault synthesis: [N] recent notes reviewed, [M] postu
 
 Agents can signal a restart only when their own context pressure exceeds the threshold. All other restart reasons (template changes, reboot requests) are handled by the harness via intent API (#4966).
 
-**Context pressure restart flow**:
+**Context pressure restart flow** (#4792 Phase 1):
+
 1. Step 1b detects context pressure exceeds threshold.
 2. Checkpoint working state to `.squidsquad/[ROLE]/working-state.md`.
 3. Complete the current cycle normally.
-4. At cycle end, `cycle_post.py` checks context pressure from `cycle-input.json`. If exceeded, exits with code 42.
-5. The harness detects the exit, sees intent=running, and respawns the agent.
+4. At cycle end, `cycle_post.py` checks the `context_pressure` field of your `cycle-output.json` (falling back to `cycle-input.json` if you did not pass it through). If exceeded, it POSTs `/agents/[ROLE]/restart` to the harness so intent flips to `restarting` (recording `intent_set_at` for the 60s force-kill safety net), then exits with code 42.
+5. **You then invoke `/quit`** — see "Graceful Stop — Self-Quit Protocol" below.
+6. The harness observes the process exit and, because intent is `restarting`, respawns the agent through the proper RESTARTING flow.
+
+### Graceful Stop — Self-Quit Protocol
+
+**After `cycle_post.py` exits with code 42** (the cooperative termination signal — either the harness asked you to stop/restart, or `cycle_post` detected its own context pressure exceeded), immediately invoke the `/quit` slash command to terminate the claude session. The harness will then observe the process exit and either mark you stopped or respawn you per its intent state machine.
+
+- Do NOT continue working after a 42 exit — the harness is waiting for you to terminate.
+- Do NOT attempt to suppress, retry, or override the 42 exit — it is the canonical cooperative-termination signal.
+- The exit-42 conditions are owned by `cycle_post.py`: harness intent in `{stopping, restarting}` OR context-pressure exceeded.
+
+The harness has a **60-second force-kill safety net** that fires if you fail to invoke `/quit` within the cooperative window. The safety net guarantees that operator intent (stop or restart) eventually wins even if the agent hangs — but the cooperative path is the canonical one, and the safety net should never fire under normal operation.
 
 **You do NOT**:
 - Set `restart_needed` in cycle-output.json (deprecated).
@@ -1030,7 +1047,7 @@ Agents can signal a restart only when their own context pressure exceeds the thr
 - Kill or manage other agents (harness handles this).
 - Implement any restart loop logic (harness handles respawn).
 
-Write `idle|` to `current-state` at cycle end so health monitoring works.
+At the end of a **normal** cycle (no exit-42 imminent), write `idle|` to `current-state` so health monitoring works. Do NOT overwrite it on the restart path — `cycle_post.py` writes `restarting|…` itself when the 42-exit condition fires, and clobbering that would hide the transition from the operator and TUI.
 <!-- /sub-skill: self-restart -->
 
 <!-- sub-skill: agent-lifecycle -->
@@ -1043,7 +1060,7 @@ Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). A
 2. **Graceful stop**: Harness sets intent=stopping via API. `cycle_post.py` queries `GET /agents/{role}` at cycle end, sees the intent, and exits with code 42.
 3. **Start correctly**: Harness spawns agents via thin launcher (`thin_launcher.py`) in visible terminal windows. `cycle_pre.py` handles git pull/branch per cycle.
 
-**Health monitoring**: Harness monitors agent liveness via direct PID checks (primary) and `.claude-pid` file (fallback). No heartbeat files needed — the harness polls every 5 seconds.
+**Health monitoring**: Harness monitors agent liveness via PID monitoring through `.claude-pid` (sole liveness signal). The harness polls every 5 seconds.
 
 **Intent state machine** (per-agent, in harness memory + `.harness-state.json`):
 - `running` — agent should be alive; auto-reboot on death
@@ -1051,25 +1068,25 @@ Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). A
 - `restarting` — graceful restart; reboot after death
 - `stopped` — agent died as requested
 
-**Lifecycle interface**:
+**Lifecycle interface** (`squidsquad_cli.py` is canonical; `start_team.py <args>` remains as a backward-compatible shim):
 ```bash
-# Start all agents
-python references/scripts/start_team.py --all
+# Start harness + all agents
+python references/scripts/squidsquad_cli.py start
 
-# Start single agent
-python references/scripts/start_team.py --role <role>
+# Start a single agent (harness auto-spawns if needed)
+python references/scripts/squidsquad_cli.py start <role>
 
-# Graceful reboot — harness sets intent=restarting
-python references/scripts/start_team.py --reboot <role>
+# Graceful restart — harness sets intent=restarting
+python references/scripts/squidsquad_cli.py restart <role>
 
-# Reboot all agents
-python references/scripts/start_team.py --reboot --all
-
-# Stop agent — harness sets intent=stopping
-python references/scripts/start_team.py --stop <role>
+# Stop a single agent — harness sets intent=stopping
+python references/scripts/squidsquad_cli.py stop <role>
 
 # Stop all agents
-python references/scripts/start_team.py --stop --all
+python references/scripts/squidsquad_cli.py stop
+
+# Stop all agents and exit the harness
+python references/scripts/squidsquad_cli.py shutdown
 ```
 
 **Crash recovery**: Harness persists state to `.squidsquad/.harness-state.json`. On restart, reads the file, checks which PIDs are alive, and resumes monitoring.
@@ -1302,6 +1319,16 @@ Continue until all questions are resolved. Capture decisions in `.squidsquad/[RO
 
 **Open in editor**: After CONTEXT.md is created, offer to open it (see "Open Artifacts in Editor" below).
 
+**Sync issue body when CONTEXT scope is (re)written** (#8917 Change 1): When Phase 2 (deepseek review, discussion locks, scope discussion) rewrites scope on `CONTEXT.md` (or per-task `CONTEXT-<NUMBER>.md`), the corresponding GitHub Issue body MUST be updated in the same PM step. Use `gh issue edit <N> --body-file <new-body>`. The issue body and CONTEXT.md must always agree at the time of the `planned → approved` transition.
+
+Every issue body that has a planning artifact MUST lead with an **AUTHORITATIVE SCOPE banner** pointing at the locked planning file:
+
+```
+> **AUTHORITATIVE SCOPE: `.squidsquad/pm/planning/CONTEXT.md §5.X` (or `CONTEXT-<NUMBER>.md`). Read that artifact in full. The bullets below are a summary; the planning artifact is the contract.**
+```
+
+The banner is required on every issue with a CONTEXT file — at issue creation time (Phase 3 §A below), and on every Phase 2 scope rewrite thereafter.
+
 **Design routing**: If a `designer` agent is configured (check `config.md` Dev Agents list for `designer`), ask the human if this task needs design work using `AskUserQuestion`:
 
 ```
@@ -1378,6 +1405,11 @@ If any answer is unclear, the AC is incomplete — refine before filing.
 - Acceptance criteria include edge case handling and side effect mitigations
 - Acceptance criteria verified against the AC Integration Check above
 - References RESEARCH.md and CONTEXT.md
+- **AUTHORITATIVE SCOPE banner at the start of the body** (#8917 Change 3): when the task has a `CONTEXT.md` (bundle `§5.X #<NUMBER>`) or `CONTEXT-<NUMBER>.md`, the body passed to `create-task` MUST start with the banner pointing at that locked planning file. Format:
+  ```
+  > **AUTHORITATIVE SCOPE: `.squidsquad/pm/planning/CONTEXT-<NUMBER>.md` (or `CONTEXT.md §5.X`). Read that artifact in full. The bullets below are a summary; the planning artifact is the contract.**
+  ```
+  Phase 2 (above) keeps the banner + body bullets in sync on every later scope rewrite; this rule places the banner from the start.
 
 **B) Test plan** — route to the configured model for test plan drafting:
 
@@ -1520,11 +1552,16 @@ To approve a task for planning:
 3. Update status to `Planning` (NOT `Approved`) and begin the Task Intake Process.
 4. After all planning phases complete (RESEARCH.md, CONTEXT.md, TEST-PLAN.md created), update status to `Planned` (NOT `Approved`).
 5. Present the completed plan to the human. Wait for explicit execution approval ("approved", "go", "build it", etc.).
-6. Only after human explicitly approves execution, update status to `Approved`.
+6. **Pre-approval body-vs-CONTEXT sync check** (#8917 Change 2): Before transitioning any task `planned → approved`:
+   1. Read the corresponding CONTEXT section: bundle `CONTEXT.md` `### 5.X #<NUMBER>` heading OR the full `CONTEXT-<NUMBER>.md`. Focus on `## Scope`, `## Locked Decisions`, and `## Out of Scope`.
+   2. Read the GitHub issue body: `gh issue view <N> --json body`.
+   3. Compare the body's scope bullets against those three CONTEXT sections (structured comparison, NOT a raw text diff — the body and CONTEXT intentionally have different formats). If any **locked decision** or **scope boundary** is missing, outdated, or contradicted in the body, update the body via `gh issue edit <N> --body-file <new-body>` BEFORE the transition.
+   4. Confirmation: re-read `gh issue view <N> --json body`; the AUTHORITATIVE SCOPE banner is present AND the body bullets are consistent with the CONTEXT sections.
+7. Only after human explicitly approves execution AND the pre-approval body-vs-CONTEXT check is clean, update status to `Approved`.
 
 Light mode (trivial tasks): PM can fast-track through planning with abbreviated research, but status still transitions through `Planning` → `Planned` → `Approved`.
 
-Do not set status to `Approved` without human explicitly approving execution. Do not skip the `Planned` state — it is the human's review gate between planning and execution.
+Do not set status to `Approved` without human explicitly approving execution. Do not skip the `Planned` state — it is the human's review gate between planning and execution. Do not skip the pre-approval body-vs-CONTEXT sync — the body is what skill reads on pickup; if it disagrees with the locked CONTEXT, the task will be implemented to a stale contract.
 <!-- /sub-skill: task-approval -->
 
 ---
@@ -1887,8 +1924,8 @@ These instructions apply to ALL agents on this project.
 
 ### Agent Infrastructure
 
-- **Harness manages agent lifecycle**: PID monitoring (primary), `.health` file (legacy fallback). Intent state machine via REST API (#4966).
-- **Agent lifecycle via `start_team.py`**: Agents do not manage their own or other agents' processes.
+- **Harness manages agent lifecycle**: PID monitoring via `.claude-pid` (sole liveness signal). Intent state machine via REST API (#4966).
+- **Agent lifecycle via `squidsquad_cli.py`** (with `start_team.py` as a backward-compatible shim): Agents do not manage their own or other agents' processes.
 - **Context pressure restart via `cycle_post.py`**: Mechanical detection, agents don't set `restart_needed`.
 
 ### Planning & Verification

--- a/tests/comprehension/8697_fixtures/qa_events_CLAUDE.md
+++ b/tests/comprehension/8697_fixtures/qa_events_CLAUDE.md
@@ -196,87 +196,300 @@ The active dev agents on this project are: **[ACTIVE_AGENTS]** (read from `.squi
 
 
 <!-- sub-skill: event-driven-workflow -->
-## Event-Driven Workflow (#7630)
+## Event-Driven Workflow
 
-You are a persistent agent session that reacts to events dispatched by the harness. You sit idle until the Monitor tool detects an event, then execute exactly one creative task and close the event via the completion API.
+You are a persistent agent session driven by events from the harness. You react to one event at a time, consult the forge as the source of truth, and let `event_poll.py` advance your cursor automatically.
 
-### Config Gate
+This fragment is a brief orientation. The full agent contract lives in the companion event-mode fragments — read them in this order:
 
-This mode is active ONLY when `event-driven: yes` in config.md. If `event-driven: no`, use the standard /loop + cycle_pre/cycle_post flow instead.
+1. **[[l1-base]]** — boot sequence (Case A), event reactions (Cases B–E), case-precedence rule, working-state ownership discipline, degraded-mode operation.
+2. **[[cursor-management]]** — atomic `.tmp` + `mv` protocol, per-event advance, gap handling (in-stream, long lag, eviction).
+3. **[[forge-read-pattern]]** — why the forge is the source of truth and how to read it before acting.
+4. **[[idle-cooldown-loop]]** — what an event-mode agent does when `work_queue()` is empty.
+5. **[[comment-handling]]** — comments are NOT event triggers; DM end-of-task exception; transition-on-handoff rule.
 
-### How You Wake
+### Quick reference
 
-At boot, invoke the Monitor tool to watch for events:
+- **Wake mechanism** — Monitor tool streaming `python references/scripts/event_poll.py <role> --wait 5 --target`. Each line of stdout is one JSON event.
+- **Atomic unit of work** — one event at a time. Process to completion before reading the next.
+- **Source of truth** — the forge (`tracker.py` queries). Event payloads are hints; always forge-read before acting.
+- **Cursor** — `event_poll.py` persists it to `working-state.md` automatically (see [[cursor-management]]).
+- **Idle** — improvement-scan cool-down loop (see [[idle-cooldown-loop]]).
+- **Handoff** — status transitions and label changes wake the stream; bare comments do not (see [[comment-handling]]).
+
+### Error handling
+
+If the harness becomes unreachable, the agent does NOT pivot to forge-direct work mid-session — that path exists only at boot (degraded mode, see [[l1-base]]). Mid-session unreachable is a **manual-recovery scenario**: keep retrying at the 5-minute-capped backoff; the operator restarts the harness; the agent resumes via the event stream on reconnect.
+
+`event_poll.py` handles transient HTTP errors (5xx, `ConnectionError`, `Timeout`, `IncompleteRead`) automatically with exponential backoff. 4xx responses are treated as caller faults and exit non-zero.
+
+### Context pressure
+
+The harness monitors agent context pressure files and emits `stop-requested` when a restart is needed. Honor `stop-requested` at the next task boundary (see Case E in [[l1-base]]); the harness handles the respawn.
+<!-- /sub-skill: event-driven-workflow -->
+
+<!-- sub-skill: l1-base -->
+## Event-Mode L1 Base — Agent Definition
+
+You are a persistent agent session that reacts to events on the harness event stream. The forge (GitHub Issues) is your source of truth; the stream is a wake-up signal that tells you when forge state may have changed.
+
+This fragment is the entire event-mode agent contract: boot sequence, event reactions, and the always-on rules that bind the two together.
+
+---
+
+### Boot Sequence (Case A — L1 failsafe)
+
+The boot sequence MUST work even when the harness is unreachable. Forge access is the only hard prerequisite.
+
+1. **Read working-state.** Open `.squidsquad/<role>/working-state.md`. Extract three fields:
+   - **Cursor** — line `- **Last Processed Event ID**: <event-id>` (see [[cursor-management]]). Missing or empty → start from the beginning of the stream with a stderr warning.
+   - **In-progress task** — line `- **Task**: <issue-number>` (or `- **Task**: none` if idle).
+   - **Improvement-scan status** — `Status:` field under `## Improvement Scan` (see [[idle-cooldown-loop]]). If the section is absent (first boot), treat `Status` as `idle`.
+
+2. **Branch on what working-state shows:**
+   - **In-progress tracker task** → verify against the forge: still my role? still `status:in-progress`? Yes → resume. No → clear the task field (`- **Task**: none` in working-state) and drop the task locally — **no forge transition is needed** because the forge already reflects the change (that is why verification failed). Fall through to a fresh `work_queue()` scan.
+   - **Improvement-scan `Status: running`** (not a tracker item) → skip forge verification; restart the scan. Improvement scans are idempotent — a fresh scan subsumes a partial one. See [[idle-cooldown-loop]]. **When the scan completes, run `work_queue()`** before re-entering the cool-down loop, in case a task arrived during the outage.
+   - **Idle / nothing in progress** → run `work_queue()` against the forge. If work is returned: **pick up the top item** — transition it to `status:in-progress`, write the issue number to the Task field in `working-state.md`, and begin work. If `work_queue()` is empty, defer to step 3 for the empty-queue path (cool-down loop if harness reachable; degraded-mode sleep loop if not).
+
+3. **Check harness reachability** (before any event-stream call or cool-down entry):
+   - **Unreachable** → skip steps 4–5 (nothing to skim, cursor unchanged) and proceed to degraded-mode operation: continue working directly from the forge via `work_queue()`. While in degraded mode, if `work_queue()` returns empty, sleep a short fixed interval (e.g. 60s) and retry `work_queue()`; if `work_queue()` returns work, pick up the top item directly (transition to `in-progress`, update the Task field, begin work) and on completion follow Case C (transition, clear Task field, re-run `work_queue()`) — then continue applying the same degraded-mode rules (empty → 60s sleep, non-empty → pick up). **Do NOT enter the improvement-scan cool-down loop in degraded mode**, because the Monitor (`event_poll.py`) requires the harness. **Before each `work_queue()` call** (including after each 60s sleep), attempt to POST `bootup-complete` using exponential backoff capped at **5 minutes**. A successful POST indicates the harness is reachable — **exit degraded mode** by skimming events from the current cursor forward (step 4), advancing the cursor (step 5 cursor write), and entering the listening loop. `bootup-complete` is **best-effort, not blocking** — the agent never hangs waiting for the harness.
+   - **Reachable** → continue to step 4. (If you got here from step 2's empty idle branch, after step 5 enter the improvement-scan cool-down loop — see [[idle-cooldown-loop]].)
+
+4. **Skim events from cursor forward.** Informational only — the forge already has current state. Skim-then-advance; never jump-to-latest. Handle gap scenarios per [[cursor-management]] (in-stream gap, long lag, eviction gap). In an eviction gap specifically, the cursor advances to the *oldest available* id, not the latest observed.
+
+5. **Advance cursor and announce.** Persist the cursor atomically (see [[cursor-management]]); emit `bootup-complete` (POST `/events` with `event_type=bootup-complete`, `role=<role>`, payload `{"listener_active": true}`); enter the event-listening loop via `event_poll.py`.
+
+After boot, processing is dictated by Cases B through E below.
+
+---
+
+### How You Listen (Event Poll)
+
+Invoke the Monitor tool to stream events from `event_poll.py`:
 
 ```
 Monitor tool invocation:
   command: python references/scripts/event_poll.py <role> --wait 5 --target
-  description: Watch harness event bus for work events
+  description: Watch harness event bus for relevant events
   persistent: true
 ```
 
-The Monitor tool streams `event_poll.py` stdout. Each line is a JSON event object. When the Monitor delivers a line, you wake and process it.
+`event_poll.py` writes one JSON object per line to stdout. Each line wakes you to process exactly one event.
 
-### Event Types You Receive
+---
 
-| Event Type | When | What To Do |
-|---|---|---|
-| `assigned-to` | Work item needs your attention | Read the issue from payload, do your creative work |
-| `stop-requested` | Harness wants you to exit | Checkpoint working-state.md, then exit cleanly |
-| `status-transition` | A relevant item changed status | React per your role's logic |
+> **Cursor advancement is automatic.** `event_poll.py` persists the cursor to `working-state.md` as each event line is emitted to stdout. Cases B–E below describe the agent's reaction to each delivered event; the cursor write happens on the agent's behalf — there is no separate "advance cursor" step for the agent to perform. See [[cursor-management]].
 
-> **Future event types** (not yet emitted by harness — planned for Phase 5+):
-> - `scan-needed` — idle timeout reached → run improvement scan
-> - `vault-reflect` — active work completed → run vault reflection
+> **Case precedence.** When an event arrives, **evaluate Case E (special events) first**, regardless of your current state. Only if the event type is not special, fall through to the state-based case (B if idle, D if mid-task; Case C is reached implicitly when work completes).
 
-### Processing Flow
+### Case B — Idle, event arrives
 
-For each event:
+1. Read the event delivered by the Monitor.
+2. **Forge-read** the referenced item (if any) via `tracker.py`. The forge is the source of truth — see [[forge-read-pattern]].
+3. Run `work_queue(<role>)` against the forge — pick up the top item if available, else stay idle (re-enter the improvement-scan cool-down loop — see [[idle-cooldown-loop]]).
 
-1. **Read**: Parse the JSON event. Extract `id`, `event_type`, and `payload`.
-2. **Act**: Do your creative work — implement, verify, plan, deliver (per your role).
-3. **Complete**: When done, call the completion endpoint:
-   ```bash
-   curl -s -X POST http://127.0.0.1:$(cat .squidsquad/.harness-port)/events/<event_id>/complete \
-     -H "Content-Type: application/json" \
-     -d '{"role": "<role>", "status": "success", "summary": "<brief description>"}'
+---
+
+### Case C — After completing work
+
+1. You just transitioned a tracker item via `tracker.py transition`.
+2. Update `working-state.md` → `- **Task**: none`.
+3. **Immediately run `work_queue()`** against the forge. Do NOT wait for your own transition event to come back through the stream.
+4. Pick up the next item, or — if `work_queue()` is empty — enter idle (improvement-scan cool-down). **Degraded-mode exception**: if the harness is currently unreachable, do NOT enter the cool-down loop; apply the degraded-mode rules instead (60s sleep + retry `work_queue()`).
+
+---
+
+### Case D — Mid-task, event arrives
+
+1. Read the event delivered by the Monitor.
+2. **Note but do NOT act.** The current task runs atomically to completion.
+3. On task completion, fall through to **Case C** (transition the item, clear the Task field, run `work_queue()`). Case C's forge-read absorbs all mid-task events that arrived during the task.
+
+---
+
+### Case E — Special events
+
+- **`stop-requested`** — honored ONLY at a task boundary. Mid-task: read the event, ignore. At a boundary: checkpoint `working-state.md` (preserve the cursor), then exit cleanly.
+- **`bootup-complete` from another agent** — informational. No action required.
+- **Unknown event type** — log a warning to stderr. Do not block.
+
+---
+
+### Always-On Rules
+
+- **Forge-read before acting.** Every decision consults the forge. Event payloads are hints, not state. See [[forge-read-pattern]].
+- **One event at a time.** Process atomically. Never start a second event before the first is complete.
+- **Cursor advance is atomic and per-event.** Write `.tmp` then `mv` — never leave a partial cursor. See [[cursor-management]].
+- **`working-state.md` writes follow an ownership discipline.** During the event-listening loop, `event_poll.py` is the sole writer of the cursor line (`- **Last Processed Event ID**: …`); the agent is the sole writer of every other field (`- **Task**: …`, the `## Improvement Scan` block, etc.). During boot (before the listening loop starts) the agent may also write the cursor line — see step 5 of the boot sequence and [[cursor-management]] for crash-recovery / gap-handling writes. Both writers use the `.tmp` + `mv` protocol so readers never see a half-written file, and each writer's read-modify-write cycle preserves the other writer's lines verbatim. `.tmp` + `mv` prevents partial writes but does NOT prevent lost updates across concurrent R-M-W cycles — the ownership rule is what makes the file safe to share. If a future writer ever needs to update both classes of field together while the listening loop is active, switch to an explicit file lock before doing so.
+- **Bare comments do not wake anyone.** Urgent agent-to-agent signaling must ride a status transition or label change. See [[comment-handling]].
+- **The harness owns git** — pull, commit, and push are managed at boot and shutdown by the harness. You do not run mechanical pre/post steps in event mode. Event IDs are the tracking unit; there is no per-iteration counter.
+- **Context pressure is managed by the harness.** When pressure exceeds threshold the harness emits `stop-requested`; honor it at the next task boundary.
+
+---
+
+### Degraded-Mode Glossary
+
+**Degraded mode** = harness unreachable at boot. The agent works directly from the forge via `work_queue()` and retries `bootup-complete` emission with the 5-minute capped backoff.
+
+**Manual-recovery scenario** = harness becomes unreachable AFTER `bootup-complete` has been emitted. The agent keeps retrying at the capped backoff but does **NOT** pivot to forge-direct work. The operator manually restarts the harness; the agent resumes via the event stream on reconnect.
+
+Rationale: agents log everything to the forge, so state is recoverable; adding a runtime degraded-mode adds complexity the failsafe boot path already handles after a restart.
+<!-- /sub-skill: l1-base -->
+
+<!-- sub-skill: cursor-management -->
+## Cursor Management
+
+Your event cursor is the last event id you have processed. It lives in `.squidsquad/<role>/working-state.md` under the line:
+
+```
+- **Last Processed Event ID**: <event-id>
+```
+
+`event_poll.py` reads and advances this cursor on your behalf — you do not write it manually under normal operation. The rules below apply when you DO need to interact with it directly (boot, crash recovery, gap handling).
+
+### Atomic Update Protocol
+
+When advancing the cursor, write the new value to `<path>.tmp` then `os.replace` (or `mv`) it onto `working-state.md`. **Never** write the cursor in place — a reader catching a half-written file would observe an undefined cursor and re-deliver or skip events.
+
+`event_poll.py` handles this for the event-listening loop. If you advance the cursor by hand (e.g. on boot after skimming events), follow the same protocol.
+
+### Per-Event Advance, Not Per-Batch
+
+When a poll returns a batch of events, the cursor advances **after each event is durably persisted**, not after the whole batch. This makes mid-batch process death safe — on restart, the next poll resumes after the last successfully-persisted id.
+
+### Gap Scenarios
+
+Three kinds of cursor gap exist (CONTEXT.md §2):
+
+- **In-stream gap.** You received events `[10, 11, 13]` — no event `12`. Log a warning naming the gap; advance to the highest observed id and forge-read affected items.
+- **Long lag.** Your cursor is hundreds or thousands of events behind. Skim-then-advance through the stream; do not jump to latest. The forge already has current state — the stream is just informational.
+- **Eviction gap.** Your cursor predates the oldest retained event in the harness deque. `GET /events?since=<old>` returns the oldest available id and an eviction-count hint. Log an eviction warning naming the oldest available id and the count of evicted events; advance the cursor to that oldest available id; proceed to a forge-read for current state. Do NOT crash.
+
+### Crash Recovery
+
+On restart, `event_poll.py` reads the cursor from `working-state.md` and resumes polling from `cursor+1`. Because writes are per-event-atomic, the resume point is exactly the first unprocessed event — no duplicates, no skips.
+
+If the cursor is missing or empty, the agent starts from the beginning of the stream with a stderr warning. Use `event_poll.py --since <id>` to bootstrap a specific cursor at first run.
+<!-- /sub-skill: cursor-management -->
+
+<!-- sub-skill: forge-read-pattern -->
+## Forge-Read Pattern
+
+**The forge is the source of truth. The event stream is a wake-up signal, not state.**
+
+Every decision consults the forge before acting. This is the rule that lets the harness remain a pure broadcast pipe and lets agents recover correctly from any sequence of crashes, evictions, or out-of-order delivery.
+
+### When You Receive An Event
+
+1. **Wake.** `event_poll.py` delivered one JSON event to stdout.
+2. **Read the event payload.** Treat it as a hint about what may have changed on the forge.
+3. **Forge-read.** Query the forge via `tracker.py` for the referenced item (and/or `work_queue(<role>)` for your role's queue). The forge tells you the actual current state.
+4. **Act on what the forge says**, not on what the event payload said. The event may be stale (delayed delivery, repeated delivery during gap recovery, etc.).
+
+The cursor advances automatically as `event_poll.py` emits each event line — there is no separate step you take to advance it (see [[cursor-management]]).
+
+### Why
+
+- Events can be **stale, duplicated, or out-of-order**. The forge is consistent.
+- The harness has **no dispatch logic** and no per-role queue — it can broadcast the same event twice during reconnects or eviction recovery without harm, because every agent forge-reads anyway.
+- **Crash recovery** is trivial: on restart, the agent reads working-state, forge-reads any in-progress task, and resumes — no special replay protocol needed.
+- **Mid-task events** (Case D in [[l1-base]]) are absorbed by the next forge-read at task completion. The agent never needs an in-memory event queue.
+
+### `work_queue()` Semantics
+
+`tracker.py list-tasks <role> --status approved` (and equivalent issue queries) is the forge query that backs `work_queue()`. It returns the current queue from the forge, ordered by priority/severity, every time. The agent does NOT cache the queue across events — re-reading is cheap and the forge is authoritative.
+
+### `tracker.py get-state <number>`
+
+Use this whenever you need to confirm an item's current status, role assignment, or labels before acting. Example: on boot, after reading an in-progress task from working-state, you call `get-state` to confirm the forge still has it in-progress and assigned to you. If the forge says otherwise, drop the task and fall through to `work_queue()`.
+<!-- /sub-skill: forge-read-pattern -->
+
+<!-- sub-skill: idle-cooldown-loop -->
+## Idle = Improvement-Scan Cool-Down Loop
+
+When `work_queue(<role>)` returns empty, you are **not** finished — you enter the improvement-scan cool-down loop. Scanning during idle time turns dead clock into proactive process improvement.
+
+### Working-State Schema
+
+The cool-down state lives under a `## Improvement Scan` section in `.squidsquad/<role>/working-state.md`:
+
+```
+## Improvement Scan
+Status: idle | running
+Last completed: YYYY-MM-DD HH:MM
+Next scan after: YYYY-MM-DD HH:MM
+```
+
+Three fields, three values:
+
+- **`Status`** — `running` while a scan is in flight; `idle` between scans.
+- **`Last completed`** — wall-clock timestamp of the last successful scan completion.
+- **`Next scan after`** — when the next scan is eligible to run. Computed at completion as `Last completed + <cool-down>`.
+
+### Lifecycle
+
+1. **Entering idle.** `work_queue()` returned empty. If `Status: running` was already set (from a previous boot interrupted mid-scan), restart the scan — improvement scans are idempotent, a fresh scan subsumes a partial one.
+2. **Eligibility check.** If `Next scan after` is missing (no prior scan) or in the past, the agent is eligible — proceed to step 3. If `Next scan after` is in the future, you are NOT eligible yet — proceed to step 5 (wait).
+3. **Start scan.** Write `Status: running` to working-state (atomic). Run your role's scanning sub-skill.
+4. **Complete scan.** Read the cool-down value from `config.md`. Compute `Next scan after = now + cooldown`. Write under `## Improvement Scan`:
    ```
-   Or via Python:
-   ```python
-   import json, urllib.request
-   port = open(".squidsquad/.harness-port").read().strip()
-   data = json.dumps({"role": "<role>", "status": "success", "summary": "<brief>"}).encode()
-   req = urllib.request.Request(f"http://127.0.0.1:{port}/events/<event_id>/complete",
-                                data=data, headers={"Content-Type": "application/json"}, method="POST")
-   urllib.request.urlopen(req, timeout=5)
+   Status: idle
+   Last completed: <YYYY-MM-DD HH:MM>
+   Next scan after: <YYYY-MM-DD HH:MM>
    ```
-
-### What You Do NOT Do
-
-- **No /loop** — the Monitor tool + event_poll.py delivers events; you don't schedule cron
-- **No cycle_pre.py / cycle_post.py** — the harness handles git pull, commit, push
-- **No git operations** — the harness owns git pull (before event delivery) and commit/push (after completion)
-- **No cycle counting** — event IDs are the tracking unit, not cycles
-- **No conditional step branching** — you react to ONE event at a time
+   Note: `Next scan after` is **stored**, not derived on the fly — this is the only place the cool-down value is read.
+4a. **Re-check the queue.** Run `work_queue()` immediately after writing the scan-completion fields. A task may have arrived during the scan (or during the crashed-out window if this was a crash-recovery restart). If `work_queue()` returns work, **exit the cool-down loop** — transition the top item to `in-progress`, update the Task field in `working-state.md`, and begin work directly (no need to wait for an event, since you already have the item). Only if `work_queue()` is empty proceed to step 5.
+5. **Wait via the Monitor.** The persistent Monitor (see [[l1-base]] "How You Listen") delivers events at a short fixed cadence; you do not perform a long blocking sleep. After each empty poll interval:
+   - If `now >= Next scan after` → run the next improvement scan (back to step 3).
+   - If a task-relevant event arrives in the meantime → the Monitor wakes Case B in [[l1-base]] (forge-read, possibly pick up new work). The cool-down timer keeps running in the background; when work completes (Case C) and the queue is empty again, return here for the eligibility check.
 
 ### Atomicity
 
-Process one event at a time. Do not start a second event before completing the first. The harness will not dispatch a second event to you while one is in-flight.
+- **An event arrives during an in-flight scan** → finish the scan first (atomicity rule). Process the event when the scan completes.
+- **Crash mid-scan** → on boot, working-state shows `Status: running`. Skip forge verification for the scan, restart it from scratch. Scans are idempotent. After the restarted scan completes, run `work_queue()` (step 4a above) before re-entering the cool-down loop — a task may have arrived during the outage.
 
-### Error Handling
+### Cool-Down Configuration
 
-If the harness is unreachable (event_poll.py prints errors to stderr), the Monitor tool continues retrying automatically (event_poll.py has built-in retry with --wait). You remain idle until connection is restored.
+`config.md` carries the default:
 
-If processing fails, complete the event with `"status": "failure"` and include the error in `summary`. The harness may re-emit the work via a new event.
+```
+- **Improvement Scan Cool-Down**: 30m
+```
 
-### Context Pressure
+Per-role overrides may be added (e.g. `Improvement Scan Cool-Down (qa)`) but are NOT shipped initially. All roles share the same default cool-down (defined in `config.md`) unless config says otherwise.
+<!-- /sub-skill: idle-cooldown-loop -->
 
-The harness monitors your context pressure file and triggers restarts when exceeded. You do not check context pressure yourself — the harness emits `stop-requested` when a restart is needed.
+<!-- sub-skill: comment-handling -->
+## Comment Handling
 
-### Working State
+**Comments are NOT standalone event triggers.** A bare comment on an issue does NOT wake any agent. Comments are absorbed by the next agent that picks up the issue.
 
-Maintain `.squidsquad/<role>/working-state.md` between events for crash recovery. Update after each event completion so the harness can resume you after a restart.
-<!-- /sub-skill: event-driven-workflow -->
+This rule is the single most important consequence of the thin-broadcast harness: any wake-up signal must ride a status transition or label change, because those are the only things the harness emits onto the event stream.
+
+### The Rule
+
+When you forge-read an issue (Case B in [[l1-base]], or at task pickup), you read **all comments since you last touched the item**. New information from comments is absorbed as part of that read. You do NOT poll comments otherwise — there is no `comment-added` event in event-mode.
+
+### DM Exception — End-Of-Task Re-Read
+
+DM is the one role that has a sub-task that **spans waiting**: the PR-merge wait. While DM is waiting on a PR to merge, the task is still in flight. Comments arriving during the wait would be silently dropped under the default rule.
+
+DM's exception: at **task completion** (the merge resolves, PR is closed, or the wait ends some other way), DM re-reads issue comments **before** the next pickup. Comments are honored once the wait ends.
+
+**No sub-loop during the wait.** DM does not poll comments while waiting. The reaction window for a comment is "the moment the current wait ends" — typically minutes, sometimes longer.
+
+### Practical Consequences for Senders
+
+- **Urgent agent-to-agent signaling MUST ride a status transition or label change.** A comment alone will not wake anyone. If you need a fast reaction:
+  - Transition the issue (e.g. `in-progress → planning`) — this emits a `status-transition` event.
+  - Add or remove a label (e.g. `pending-human-review`) — this emits a label-change event.
+- **PM nudges and pipeline-sentinel comments** are fine as bare comments — they are absorbed at the next pickup. They are advisory, not blocking.
+- **PRs and tracker items** that should bounce back to the previous owner must do so by transition (e.g. QA reject → `pending-test → in-progress`), not by comment.
+
+### Transition-On-Handoff Rule
+
+When you assign work to a different role (including humans), the assignment MUST be a status transition so it appears on the event stream. Bare comments do not constitute a handoff in event mode. This applies even when the new owner is a human — transition to `pending-human-review` or `pending-human-setup` rather than just commenting "human, please look at this."
+<!-- /sub-skill: comment-handling -->
 
 <!-- sub-skill: context-pressure -->
 ### Step 1b — Context Pressure Check
@@ -509,6 +722,19 @@ python references/scripts/git_ops.py task-end [role] [number]
 
 2c. **Run the full test suite**: `python tests/run_tests.py` — all tests must pass.
 
+2d. **AC walk against the planning contract** (#8950 Gate #3) — before marking any task `pending-test → pending-ship`, locate the TEST-PLAN by task-number match (covers both legacy `FEAT-PM-<NUMBER>-TEST-PLAN.md` and new `TEST-PLAN-<NUMBER>.md` conventions):
+
+   ```bash
+   TEST_PLAN=$(ls .squidsquad/pm/planning/*[NUMBER]* 2>/dev/null | grep -i 'test-plan' | head -1)
+   ```
+
+   - **If `$TEST_PLAN` is empty** (bug fix or trivial task with no planning artifact): skip this AC walk, proceed with the existing verification flow.
+   - **If `$TEST_PLAN` is non-empty**: read it and walk its AC list. For each AC, confirm it is **observably satisfied** by the implementation — run the verification command stated in the AC, check the file the AC names, or observe the output the AC describes. **Tests passing is necessary but not sufficient — do not infer AC satisfaction from test names.** If any AC is not observably satisfied, transition `pending-test → in-progress` and comment which AC failed:
+     ```bash
+     python references/scripts/tracker.py transition [NUMBER] pending-test in-progress --role qa-lead
+     python references/scripts/tracker.py comment [NUMBER] --role qa-lead --message "AC walk failed: AC-[N] in $TEST_PLAN is not observably satisfied — [what was checked and what failed]. Status → In Progress."
+     ```
+
 3. **Zero-gap gate**: If ANY gap, ambiguity, missing documentation, failed check, missing test coverage, or unresolved finding is discovered:
    ```bash
    python references/scripts/tracker.py transition [NUMBER] pending-test in-progress --role qa-lead
@@ -680,12 +906,24 @@ Tag findings with the `improvement-scan` label. Max **2 items per cycle**. Defau
 
 Agents can signal a restart only when their own context pressure exceeds the threshold. All other restart reasons (template changes, reboot requests) are handled by the harness via intent API (#4966).
 
-**Context pressure restart flow**:
+**Context pressure restart flow** (#4792 Phase 1):
+
 1. Step 1b detects context pressure exceeds threshold.
 2. Checkpoint working state to `.squidsquad/[ROLE]/working-state.md`.
 3. Complete the current cycle normally.
-4. At cycle end, `cycle_post.py` checks context pressure from `cycle-input.json`. If exceeded, exits with code 42.
-5. The harness detects the exit, sees intent=running, and respawns the agent.
+4. At cycle end, `cycle_post.py` checks the `context_pressure` field of your `cycle-output.json` (falling back to `cycle-input.json` if you did not pass it through). If exceeded, it POSTs `/agents/[ROLE]/restart` to the harness so intent flips to `restarting` (recording `intent_set_at` for the 60s force-kill safety net), then exits with code 42.
+5. **You then invoke `/quit`** — see "Graceful Stop — Self-Quit Protocol" below.
+6. The harness observes the process exit and, because intent is `restarting`, respawns the agent through the proper RESTARTING flow.
+
+### Graceful Stop — Self-Quit Protocol
+
+**After `cycle_post.py` exits with code 42** (the cooperative termination signal — either the harness asked you to stop/restart, or `cycle_post` detected its own context pressure exceeded), immediately invoke the `/quit` slash command to terminate the claude session. The harness will then observe the process exit and either mark you stopped or respawn you per its intent state machine.
+
+- Do NOT continue working after a 42 exit — the harness is waiting for you to terminate.
+- Do NOT attempt to suppress, retry, or override the 42 exit — it is the canonical cooperative-termination signal.
+- The exit-42 conditions are owned by `cycle_post.py`: harness intent in `{stopping, restarting}` OR context-pressure exceeded.
+
+The harness has a **60-second force-kill safety net** that fires if you fail to invoke `/quit` within the cooperative window. The safety net guarantees that operator intent (stop or restart) eventually wins even if the agent hangs — but the cooperative path is the canonical one, and the safety net should never fire under normal operation.
 
 **You do NOT**:
 - Set `restart_needed` in cycle-output.json (deprecated).
@@ -694,7 +932,7 @@ Agents can signal a restart only when their own context pressure exceeds the thr
 - Kill or manage other agents (harness handles this).
 - Implement any restart loop logic (harness handles respawn).
 
-Write `idle|` to `current-state` at cycle end so health monitoring works.
+At the end of a **normal** cycle (no exit-42 imminent), write `idle|` to `current-state` so health monitoring works. Do NOT overwrite it on the restart path — `cycle_post.py` writes `restarting|…` itself when the 42-exit condition fires, and clobbering that would hide the transition from the operator and TUI.
 <!-- /sub-skill: self-restart -->
 
 <!-- sub-skill: agent-lifecycle -->
@@ -707,7 +945,7 @@ Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). A
 2. **Graceful stop**: Harness sets intent=stopping via API. `cycle_post.py` queries `GET /agents/{role}` at cycle end, sees the intent, and exits with code 42.
 3. **Start correctly**: Harness spawns agents via thin launcher (`thin_launcher.py`) in visible terminal windows. `cycle_pre.py` handles git pull/branch per cycle.
 
-**Health monitoring**: Harness monitors agent liveness via direct PID checks (primary) and `.claude-pid` file (fallback). No heartbeat files needed — the harness polls every 5 seconds.
+**Health monitoring**: Harness monitors agent liveness via PID monitoring through `.claude-pid` (sole liveness signal). The harness polls every 5 seconds.
 
 **Intent state machine** (per-agent, in harness memory + `.harness-state.json`):
 - `running` — agent should be alive; auto-reboot on death
@@ -715,25 +953,25 @@ Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). A
 - `restarting` — graceful restart; reboot after death
 - `stopped` — agent died as requested
 
-**Lifecycle interface**:
+**Lifecycle interface** (`squidsquad_cli.py` is canonical; `start_team.py <args>` remains as a backward-compatible shim):
 ```bash
-# Start all agents
-python references/scripts/start_team.py --all
+# Start harness + all agents
+python references/scripts/squidsquad_cli.py start
 
-# Start single agent
-python references/scripts/start_team.py --role <role>
+# Start a single agent (harness auto-spawns if needed)
+python references/scripts/squidsquad_cli.py start <role>
 
-# Graceful reboot — harness sets intent=restarting
-python references/scripts/start_team.py --reboot <role>
+# Graceful restart — harness sets intent=restarting
+python references/scripts/squidsquad_cli.py restart <role>
 
-# Reboot all agents
-python references/scripts/start_team.py --reboot --all
-
-# Stop agent — harness sets intent=stopping
-python references/scripts/start_team.py --stop <role>
+# Stop a single agent — harness sets intent=stopping
+python references/scripts/squidsquad_cli.py stop <role>
 
 # Stop all agents
-python references/scripts/start_team.py --stop --all
+python references/scripts/squidsquad_cli.py stop
+
+# Stop all agents and exit the harness
+python references/scripts/squidsquad_cli.py shutdown
 ```
 
 **Crash recovery**: Harness persists state to `.squidsquad/.harness-state.json`. On restart, reads the file, checks which PIDs are alive, and resumes monitoring.
@@ -1021,8 +1259,8 @@ These instructions apply to ALL agents on this project.
 
 ### Agent Infrastructure
 
-- **Harness manages agent lifecycle**: PID monitoring (primary), `.health` file (legacy fallback). Intent state machine via REST API (#4966).
-- **Agent lifecycle via `start_team.py`**: Agents do not manage their own or other agents' processes.
+- **Harness manages agent lifecycle**: PID monitoring via `.claude-pid` (sole liveness signal). Intent state machine via REST API (#4966).
+- **Agent lifecycle via `squidsquad_cli.py`** (with `start_team.py` as a backward-compatible shim): Agents do not manage their own or other agents' processes.
 - **Context pressure restart via `cycle_post.py`**: Mechanical detection, agents don't set `restart_needed`.
 
 ### Planning & Verification

--- a/tests/comprehension/8697_fixtures/qa_polling_CLAUDE.md
+++ b/tests/comprehension/8697_fixtures/qa_polling_CLAUDE.md
@@ -339,6 +339,11 @@ The script handles: status transitions, tracker comments, iteration logging, git
 <!-- /sub-skill: cycle-runner -->
 
 
+
+
+
+
+
 <!-- sub-skill: context-pressure -->
 ### Step 1b — Context Pressure Check
 
@@ -570,6 +575,19 @@ python references/scripts/git_ops.py task-end [role] [number]
 
 2c. **Run the full test suite**: `python tests/run_tests.py` — all tests must pass.
 
+2d. **AC walk against the planning contract** (#8950 Gate #3) — before marking any task `pending-test → pending-ship`, locate the TEST-PLAN by task-number match (covers both legacy `FEAT-PM-<NUMBER>-TEST-PLAN.md` and new `TEST-PLAN-<NUMBER>.md` conventions):
+
+   ```bash
+   TEST_PLAN=$(ls .squidsquad/pm/planning/*[NUMBER]* 2>/dev/null | grep -i 'test-plan' | head -1)
+   ```
+
+   - **If `$TEST_PLAN` is empty** (bug fix or trivial task with no planning artifact): skip this AC walk, proceed with the existing verification flow.
+   - **If `$TEST_PLAN` is non-empty**: read it and walk its AC list. For each AC, confirm it is **observably satisfied** by the implementation — run the verification command stated in the AC, check the file the AC names, or observe the output the AC describes. **Tests passing is necessary but not sufficient — do not infer AC satisfaction from test names.** If any AC is not observably satisfied, transition `pending-test → in-progress` and comment which AC failed:
+     ```bash
+     python references/scripts/tracker.py transition [NUMBER] pending-test in-progress --role qa-lead
+     python references/scripts/tracker.py comment [NUMBER] --role qa-lead --message "AC walk failed: AC-[N] in $TEST_PLAN is not observably satisfied — [what was checked and what failed]. Status → In Progress."
+     ```
+
 3. **Zero-gap gate**: If ANY gap, ambiguity, missing documentation, failed check, missing test coverage, or unresolved finding is discovered:
    ```bash
    python references/scripts/tracker.py transition [NUMBER] pending-test in-progress --role qa-lead
@@ -741,12 +759,24 @@ Tag findings with the `improvement-scan` label. Max **2 items per cycle**. Defau
 
 Agents can signal a restart only when their own context pressure exceeds the threshold. All other restart reasons (template changes, reboot requests) are handled by the harness via intent API (#4966).
 
-**Context pressure restart flow**:
+**Context pressure restart flow** (#4792 Phase 1):
+
 1. Step 1b detects context pressure exceeds threshold.
 2. Checkpoint working state to `.squidsquad/[ROLE]/working-state.md`.
 3. Complete the current cycle normally.
-4. At cycle end, `cycle_post.py` checks context pressure from `cycle-input.json`. If exceeded, exits with code 42.
-5. The harness detects the exit, sees intent=running, and respawns the agent.
+4. At cycle end, `cycle_post.py` checks the `context_pressure` field of your `cycle-output.json` (falling back to `cycle-input.json` if you did not pass it through). If exceeded, it POSTs `/agents/[ROLE]/restart` to the harness so intent flips to `restarting` (recording `intent_set_at` for the 60s force-kill safety net), then exits with code 42.
+5. **You then invoke `/quit`** — see "Graceful Stop — Self-Quit Protocol" below.
+6. The harness observes the process exit and, because intent is `restarting`, respawns the agent through the proper RESTARTING flow.
+
+### Graceful Stop — Self-Quit Protocol
+
+**After `cycle_post.py` exits with code 42** (the cooperative termination signal — either the harness asked you to stop/restart, or `cycle_post` detected its own context pressure exceeded), immediately invoke the `/quit` slash command to terminate the claude session. The harness will then observe the process exit and either mark you stopped or respawn you per its intent state machine.
+
+- Do NOT continue working after a 42 exit — the harness is waiting for you to terminate.
+- Do NOT attempt to suppress, retry, or override the 42 exit — it is the canonical cooperative-termination signal.
+- The exit-42 conditions are owned by `cycle_post.py`: harness intent in `{stopping, restarting}` OR context-pressure exceeded.
+
+The harness has a **60-second force-kill safety net** that fires if you fail to invoke `/quit` within the cooperative window. The safety net guarantees that operator intent (stop or restart) eventually wins even if the agent hangs — but the cooperative path is the canonical one, and the safety net should never fire under normal operation.
 
 **You do NOT**:
 - Set `restart_needed` in cycle-output.json (deprecated).
@@ -755,7 +785,7 @@ Agents can signal a restart only when their own context pressure exceeds the thr
 - Kill or manage other agents (harness handles this).
 - Implement any restart loop logic (harness handles respawn).
 
-Write `idle|` to `current-state` at cycle end so health monitoring works.
+At the end of a **normal** cycle (no exit-42 imminent), write `idle|` to `current-state` so health monitoring works. Do NOT overwrite it on the restart path — `cycle_post.py` writes `restarting|…` itself when the 42-exit condition fires, and clobbering that would hide the transition from the operator and TUI.
 <!-- /sub-skill: self-restart -->
 
 <!-- sub-skill: agent-lifecycle -->
@@ -768,7 +798,7 @@ Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). A
 2. **Graceful stop**: Harness sets intent=stopping via API. `cycle_post.py` queries `GET /agents/{role}` at cycle end, sees the intent, and exits with code 42.
 3. **Start correctly**: Harness spawns agents via thin launcher (`thin_launcher.py`) in visible terminal windows. `cycle_pre.py` handles git pull/branch per cycle.
 
-**Health monitoring**: Harness monitors agent liveness via direct PID checks (primary) and `.claude-pid` file (fallback). No heartbeat files needed — the harness polls every 5 seconds.
+**Health monitoring**: Harness monitors agent liveness via PID monitoring through `.claude-pid` (sole liveness signal). The harness polls every 5 seconds.
 
 **Intent state machine** (per-agent, in harness memory + `.harness-state.json`):
 - `running` — agent should be alive; auto-reboot on death
@@ -776,25 +806,25 @@ Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). A
 - `restarting` — graceful restart; reboot after death
 - `stopped` — agent died as requested
 
-**Lifecycle interface**:
+**Lifecycle interface** (`squidsquad_cli.py` is canonical; `start_team.py <args>` remains as a backward-compatible shim):
 ```bash
-# Start all agents
-python references/scripts/start_team.py --all
+# Start harness + all agents
+python references/scripts/squidsquad_cli.py start
 
-# Start single agent
-python references/scripts/start_team.py --role <role>
+# Start a single agent (harness auto-spawns if needed)
+python references/scripts/squidsquad_cli.py start <role>
 
-# Graceful reboot — harness sets intent=restarting
-python references/scripts/start_team.py --reboot <role>
+# Graceful restart — harness sets intent=restarting
+python references/scripts/squidsquad_cli.py restart <role>
 
-# Reboot all agents
-python references/scripts/start_team.py --reboot --all
-
-# Stop agent — harness sets intent=stopping
-python references/scripts/start_team.py --stop <role>
+# Stop a single agent — harness sets intent=stopping
+python references/scripts/squidsquad_cli.py stop <role>
 
 # Stop all agents
-python references/scripts/start_team.py --stop --all
+python references/scripts/squidsquad_cli.py stop
+
+# Stop all agents and exit the harness
+python references/scripts/squidsquad_cli.py shutdown
 ```
 
 **Crash recovery**: Harness persists state to `.squidsquad/.harness-state.json`. On restart, reads the file, checks which PIDs are alive, and resumes monitoring.
@@ -1082,8 +1112,8 @@ These instructions apply to ALL agents on this project.
 
 ### Agent Infrastructure
 
-- **Harness manages agent lifecycle**: PID monitoring (primary), `.health` file (legacy fallback). Intent state machine via REST API (#4966).
-- **Agent lifecycle via `start_team.py`**: Agents do not manage their own or other agents' processes.
+- **Harness manages agent lifecycle**: PID monitoring via `.claude-pid` (sole liveness signal). Intent state machine via REST API (#4966).
+- **Agent lifecycle via `squidsquad_cli.py`** (with `start_team.py` as a backward-compatible shim): Agents do not manage their own or other agents' processes.
 - **Context pressure restart via `cycle_post.py`**: Mechanical detection, agents don't set `restart_needed`.
 
 ### Planning & Verification

--- a/tests/comprehension/8697_fixtures/skill_events_CLAUDE.md
+++ b/tests/comprehension/8697_fixtures/skill_events_CLAUDE.md
@@ -190,87 +190,300 @@ You are the [ROLE] Lead on the SquidSquad autonomous dev team. You operate conti
 
 
 <!-- sub-skill: event-driven-workflow -->
-## Event-Driven Workflow (#7630)
+## Event-Driven Workflow
 
-You are a persistent agent session that reacts to events dispatched by the harness. You sit idle until the Monitor tool detects an event, then execute exactly one creative task and close the event via the completion API.
+You are a persistent agent session driven by events from the harness. You react to one event at a time, consult the forge as the source of truth, and let `event_poll.py` advance your cursor automatically.
 
-### Config Gate
+This fragment is a brief orientation. The full agent contract lives in the companion event-mode fragments — read them in this order:
 
-This mode is active ONLY when `event-driven: yes` in config.md. If `event-driven: no`, use the standard /loop + cycle_pre/cycle_post flow instead.
+1. **[[l1-base]]** — boot sequence (Case A), event reactions (Cases B–E), case-precedence rule, working-state ownership discipline, degraded-mode operation.
+2. **[[cursor-management]]** — atomic `.tmp` + `mv` protocol, per-event advance, gap handling (in-stream, long lag, eviction).
+3. **[[forge-read-pattern]]** — why the forge is the source of truth and how to read it before acting.
+4. **[[idle-cooldown-loop]]** — what an event-mode agent does when `work_queue()` is empty.
+5. **[[comment-handling]]** — comments are NOT event triggers; DM end-of-task exception; transition-on-handoff rule.
 
-### How You Wake
+### Quick reference
 
-At boot, invoke the Monitor tool to watch for events:
+- **Wake mechanism** — Monitor tool streaming `python references/scripts/event_poll.py <role> --wait 5 --target`. Each line of stdout is one JSON event.
+- **Atomic unit of work** — one event at a time. Process to completion before reading the next.
+- **Source of truth** — the forge (`tracker.py` queries). Event payloads are hints; always forge-read before acting.
+- **Cursor** — `event_poll.py` persists it to `working-state.md` automatically (see [[cursor-management]]).
+- **Idle** — improvement-scan cool-down loop (see [[idle-cooldown-loop]]).
+- **Handoff** — status transitions and label changes wake the stream; bare comments do not (see [[comment-handling]]).
+
+### Error handling
+
+If the harness becomes unreachable, the agent does NOT pivot to forge-direct work mid-session — that path exists only at boot (degraded mode, see [[l1-base]]). Mid-session unreachable is a **manual-recovery scenario**: keep retrying at the 5-minute-capped backoff; the operator restarts the harness; the agent resumes via the event stream on reconnect.
+
+`event_poll.py` handles transient HTTP errors (5xx, `ConnectionError`, `Timeout`, `IncompleteRead`) automatically with exponential backoff. 4xx responses are treated as caller faults and exit non-zero.
+
+### Context pressure
+
+The harness monitors agent context pressure files and emits `stop-requested` when a restart is needed. Honor `stop-requested` at the next task boundary (see Case E in [[l1-base]]); the harness handles the respawn.
+<!-- /sub-skill: event-driven-workflow -->
+
+<!-- sub-skill: l1-base -->
+## Event-Mode L1 Base — Agent Definition
+
+You are a persistent agent session that reacts to events on the harness event stream. The forge (GitHub Issues) is your source of truth; the stream is a wake-up signal that tells you when forge state may have changed.
+
+This fragment is the entire event-mode agent contract: boot sequence, event reactions, and the always-on rules that bind the two together.
+
+---
+
+### Boot Sequence (Case A — L1 failsafe)
+
+The boot sequence MUST work even when the harness is unreachable. Forge access is the only hard prerequisite.
+
+1. **Read working-state.** Open `.squidsquad/<role>/working-state.md`. Extract three fields:
+   - **Cursor** — line `- **Last Processed Event ID**: <event-id>` (see [[cursor-management]]). Missing or empty → start from the beginning of the stream with a stderr warning.
+   - **In-progress task** — line `- **Task**: <issue-number>` (or `- **Task**: none` if idle).
+   - **Improvement-scan status** — `Status:` field under `## Improvement Scan` (see [[idle-cooldown-loop]]). If the section is absent (first boot), treat `Status` as `idle`.
+
+2. **Branch on what working-state shows:**
+   - **In-progress tracker task** → verify against the forge: still my role? still `status:in-progress`? Yes → resume. No → clear the task field (`- **Task**: none` in working-state) and drop the task locally — **no forge transition is needed** because the forge already reflects the change (that is why verification failed). Fall through to a fresh `work_queue()` scan.
+   - **Improvement-scan `Status: running`** (not a tracker item) → skip forge verification; restart the scan. Improvement scans are idempotent — a fresh scan subsumes a partial one. See [[idle-cooldown-loop]]. **When the scan completes, run `work_queue()`** before re-entering the cool-down loop, in case a task arrived during the outage.
+   - **Idle / nothing in progress** → run `work_queue()` against the forge. If work is returned: **pick up the top item** — transition it to `status:in-progress`, write the issue number to the Task field in `working-state.md`, and begin work. If `work_queue()` is empty, defer to step 3 for the empty-queue path (cool-down loop if harness reachable; degraded-mode sleep loop if not).
+
+3. **Check harness reachability** (before any event-stream call or cool-down entry):
+   - **Unreachable** → skip steps 4–5 (nothing to skim, cursor unchanged) and proceed to degraded-mode operation: continue working directly from the forge via `work_queue()`. While in degraded mode, if `work_queue()` returns empty, sleep a short fixed interval (e.g. 60s) and retry `work_queue()`; if `work_queue()` returns work, pick up the top item directly (transition to `in-progress`, update the Task field, begin work) and on completion follow Case C (transition, clear Task field, re-run `work_queue()`) — then continue applying the same degraded-mode rules (empty → 60s sleep, non-empty → pick up). **Do NOT enter the improvement-scan cool-down loop in degraded mode**, because the Monitor (`event_poll.py`) requires the harness. **Before each `work_queue()` call** (including after each 60s sleep), attempt to POST `bootup-complete` using exponential backoff capped at **5 minutes**. A successful POST indicates the harness is reachable — **exit degraded mode** by skimming events from the current cursor forward (step 4), advancing the cursor (step 5 cursor write), and entering the listening loop. `bootup-complete` is **best-effort, not blocking** — the agent never hangs waiting for the harness.
+   - **Reachable** → continue to step 4. (If you got here from step 2's empty idle branch, after step 5 enter the improvement-scan cool-down loop — see [[idle-cooldown-loop]].)
+
+4. **Skim events from cursor forward.** Informational only — the forge already has current state. Skim-then-advance; never jump-to-latest. Handle gap scenarios per [[cursor-management]] (in-stream gap, long lag, eviction gap). In an eviction gap specifically, the cursor advances to the *oldest available* id, not the latest observed.
+
+5. **Advance cursor and announce.** Persist the cursor atomically (see [[cursor-management]]); emit `bootup-complete` (POST `/events` with `event_type=bootup-complete`, `role=<role>`, payload `{"listener_active": true}`); enter the event-listening loop via `event_poll.py`.
+
+After boot, processing is dictated by Cases B through E below.
+
+---
+
+### How You Listen (Event Poll)
+
+Invoke the Monitor tool to stream events from `event_poll.py`:
 
 ```
 Monitor tool invocation:
   command: python references/scripts/event_poll.py <role> --wait 5 --target
-  description: Watch harness event bus for work events
+  description: Watch harness event bus for relevant events
   persistent: true
 ```
 
-The Monitor tool streams `event_poll.py` stdout. Each line is a JSON event object. When the Monitor delivers a line, you wake and process it.
+`event_poll.py` writes one JSON object per line to stdout. Each line wakes you to process exactly one event.
 
-### Event Types You Receive
+---
 
-| Event Type | When | What To Do |
-|---|---|---|
-| `assigned-to` | Work item needs your attention | Read the issue from payload, do your creative work |
-| `stop-requested` | Harness wants you to exit | Checkpoint working-state.md, then exit cleanly |
-| `status-transition` | A relevant item changed status | React per your role's logic |
+> **Cursor advancement is automatic.** `event_poll.py` persists the cursor to `working-state.md` as each event line is emitted to stdout. Cases B–E below describe the agent's reaction to each delivered event; the cursor write happens on the agent's behalf — there is no separate "advance cursor" step for the agent to perform. See [[cursor-management]].
 
-> **Future event types** (not yet emitted by harness — planned for Phase 5+):
-> - `scan-needed` — idle timeout reached → run improvement scan
-> - `vault-reflect` — active work completed → run vault reflection
+> **Case precedence.** When an event arrives, **evaluate Case E (special events) first**, regardless of your current state. Only if the event type is not special, fall through to the state-based case (B if idle, D if mid-task; Case C is reached implicitly when work completes).
 
-### Processing Flow
+### Case B — Idle, event arrives
 
-For each event:
+1. Read the event delivered by the Monitor.
+2. **Forge-read** the referenced item (if any) via `tracker.py`. The forge is the source of truth — see [[forge-read-pattern]].
+3. Run `work_queue(<role>)` against the forge — pick up the top item if available, else stay idle (re-enter the improvement-scan cool-down loop — see [[idle-cooldown-loop]]).
 
-1. **Read**: Parse the JSON event. Extract `id`, `event_type`, and `payload`.
-2. **Act**: Do your creative work — implement, verify, plan, deliver (per your role).
-3. **Complete**: When done, call the completion endpoint:
-   ```bash
-   curl -s -X POST http://127.0.0.1:$(cat .squidsquad/.harness-port)/events/<event_id>/complete \
-     -H "Content-Type: application/json" \
-     -d '{"role": "<role>", "status": "success", "summary": "<brief description>"}'
+---
+
+### Case C — After completing work
+
+1. You just transitioned a tracker item via `tracker.py transition`.
+2. Update `working-state.md` → `- **Task**: none`.
+3. **Immediately run `work_queue()`** against the forge. Do NOT wait for your own transition event to come back through the stream.
+4. Pick up the next item, or — if `work_queue()` is empty — enter idle (improvement-scan cool-down). **Degraded-mode exception**: if the harness is currently unreachable, do NOT enter the cool-down loop; apply the degraded-mode rules instead (60s sleep + retry `work_queue()`).
+
+---
+
+### Case D — Mid-task, event arrives
+
+1. Read the event delivered by the Monitor.
+2. **Note but do NOT act.** The current task runs atomically to completion.
+3. On task completion, fall through to **Case C** (transition the item, clear the Task field, run `work_queue()`). Case C's forge-read absorbs all mid-task events that arrived during the task.
+
+---
+
+### Case E — Special events
+
+- **`stop-requested`** — honored ONLY at a task boundary. Mid-task: read the event, ignore. At a boundary: checkpoint `working-state.md` (preserve the cursor), then exit cleanly.
+- **`bootup-complete` from another agent** — informational. No action required.
+- **Unknown event type** — log a warning to stderr. Do not block.
+
+---
+
+### Always-On Rules
+
+- **Forge-read before acting.** Every decision consults the forge. Event payloads are hints, not state. See [[forge-read-pattern]].
+- **One event at a time.** Process atomically. Never start a second event before the first is complete.
+- **Cursor advance is atomic and per-event.** Write `.tmp` then `mv` — never leave a partial cursor. See [[cursor-management]].
+- **`working-state.md` writes follow an ownership discipline.** During the event-listening loop, `event_poll.py` is the sole writer of the cursor line (`- **Last Processed Event ID**: …`); the agent is the sole writer of every other field (`- **Task**: …`, the `## Improvement Scan` block, etc.). During boot (before the listening loop starts) the agent may also write the cursor line — see step 5 of the boot sequence and [[cursor-management]] for crash-recovery / gap-handling writes. Both writers use the `.tmp` + `mv` protocol so readers never see a half-written file, and each writer's read-modify-write cycle preserves the other writer's lines verbatim. `.tmp` + `mv` prevents partial writes but does NOT prevent lost updates across concurrent R-M-W cycles — the ownership rule is what makes the file safe to share. If a future writer ever needs to update both classes of field together while the listening loop is active, switch to an explicit file lock before doing so.
+- **Bare comments do not wake anyone.** Urgent agent-to-agent signaling must ride a status transition or label change. See [[comment-handling]].
+- **The harness owns git** — pull, commit, and push are managed at boot and shutdown by the harness. You do not run mechanical pre/post steps in event mode. Event IDs are the tracking unit; there is no per-iteration counter.
+- **Context pressure is managed by the harness.** When pressure exceeds threshold the harness emits `stop-requested`; honor it at the next task boundary.
+
+---
+
+### Degraded-Mode Glossary
+
+**Degraded mode** = harness unreachable at boot. The agent works directly from the forge via `work_queue()` and retries `bootup-complete` emission with the 5-minute capped backoff.
+
+**Manual-recovery scenario** = harness becomes unreachable AFTER `bootup-complete` has been emitted. The agent keeps retrying at the capped backoff but does **NOT** pivot to forge-direct work. The operator manually restarts the harness; the agent resumes via the event stream on reconnect.
+
+Rationale: agents log everything to the forge, so state is recoverable; adding a runtime degraded-mode adds complexity the failsafe boot path already handles after a restart.
+<!-- /sub-skill: l1-base -->
+
+<!-- sub-skill: cursor-management -->
+## Cursor Management
+
+Your event cursor is the last event id you have processed. It lives in `.squidsquad/<role>/working-state.md` under the line:
+
+```
+- **Last Processed Event ID**: <event-id>
+```
+
+`event_poll.py` reads and advances this cursor on your behalf — you do not write it manually under normal operation. The rules below apply when you DO need to interact with it directly (boot, crash recovery, gap handling).
+
+### Atomic Update Protocol
+
+When advancing the cursor, write the new value to `<path>.tmp` then `os.replace` (or `mv`) it onto `working-state.md`. **Never** write the cursor in place — a reader catching a half-written file would observe an undefined cursor and re-deliver or skip events.
+
+`event_poll.py` handles this for the event-listening loop. If you advance the cursor by hand (e.g. on boot after skimming events), follow the same protocol.
+
+### Per-Event Advance, Not Per-Batch
+
+When a poll returns a batch of events, the cursor advances **after each event is durably persisted**, not after the whole batch. This makes mid-batch process death safe — on restart, the next poll resumes after the last successfully-persisted id.
+
+### Gap Scenarios
+
+Three kinds of cursor gap exist (CONTEXT.md §2):
+
+- **In-stream gap.** You received events `[10, 11, 13]` — no event `12`. Log a warning naming the gap; advance to the highest observed id and forge-read affected items.
+- **Long lag.** Your cursor is hundreds or thousands of events behind. Skim-then-advance through the stream; do not jump to latest. The forge already has current state — the stream is just informational.
+- **Eviction gap.** Your cursor predates the oldest retained event in the harness deque. `GET /events?since=<old>` returns the oldest available id and an eviction-count hint. Log an eviction warning naming the oldest available id and the count of evicted events; advance the cursor to that oldest available id; proceed to a forge-read for current state. Do NOT crash.
+
+### Crash Recovery
+
+On restart, `event_poll.py` reads the cursor from `working-state.md` and resumes polling from `cursor+1`. Because writes are per-event-atomic, the resume point is exactly the first unprocessed event — no duplicates, no skips.
+
+If the cursor is missing or empty, the agent starts from the beginning of the stream with a stderr warning. Use `event_poll.py --since <id>` to bootstrap a specific cursor at first run.
+<!-- /sub-skill: cursor-management -->
+
+<!-- sub-skill: forge-read-pattern -->
+## Forge-Read Pattern
+
+**The forge is the source of truth. The event stream is a wake-up signal, not state.**
+
+Every decision consults the forge before acting. This is the rule that lets the harness remain a pure broadcast pipe and lets agents recover correctly from any sequence of crashes, evictions, or out-of-order delivery.
+
+### When You Receive An Event
+
+1. **Wake.** `event_poll.py` delivered one JSON event to stdout.
+2. **Read the event payload.** Treat it as a hint about what may have changed on the forge.
+3. **Forge-read.** Query the forge via `tracker.py` for the referenced item (and/or `work_queue(<role>)` for your role's queue). The forge tells you the actual current state.
+4. **Act on what the forge says**, not on what the event payload said. The event may be stale (delayed delivery, repeated delivery during gap recovery, etc.).
+
+The cursor advances automatically as `event_poll.py` emits each event line — there is no separate step you take to advance it (see [[cursor-management]]).
+
+### Why
+
+- Events can be **stale, duplicated, or out-of-order**. The forge is consistent.
+- The harness has **no dispatch logic** and no per-role queue — it can broadcast the same event twice during reconnects or eviction recovery without harm, because every agent forge-reads anyway.
+- **Crash recovery** is trivial: on restart, the agent reads working-state, forge-reads any in-progress task, and resumes — no special replay protocol needed.
+- **Mid-task events** (Case D in [[l1-base]]) are absorbed by the next forge-read at task completion. The agent never needs an in-memory event queue.
+
+### `work_queue()` Semantics
+
+`tracker.py list-tasks <role> --status approved` (and equivalent issue queries) is the forge query that backs `work_queue()`. It returns the current queue from the forge, ordered by priority/severity, every time. The agent does NOT cache the queue across events — re-reading is cheap and the forge is authoritative.
+
+### `tracker.py get-state <number>`
+
+Use this whenever you need to confirm an item's current status, role assignment, or labels before acting. Example: on boot, after reading an in-progress task from working-state, you call `get-state` to confirm the forge still has it in-progress and assigned to you. If the forge says otherwise, drop the task and fall through to `work_queue()`.
+<!-- /sub-skill: forge-read-pattern -->
+
+<!-- sub-skill: idle-cooldown-loop -->
+## Idle = Improvement-Scan Cool-Down Loop
+
+When `work_queue(<role>)` returns empty, you are **not** finished — you enter the improvement-scan cool-down loop. Scanning during idle time turns dead clock into proactive process improvement.
+
+### Working-State Schema
+
+The cool-down state lives under a `## Improvement Scan` section in `.squidsquad/<role>/working-state.md`:
+
+```
+## Improvement Scan
+Status: idle | running
+Last completed: YYYY-MM-DD HH:MM
+Next scan after: YYYY-MM-DD HH:MM
+```
+
+Three fields, three values:
+
+- **`Status`** — `running` while a scan is in flight; `idle` between scans.
+- **`Last completed`** — wall-clock timestamp of the last successful scan completion.
+- **`Next scan after`** — when the next scan is eligible to run. Computed at completion as `Last completed + <cool-down>`.
+
+### Lifecycle
+
+1. **Entering idle.** `work_queue()` returned empty. If `Status: running` was already set (from a previous boot interrupted mid-scan), restart the scan — improvement scans are idempotent, a fresh scan subsumes a partial one.
+2. **Eligibility check.** If `Next scan after` is missing (no prior scan) or in the past, the agent is eligible — proceed to step 3. If `Next scan after` is in the future, you are NOT eligible yet — proceed to step 5 (wait).
+3. **Start scan.** Write `Status: running` to working-state (atomic). Run your role's scanning sub-skill.
+4. **Complete scan.** Read the cool-down value from `config.md`. Compute `Next scan after = now + cooldown`. Write under `## Improvement Scan`:
    ```
-   Or via Python:
-   ```python
-   import json, urllib.request
-   port = open(".squidsquad/.harness-port").read().strip()
-   data = json.dumps({"role": "<role>", "status": "success", "summary": "<brief>"}).encode()
-   req = urllib.request.Request(f"http://127.0.0.1:{port}/events/<event_id>/complete",
-                                data=data, headers={"Content-Type": "application/json"}, method="POST")
-   urllib.request.urlopen(req, timeout=5)
+   Status: idle
+   Last completed: <YYYY-MM-DD HH:MM>
+   Next scan after: <YYYY-MM-DD HH:MM>
    ```
-
-### What You Do NOT Do
-
-- **No /loop** — the Monitor tool + event_poll.py delivers events; you don't schedule cron
-- **No cycle_pre.py / cycle_post.py** — the harness handles git pull, commit, push
-- **No git operations** — the harness owns git pull (before event delivery) and commit/push (after completion)
-- **No cycle counting** — event IDs are the tracking unit, not cycles
-- **No conditional step branching** — you react to ONE event at a time
+   Note: `Next scan after` is **stored**, not derived on the fly — this is the only place the cool-down value is read.
+4a. **Re-check the queue.** Run `work_queue()` immediately after writing the scan-completion fields. A task may have arrived during the scan (or during the crashed-out window if this was a crash-recovery restart). If `work_queue()` returns work, **exit the cool-down loop** — transition the top item to `in-progress`, update the Task field in `working-state.md`, and begin work directly (no need to wait for an event, since you already have the item). Only if `work_queue()` is empty proceed to step 5.
+5. **Wait via the Monitor.** The persistent Monitor (see [[l1-base]] "How You Listen") delivers events at a short fixed cadence; you do not perform a long blocking sleep. After each empty poll interval:
+   - If `now >= Next scan after` → run the next improvement scan (back to step 3).
+   - If a task-relevant event arrives in the meantime → the Monitor wakes Case B in [[l1-base]] (forge-read, possibly pick up new work). The cool-down timer keeps running in the background; when work completes (Case C) and the queue is empty again, return here for the eligibility check.
 
 ### Atomicity
 
-Process one event at a time. Do not start a second event before completing the first. The harness will not dispatch a second event to you while one is in-flight.
+- **An event arrives during an in-flight scan** → finish the scan first (atomicity rule). Process the event when the scan completes.
+- **Crash mid-scan** → on boot, working-state shows `Status: running`. Skip forge verification for the scan, restart it from scratch. Scans are idempotent. After the restarted scan completes, run `work_queue()` (step 4a above) before re-entering the cool-down loop — a task may have arrived during the outage.
 
-### Error Handling
+### Cool-Down Configuration
 
-If the harness is unreachable (event_poll.py prints errors to stderr), the Monitor tool continues retrying automatically (event_poll.py has built-in retry with --wait). You remain idle until connection is restored.
+`config.md` carries the default:
 
-If processing fails, complete the event with `"status": "failure"` and include the error in `summary`. The harness may re-emit the work via a new event.
+```
+- **Improvement Scan Cool-Down**: 30m
+```
 
-### Context Pressure
+Per-role overrides may be added (e.g. `Improvement Scan Cool-Down (qa)`) but are NOT shipped initially. All roles share the same default cool-down (defined in `config.md`) unless config says otherwise.
+<!-- /sub-skill: idle-cooldown-loop -->
 
-The harness monitors your context pressure file and triggers restarts when exceeded. You do not check context pressure yourself — the harness emits `stop-requested` when a restart is needed.
+<!-- sub-skill: comment-handling -->
+## Comment Handling
 
-### Working State
+**Comments are NOT standalone event triggers.** A bare comment on an issue does NOT wake any agent. Comments are absorbed by the next agent that picks up the issue.
 
-Maintain `.squidsquad/<role>/working-state.md` between events for crash recovery. Update after each event completion so the harness can resume you after a restart.
-<!-- /sub-skill: event-driven-workflow -->
+This rule is the single most important consequence of the thin-broadcast harness: any wake-up signal must ride a status transition or label change, because those are the only things the harness emits onto the event stream.
+
+### The Rule
+
+When you forge-read an issue (Case B in [[l1-base]], or at task pickup), you read **all comments since you last touched the item**. New information from comments is absorbed as part of that read. You do NOT poll comments otherwise — there is no `comment-added` event in event-mode.
+
+### DM Exception — End-Of-Task Re-Read
+
+DM is the one role that has a sub-task that **spans waiting**: the PR-merge wait. While DM is waiting on a PR to merge, the task is still in flight. Comments arriving during the wait would be silently dropped under the default rule.
+
+DM's exception: at **task completion** (the merge resolves, PR is closed, or the wait ends some other way), DM re-reads issue comments **before** the next pickup. Comments are honored once the wait ends.
+
+**No sub-loop during the wait.** DM does not poll comments while waiting. The reaction window for a comment is "the moment the current wait ends" — typically minutes, sometimes longer.
+
+### Practical Consequences for Senders
+
+- **Urgent agent-to-agent signaling MUST ride a status transition or label change.** A comment alone will not wake anyone. If you need a fast reaction:
+  - Transition the issue (e.g. `in-progress → planning`) — this emits a `status-transition` event.
+  - Add or remove a label (e.g. `pending-human-review`) — this emits a label-change event.
+- **PM nudges and pipeline-sentinel comments** are fine as bare comments — they are absorbed at the next pickup. They are advisory, not blocking.
+- **PRs and tracker items** that should bounce back to the previous owner must do so by transition (e.g. QA reject → `pending-test → in-progress`), not by comment.
+
+### Transition-On-Handoff Rule
+
+When you assign work to a different role (including humans), the assignment MUST be a status transition so it appears on the event stream. Bare comments do not constitute a handoff in event mode. This applies even when the new owner is a human — transition to `pending-human-review` or `pending-human-setup` rather than just commenting "human, please look at this."
+<!-- /sub-skill: comment-handling -->
 
 <!-- sub-skill: context-pressure -->
 ### Step 1b — Context Pressure Check
@@ -390,12 +603,21 @@ Print: `[🦑 HH:MM:SS] Implementing #[NUMBER]...`
    python references/scripts/tracker.py transition [NUMBER] approved in-progress --role [ROLE]-lead
    ```
 1b. **Branch checkout** (#3296): `python references/scripts/git_ops.py task-begin [ROLE] [NUMBER]` — checks out the task's feature branch if branch-workflow is enabled.
-2. **Read planning artifacts** — PM creates these during task intake. Check both locations:
-   - `.squidsquad/pm/planning/` (PM's planning directory — primary location)
-   - `.squidsquad/[ROLE]/planning/` (your own planning directory — fallback)
-   - Look for files matching the issue number (e.g. `FEAT-SKILL-195-CONTEXT.md`)
-   - RESEARCH.md, CONTEXT.md, TEST-PLAN.md — respect locked decisions, note dev discretion areas
-   - If PM comments reference planning artifacts but you cannot find them, **push back** (see Prohibitions)
+2. **Read planning artifacts first — CONTEXT.md is authoritative** (#8916).
+
+   Before writing any code for a task, check whether planning artifacts exist:
+   - `.squidsquad/pm/planning/CONTEXT.md` (bundle-level; the per-task section is `### 5.X #<NUMBER> — …`)
+   - `.squidsquad/pm/planning/CONTEXT-<NUMBER>.md` (per-task)
+   - `.squidsquad/pm/planning/TEST-PLAN-<NUMBER>.md` (acceptance criteria + comprehension tests)
+   - Fallback location: `.squidsquad/[ROLE]/planning/` (your own planning directory) — same file patterns
+
+   If a planning artifact exists, **the planning artifact is the authoritative scope.** The GitHub issue body is a high-level pointer; the planning artifact is the contract. Read the relevant CONTEXT section (`### 5.X #<NUMBER>` for bundle CONTEXT.md, OR the full per-task `CONTEXT-<NUMBER>.md`) AND the `TEST-PLAN-<NUMBER>.md` acceptance criteria **in full** before writing code.
+
+   **Divergence handling**:
+   - If the issue body and the planning artifact **agree**, proceed normally. Do not add a planning-artifact note to the PR description.
+   - If the issue body and the planning artifact **disagree**, the planning artifact wins. Implement to the planning artifact. Flag the divergence in your implementation PR description (one sentence pointing PM at the body/artifact mismatch) so PM can update the body via the #8917 workflow.
+
+   If PM comments reference planning artifacts but you cannot find them, **push back** (see Prohibitions). If no planning artifact exists (bug fix or trivial task), proceed to step 2c.
 2c. **Consult the vault** (#5572) — before implementing, search the vault for relevant context:
    ```bash
    grep -rl "[keyword]" .squidsquad/vault/ --include="*.md" | head -5
@@ -421,14 +643,27 @@ Print: `[🦑 HH:MM:SS] Implementing #[NUMBER]...`
    git add -A
    ```
 
+   **Locate planning artifacts** — when a task has a CONTEXT/TEST-PLAN
+   in `.squidsquad/pm/planning/`, the review must check the diff against
+   those architectural locks, not only code quality (#8950 Gate #2 / #8916
+   §9c). Discover by task-number match — this covers both legacy
+   `FEAT-PM-<NUMBER>-TEST-PLAN.md` and new `TEST-PLAN-<NUMBER>.md`
+   conventions, and any sibling `CONTEXT-<NUMBER>.md`:
+   ```bash
+   ARTIFACTS=$(ls .squidsquad/pm/planning/*[NUMBER]* 2>/dev/null | paste -sd, -)
+   ```
+
    **Get changed files and run review**:
    ```bash
    CHANGED_FILES=$(git diff --cached --name-only | paste -sd, -)
+   # If $ARTIFACTS is non-empty, append it after a comma so the review
+   # agent sees both the diff and the planning contract.
+   INPUT_FILES="$CHANGED_FILES${ARTIFACTS:+,$ARTIFACTS}"
    python references/scripts/model_router.py code-review \
      --task-id "#[NUMBER]" \
-     --input-files "$CHANGED_FILES" \
+     --input-files "$INPUT_FILES" \
      --output-file ".squidsquad/[ROLE]/planning/CODE-REVIEW-[NUMBER].md" \
-     --context "Task: [title]. ACs: [acceptance criteria summary]. Project philosophy: [key constraints]."
+     --context "Task: [title]. ACs: [acceptance criteria summary]. Project philosophy: [key constraints]. If planning artifacts (CONTEXT-*, TEST-PLAN-*) are present in --input-files, verify the diff conforms to the architectural locks documented there — not only code quality."
    ```
 
    **If external model unavailable** (exit code 1 or 2): fall back to Claude via the Agent tool with the same review prompt (read the changed files, review against ACs and project philosophy, output structured findings).
@@ -818,12 +1053,24 @@ python references/scripts/git_ops.py commit-push [ROLE] "[brief description of w
 
 Agents can signal a restart only when their own context pressure exceeds the threshold. All other restart reasons (template changes, reboot requests) are handled by the harness via intent API (#4966).
 
-**Context pressure restart flow**:
+**Context pressure restart flow** (#4792 Phase 1):
+
 1. Step 1b detects context pressure exceeds threshold.
 2. Checkpoint working state to `.squidsquad/[ROLE]/working-state.md`.
 3. Complete the current cycle normally.
-4. At cycle end, `cycle_post.py` checks context pressure from `cycle-input.json`. If exceeded, exits with code 42.
-5. The harness detects the exit, sees intent=running, and respawns the agent.
+4. At cycle end, `cycle_post.py` checks the `context_pressure` field of your `cycle-output.json` (falling back to `cycle-input.json` if you did not pass it through). If exceeded, it POSTs `/agents/[ROLE]/restart` to the harness so intent flips to `restarting` (recording `intent_set_at` for the 60s force-kill safety net), then exits with code 42.
+5. **You then invoke `/quit`** — see "Graceful Stop — Self-Quit Protocol" below.
+6. The harness observes the process exit and, because intent is `restarting`, respawns the agent through the proper RESTARTING flow.
+
+### Graceful Stop — Self-Quit Protocol
+
+**After `cycle_post.py` exits with code 42** (the cooperative termination signal — either the harness asked you to stop/restart, or `cycle_post` detected its own context pressure exceeded), immediately invoke the `/quit` slash command to terminate the claude session. The harness will then observe the process exit and either mark you stopped or respawn you per its intent state machine.
+
+- Do NOT continue working after a 42 exit — the harness is waiting for you to terminate.
+- Do NOT attempt to suppress, retry, or override the 42 exit — it is the canonical cooperative-termination signal.
+- The exit-42 conditions are owned by `cycle_post.py`: harness intent in `{stopping, restarting}` OR context-pressure exceeded.
+
+The harness has a **60-second force-kill safety net** that fires if you fail to invoke `/quit` within the cooperative window. The safety net guarantees that operator intent (stop or restart) eventually wins even if the agent hangs — but the cooperative path is the canonical one, and the safety net should never fire under normal operation.
 
 **You do NOT**:
 - Set `restart_needed` in cycle-output.json (deprecated).
@@ -832,7 +1079,7 @@ Agents can signal a restart only when their own context pressure exceeds the thr
 - Kill or manage other agents (harness handles this).
 - Implement any restart loop logic (harness handles respawn).
 
-Write `idle|` to `current-state` at cycle end so health monitoring works.
+At the end of a **normal** cycle (no exit-42 imminent), write `idle|` to `current-state` so health monitoring works. Do NOT overwrite it on the restart path — `cycle_post.py` writes `restarting|…` itself when the 42-exit condition fires, and clobbering that would hide the transition from the operator and TUI.
 <!-- /sub-skill: self-restart -->
 
 <!-- sub-skill: agent-lifecycle -->
@@ -845,7 +1092,7 @@ Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). A
 2. **Graceful stop**: Harness sets intent=stopping via API. `cycle_post.py` queries `GET /agents/{role}` at cycle end, sees the intent, and exits with code 42.
 3. **Start correctly**: Harness spawns agents via thin launcher (`thin_launcher.py`) in visible terminal windows. `cycle_pre.py` handles git pull/branch per cycle.
 
-**Health monitoring**: Harness monitors agent liveness via direct PID checks (primary) and `.claude-pid` file (fallback). No heartbeat files needed — the harness polls every 5 seconds.
+**Health monitoring**: Harness monitors agent liveness via PID monitoring through `.claude-pid` (sole liveness signal). The harness polls every 5 seconds.
 
 **Intent state machine** (per-agent, in harness memory + `.harness-state.json`):
 - `running` — agent should be alive; auto-reboot on death
@@ -853,25 +1100,25 @@ Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). A
 - `restarting` — graceful restart; reboot after death
 - `stopped` — agent died as requested
 
-**Lifecycle interface**:
+**Lifecycle interface** (`squidsquad_cli.py` is canonical; `start_team.py <args>` remains as a backward-compatible shim):
 ```bash
-# Start all agents
-python references/scripts/start_team.py --all
+# Start harness + all agents
+python references/scripts/squidsquad_cli.py start
 
-# Start single agent
-python references/scripts/start_team.py --role <role>
+# Start a single agent (harness auto-spawns if needed)
+python references/scripts/squidsquad_cli.py start <role>
 
-# Graceful reboot — harness sets intent=restarting
-python references/scripts/start_team.py --reboot <role>
+# Graceful restart — harness sets intent=restarting
+python references/scripts/squidsquad_cli.py restart <role>
 
-# Reboot all agents
-python references/scripts/start_team.py --reboot --all
-
-# Stop agent — harness sets intent=stopping
-python references/scripts/start_team.py --stop <role>
+# Stop a single agent — harness sets intent=stopping
+python references/scripts/squidsquad_cli.py stop <role>
 
 # Stop all agents
-python references/scripts/start_team.py --stop --all
+python references/scripts/squidsquad_cli.py stop
+
+# Stop all agents and exit the harness
+python references/scripts/squidsquad_cli.py shutdown
 ```
 
 **Crash recovery**: Harness persists state to `.squidsquad/.harness-state.json`. On restart, reads the file, checks which PIDs are alive, and resumes monitoring.
@@ -1245,8 +1492,8 @@ These instructions apply to ALL agents on this project.
 
 ### Agent Infrastructure
 
-- **Harness manages agent lifecycle**: PID monitoring (primary), `.health` file (legacy fallback). Intent state machine via REST API (#4966).
-- **Agent lifecycle via `start_team.py`**: Agents do not manage their own or other agents' processes.
+- **Harness manages agent lifecycle**: PID monitoring via `.claude-pid` (sole liveness signal). Intent state machine via REST API (#4966).
+- **Agent lifecycle via `squidsquad_cli.py`** (with `start_team.py` as a backward-compatible shim): Agents do not manage their own or other agents' processes.
 - **Context pressure restart via `cycle_post.py`**: Mechanical detection, agents don't set `restart_needed`.
 
 ### Planning & Verification

--- a/tests/comprehension/8697_fixtures/skill_polling_CLAUDE.md
+++ b/tests/comprehension/8697_fixtures/skill_polling_CLAUDE.md
@@ -330,6 +330,11 @@ The script handles: status transitions, tracker comments, iteration logging, git
 <!-- /sub-skill: cycle-runner -->
 
 
+
+
+
+
+
 <!-- sub-skill: context-pressure -->
 ### Step 1b — Context Pressure Check
 
@@ -464,12 +469,21 @@ Print: `[🦑 HH:MM:SS] Implementing #[NUMBER]...`
    python references/scripts/tracker.py transition [NUMBER] approved in-progress --role [ROLE]-lead
    ```
 1b. **Branch checkout** (#3296): `python references/scripts/git_ops.py task-begin [ROLE] [NUMBER]` — checks out the task's feature branch if branch-workflow is enabled.
-2. **Read planning artifacts** — PM creates these during task intake. Check both locations:
-   - `.squidsquad/pm/planning/` (PM's planning directory — primary location)
-   - `.squidsquad/[ROLE]/planning/` (your own planning directory — fallback)
-   - Look for files matching the issue number (e.g. `FEAT-SKILL-195-CONTEXT.md`)
-   - RESEARCH.md, CONTEXT.md, TEST-PLAN.md — respect locked decisions, note dev discretion areas
-   - If PM comments reference planning artifacts but you cannot find them, **push back** (see Prohibitions)
+2. **Read planning artifacts first — CONTEXT.md is authoritative** (#8916).
+
+   Before writing any code for a task, check whether planning artifacts exist:
+   - `.squidsquad/pm/planning/CONTEXT.md` (bundle-level; the per-task section is `### 5.X #<NUMBER> — …`)
+   - `.squidsquad/pm/planning/CONTEXT-<NUMBER>.md` (per-task)
+   - `.squidsquad/pm/planning/TEST-PLAN-<NUMBER>.md` (acceptance criteria + comprehension tests)
+   - Fallback location: `.squidsquad/[ROLE]/planning/` (your own planning directory) — same file patterns
+
+   If a planning artifact exists, **the planning artifact is the authoritative scope.** The GitHub issue body is a high-level pointer; the planning artifact is the contract. Read the relevant CONTEXT section (`### 5.X #<NUMBER>` for bundle CONTEXT.md, OR the full per-task `CONTEXT-<NUMBER>.md`) AND the `TEST-PLAN-<NUMBER>.md` acceptance criteria **in full** before writing code.
+
+   **Divergence handling**:
+   - If the issue body and the planning artifact **agree**, proceed normally. Do not add a planning-artifact note to the PR description.
+   - If the issue body and the planning artifact **disagree**, the planning artifact wins. Implement to the planning artifact. Flag the divergence in your implementation PR description (one sentence pointing PM at the body/artifact mismatch) so PM can update the body via the #8917 workflow.
+
+   If PM comments reference planning artifacts but you cannot find them, **push back** (see Prohibitions). If no planning artifact exists (bug fix or trivial task), proceed to step 2c.
 2c. **Consult the vault** (#5572) — before implementing, search the vault for relevant context:
    ```bash
    grep -rl "[keyword]" .squidsquad/vault/ --include="*.md" | head -5
@@ -495,14 +509,27 @@ Print: `[🦑 HH:MM:SS] Implementing #[NUMBER]...`
    git add -A
    ```
 
+   **Locate planning artifacts** — when a task has a CONTEXT/TEST-PLAN
+   in `.squidsquad/pm/planning/`, the review must check the diff against
+   those architectural locks, not only code quality (#8950 Gate #2 / #8916
+   §9c). Discover by task-number match — this covers both legacy
+   `FEAT-PM-<NUMBER>-TEST-PLAN.md` and new `TEST-PLAN-<NUMBER>.md`
+   conventions, and any sibling `CONTEXT-<NUMBER>.md`:
+   ```bash
+   ARTIFACTS=$(ls .squidsquad/pm/planning/*[NUMBER]* 2>/dev/null | paste -sd, -)
+   ```
+
    **Get changed files and run review**:
    ```bash
    CHANGED_FILES=$(git diff --cached --name-only | paste -sd, -)
+   # If $ARTIFACTS is non-empty, append it after a comma so the review
+   # agent sees both the diff and the planning contract.
+   INPUT_FILES="$CHANGED_FILES${ARTIFACTS:+,$ARTIFACTS}"
    python references/scripts/model_router.py code-review \
      --task-id "#[NUMBER]" \
-     --input-files "$CHANGED_FILES" \
+     --input-files "$INPUT_FILES" \
      --output-file ".squidsquad/[ROLE]/planning/CODE-REVIEW-[NUMBER].md" \
-     --context "Task: [title]. ACs: [acceptance criteria summary]. Project philosophy: [key constraints]."
+     --context "Task: [title]. ACs: [acceptance criteria summary]. Project philosophy: [key constraints]. If planning artifacts (CONTEXT-*, TEST-PLAN-*) are present in --input-files, verify the diff conforms to the architectural locks documented there — not only code quality."
    ```
 
    **If external model unavailable** (exit code 1 or 2): fall back to Claude via the Agent tool with the same review prompt (read the changed files, review against ACs and project philosophy, output structured findings).
@@ -892,12 +919,24 @@ python references/scripts/git_ops.py commit-push [ROLE] "[brief description of w
 
 Agents can signal a restart only when their own context pressure exceeds the threshold. All other restart reasons (template changes, reboot requests) are handled by the harness via intent API (#4966).
 
-**Context pressure restart flow**:
+**Context pressure restart flow** (#4792 Phase 1):
+
 1. Step 1b detects context pressure exceeds threshold.
 2. Checkpoint working state to `.squidsquad/[ROLE]/working-state.md`.
 3. Complete the current cycle normally.
-4. At cycle end, `cycle_post.py` checks context pressure from `cycle-input.json`. If exceeded, exits with code 42.
-5. The harness detects the exit, sees intent=running, and respawns the agent.
+4. At cycle end, `cycle_post.py` checks the `context_pressure` field of your `cycle-output.json` (falling back to `cycle-input.json` if you did not pass it through). If exceeded, it POSTs `/agents/[ROLE]/restart` to the harness so intent flips to `restarting` (recording `intent_set_at` for the 60s force-kill safety net), then exits with code 42.
+5. **You then invoke `/quit`** — see "Graceful Stop — Self-Quit Protocol" below.
+6. The harness observes the process exit and, because intent is `restarting`, respawns the agent through the proper RESTARTING flow.
+
+### Graceful Stop — Self-Quit Protocol
+
+**After `cycle_post.py` exits with code 42** (the cooperative termination signal — either the harness asked you to stop/restart, or `cycle_post` detected its own context pressure exceeded), immediately invoke the `/quit` slash command to terminate the claude session. The harness will then observe the process exit and either mark you stopped or respawn you per its intent state machine.
+
+- Do NOT continue working after a 42 exit — the harness is waiting for you to terminate.
+- Do NOT attempt to suppress, retry, or override the 42 exit — it is the canonical cooperative-termination signal.
+- The exit-42 conditions are owned by `cycle_post.py`: harness intent in `{stopping, restarting}` OR context-pressure exceeded.
+
+The harness has a **60-second force-kill safety net** that fires if you fail to invoke `/quit` within the cooperative window. The safety net guarantees that operator intent (stop or restart) eventually wins even if the agent hangs — but the cooperative path is the canonical one, and the safety net should never fire under normal operation.
 
 **You do NOT**:
 - Set `restart_needed` in cycle-output.json (deprecated).
@@ -906,7 +945,7 @@ Agents can signal a restart only when their own context pressure exceeds the thr
 - Kill or manage other agents (harness handles this).
 - Implement any restart loop logic (harness handles respawn).
 
-Write `idle|` to `current-state` at cycle end so health monitoring works.
+At the end of a **normal** cycle (no exit-42 imminent), write `idle|` to `current-state` so health monitoring works. Do NOT overwrite it on the restart path — `cycle_post.py` writes `restarting|…` itself when the 42-exit condition fires, and clobbering that would hide the transition from the operator and TUI.
 <!-- /sub-skill: self-restart -->
 
 <!-- sub-skill: agent-lifecycle -->
@@ -919,7 +958,7 @@ Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). A
 2. **Graceful stop**: Harness sets intent=stopping via API. `cycle_post.py` queries `GET /agents/{role}` at cycle end, sees the intent, and exits with code 42.
 3. **Start correctly**: Harness spawns agents via thin launcher (`thin_launcher.py`) in visible terminal windows. `cycle_pre.py` handles git pull/branch per cycle.
 
-**Health monitoring**: Harness monitors agent liveness via direct PID checks (primary) and `.claude-pid` file (fallback). No heartbeat files needed — the harness polls every 5 seconds.
+**Health monitoring**: Harness monitors agent liveness via PID monitoring through `.claude-pid` (sole liveness signal). The harness polls every 5 seconds.
 
 **Intent state machine** (per-agent, in harness memory + `.harness-state.json`):
 - `running` — agent should be alive; auto-reboot on death
@@ -927,25 +966,25 @@ Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). A
 - `restarting` — graceful restart; reboot after death
 - `stopped` — agent died as requested
 
-**Lifecycle interface**:
+**Lifecycle interface** (`squidsquad_cli.py` is canonical; `start_team.py <args>` remains as a backward-compatible shim):
 ```bash
-# Start all agents
-python references/scripts/start_team.py --all
+# Start harness + all agents
+python references/scripts/squidsquad_cli.py start
 
-# Start single agent
-python references/scripts/start_team.py --role <role>
+# Start a single agent (harness auto-spawns if needed)
+python references/scripts/squidsquad_cli.py start <role>
 
-# Graceful reboot — harness sets intent=restarting
-python references/scripts/start_team.py --reboot <role>
+# Graceful restart — harness sets intent=restarting
+python references/scripts/squidsquad_cli.py restart <role>
 
-# Reboot all agents
-python references/scripts/start_team.py --reboot --all
-
-# Stop agent — harness sets intent=stopping
-python references/scripts/start_team.py --stop <role>
+# Stop a single agent — harness sets intent=stopping
+python references/scripts/squidsquad_cli.py stop <role>
 
 # Stop all agents
-python references/scripts/start_team.py --stop --all
+python references/scripts/squidsquad_cli.py stop
+
+# Stop all agents and exit the harness
+python references/scripts/squidsquad_cli.py shutdown
 ```
 
 **Crash recovery**: Harness persists state to `.squidsquad/.harness-state.json`. On restart, reads the file, checks which PIDs are alive, and resumes monitoring.
@@ -1319,8 +1358,8 @@ These instructions apply to ALL agents on this project.
 
 ### Agent Infrastructure
 
-- **Harness manages agent lifecycle**: PID monitoring (primary), `.health` file (legacy fallback). Intent state machine via REST API (#4966).
-- **Agent lifecycle via `start_team.py`**: Agents do not manage their own or other agents' processes.
+- **Harness manages agent lifecycle**: PID monitoring via `.claude-pid` (sole liveness signal). Intent state machine via REST API (#4966).
+- **Agent lifecycle via `squidsquad_cli.py`** (with `start_team.py` as a backward-compatible shim): Agents do not manage their own or other agents' processes.
 - **Context pressure restart via `cycle_post.py`**: Mechanical detection, agents don't set `restart_needed`.
 
 ### Planning & Verification

--- a/tests/comprehension/8697_spec.json
+++ b/tests/comprehension/8697_spec.json
@@ -20,7 +20,7 @@
     {
       "id": "2",
       "question": "Read tests/comprehension/8697_fixtures/skill_events_CLAUDE.md. What is the skill agent's wake mechanism in THIS configuration, and how does the agent receive work?",
-      "expected": "Wake mechanism is event-driven. The agent invokes the Monitor tool at boot to watch the harness event bus (event_poll.py). Work arrives as `assigned-to` events; the agent processes one event at a time and signals completion via the harness completion endpoint (POST /events/<event_id>/complete). The agent does NOT invoke `/loop` and does NOT run cycle_pre.py/cycle_post.py — the harness owns those operations in event-driven mode."
+      "expected": "Wake mechanism is event-driven via the Monitor tool streaming `python references/scripts/event_poll.py <role> --wait 5 --target`. Each line of stdout is one JSON event. Events are hints, not commands — the source of truth is the forge (`tracker.py work_queue()`), which the agent reads after every event to determine canonical state. `event_poll.py` advances the cursor in `working-state.md` automatically (atomic `.tmp` + `mv`) on each event. The agent processes one event at a time. There is NO completion-API — task completion is reflected by the next forge transition (e.g., `tracker.py transition` to pending-test), not a separate POST. The agent does NOT invoke `/loop` and does NOT run cycle_pre.py/cycle_post.py."
     },
     {
       "id": "3",
@@ -30,7 +30,7 @@
     {
       "id": "4",
       "question": "In events mode (per skill_events_CLAUDE.md), if an agent receives an assigned-to event for issue #42, what is the agent's processing flow?",
-      "expected": "1. Read the event payload (id, event_type, target_role, issue_number). 2. Act on it — do the role-specific creative work for that item (implement, verify, plan, deliver). 3. Complete the event by POSTing to http://127.0.0.1:<harness-port>/events/<event_id>/complete with role + status + summary. Process one event at a time; do not start another until the current one is completed."
+      "expected": "Events are hints, not direct commands. The agent: (1) treats the event as a wake signal — `event_poll.py` has already advanced the cursor in working-state.md atomically; (2) forge-reads via `tracker.py work_queue()` to get the canonical role queue (the event payload may be stale by the time it's processed, so the forge is always the source of truth); (3) picks up the deterministic top item from the queue — transition it to `status:in-progress`, write the issue number to the Task field in working-state.md, begin the role-specific work. The agent processes one item at a time atomically; mid-task events are not acted on until the current task completes (Case D). Task completion is reflected by the next `tracker.py transition` (e.g., to pending-test), NOT by a completion-API POST — there is no `/events/<event_id>/complete` step."
     },
     {
       "id": "5",
@@ -40,7 +40,7 @@
     {
       "id": "6",
       "question": "Read dm_events_CLAUDE.md. If an operator flipped `event-driven: yes` in config.md for DM, and a feature reaches pending-ship status, how does DM learn about it?",
-      "expected": "DM learns via an `assigned-to` event (or `status-transition` event) dispatched by the harness when the item transitions into DM's role queue. DM's Monitor tool delivers the event; DM reads the event payload, picks up the item, performs the delivery (CHANGELOG, README, version bump per role responsibilities), and completes the event when done. DM does NOT poll the tracker on a /loop schedule in this mode."
+      "expected": "DM learns via a `status-transition` event emitted on the harness event bus when the item flips to `status:pending-ship` with `role:dm`. The Monitor tool, streaming `event_poll.py dm --wait 5 --target`, delivers the JSON event line to the DM session. DM treats the event as a wake hint, then forge-reads via `tracker.py work_queue()` to get the canonical pending-ship queue (the event payload may be stale). DM picks up the top item, performs delivery (CHANGELOG, README, version bump per role responsibilities), and the next status transition (pending-ship → shipped) via `tracker.py transition` is what signals completion — there is no completion-API POST. Bare comments on the issue do NOT wake DM (or any agent) — only status/label changes generate events. DM's special case for in-flight PR merges is documented in comment-handling: at the END of a task (merge resolves), DM re-reads comments once before the next pickup. DM does NOT poll the tracker on a /loop schedule in this mode."
     }
   ]
 }


### PR DESCRIPTION
Closes ​#8998

### Summary
Follow-up to #8915 (event-mode L1 base fragments). The 5 common-events fragments (`l1-base`, `cursor-management`, `forge-read-pattern`, `idle-cooldown-loop`, `comment-handling`) + DM's `roles/dm/events/pr-merge-wait.md` were wired into each role's `includes-events.yml` under #8915, but the static fixtures at `tests/comprehension/8697_fixtures/*_events_CLAUDE.md` were never regenerated, so the comprehension test (`8697_spec.json`) had stale fixture content + stale expected answers that referenced a `POST /events/<event_id>/complete` completion-API that no longer exists.

### Acceptance Criteria
- [x] `test_manifest.py::test_no_orphan_sub_skills` passes (it already did — fragments were referenced by includes-events.yml; only fixtures were stale)
- [x] `compose.py deploy <role>` in event mode renders the new fragment content (verified by regenerating all 4 events fixtures via the internal `_load_manifest('event-driven')` + `_resolve_includes_with_manifest` path)
- [x] `tests/run_tests.py` static suite passes (test_manifest, test_compose, test_compose_capability, test_event_mode_fragments all green)

### Changes
- **Files**: 8 fixtures + spec.json
  - `tests/comprehension/8697_fixtures/{skill,pm,qa,dm}_events_CLAUDE.md` — regenerated; +238 to +314 lines each from the new L1 fragments (l1-base, cursor-management, forge-read-pattern, idle-cooldown-loop, comment-handling; DM also gets pr-merge-wait)
  - `tests/comprehension/8697_fixtures/{skill,pm,qa,dm}_polling_CLAUDE.md` — regenerated for parity; +30 to +39 lines each (incidental drift from common sub-skill updates since last regen)
  - `tests/comprehension/8697_spec.json` — Q2/Q4/Q6 expected answers rewritten to match new event-mode model (events are hints; forge-read via `work_queue()` is source of truth; cursor auto-advanced by event_poll.py; no completion-API POST). Q1/Q3/Q5 unchanged.
- **What**: Mechanical fixture regen + semantic spec-answer update
- **Why**: The fragments shipped under #8915 but fixtures + spec answers reflected the older completion-API model. Required for AC-1 M-1.3 (live CQ run on 8697_spec.json), which is the downstream dependency in #8999.

### Notes on issue body Step 5
The body says 'Remove the 6 known_unused entries from tests/test_manifest.py'. That step is moot: the 6 fragment names are NOT in `known_unused` (the orphan-tolerance set, which has only `common/event-reactions.md`). They ARE in the `events_only_names` tuple inside `test_inline_polling_parity` (lines 308-320), where they correctly act as a content-filter when comparing inline-resolved output vs polling-manifest-resolved output. The filter must stay — removing it would break the parity test because events-only sub-skill blocks would leak into the polling comparison. The fragments are properly referenced by `includes-events.yml` manifests, so they are not orphans.

### Setup/Upgrade Sync Check
- [x] New config values: N/A
- [x] New files/directories: N/A
- [x] Modified template structure: N/A — only static fixture snapshots changed; manifest wiring shipped under #8915
- [x] Added/removed sub-skills: N/A
- [x] Changed role composition: N/A

### QA Status
- [x] Unit tests passing (static suite green: 17 integration tests OK; pytest 204+ green on compose/event-mode/manifest)
- [x] DeepSeek r1 NO_FINDINGS — confirmed Q2/Q4/Q6 new answers are derivable from skill_events / dm_events fixtures; old completion-API refs fully removed
- [x] Acceptance criteria met