### PR TITLE
skill: #9318 — drop stale 'qa' from Dev Agents (+ fix downstream silent breakage)

### DIFF
--- a/.squidsquad/config.md
+++ b/.squidsquad/config.md
@@ -6,7 +6,7 @@
 
 ## Agents
 
-- **Dev Agents**: qa, skill
+- **Dev Agents**: skill
 - **PM**: always present
 - **QA**: always present
 - **DM**: present

--- a/.squidsquad/dm/CLAUDE.md
+++ b/.squidsquad/dm/CLAUDE.md
@@ -182,7 +182,7 @@ Read `.squidsquad/dm/SOUL.md` at session start and follow its instructions as yo
 
 You are the Delivery Manager on the SquidSquad autonomous dev team. You own the "last mile" of shipping — when a feature reaches `Pending Ship` status, you take over to create a delivery package of all user-facing materials before marking the feature `Shipped`. You operate continuously — your wake mechanism (polling-loop or event-driven) is documented in the sections that follow.
 
-The active dev agents on this project are: **qa, skill** (read from `.squidsquad/config.md`).
+The active dev agents on this project are: **skill** (read from `.squidsquad/config.md`).
 
 ---
 

--- a/.squidsquad/pm/CLAUDE.md
+++ b/.squidsquad/pm/CLAUDE.md
@@ -182,7 +182,7 @@ Read `.squidsquad/pm/SOUL.md` at session start and follow its instructions as yo
 
 You are the PM on the SquidSquad autonomous dev team. You are the bridge between the human and the dev agents. You approve features, manage task intake, check in with the human each cycle, and coordinate all agents. QA handles verification independently. DM handles delivery. You operate continuously — your wake mechanism (polling-loop or event-driven) is documented in the sections that follow.
 
-The active dev agents on this project are: **qa, skill** (read from `.squidsquad/config.md`).
+The active dev agents on this project are: **skill** (read from `.squidsquad/config.md`).
 
 ---
 

--- a/.squidsquad/qa/CLAUDE.md
+++ b/.squidsquad/qa/CLAUDE.md
@@ -182,7 +182,7 @@ Read `.squidsquad/qa/SOUL.md` at session start and follow its instructions as yo
 
 You are the QA agent on the SquidSquad autonomous dev team. You independently verify work from ALL dev and designer agents — running tests, checking acceptance criteria, verifying bug fixes, and filing bugs for failures. You hand verified work to DM for delivery. You operate continuously — your wake mechanism (polling-loop or event-driven) is documented in the sections that follow.
 
-The active dev agents on this project are: **qa, skill** (read from `.squidsquad/config.md`).
+The active dev agents on this project are: **skill** (read from `.squidsquad/config.md`).
 
 ---
 

--- a/.squidsquad/skill/planning/CODE-REVIEW-9318-R2.md
+++ b/.squidsquad/skill/planning/CODE-REVIEW-9318-R2.md
@@ -1,0 +1,17 @@
+### Finding 1
+
+- **File**: tests/test_cycle_pre.py
+- **Line**: 820–823 (assertion block of `test_qa_queries_all_roles`)
+- **Severity**: warning
+- **Issue**: `test_qa_queries_all_roles` does not assert that `"qa"` is in `queried_roles`, even though #9318 added `qa` to `_get_verifiable_roles()`. The test name promises "all roles" but only validates `dm` and `pm`. If `roles.add("qa")` were later removed, `test_always_includes_mandatory_roles` would catch the unit-level regression, but this integration test would silently pass despite QA no longer querying itself for pending-test items.
+- **Evidence**: The mock `_config_get` sets `"dev-agents": "skill"` (line 792). Post-#9318, `_get_verifiable_roles()` returns `["dm", "pm", "qa", "skill"]`. The `fake_run_script` records every queried role in `queried_roles` (lines 804, 809), so `"qa"` is present in that list at runtime — but the test only asserts `"dm" in queried_roles` and `"pm" in queried_roles` (lines 821–822), never `"qa"`.
+- **Suggested fix**: Add `assert "qa" in queried_roles, "QA input must query qa role for pending-test items"` alongside the existing dm/pm assertions.
+
+### Finding 2
+
+- **File**: tests/test_cycle_pre.py
+- **Line**: 868–870 (assertion block of `test_pm_queries_all_roles`)
+- **Severity**: warning
+- **Issue**: Same gap in `TestPMInputMultiRole.test_pm_queries_all_roles` — the test records all queried roles but only asserts `"dm" in queried_roles`, never `"qa"`. Post-#9318, PM should also query `qa` for pending-test items.
+- **Evidence**: The mock `_config_get` sets `"dev-agents": "skill"` (line 851). `fake_run_script` appends every role argument to `queried_roles` (lines 842, 845). Only `"dm"` is asserted (line 869); `"qa"` is not checked.
+- **Suggested fix**: Add `assert "qa" in queried_roles, "PM input must query qa role for pending-test items"` alongside the existing dm assertion.

--- a/.squidsquad/skill/planning/CODE-REVIEW-9318-R3.md
+++ b/.squidsquad/skill/planning/CODE-REVIEW-9318-R3.md
@@ -1,0 +1,22 @@
+All tests have been systematically checked. Here's the complete analysis:
+
+---
+
+**Tests that assert specific roles in verifiable/queried contexts:**
+
+| Test | qa assertion present? |
+|---|---|
+| `TestGetVerifiableRoles.test_includes_config_dev_agents` (line 832) | ✅ `assert "qa" in roles` (line 837) |
+| `TestGetVerifiableRoles.test_always_includes_mandatory_roles` (line 839) | ✅ `assert "qa" in roles` (line 851) |
+| `TestGetVerifiableRoles.test_fallback_when_config_empty` (line 853) | ✅ `assert "qa" in roles` (line 861) |
+| `TestGetVerifiableRoles.test_deduplicates` (line 863) | N/A — only checks dedup, not specific roles |
+| `TestGetVerifiableRoles.test_returns_sorted` (line 869) | N/A — only checks sort order, not specific roles |
+| `TestQAInputMultiRole.test_qa_queries_all_roles` (line 879) | ✅ `assert "qa" in queried_roles` (line 923) |
+| `TestQAInputMultiRole.test_qa_items_have_source_role` (line 929) | N/A — asserts `source_role` field on dm items only |
+| `TestQAInputMultiRole.test_qa_branch_uses_correct_role_prefix` (line 961) | N/A — asserts branch naming for qa items (the test itself exercises qa) |
+| `TestPMInputMultiRole.test_pm_queries_all_roles` (line 1003) | ✅ `assert "qa" in queried_roles` (line 1042) |
+| `TestPMInputMultiRole.test_pm_items_have_source_role` (line 1045) | N/A — asserts `source_role` field on dm items only |
+
+Every test that asserts specific verifiable/queried roles already includes a `qa` check. The two tests identified in R2 (`test_qa_queries_all_roles` and `test_pm_queries_all_roles`) have been correctly fixed (lines 923 and 1042 respectively).
+
+NO_FINDINGS

--- a/.squidsquad/skill/planning/CODE-REVIEW-9318.md
+++ b/.squidsquad/skill/planning/CODE-REVIEW-9318.md
@@ -1,0 +1,45 @@
+Now I have a complete picture. Let me produce the final analysis.
+
+---
+
+### Finding 1
+
+- **File**: `references/scripts/cycle_pre.py`
+- **Line**: 506–526
+- **Severity**: warning
+- **Issue**: `_get_verifiable_roles()` explicitly adds `dm` and `pm` (lines 524–525) but does NOT add `qa`. After #6055, `qa` is a mandatory role alongside `pm` and `dm` (per `MANDATORY_ROLES` at `compose.py:1202`). Before this config change, `qa` was listed in `Dev Agents` (`qa, skill`), so the function picked it up from config. Now that `qa` has been removed from `Dev Agents` (config.md), this function returns `["dm", "pm", "skill"]` — missing `qa`. Both `_build_qa_input` (line 649) and `_build_pm_input` (line 826) iterate over this set when querying `tracker.py list-issues` / `list-tasks` for `pending-test` items, so PM will no longer query QA's pending-test items.
+
+- **Evidence**: Compare with every other function that reads dev-agents and adds mandatory roles:
+  - `compose.py:_collect_all_roles()` (line 1210): appends `"pm"`, `"qa"`, `"dm"` 
+  - `boot_remote.py:_get_all_roles()` (line 128): `roles.update({"pm", "qa", "dm"})`
+  - `add_role.py:_get_configured_agents()` (line 63): iterates `("pm", "qa", "dm")`
+  - `config.py:_parse_agents_v1()` (line 407): iterates `("qa", "dm")` + explicit `"pm"` at line 381
+  Only `cycle_pre.py:_get_verifiable_roles()` omits `qa` while including `dm` and `pm`.
+
+- **Suggested fix**: Add `roles.add("qa")` alongside the existing `roles.add("dm")` / `roles.add("pm")` calls at lines 524–525. Also update the docstring example (line 509) from `'designer, qa, skill'` to `'designer, skill'` to match the post-#6055 semantics.
+
+---
+
+### Finding 2
+
+- **File**: `references/scripts/cycle_pre.py`
+- **Line**: 509 (docstring)
+- **Severity**: warning
+- **Issue**: Stale docstring example in `_get_verifiable_roles()`. The docstring reads `(e.g. 'designer, qa, skill')` — listing `qa` as a dev agent. After #6055, qa is mandatory and should not appear as an example of a dev agent.
+
+- **Evidence**: The config.md now has `Dev Agents: skill` only. QA is listed under "always present" in the Agents section. The example is misleading for anyone reading the code in the post-#6055 era.
+
+- **Suggested fix**: Change the docstring to remove `qa` from the example, e.g., `(e.g. 'designer, skill')`.
+
+---
+
+### Finding 3
+
+- **File**: `tests/test_cycle_pre.py`
+- **Line**: 832–837
+- **Severity**: warning
+- **Issue**: `TestGetVerifiableRoles.test_includes_config_dev_agents` mocks `dev-agents` as `"skill, qa"`. There's a corresponding test `test_always_includes_dm_and_pm` (line 839–844) that verifies `dm` and `pm` are always included **regardless of config**. No equivalent test exists for `qa`. After the config change, if qa is removed from dev-agents, there's no test asserting that qa is still included in verifiable roles.
+
+- **Evidence**: The test at line 839 asserts `dm` and `pm` are always present. The test at line 832 only verifies qa is present *when it is in dev-agents*. The post-#6055 invariant — that mandatory roles (pm, qa, dm) are always in verifiable roles — is not fully covered.
+
+- **Suggested fix**: Add a test (or extend `test_always_includes_dm_and_pm`) to also assert `"qa" in roles`, mirroring the dm/pm check, once `_get_verifiable_roles()` is fixed to add qa explicitly.

--- a/references/scripts/cycle_pre.py
+++ b/references/scripts/cycle_pre.py
@@ -506,9 +506,15 @@ def _read_config_flags():
 def _get_verifiable_roles():
     """Return all roles whose items QA/PM should verify (pending-test).
 
-    Reads dev-agents from config (e.g. 'designer, qa, skill') and adds
-    dm and pm — any role can potentially have pending-test items.
-    Deduplicates and returns a sorted list.
+    Reads dev-agents from config (e.g. 'designer, skill') and adds the
+    mandatory roles (pm, qa, dm) — any role can potentially have
+    pending-test items. Deduplicates and returns a sorted list.
+
+    Note (#9318): qa was previously sourced from dev-agents because the
+    pre-#6055 config listed it there. Post-#6055 qa is mandatory and
+    config.md only carries dev-style optional add-ons, so we add qa
+    explicitly here alongside dm and pm — same pattern every other
+    role-collector uses (compose._collect_all_roles, boot_remote._get_all_roles).
     """
     roles = set()
     raw = _config_get("dev-agents")
@@ -520,9 +526,12 @@ def _get_verifiable_roles():
     else:
         # Fallback: if config returned nothing, at least include skill
         roles.add("skill")
-    # Always include dm and pm — they can have pending-test items too
+    # Always include the mandatory roles (pm, qa, dm) — any of them can
+    # have pending-test items. qa added explicitly per #9318 after
+    # config.md stopped listing it in dev-agents.
     roles.add("dm")
     roles.add("pm")
+    roles.add("qa")
     return sorted(roles)
 
 

--- a/tests/test_cycle_pre.py
+++ b/tests/test_cycle_pre.py
@@ -836,21 +836,29 @@ class TestGetVerifiableRoles:
         assert "skill" in roles
         assert "qa" in roles
 
-    def test_always_includes_dm_and_pm(self, monkeypatch):
-        """dm and pm are always included regardless of config."""
+    def test_always_includes_mandatory_roles(self, monkeypatch):
+        """pm, qa, dm are always included regardless of config (#9318).
+
+        Post-#6055 these are mandatory roles. qa was previously sourced
+        from dev-agents — when config.md stopped listing it there
+        (#9318), the test below catches the regression where qa would
+        silently drop out of PM's verifiable-role queries.
+        """
         monkeypatch.setattr(cycle_pre, "_config_get", lambda f: "skill" if f == "dev-agents" else "")
         roles = cycle_pre._get_verifiable_roles()
         assert "dm" in roles
         assert "pm" in roles
+        assert "qa" in roles
 
     def test_fallback_when_config_empty(self, monkeypatch):
         """If config returns empty, at least skill is present."""
         monkeypatch.setattr(cycle_pre, "_config_get", lambda f: "")
         roles = cycle_pre._get_verifiable_roles()
         assert "skill" in roles
-        # dm and pm always added
+        # mandatory roles always added (pm, qa, dm — #9318)
         assert "dm" in roles
         assert "pm" in roles
+        assert "qa" in roles
 
     def test_deduplicates(self, monkeypatch):
         """Roles are not duplicated even if they appear in config and hardcoded."""
@@ -910,6 +918,9 @@ class TestQAInputMultiRole:
         # Verify dm was queried (the core bug fix)
         assert "dm" in queried_roles, "QA input must query dm role for pending-test items"
         assert "pm" in queried_roles, "QA input must query pm role for pending-test items"
+        # #9318: qa is a mandatory role and must also be queried — otherwise
+        # QA wouldn't verify its own pending-test items.
+        assert "qa" in queried_roles, "QA input must query qa role for pending-test items"
         # Verify dm items appear in verification queue
         numbers = [i["number"] for i in result["verification_queue"]["pending_test_issues"]]
         assert 3969 in numbers, "DM pending-test issue must appear in QA verification queue"
@@ -1026,6 +1037,9 @@ class TestPMInputMultiRole:
 
         result = cycle_pre._build_pm_input("pm")
         assert "dm" in queried_roles, "PM input must query dm role for pending-test items"
+        # #9318: qa is a mandatory role and must also be queried — otherwise
+        # PM wouldn't see QA's pending-test items.
+        assert "qa" in queried_roles, "PM input must query qa role for pending-test items"
         assert 3969 in [i["number"] for i in result["tracker"]["pending_test_issues"]]
 
     def test_pm_items_have_source_role(self, patch_dirs, squid_dir, monkeypatch):


### PR DESCRIPTION
Closes #9318

### Summary
Drop the stale `qa` from `config.md` Dev Agents (post-#6055 semantic: optional dev roles only) AND fix a latent bug deepseek R1 caught — `cycle_pre._get_verifiable_roles()` was silently relying on `qa` being in `dev-agents` to include it; removing `qa` would have silently broken PM/QA's verifiable-role queries.

### Acceptance
- [x] `config.md` Dev Agents value reflects optional dev-style roles only (no pm/qa/dm).
- [x] Composed L1 line 185 across pm/qa/dm CLAUDE.md reads `active dev agents: skill`.
- [x] No regression in `compose.py` or tracker label generation.
- [x] **New**: `cycle_pre._get_verifiable_roles()` adds `qa` explicitly (defense against the silent breakage path).

### Changes
- **`.squidsquad/config.md`**: `Dev Agents: qa, skill` → `Dev Agents: skill`.
- **`.squidsquad/{pm,qa,dm}/CLAUDE.md`**: recomposed via `compose.py deploy-all`. Skill template doesn't reference this line.
- **`references/scripts/cycle_pre.py::_get_verifiable_roles`**: explicitly adds `qa` alongside existing `dm`/`pm`. Every other role-collector already did this (`compose._collect_all_roles`, `boot_remote._get_all_roles`); cycle_pre was the only exception, relying on `qa ∈ dev-agents`. Docstring updated to drop `qa` from the example and document the #9318 rationale.
- **`tests/test_cycle_pre.py`**:
  - `test_always_includes_dm_and_pm` → `test_always_includes_mandatory_roles`, extended to assert `qa in roles`.
  - `test_fallback_when_config_empty` extended to assert `qa`.
  - `test_qa_queries_all_roles` + `test_pm_queries_all_roles` (the #4803 integration tests): added `assert "qa" in queried_roles` so the qa regression can't slip through silently.

### Out of scope
- Skill CLAUDE.md doesn't reference the "active dev agents" line at all (different template) — no edit needed.
- No tooling test asserts `qa` is in `dev-agents`; the references in `test_boot_remote.py` and `test_cycle_pre.py` are mock-setup, not invariants.

### QA Status
- [x] `python tests/run_tests.py` — passes with no regressions.
- [x] `python -m pytest tests/test_cycle_pre.py` — 107 tests pass.
- [x] Self-review clean.
- [x] External code review (deepseek-v4-pro, **3 rounds**):
  - R1 = 3 real findings: (1) cycle_pre silently drops qa, (2) stale docstring, (3) missing test coverage. All fixed.
  - R2 = 2 integration-test coverage gaps in `test_qa_queries_all_roles` and `test_pm_queries_all_roles`. Both fixed.
  - R3 = **NO_FINDINGS** after full audit of every test asserting verifiable/queried roles.

### Setup/Upgrade Sync Check
- [x] New config values: N/A (changing an existing value)
- [x] New files/directories: 3 review artifacts under skill/planning (test-only)
- [x] Modified template structure: N/A (compose output regenerated to match source)
- [x] Added/removed sub-skills: N/A
- [x] Changed role composition: N/A
