### PR TITLE
skill: #9243 — harness exposes code_version via /status + slim GET /

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -144,6 +144,10 @@ class HarnessState:
         self.agents: dict[str, AgentState] = {}
         self.start_time = time.time()
         self.port = DEFAULT_PORT
+        # #9243: code_version probed once at boot, cached. Includes
+        # squidsquad_version, git_sha, git_branch, git_dirty — see
+        # compute_code_version(). Stays None until lifespan fills it.
+        self.code_version = None
         self._lock = threading.Lock()
         self._poller_running = False
         self._poller_thread = None
@@ -707,6 +711,69 @@ def _log(msg: str):
 
 
 # ---------------------------------------------------------------------------
+# Code-version probe (#9243) — read once at boot, cache for /status + /
+# ---------------------------------------------------------------------------
+
+
+def _read_squidsquad_version():
+    """Read `SquidSquad Version` from config.md. Returns the value string or
+    None if config.md is missing or the field is absent. Never raises."""
+    try:
+        cfg = SQUIDSQUAD_DIR / "config.md"
+        for line in cfg.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if stripped.startswith("- **SquidSquad Version**:"):
+                return stripped.split(":", 1)[1].strip()
+    except (OSError, UnicodeDecodeError):
+        pass
+    return None
+
+
+def _git_probe(args):
+    """Run `git <args>` in REPO_ROOT and return stripped stdout, or None on
+    any failure (no git, not a repo, non-zero exit). Never raises."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=2,
+            check=False,
+        )
+    except Exception:
+        # "Never raises" boot-time contract — catch broadly so a stray
+        # ValueError / malformed args / locale glitch on Windows cannot
+        # bring down the lifespan probe.
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def compute_code_version():
+    """Probe squidsquad version + git state once at boot. All fields
+    individually fall back to `None` on failure so a non-git environment or
+    missing config.md still produces a stable response shape."""
+    version = _read_squidsquad_version()
+    sha = _git_probe(["rev-parse", "--short=8", "HEAD"])
+    branch = _git_probe(["rev-parse", "--abbrev-ref", "HEAD"])
+    porcelain = _git_probe(["status", "--porcelain"])
+    if porcelain is None:
+        dirty = None
+    else:
+        dirty = bool(porcelain)
+    return {
+        "squidsquad_version": version,
+        "git_sha": sha,
+        "git_branch": branch,
+        "git_dirty": dirty,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Legacy-sentinel cleanup (#4792 Phase 2 §5.1)
 # ---------------------------------------------------------------------------
 
@@ -767,6 +834,16 @@ def _cleanup_legacy_sentinels(clone_paths):
 async def lifespan(app: FastAPI):
     """Startup and shutdown hooks."""
     _log(f"Harness starting on port {state.port}...")
+
+    # #9243: Probe code version once at boot. Each field falls back to None
+    # on failure (no git, missing config.md) — never blocks startup.
+    state.code_version = compute_code_version()
+    cv = state.code_version
+    _log(
+        f"Code version: squidsquad={cv['squidsquad_version']} "
+        f"git_sha={cv['git_sha']} branch={cv['git_branch']} "
+        f"dirty={cv['git_dirty']}"
+    )
 
     # --- Verify agent clones ---
     _log("Verifying agent clones...")
@@ -941,14 +1018,33 @@ async def get_status():
     """Harness + all agent health."""
     state.update_health()
     uptime = int(time.time() - state.start_time)
+    # #9243: include code_version + boot_time_iso so operators can verify
+    # which code is actually running without a restart probe.
+    cv = state.code_version if state.code_version is not None else compute_code_version()
+    code_version = dict(cv)
+    code_version["boot_time_iso"] = time.strftime(
+        "%Y-%m-%dT%H:%M:%SZ", time.gmtime(state.start_time)
+    )
     return {
         "harness": {
             "status": "running",
             "port": state.port,
             "uptime_seconds": uptime,
             "uptime_human": f"{uptime // 3600}h {(uptime % 3600) // 60}m {uptime % 60}s",
+            "code_version": code_version,
         },
         "agents": state.all_agents(),
+    }
+
+
+@app.get("/")
+async def get_root():
+    """Slim liveness/version probe (#9243). Replaces the default 404."""
+    cv = state.code_version if state.code_version is not None else compute_code_version()
+    return {
+        "service": "squidsquad-harness",
+        "version": cv.get("squidsquad_version"),
+        "git_sha": cv.get("git_sha"),
     }
 
 

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -826,6 +826,165 @@ class TestConfigIntegration(unittest.TestCase):
         self.assertEqual(field, "Port")
 
 
+class TestCodeVersionProbe(unittest.TestCase):
+    """#9243 — compute_code_version + boot probe + /status + / endpoint."""
+
+    def test_compute_code_version_success_shape(self):
+        """All four fields present on a normal git checkout with config.md."""
+        from harness import compute_code_version
+        cv = compute_code_version()
+        self.assertIn("squidsquad_version", cv)
+        self.assertIn("git_sha", cv)
+        self.assertIn("git_branch", cv)
+        self.assertIn("git_dirty", cv)
+        # On the actual repo, version + git fields should be populated.
+        self.assertIsInstance(cv["squidsquad_version"], str)
+        self.assertIsNotNone(cv["git_sha"])
+        # SHA short form is hex; verify it parses
+        int(cv["git_sha"], 16)
+        self.assertIsInstance(cv["git_branch"], str)
+        self.assertIsInstance(cv["git_dirty"], bool)
+
+    def test_compute_code_version_no_git(self):
+        """When git fails (no repo / no git binary), all git fields are None
+        but the dict shape is preserved."""
+        from harness import compute_code_version
+        with patch("harness._git_probe", return_value=None):
+            cv = compute_code_version()
+        self.assertIsNone(cv["git_sha"])
+        self.assertIsNone(cv["git_branch"])
+        self.assertIsNone(cv["git_dirty"])
+        # Version still comes from config.md regardless of git
+        self.assertIn("squidsquad_version", cv)
+
+    def test_compute_code_version_dirty_tree(self):
+        """`git status --porcelain` non-empty -> dirty=True."""
+        from harness import compute_code_version
+
+        def fake_probe(args):
+            if args[:1] == ["status"]:
+                return " M some/file.py"
+            if args == ["rev-parse", "--short=8", "HEAD"]:
+                return "deadbeef"
+            if args == ["rev-parse", "--abbrev-ref", "HEAD"]:
+                return "main"
+            return None
+
+        with patch("harness._git_probe", side_effect=fake_probe):
+            cv = compute_code_version()
+        self.assertTrue(cv["git_dirty"])
+        self.assertEqual(cv["git_sha"], "deadbeef")
+
+    def test_compute_code_version_clean_tree(self):
+        """`git status --porcelain` empty -> dirty=False."""
+        from harness import compute_code_version
+
+        def fake_probe(args):
+            if args[:1] == ["status"]:
+                return ""
+            if args == ["rev-parse", "--short=8", "HEAD"]:
+                return "12345678"
+            if args == ["rev-parse", "--abbrev-ref", "HEAD"]:
+                return "feature-branch"
+            return None
+
+        with patch("harness._git_probe", side_effect=fake_probe):
+            cv = compute_code_version()
+        self.assertFalse(cv["git_dirty"])
+
+    def test_read_squidsquad_version_missing_config(self):
+        """Missing config.md returns None without crashing."""
+        from harness import _read_squidsquad_version
+        with patch("pathlib.Path.read_text", side_effect=OSError):
+            self.assertIsNone(_read_squidsquad_version())
+
+
+class TestStatusEndpointCodeVersion(unittest.TestCase):
+    """#9243 — GET /status exposes code_version block; GET / returns slim."""
+
+    @classmethod
+    def setUpClass(cls):
+        from fastapi.testclient import TestClient
+        from harness import app, state
+        state.start_time = time.time()
+        state.port = 7373
+        state.code_version = {
+            "squidsquad_version": "v0.40.0",
+            "git_sha": "01a2b6f4",
+            "git_branch": "main",
+            "git_dirty": False,
+        }
+        cls.client = TestClient(app, raise_server_exceptions=False)
+        cls.state = state
+
+    def test_status_includes_code_version(self):
+        with patch.object(self.state, "update_health"):
+            resp = self.client.get("/status")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("code_version", data["harness"])
+        cv = data["harness"]["code_version"]
+        self.assertEqual(cv["squidsquad_version"], "v0.40.0")
+        self.assertEqual(cv["git_sha"], "01a2b6f4")
+        self.assertEqual(cv["git_branch"], "main")
+        self.assertFalse(cv["git_dirty"])
+        self.assertIn("boot_time_iso", cv)
+        # Boot time ISO ends with Z (UTC)
+        self.assertTrue(cv["boot_time_iso"].endswith("Z"))
+
+    def test_root_endpoint_returns_slim_version(self):
+        resp = self.client.get("/")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["service"], "squidsquad-harness")
+        self.assertEqual(data["version"], "v0.40.0")
+        self.assertEqual(data["git_sha"], "01a2b6f4")
+
+    def test_status_falls_back_when_state_code_version_none(self):
+        """If state.code_version is None (e.g. test client bypassed
+        lifespan), the endpoint re-probes via compute_code_version() rather
+        than crashing or returning a malformed response."""
+        prior = self.state.code_version
+        try:
+            self.state.code_version = None
+            with patch.object(self.state, "update_health"), \
+                 patch("harness.compute_code_version", return_value={
+                     "squidsquad_version": "v0.0.0-probed",
+                     "git_sha": "probedsh",
+                     "git_branch": "test-fallback",
+                     "git_dirty": False,
+                 }):
+                resp = self.client.get("/status")
+            self.assertEqual(resp.status_code, 200)
+            cv = resp.json()["harness"]["code_version"]
+            self.assertEqual(cv["squidsquad_version"], "v0.0.0-probed")
+            self.assertEqual(cv["git_sha"], "probedsh")
+            self.assertIn("boot_time_iso", cv)
+        finally:
+            self.state.code_version = prior
+
+    def test_status_code_version_with_null_git(self):
+        """Boot from outside a git repo -> git fields are null in /status."""
+        prior = self.state.code_version
+        try:
+            self.state.code_version = {
+                "squidsquad_version": "v0.40.0",
+                "git_sha": None,
+                "git_branch": None,
+                "git_dirty": None,
+            }
+            with patch.object(self.state, "update_health"):
+                resp = self.client.get("/status")
+            self.assertEqual(resp.status_code, 200)
+            cv = resp.json()["harness"]["code_version"]
+            self.assertIsNone(cv["git_sha"])
+            self.assertIsNone(cv["git_branch"])
+            self.assertIsNone(cv["git_dirty"])
+            self.assertEqual(cv["squidsquad_version"], "v0.40.0")
+        finally:
+            self.state.code_version = prior
+
+
 class TestHarnessEndpoints(unittest.TestCase):
     """Test FastAPI endpoints using TestClient (if available) or mock."""
 


### PR DESCRIPTION
Closes ​#9243

### Summary
Exposes the harness version + git SHA via `GET /status` (and new slim `GET /`) so operators can verify which code is actually running without restart-and-watch. The motivating use case from the issue: after #8979 + #8998 + #9215 shipped in rapid succession, no way to tell from outside whether the running harness had any of them loaded.

### Acceptance Criteria
- [x] AC-1: `curl localhost:7373/status` includes `harness.code_version` with `squidsquad_version`, `git_sha`, `git_branch`, `git_dirty` (+ bonus `boot_time_iso`)
- [x] AC-2: `curl localhost:7373/` returns 200 with `{service, version, git_sha}` (was 404)
- [x] AC-3: Booting from a dirty tree -> `git_dirty: true` (covered by `test_compute_code_version_dirty_tree`)
- [x] AC-4: Booting outside a git repo -> `git_sha`/`git_branch`/`git_dirty` are `null` without crashing (covered by `test_compute_code_version_no_git` + `test_status_code_version_with_null_git`)
- [x] AC-5: 9 new unit tests covering all four success paths + graceful-degradation + endpoint fallback

### Changes
- **`references/scripts/harness.py`** — new section `Code-version probe (#9243)` with helpers `_read_squidsquad_version`, `_git_probe`, `compute_code_version`. `HarnessState.__init__` gets `self.code_version = None` (filled in `lifespan`). `lifespan` calls `state.code_version = compute_code_version()` once at boot and logs the result. `get_status` returns the cached dict + `boot_time_iso` (UTC). New `@app.get('/')` endpoint returns the slim version JSON.
- **`tests/test_harness.py`** — `TestCodeVersionProbe` (5 tests: shape, no-git, dirty, clean, missing-config) + `TestStatusEndpointCodeVersion` (4 tests: status block, root, null-git, none-fallback).

### Why
Issue: 'after the harness has been up for days, no signal that distinguishes "running latest main" from "running 50h-old code".' This adds the definitive signal (git SHA + branch + dirty + ISO boot time) without per-request shell-out — all four fields are probed once at lifespan startup.

### Graceful degradation
Each git probe and the config.md read fall back to `None` independently. A no-git environment, a missing config.md, a corrupt repo, a stalled `git status` (capped at 2s timeout) — all produce a stable response shape with the failed field as `null`. `_git_probe` catches a broad `Exception` to honor its 'never raises' contract on the boot-time path.

### DeepSeek code review
- **r1 (Claude subagent fallback)**: 3 warnings, all FIXED:
  1. `state.code_version or compute_code_version()` truthiness check -> `is not None` explicit check (a falsy-but-not-None value would have re-probed per-request, violating cache-at-boot)
  2. `_git_probe` `except (OSError, TimeoutExpired)` -> `except Exception` (a stray `ValueError` from malformed args would have escaped the 'never raises' contract)
  3. No test exercised the endpoint fallback when `state.code_version=None` (lifespan-bypass case) -> added `test_status_falls_back_when_state_code_version_none`
- Note: the external model_router returned empty output; fallback per §9c protocol used a Claude subagent which produced the three findings above.

### Setup/Upgrade Sync Check
- [x] New config values: N/A
- [x] New files/directories: N/A
- [x] Modified template structure: N/A — harness HTTP only, no instruction changes
- [x] Added/removed sub-skills: N/A
- [x] Changed role composition: N/A

### QA Status
- [x] Unit tests passing — `python tests/run_tests.py` zero failures; 9 new endpoint/probe tests all green
- [x] DeepSeek code review iteration complete (3 findings, all fixed)
- [x] Acceptance criteria met