### PR TITLE
skill: #9331 — harness eviction signal + event_poll.py detection

### DIFF
--- a/.squidsquad/skill/planning/CODE-REVIEW-9331-R2.md
+++ b/.squidsquad/skill/planning/CODE-REVIEW-9331-R2.md
@@ -1,0 +1,11 @@
+NO_FINDINGS
+
+**Review Summary**
+
+- **R1 Finding 1** (get_since docstring): Resolved — docstring now explicitly documents oldest-first ordering for the `since` path and attributes the change to PR #9320 (lines 518-527).
+- **R1 Finding 2** (test gap on cursor-FOUND truncation): Resolved — `test_cursor_in_deque_returns_oldest_first_when_truncated` (test_eviction_signal.py, line 164) exercises the case where events-after-cursor exceed `limit` and validates oldest-first ordering.
+- **R1 Finding 3** (EventLifecycleManager.load `_loaded` flag): Tracked separately as #9357; not re-raised.
+
+- **NEW regressions**: None. The eviction-signal plumbing in `EventStream.get_since_with_eviction`, `GET /events`, `GET /events/for/{role}`, and `event_poll.py` is internally consistent: `_total_emitted_count` increments under `EventStream._lock`, the hint calculation `max(0, total − len(snapshot))` is atomic with the deque snapshot, `EventLifecycleManager.load()` pushes events through `EventStream.append()` (not `EventLifecycleManager.append()`) so `_persist()` isn't re-triggered, and the `event_poll.py` re-anchor write happens before per-event cursor advancement so forward progress is guaranteed even when the role filter drops all events (validated by `test_eviction_re_anchors_when_role_filter_drops_all_events`).
+
+- **Edge cases**: Verified empty deque, cursor-at-head, cursor-not-found with non-empty deque, and cursor-not-found with empty deque — all produce correct markers or empty responses with appropriate `oldest_id` (`None` when deque is empty).

--- a/.squidsquad/skill/planning/CODE-REVIEW-9331.md
+++ b/.squidsquad/skill/planning/CODE-REVIEW-9331.md
@@ -1,0 +1,38 @@
+Here is my review.
+
+---
+
+### Finding 1
+
+- **File**: `references/scripts/harness.py`
+- **Line**: 482–491
+- **Severity**: warning
+- **Issue**: The `get_since()` wrapper is documented as "back-compat" (line 485–489) but changes the return ordering when a `since_id` cursor is provided. The old contract (documented in the `test_event_bus_reader.py` mock at line 141–150) returned **newest-first** in all branches (`items[-limit:]`, `after[-limit:]`). The new `get_since_with_eviction` (and therefore `get_since`) returns **oldest-first** when a cursor is supplied (`after[:limit]` at line 531 for cursor-found, `items[:limit]` at line 536 for cursor-evicted). While oldest-first is the correct contract for "skim-then-advance" and the HTTP endpoints were re-written to match (lines 1482–1485 apply `[:limit]` for the `since` case), the `get_since()` wrapper's claim of back-compat is misleading. Any external caller holding a reference to `EventStream.get_since` and depending on newest-first ordering would silently break.
+- **Evidence**: Compare `test_event_bus_reader.py` line 149 (`after[-limit:]` — newest-first) with `harness.py` line 531 (`after[:limit]` — oldest-first). The comment "Back-compat wrapper" on line 485 is incorrect.
+- **Suggested fix**: Either (a) update the `get_since` docstring to explicitly document the ordering contract as oldest-first-when-cursor-provided, dropping the "back-compat" claim, or (b) if true back-compat is required, make `get_since` preserve the old newest-first ordering by slicing with `[-limit:]` instead of delegating to `get_since_with_eviction`.
+
+---
+
+### Finding 2
+
+- **File**: `tests/test_eviction_signal.py`
+- **Line**: 94–102
+- **Severity**: warning
+- **Issue**: No test verifies the oldest-first ordering for the **cursor-found** (non-eviction) path when the number of events after the cursor exceeds the limit. The test `test_cursor_in_deque_returns_no_marker` (line 94–102) uses `limit=100` with only 4 events after the cursor — the truncation branch `after[:limit]` is never exercised. Every other `get_since_with_eviction` call in the test suite also uses `limit=100`. The only limit-truncation test is `test_evicted_events_returned_oldest_first` (line 144–160), which covers the **eviction** case. A regression that reverts the cursor-found branch to `after[-limit:]` (newest-first, matching the old `get_since` behavior) would pass all existing tests undetected.
+- **Evidence**: Search for `get_since_with_eviction.*limit=` in `tests/` — every call uses `limit=100` which exceeds the deque sizes in those tests. The cursor-found path's `after[:limit]` at `harness.py` line 531 is never reached with `len(after) > limit` in any test.
+- **Suggested fix**: Add a test case: create a stream with e.g. 20 events, call `get_since_with_eviction("e05", limit=3)`, assert returned IDs are `["e06", "e07", "e08"]` (oldest 3 after cursor) and marker is `None`. This catches both ordering regressions and the no-marker contract.
+
+---
+
+### Finding 3
+
+- **File**: `references/scripts/harness.py`
+- **Line**: 648–679 (specifically 650 and 679)
+- **Severity**: warning
+- **Issue**: The `EventLifecycleManager.load()` idempotency guard (`self._loaded` flag) is read and written without holding `self._lock`. While `load()` is currently only called from one place (`_deferred_init` in the lifespan), the pattern is fragile: if a future refactor calls `load()` from multiple threads, both could pass the `if self._loaded: return` check (line 650–651) and enter the event-loading loop, causing duplicate events in the stream and an inflated `_total_emitted_count`. The `_loaded = True` assignment at line 679 also races with the check.
+- **Evidence**: Compare with `dispatch()` and `ack()` which guard their critical sections with `with self._lock:`. The `_loaded` flag has no such protection. The comment "Idempotent" on line 649 is true only under the current single-caller assumption.
+- **Suggested fix**: Either check-and-set `_loaded` inside `with self._lock:` at the top of `load()`, or document that `load()` is not thread-safe and must be called exactly once during startup (matching the actual usage).
+
+---
+
+All three findings are warnings, not errors. The core eviction-signal math (`_total_emitted_count - len(items)` at line 538–539), the `event_poll.py` re-anchor logic (lines 204–234), and the endpoint wiring (lines 1487–1494, 1558–1562) are correct. Thread safety of `EventStream` is sound (all mutations/reads of `_events` and `_total_emitted_count` are under `self._lock`). The tests in `test_eviction_signal.py` otherwise provide good coverage of the eviction marker paths.

--- a/references/scripts/event_poll.py
+++ b/references/scripts/event_poll.py
@@ -221,10 +221,13 @@ def poll(role, since=None, limit=50, target_mode=False,
                 # >= oldest_id).
                 oldest_id = payload.get("oldest_id")
                 hint = payload.get("evicted_count_hint")
+                # Locked format per CONTEXT-9331 §4 — kept verbatim so
+                # QA's grep-based assertions stay deterministic across
+                # rewords.
                 print(
                     f"[event_poll] EVICTION: cursor predates retained "
-                    f"window — re-anchoring to {oldest_id}, ~{hint} "
-                    f"events have rolled off the deque since boot",
+                    f"window — advancing to {oldest_id}, "
+                    f"~{hint} events evicted",
                     file=sys.stderr,
                 )
                 if oldest_id and not _write_cursor_atomic(role, str(oldest_id)):

--- a/references/scripts/event_poll.py
+++ b/references/scripts/event_poll.py
@@ -147,9 +147,11 @@ def _build_url(port, role, cursor, limit, target_mode):
 
 
 def _fetch_once(url, http_timeout):
-    """Single HTTP attempt. Returns (events|None, retryable, fatal_message).
+    """Single HTTP attempt. Returns (payload|None, retryable, fatal_message).
 
-    - (list, False, None)        — success
+    - (dict, False, None)        — success; payload carries ``events`` plus
+                                   optional ``evicted``/``oldest_id``/
+                                   ``evicted_count_hint`` keys (#9331)
     - (None, True, reason)       — transient (retry with backoff)
     - (None, False, reason)      — fatal (4xx or invalid body); caller exits
     """
@@ -165,7 +167,7 @@ def _fetch_once(url, http_timeout):
         events = data.get("events", [])
         if not isinstance(events, list):
             return None, False, f"harness 'events' not a list: {type(events).__name__}"
-        return events, False, None
+        return data, False, None
     except urllib.error.HTTPError as e:
         if 500 <= e.code < 600:
             return None, True, f"HTTP {e.code}"
@@ -196,8 +198,40 @@ def poll(role, since=None, limit=50, target_mode=False,
 
     attempt = 0
     while True:
-        events, retryable, fatal_msg = _fetch_once(url, http_timeout)
-        if events is not None:
+        payload, retryable, fatal_msg = _fetch_once(url, http_timeout)
+        if payload is not None:
+            events = payload.get("events", [])
+            if payload.get("evicted"):
+                # Cursor predates the harness's retained window (#9331).
+                # Warn once per response naming the safe re-anchor + an
+                # operator-forensic hint on how many events have rolled
+                # off the deque since boot. Then re-anchor the cursor
+                # to `oldest_id` BEFORE processing events.
+                #
+                # Re-anchoring up front is needed because on the
+                # `/events/for/{role}` endpoint, the role filter can
+                # strip every event in the batch even when the deque
+                # is non-empty — leaving `events == []` with the
+                # cursor stuck on the (still-evicted) stale id and the
+                # warning repeating every poll. Anchoring to
+                # `oldest_id` first guarantees forward progress; if
+                # events DO survive the filter, the per-event advance
+                # below will overwrite the cursor to a later id, which
+                # is fine (events are oldest-first; their ids are
+                # >= oldest_id).
+                oldest_id = payload.get("oldest_id")
+                hint = payload.get("evicted_count_hint")
+                print(
+                    f"[event_poll] EVICTION: cursor predates retained "
+                    f"window — re-anchoring to {oldest_id}, ~{hint} "
+                    f"events have rolled off the deque since boot",
+                    file=sys.stderr,
+                )
+                if oldest_id and not _write_cursor_atomic(role, str(oldest_id)):
+                    # Same fatal-on-disk-fail policy as the per-event
+                    # advance below — silently retrying would burn CPU
+                    # forever against an unwritable cursor file.
+                    return None
             for event in events:
                 if not isinstance(event, dict):
                     print(f"WARNING: malformed event (not an object); "

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -458,10 +458,17 @@ class EventStream:
     def __init__(self, maxlen=1000):
         self._events = collections.deque(maxlen=maxlen)
         self._lock = threading.Lock()
+        # Lifetime emit counter for the eviction-signal hint (#9331).
+        # Increments on every `append`; never decrements when the deque
+        # rolls. After the deque is full, the difference from
+        # `len(self._events)` = number of events evicted from the
+        # retained window over the harness's lifetime.
+        self._total_emitted_count = 0
 
     def append(self, event: dict):
         with self._lock:
             self._events.append(event)
+            self._total_emitted_count += 1
 
     def get_all(self) -> list[dict]:
         with self._lock:
@@ -473,18 +480,75 @@ class EventStream:
             return items[-n:] if len(items) > n else items
 
     def get_since(self, since_id: str, limit: int = 100) -> list[dict]:
-        """Return events after the given ID. If ID not found, return oldest available."""
+        """Return events after the given ID. If ID not found, return oldest available.
+
+        Single-return-value wrapper around
+        :meth:`get_since_with_eviction` — drops the eviction marker.
+        Ordering follows the skim-then-advance contract
+        (CONTEXT-8694 §2): **oldest-first when ``since_id`` is set**
+        (so the agent walks the gap event-by-event), newest-first
+        otherwise. This is the same ordering change PR #9320 ships
+        for the §4.10 long-cursor-lag scenario; #9331 inherits it
+        because the eviction-aware getter must return oldest-first
+        for re-anchor to make sense. Callers that need the eviction
+        marker should use :meth:`get_since_with_eviction` directly.
+        """
+        events, _ = self.get_since_with_eviction(since_id, limit)
+        return events
+
+    def get_since_with_eviction(
+        self, since_id: str, limit: int = 100,
+    ):
+        """Return ``(events, eviction_marker)``.
+
+        ``eviction_marker`` is ``None`` for the normal case — cursor
+        was found in the retained window, or no cursor was passed.
+        When the caller supplies a ``since_id`` that is **not** in the
+        deque, the marker becomes::
+
+            {
+                "oldest_id": <str|None>,
+                "evicted_count_hint": <int>,
+            }
+
+        - ``oldest_id`` is the id of the oldest event still retained
+          (the cursor's safe re-anchor point), or ``None`` if the
+          deque is empty.
+        - ``evicted_count_hint`` is a coarse upper bound on the number
+          of events that have been pushed out of the retained window
+          since boot (lifetime emits − currently retained). Operators
+          log this for forensics; exact precision is not required
+          (#9331).
+
+        The events list itself follows the same skim-then-advance
+        contract as before (CONTEXT-8694 §2): oldest-first when
+        ``since`` is set, newest-first otherwise. With ``since``
+        present, returning newest-first would silently drop the gap
+        between cursor and (head − limit).
+        """
         with self._lock:
             items = list(self._events)
             if not since_id:
-                return items[-limit:] if len(items) > limit else items
-            # Find the index of the since_id event
+                events = items[-limit:] if len(items) > limit else items
+                return events, None
             for i, event in enumerate(items):
                 if event.get("id") == since_id:
                     after = items[i + 1:]
-                    return after[-limit:] if len(after) > limit else after
-            # ID not found (evicted) — return oldest available up to limit
-            return items[-limit:] if len(items) > limit else items
+                    events = after[:limit] if len(after) > limit else after
+                    return events, None
+            # Cursor predates the retained window — emit the eviction
+            # signal so the agent can log + advance to a known anchor
+            # instead of silently moving past the gap.
+            events = items[:limit] if len(items) > limit else items
+            oldest_id = items[0].get("id") if items else None
+            evicted_count_hint = max(
+                0, self._total_emitted_count - len(items)
+            )
+            marker = {
+                "oldest_id": oldest_id,
+                "evicted_count_hint": evicted_count_hint,
+            }
+            return events, marker
 
     def __len__(self):
         with self._lock:
@@ -1399,8 +1463,13 @@ async def get_events(
         event_type: filter by event type (comma-separated for multiple)
         limit: max events to return (default 100)
     """
+    eviction = None
     if since:
-        events = event_stream.get_since(since, limit=limit * 3)  # over-fetch before filtering
+        # Over-fetch by *3 so post-filter still has enough rows to fill
+        # the limit. Eviction marker piggybacks on this call (#9331).
+        events, eviction = event_stream.get_since_with_eviction(
+            since, limit=limit * 3
+        )
     else:
         events = event_stream.get_recent(limit * 3)
 
@@ -1411,10 +1480,25 @@ async def get_events(
         types = set(event_type.split(","))
         events = [e for e in events if e.get("event_type") in types]
 
-    # Apply limit after filtering
-    events = events[-limit:] if len(events) > limit else events
+    # Apply limit after filtering. With `since`, the agent wants the
+    # OLDEST events after the cursor (skim-then-advance, CONTEXT-8694
+    # §2) — slicing `[-limit:]` would silently drop the gap between
+    # cursor and (head − limit). Without `since`, keep newest-first for
+    # callers that want recent activity.
+    if since:
+        events = events[:limit] if len(events) > limit else events
+    else:
+        events = events[-limit:] if len(events) > limit else events
 
-    return {"events": events, "total": len(event_stream)}
+    response = {"events": events, "total": len(event_stream)}
+    if eviction is not None:
+        # Eviction signal (#9331) — present only when the caller's
+        # cursor predates the retained window. Agents log this and
+        # advance to `oldest_id` instead of silently moving on.
+        response["evicted"] = True
+        response["oldest_id"] = eviction["oldest_id"]
+        response["evicted_count_hint"] = eviction["evicted_count_hint"]
+    return response
 
 
 @app.get("/events/for/{role}")
@@ -1444,9 +1528,13 @@ async def get_events_for_role(
     except (ImportError, Exception):
         relevant_types = None
 
-    # Fetch events from stream
+    # Fetch events from stream. Eviction marker piggybacks when `since`
+    # is provided and the cursor predates the retained window (#9331).
+    eviction = None
     if since:
-        events = event_stream.get_since(since, limit=limit * 3)
+        events, eviction = event_stream.get_since_with_eviction(
+            since, limit=limit * 3
+        )
     else:
         events = event_stream.get_recent(limit * 3)
 
@@ -1460,7 +1548,12 @@ async def get_events_for_role(
         elif relevant_types and etype in relevant_types:
             filtered.append(e)
 
-    filtered = filtered[-limit:] if len(filtered) > limit else filtered
+    # Same skim-then-advance rule as GET /events: oldest-first when the
+    # caller advances a cursor, newest-first otherwise.
+    if since:
+        filtered = filtered[:limit] if len(filtered) > limit else filtered
+    else:
+        filtered = filtered[-limit:] if len(filtered) > limit else filtered
 
     # Mark dispatched in lifecycle manager
     for e in filtered:
@@ -1468,7 +1561,12 @@ async def get_events_for_role(
         if eid:
             event_lifecycle.dispatch(eid, role, e)
 
-    return {"events": filtered, "total": len(filtered)}
+    response = {"events": filtered, "total": len(filtered)}
+    if eviction is not None:
+        response["evicted"] = True
+        response["oldest_id"] = eviction["oldest_id"]
+        response["evicted_count_hint"] = eviction["evicted_count_hint"]
+    return response
 
 
 @app.post("/events/{event_id}/complete")

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -49,6 +49,7 @@ STATIC_TEST_MODULES = [
     "test_event_bus",
     "test_event_catalog",
     "test_event_poll",
+    "test_eviction_signal",
     "test_event_mode_fragments",
     "test_comprehension_8694",
     "test_event_validator",

--- a/tests/test_eviction_signal.py
+++ b/tests/test_eviction_signal.py
@@ -260,7 +260,10 @@ class TestEventPollEvictionWarning(unittest.TestCase):
                 emitted = list(result)
         return captured_stdout.getvalue(), captured_stderr.getvalue(), emitted
 
-    def test_eviction_warning_emitted_to_stderr(self):
+    def test_eviction_warning_matches_locked_format(self):
+        """CONTEXT-9331 §4 locks the stderr warning text so QA's
+        grep-based assertions remain stable. Any reword must update
+        both this test AND CONTEXT-9331 §4."""
         payload = {
             "events": [
                 {"id": "e7", "event_type": "status-transition", "role": "skill"},
@@ -273,10 +276,16 @@ class TestEventPollEvictionWarning(unittest.TestCase):
         }
         stdout, stderr, emitted = self._run_poll_with_payload(payload)
 
-        self.assertIn("EVICTION", stderr)
-        self.assertIn("e7", stderr, msg="warning must name oldest_id anchor")
-        self.assertIn("42", stderr, msg="warning must name hint")
-        # Exactly one warning per response.
+        expected_line = (
+            "[event_poll] EVICTION: cursor predates retained window — "
+            "advancing to e7, ~42 events evicted"
+        )
+        self.assertIn(
+            expected_line, stderr,
+            msg=f"stderr did not contain the locked warning line.\n"
+                f"got: {stderr!r}\nexpected substring: {expected_line!r}",
+        )
+        # Exactly one warning per response, not once per event.
         self.assertEqual(stderr.count("EVICTION"), 1)
 
         # Events still flow through stdout normally.

--- a/tests/test_eviction_signal.py
+++ b/tests/test_eviction_signal.py
@@ -1,0 +1,381 @@
+"""Unit tests for the harness eviction signal (#9331).
+
+Two layers:
+
+- ``EventStream.get_since_with_eviction`` returns an eviction marker
+  when the caller's cursor predates the retained window. The marker
+  carries ``oldest_id`` (safe re-anchor) and ``evicted_count_hint``
+  (coarse operator-forensic estimate of how many events the cursor
+  has missed). Normal cases — cursor found, or no cursor passed —
+  return ``(events, None)``.
+
+- ``event_poll.py`` consumes the ``evicted``/``oldest_id``/
+  ``evicted_count_hint`` keys on the response payload, emits exactly
+  one stderr warning per response naming the anchor + hint, and then
+  proceeds with normal event processing (the first event in the
+  payload IS ``oldest_id``, so cursor advancement happens implicitly).
+
+Unblocks: #8999 §4.4 IT-EvictionGap.
+"""
+
+import importlib.util
+import io
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO_ROOT / "references" / "scripts"
+
+
+def _load_module(name: str, source: Path):
+    """Load a module under a unique name to dodge sys.modules collisions."""
+    spec = importlib.util.spec_from_file_location(name, source)
+    if not (spec and spec.loader):
+        raise ImportError(f"cannot build spec for {source}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+try:
+    _harness = _load_module("_harness_for_eviction", SCRIPTS / "harness.py")
+    EventStream = _harness.EventStream
+    HARNESS_AVAILABLE = True
+except Exception as _e:
+    print(
+        f"[test_eviction_signal] harness import failed: "
+        f"{type(_e).__name__}: {_e}",
+        file=sys.stderr,
+    )
+    HARNESS_AVAILABLE = False
+    EventStream = None  # type: ignore
+
+
+try:
+    _ep = _load_module("_event_poll_for_eviction", SCRIPTS / "event_poll.py")
+    EVENT_POLL_AVAILABLE = True
+except Exception as _e:
+    print(
+        f"[test_eviction_signal] event_poll import failed: "
+        f"{type(_e).__name__}: {_e}",
+        file=sys.stderr,
+    )
+    EVENT_POLL_AVAILABLE = False
+    _ep = None
+
+
+def _ev(eid: str, **extra) -> dict:
+    out = {"id": eid, "event_type": "status-transition", "role": "skill"}
+    out.update(extra)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# EventStream.get_since_with_eviction
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(HARNESS_AVAILABLE, "harness module not importable")
+class TestGetSinceWithEvictionMarker(unittest.TestCase):
+    """Behavioral matrix for the eviction-aware getter."""
+
+    def test_no_cursor_returns_no_marker(self):
+        stream = EventStream(maxlen=10)
+        for i in range(5):
+            stream.append(_ev(f"e{i}"))
+
+        events, marker = stream.get_since_with_eviction(None, limit=100)
+        self.assertEqual([e["id"] for e in events], [f"e{i}" for i in range(5)])
+        self.assertIsNone(marker)
+
+    def test_cursor_in_deque_returns_no_marker(self):
+        """Normal case: cursor still in retained window."""
+        stream = EventStream(maxlen=10)
+        for i in range(5):
+            stream.append(_ev(f"e{i}"))
+
+        events, marker = stream.get_since_with_eviction("e1", limit=100)
+        self.assertEqual([e["id"] for e in events], ["e2", "e3", "e4"])
+        self.assertIsNone(marker)
+
+    def test_cursor_in_deque_returns_oldest_first_when_truncated(self):
+        """When the cursor is found but the events-after-cursor count
+        exceeds ``limit``, the returned slice must be the OLDEST
+        ``limit`` events after the cursor — same skim-then-advance
+        contract as the evicted branch. Returning newest-first would
+        silently drop the gap between cursor and (head − limit) and
+        cause the agent to jump ahead.
+        """
+        stream = EventStream(maxlen=50)
+        for i in range(20):
+            stream.append(_ev(f"e{i:02d}"))
+
+        events, marker = stream.get_since_with_eviction("e05", limit=3)
+        self.assertEqual(
+            [e["id"] for e in events], ["e06", "e07", "e08"],
+            msg="cursor-found branch must return oldest events after "
+                "the cursor when truncated by limit; otherwise the "
+                "agent jumps to the latest and silently drops the gap.",
+        )
+        self.assertIsNone(marker)
+
+    def test_cursor_evicted_returns_marker_with_oldest_id(self):
+        """Cursor predates the retained window — marker names the
+        anchor + how many events have rolled off."""
+        stream = EventStream(maxlen=5)
+        # Emit 12 events; only the last 5 (e7..e11) stay retained.
+        for i in range(12):
+            stream.append(_ev(f"e{i}"))
+
+        events, marker = stream.get_since_with_eviction("e1", limit=100)
+        self.assertEqual(
+            [e["id"] for e in events],
+            ["e7", "e8", "e9", "e10", "e11"],
+        )
+        self.assertIsNotNone(marker)
+        assert marker is not None  # narrow for type checker
+        self.assertEqual(marker["oldest_id"], "e7")
+        # 12 emitted − 5 retained = 7 evicted.
+        self.assertEqual(marker["evicted_count_hint"], 7)
+
+    def test_empty_deque_with_evicted_cursor_has_none_oldest_id(self):
+        """Degenerate: harness cold-start with stale cursor → no anchor."""
+        stream = EventStream(maxlen=10)
+
+        events, marker = stream.get_since_with_eviction("stale", limit=100)
+        self.assertEqual(events, [])
+        self.assertIsNotNone(marker)
+        assert marker is not None
+        self.assertIsNone(marker["oldest_id"])
+        self.assertEqual(marker["evicted_count_hint"], 0)
+
+    def test_cursor_at_head_returns_empty_no_marker(self):
+        """Cursor IS the most recent event — empty, no marker."""
+        stream = EventStream(maxlen=10)
+        for i in range(3):
+            stream.append(_ev(f"e{i}"))
+
+        events, marker = stream.get_since_with_eviction("e2", limit=100)
+        self.assertEqual(events, [])
+        self.assertIsNone(marker)
+
+    def test_evicted_events_returned_oldest_first(self):
+        """When cursor is evicted, the returned slice MUST be oldest-first
+        — the agent skims through the gap rather than jumping to the
+        latest event and silently dropping the in-between."""
+        stream = EventStream(maxlen=20)
+        for i in range(20):
+            stream.append(_ev(f"e{i:02d}"))
+
+        events, marker = stream.get_since_with_eviction(
+            "evicted-stale", limit=5
+        )
+        self.assertEqual(
+            [e["id"] for e in events],
+            ["e00", "e01", "e02", "e03", "e04"],
+            msg="skim-then-advance: expected oldest 5 after eviction",
+        )
+        self.assertIsNotNone(marker)
+
+    def test_total_emitted_count_increments_on_append(self):
+        stream = EventStream(maxlen=3)
+        self.assertEqual(stream._total_emitted_count, 0)
+        for i in range(7):
+            stream.append(_ev(f"e{i}"))
+        self.assertEqual(stream._total_emitted_count, 7)
+        self.assertEqual(len(stream), 3)
+
+    def test_legacy_get_since_wrapper_drops_marker(self):
+        """Back-compat: ``get_since`` still returns only the list."""
+        stream = EventStream(maxlen=5)
+        for i in range(10):
+            stream.append(_ev(f"e{i}"))
+
+        events = stream.get_since("stale", limit=100)
+        self.assertEqual(
+            [e["id"] for e in events],
+            ["e5", "e6", "e7", "e8", "e9"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# event_poll.py — eviction warning + cursor advance
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(EVENT_POLL_AVAILABLE, "event_poll module not importable")
+class TestEventPollEvictionWarning(unittest.TestCase):
+    """``poll()`` must emit a single stderr warning when the response
+    carries ``evicted: true``, then process events normally."""
+
+    def setUp(self):
+        # Patch port discovery so poll() doesn't try to read a real
+        # .harness-port file (which may or may not exist in CI).
+        self._port_patch = mock.patch.object(_ep, "_discover_port",
+                                             return_value=4321)
+        self._port_patch.start()
+        self.addCleanup(self._port_patch.stop)
+
+        # Patch cursor read/write to in-memory state for determinism.
+        self._stored_cursor = ""
+
+        def _read_cursor(role, since_arg=None):
+            if since_arg is not None:
+                return str(since_arg)
+            return self._stored_cursor
+
+        def _write_cursor(role, value):
+            self._stored_cursor = str(value)
+            return True
+
+        self._read_patch = mock.patch.object(_ep, "_resolve_cursor",
+                                             side_effect=_read_cursor)
+        self._write_patch = mock.patch.object(_ep, "_write_cursor_atomic",
+                                              side_effect=_write_cursor)
+        self._read_patch.start()
+        self._write_patch.start()
+        self.addCleanup(self._read_patch.stop)
+        self.addCleanup(self._write_patch.stop)
+
+    def _run_poll_with_payload(self, payload: dict) -> tuple[str, str, list]:
+        """Drive poll() with a single fake harness response.
+
+        Returns (stdout, stderr, events_emitted) for assertions.
+        """
+        captured_stdout = io.StringIO()
+        captured_stderr = io.StringIO()
+        emitted = []
+
+        def fake_fetch(url, timeout):
+            return payload, False, None
+
+        with mock.patch.object(_ep, "_fetch_once", side_effect=fake_fetch), \
+             mock.patch("sys.stdout", captured_stdout), \
+             mock.patch("sys.stderr", captured_stderr):
+            result = _ep.poll("skill", since="stale-cursor", limit=10)
+            if result is not None:
+                emitted = list(result)
+        return captured_stdout.getvalue(), captured_stderr.getvalue(), emitted
+
+    def test_eviction_warning_emitted_to_stderr(self):
+        payload = {
+            "events": [
+                {"id": "e7", "event_type": "status-transition", "role": "skill"},
+                {"id": "e8", "event_type": "status-transition", "role": "skill"},
+            ],
+            "total": 2,
+            "evicted": True,
+            "oldest_id": "e7",
+            "evicted_count_hint": 42,
+        }
+        stdout, stderr, emitted = self._run_poll_with_payload(payload)
+
+        self.assertIn("EVICTION", stderr)
+        self.assertIn("e7", stderr, msg="warning must name oldest_id anchor")
+        self.assertIn("42", stderr, msg="warning must name hint")
+        # Exactly one warning per response.
+        self.assertEqual(stderr.count("EVICTION"), 1)
+
+        # Events still flow through stdout normally.
+        self.assertEqual([e["id"] for e in emitted], ["e7", "e8"])
+        # Cursor advanced past last event in the batch.
+        self.assertEqual(self._stored_cursor, "e8")
+
+    def test_no_warning_when_payload_lacks_evicted_flag(self):
+        """Normal response — no warning, no spurious noise on stderr."""
+        payload = {
+            "events": [
+                {"id": "a1", "event_type": "status-transition", "role": "skill"},
+            ],
+            "total": 1,
+        }
+        stdout, stderr, emitted = self._run_poll_with_payload(payload)
+
+        self.assertNotIn("EVICTION", stderr)
+        self.assertEqual([e["id"] for e in emitted], ["a1"])
+        self.assertEqual(self._stored_cursor, "a1")
+
+    def test_no_warning_when_evicted_explicitly_false(self):
+        """``evicted: false`` is treated the same as the field being
+        absent — no warning."""
+        payload = {
+            "events": [
+                {"id": "b1", "event_type": "status-transition", "role": "skill"},
+            ],
+            "total": 1,
+            "evicted": False,
+        }
+        stdout, stderr, emitted = self._run_poll_with_payload(payload)
+        self.assertNotIn("EVICTION", stderr)
+
+    def test_eviction_with_empty_events_still_warns(self):
+        """Harness deque empty + stale cursor → warn but no cursor
+        advance (no anchor available). Operator can see the harness
+        is degraded; the warning repeats on subsequent polls until
+        events start flowing again."""
+        payload = {
+            "events": [],
+            "total": 0,
+            "evicted": True,
+            "oldest_id": None,
+            "evicted_count_hint": 0,
+        }
+        stdout, stderr, emitted = self._run_poll_with_payload(payload)
+        self.assertIn("EVICTION", stderr)
+        self.assertEqual(emitted, [])
+        # Cursor unchanged — nothing to advance to.
+        self.assertEqual(self._stored_cursor, "")
+
+    def test_eviction_re_anchors_when_role_filter_drops_all_events(self):
+        """`/events/for/{role}` can return ``evicted: true`` with an
+        empty events list when the role filter strips every event in
+        the batch — even though the deque is non-empty and
+        ``oldest_id`` is set. Without re-anchoring, the cursor stays
+        on the stale id and the warning loops forever. The fix:
+        advance the cursor to ``oldest_id`` up front whenever the
+        eviction signal is present and an anchor is available, so
+        forward progress is guaranteed regardless of whether the
+        filter kept any events."""
+        payload = {
+            "events": [],
+            "total": 0,
+            "evicted": True,
+            "oldest_id": "anchor-id",
+            "evicted_count_hint": 17,
+        }
+        stdout, stderr, emitted = self._run_poll_with_payload(payload)
+        self.assertIn("EVICTION", stderr)
+        self.assertEqual(emitted, [])
+        # Cursor re-anchored to oldest_id even though no events flowed.
+        self.assertEqual(
+            self._stored_cursor, "anchor-id",
+            msg="cursor must advance to oldest_id when role filter "
+                "drops every event — otherwise the agent loops on the "
+                "same stale cursor and the warning never clears.",
+        )
+
+    def test_eviction_re_anchor_then_events_advance_cursor_further(self):
+        """When events DO survive the role filter, the up-front
+        re-anchor to ``oldest_id`` is followed by normal per-event
+        cursor advance. Final cursor = last event id, not
+        ``oldest_id``."""
+        payload = {
+            "events": [
+                {"id": "later-1", "event_type": "status-transition", "role": "skill"},
+                {"id": "later-2", "event_type": "status-transition", "role": "skill"},
+            ],
+            "total": 2,
+            "evicted": True,
+            "oldest_id": "anchor-id",
+            "evicted_count_hint": 9,
+        }
+        stdout, stderr, emitted = self._run_poll_with_payload(payload)
+        self.assertEqual([e["id"] for e in emitted], ["later-1", "later-2"])
+        self.assertEqual(self._stored_cursor, "later-2")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #9331

### Summary
Closes the gap CONTEXT-8694 §2 and `cursor-management.md` spec but the shipped code never implemented: when an agent's cursor predates the harness's retained event window, the agent must log a warning naming the safe re-anchor and a coarse hint at how many events have rolled off, then advance past the gap. Prior behavior: agent silently advanced past the eviction.

**Unblocks #8999 §4.4 IT-EvictionGap** (deferred there pending this infrastructure).

### Acceptance
- [x] `get_since` payload carries the eviction marker (`evicted` / `oldest_id` / `evicted_count_hint`) when cursor is not in the deque; unchanged when cursor IS in deque.
- [x] `event_poll.py` detects `evicted: true` and emits the warning to stderr exactly once per detection.
- [x] Unit tests cover both the harness shape change and event_poll.py's detection path.
- [x] After this lands, #8999 §4.4 IT-EvictionGap is unblocked.

### Changes
- **harness.py — EventStream**: `_total_emitted_count` lifetime counter; new `get_since_with_eviction(since_id, limit) -> (events, marker_or_None)`. Marker carries `oldest_id` (safe re-anchor) and `evicted_count_hint` (coarse upper bound on lifetime evictions). Legacy `get_since` becomes a single-return-value wrapper with explicit oldest-first-when-cursor-set docstring.
- **harness.py — endpoints**: `GET /events` and `GET /events/for/{role}` surface `evicted`/`oldest_id`/`evicted_count_hint` keys when the marker is present. Endpoints also flipped post-filter slicing to `[:limit]` when `since` is set (skim-then-advance contract) — same change PR #9320 ships; trivial conflict resolution at merge time.
- **event_poll.py**: `_fetch_once` returns the parsed payload dict; `poll()` detects `evicted:true`, emits one stderr warning per response, re-anchors cursor to `oldest_id` BEFORE per-event advance. Re-anchor-up-front fixes a Bug-1 deepseek caught: `/events/for/{role}` role filter can strip every event in the batch even when the deque is non-empty, leaving the cursor stuck on the stale id and the warning looping every poll.
- **tests/test_eviction_signal.py**: 15 new tests across two classes (`TestGetSinceWithEvictionMarker`, `TestEventPollEvictionWarning`).

### Out of scope
- In-stream gap detection — covered separately by #9265 (architectural decision: monotonic vs hex ids).
- CONTEXT-8694 §2 — eviction-gap design is correct; this task just lands the missing implementation.
- `EventLifecycleManager.load()` unguarded `_loaded` flag — filed separately as #9357 (deepseek R1 finding, out of #9331 scope).

### QA Status
- [x] `python -m pytest tests/test_eviction_signal.py -v` — 15/15 pass.
- [x] `python tests/run_tests.py` (full suite) — passes, no regressions.
- [x] Self-review: regression / integration / philosophy / personas checks clean.
- [x] External code review (deepseek-v4-pro, 2 rounds): R1 = 3 findings (1 docstring clarity, 1 test gap, 1 out-of-scope race filed as #9357). R2 = NO_FINDINGS.

### Setup/Upgrade Sync Check
- [x] New config values: N/A
- [x] New files/directories: N/A
- [x] Modified template structure: N/A
- [x] Added/removed sub-skills: N/A
- [x] Changed role composition: N/A
