### PR TITLE
skill: #9272 — permit PM-driven boot on harness failure / stall recovery

### DIFF
--- a/.squidsquad/dm/CLAUDE.md
+++ b/.squidsquad/dm/CLAUDE.md
@@ -722,7 +722,7 @@ At the end of a **normal** cycle (no exit-42 imminent), write `idle|` to `curren
 <!-- sub-skill: agent-lifecycle -->
 ### Agent Lifecycle
 
-Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly.
+Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly during normal operation. **Stall-recovery exception (#9272)**: PM may invoke `python references/scripts/boot_remote.py --role <name>` directly to spawn a stalled agent when the harness is unreachable (#9242) or when an agent stays dead despite auto-boot — see the `boot-remote-agents` sub-skill for the full policy. No other role boots agents directly.
 
 **Three guarantees**:
 1. **Singleton**: Only one instance per role runs at a time (harness process table).

--- a/.squidsquad/pm/CLAUDE.md
+++ b/.squidsquad/pm/CLAUDE.md
@@ -567,6 +567,7 @@ For each `in-progress` item, extract the `role:*` label. Cross-reference with ag
 python references/scripts/health_check.py --json
 ```
 Parse the JSON output. If the assigned agent's health is `stalled`, `stopped`, or `unknown`:
+- **Tier 0** (#9272 — try recovery first): if auto-boot in `cycle_pre.py` did not recover the agent, attempt manual stall recovery via `python references/scripts/boot_remote.py --role <name>` (see `boot-remote-agents` sub-skill). Only if the boot fails OR the agent remains unhealthy on the next health check, proceed to Tier 1. Skip this tier if the agent's intent is `stopping` or `stopped` (genuinely shut down on operator request, not a stall).
 - **Tier 1**: Transition the task back to `approved` so another agent (or the same agent after restart) can pick it up:
   ```bash
   python references/scripts/tracker.py transition [NUMBER] in-progress approved --role pm-lead
@@ -618,7 +619,7 @@ Log the script's output in `pm/qa-log.md`. For any agent reporting stalled (👻
 1. Append a Discussion note to that agent's latest open tracker item.
 2. If no open item exists, log in `qa-log.md` only.
 
-**Context pressure monitoring**: Check each agent's context pressure file. If any agent exceeds threshold, report to the human with the agent role and pressure percentage. **PM does not execute reboots directly** — agent lifecycle is managed by the harness; operators use `squidsquad_cli.py` (or the backward-compatible `start_team.py` shim) (#4966).
+**Context pressure monitoring**: Check each agent's context pressure file. If any agent exceeds threshold, report to the human with the agent role and pressure percentage. **PM does not execute reboots for healthy agents** — graceful restart belongs to the harness via `squidsquad_cli.py` (or the backward-compatible `start_team.py` shim) (#4966). **On stall (harness down per #9242, or a specific agent stays dead despite auto-boot), PM may invoke `python references/scripts/boot_remote.py --role <name>` directly** — see the `boot-remote-agents` sub-skill for the full stall-recovery policy.
 
 For programmatic use, the script accepts `--json` for structured output.
 <!-- /sub-skill: health-check -->
@@ -667,7 +668,7 @@ If any agents were spawned, print: `[🦑 HH:MM:SS] Booted: [role1, role2, ...]`
 
 If all agents alive or stopped, print nothing — silent pass.
 
-**PM does not boot agents directly.** Agent lifecycle is managed by the harness (`harness.py`) and `start_team.py` (#4966). If PM detects a stalled or dead agent, report to the human — do not attempt to spawn or restart agents.
+**Manual boot is permitted on stall.** Routine agent lifecycle (start/stop on demand, restart on healthy cycles) belongs to the harness (`harness.py`) and `start_team.py` (#4966) — and the auto-boot path in `cycle_pre.py` runs before every PM cycle. When auto-boot is unavailable (harness down — see #9242) or insufficient (a specific agent stayed dead), PM may invoke `python references/scripts/boot_remote.py --role <name>` directly to spawn the stalled agent. Use `--all` only on explicit human request. Manual PM intervention is reserved for stall recovery — do NOT pre-emptively boot healthy agents (#9272, memory rule `feedback_manual_agents`).
 <!-- /sub-skill: boot-remote-agents -->
 
 <!-- sub-skill: soul-shepherd -->
@@ -1062,7 +1063,7 @@ At the end of a **normal** cycle (no exit-42 imminent), write `idle|` to `curren
 <!-- sub-skill: agent-lifecycle -->
 ### Agent Lifecycle
 
-Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly.
+Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly during normal operation. **Stall-recovery exception (#9272)**: PM may invoke `python references/scripts/boot_remote.py --role <name>` directly to spawn a stalled agent when the harness is unreachable (#9242) or when an agent stays dead despite auto-boot — see the `boot-remote-agents` sub-skill for the full policy. No other role boots agents directly.
 
 **Three guarantees**:
 1. **Singleton**: Only one instance per role runs at a time (harness process table).
@@ -1724,7 +1725,7 @@ These instructions apply to the PM agent on this project.
 - **NEVER modify dev agent branches.** If a PR has merge conflicts, comment on the issue telling the dev agent to merge main and re-push. The dev agent owns their branch — conflict resolution is their responsibility, not PM's.
 - **QA handles all verification**: PM holds QA accountable but never verifies directly.
 - **Post-merge recompose**: when merged branches touch `references/`, run `compose.py deploy-all`.
-- **Agent lifecycle via `start_team.py`** — PM does not boot agents directly. Report stalled agents to human.
+- **Agent lifecycle via `start_team.py`** — routine start/stop/restart belongs to the harness + `cycle_pre.py` auto-boot. On stall (auto-boot unavailable or specific agent stays dead), PM may invoke `python references/scripts/boot_remote.py --role <name>` directly per #9272 + memory rule `feedback_manual_agents`; otherwise leave lifecycle to the harness.
 
 ### Task Lifecycle
 

--- a/.squidsquad/project/pm-instructions.md
+++ b/.squidsquad/project/pm-instructions.md
@@ -18,7 +18,7 @@ These instructions apply to the PM agent on this project.
 - **NEVER modify dev agent branches.** If a PR has merge conflicts, comment on the issue telling the dev agent to merge main and re-push. The dev agent owns their branch — conflict resolution is their responsibility, not PM's.
 - **QA handles all verification**: PM holds QA accountable but never verifies directly.
 - **Post-merge recompose**: when merged branches touch `references/`, run `compose.py deploy-all`.
-- **Agent lifecycle via `start_team.py`** — PM does not boot agents directly. Report stalled agents to human.
+- **Agent lifecycle via `start_team.py`** — routine start/stop/restart belongs to the harness + `cycle_pre.py` auto-boot. On stall (auto-boot unavailable or specific agent stays dead), PM may invoke `python references/scripts/boot_remote.py --role <name>` directly per #9272 + memory rule `feedback_manual_agents`; otherwise leave lifecycle to the harness.
 
 ### Task Lifecycle
 

--- a/.squidsquad/qa/CLAUDE.md
+++ b/.squidsquad/qa/CLAUDE.md
@@ -857,7 +857,7 @@ At the end of a **normal** cycle (no exit-42 imminent), write `idle|` to `curren
 <!-- sub-skill: agent-lifecycle -->
 ### Agent Lifecycle
 
-Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly.
+Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly during normal operation. **Stall-recovery exception (#9272)**: PM may invoke `python references/scripts/boot_remote.py --role <name>` directly to spawn a stalled agent when the harness is unreachable (#9242) or when an agent stays dead despite auto-boot — see the `boot-remote-agents` sub-skill for the full policy. No other role boots agents directly.
 
 **Three guarantees**:
 1. **Singleton**: Only one instance per role runs at a time (harness process table).

--- a/.squidsquad/skill/CLAUDE.md
+++ b/.squidsquad/skill/CLAUDE.md
@@ -968,7 +968,7 @@ At the end of a **normal** cycle (no exit-42 imminent), write `idle|` to `curren
 <!-- sub-skill: agent-lifecycle -->
 ### Agent Lifecycle
 
-Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly.
+Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly during normal operation. **Stall-recovery exception (#9272)**: PM may invoke `python references/scripts/boot_remote.py --role <name>` directly to spawn a stalled agent when the harness is unreachable (#9242) or when an agent stays dead despite auto-boot — see the `boot-remote-agents` sub-skill for the full policy. No other role boots agents directly.
 
 **Three guarantees**:
 1. **Singleton**: Only one instance per role runs at a time (harness process table).

--- a/.squidsquad/skill/planning/CODE-REVIEW-9272-R2.md
+++ b/.squidsquad/skill/planning/CODE-REVIEW-9272-R2.md
@@ -1,0 +1,18 @@
+After thorough review of all six changed files, I traced the #9272 stall-recovery policy through every sub-skill and composed output.
+
+## Analysis Summary
+
+**R1 findings correctly addressed:**
+1. `agent-lifecycle.md` now carves out the #9272 exception with "during normal operation" qualifier + explicit PM boot permission (line ~5)
+2. `health-check.md` now qualifies "PM does not execute reboots **for healthy agents**" and adds the stall-recovery clause referencing boot-remote-agents (line ~18)
+3. `pipeline-sentinel.md` 4f now has Tier 0 — try manual boot before re-queuing (line ~132)
+
+**Cross-file consistency verified:**
+- All four policy files consistently state: harness manages routine lifecycle; PM may boot only on stall (harness down #9242, or agent stays dead despite auto-boot); never pre-emptively boot healthy agents (#9272, `feedback_manual_agents`)
+- `pm-instructions.md` and composed `CLAUDE.md` both embed the same stall-recovery permission with identical wording
+- All cross-references point to `boot-remote-agents` sub-skill as the authoritative source — no orphaned or circular references
+- Pipeline-sentinel 4f Tier 0 skip condition (`stopping`/`stopped` intent) correctly prevents booting intentionally shut-down agents
+
+**Minor variance noted but not a conflict:** `boot-remote-agents.md` and `pm-instructions.md` reference `start_team.py` without mentioning `squidsquad_cli.py` as canonical (as `agent-lifecycle.md` does). Both tools work — `start_team.py` is the documented backward-compatible shim — and PM is instructed to leave lifecycle to the harness anyway. No incorrect behavior can result.
+
+NO_FINDINGS

--- a/.squidsquad/skill/planning/CODE-REVIEW-9272.md
+++ b/.squidsquad/skill/planning/CODE-REVIEW-9272.md
@@ -1,0 +1,57 @@
+# Review of #9272 — PM boot-remote policy changes
+
+I've reviewed all 5 provided files (1 source sub-skill, 1 L4 project instruction, 1 composed CLAUDE.md, 2 comprehension fixtures). The new `boot-remote-agents` text is consistent across all 5 files. However, there are **genuine contradictions** with other sub-skills in the same composed output.
+
+---
+
+### Finding 1
+
+- **File**: `.squidsquad/pm/CLAUDE.md` (and both `tests/comprehension/8697_fixtures/pm_*_CLAUDE.md`)
+- **Line**: `health-check` sub-skill
+- **Severity**: error
+- **Issue**: The `health-check` sub-skill states: **"PM does not execute reboots directly — agent lifecycle is managed by the harness"**. The new `boot-remote-agents` text says: **"PM may invoke `python references/scripts/boot_remote.py --role <name>` directly to spawn the stalled agent."** These directly contradict each other within the same composed file. While "reboots" and "boots" are technically distinct operations, the `health-check` text broadly asserts "agent lifecycle is managed by the harness" with no carve-out — and an LLM agent reading both cannot determine which instruction takes precedence.
+- **Evidence**: The `health-check` sub-skill (appearing in all 3 CLAUDE.md files) declares PM has zero direct lifecycle authority. The `boot-remote-agents` sub-skill (also in all 3 files) now grants PM explicit authority to invoke `boot_remote.py` directly on stall. A fresh agent given only these files would see a flat contradiction.
+- **Suggested fix**: Add a sentence to the `health-check` sub-skill acknowledging the stall-recovery exception: *"On stall (harness down per #9242, or a specific agent stays dead despite auto-boot), PM may invoke `boot_remote.py --role <name>` directly — see `boot-remote-agents` sub-skill for the full policy."* Alternatively, remove the absolute "PM does not execute reboots directly" and replace with a cross-reference to the `boot-remote-agents` sub-skill.
+
+---
+
+### Finding 2
+
+- **File**: `.squidsquad/pm/CLAUDE.md` (and both `tests/comprehension/8697_fixtures/pm_*_CLAUDE.md`)
+- **Line**: `agent-lifecycle` sub-skill
+- **Severity**: error
+- **Issue**: The `agent-lifecycle` sub-skill states: **"Agents do not manage their own or other agents' processes directly."** This is a shared fragment (applies to all roles) and is unqualified — no exceptions, no carve-outs. The new `boot-remote-agents` text explicitly gives PM authority to manage other agents' processes via `boot_remote.py`. This is a direct contradiction between a shared rule and a role-specific permission.
+- **Evidence**: `agent-lifecycle` sub-skill, first paragraph: *"Agent lifecycle is managed by the harness (harness.py) via REST API (#4966). Agents do not manage their own or other agents' processes directly."* Compare with `boot-remote-agents`: *"PM may invoke `python references/scripts/boot_remote.py --role <name>` directly to spawn the stalled agent."* Invoking a script to spawn another agent is, by definition, managing another agent's process directly.
+- **Suggested fix**: Either (a) qualify the `agent-lifecycle` blanket rule with a PM exception: *"Agents do not manage their own or other agents' processes directly — except PM may boot stalled agents via `boot_remote.py` on stall (see `boot-remote-agents` sub-skill)."* Or (b) move the stall-boot authority into the `agent-lifecycle` sub-skill as an explicit carve-out so there's a single source of truth.
+
+---
+
+### Finding 3
+
+- **File**: `.squidsquad/pm/CLAUDE.md` (and both `tests/comprehension/8697_fixtures/pm_*_CLAUDE.md`)
+- **Line**: `pipeline-sentinel` sub-skill, section 4f ("In-progress on dead agent")
+- **Severity**: warning
+- **Issue**: Pipeline sentinel 4f detects in-progress tasks on dead/stalled agents and immediately transitions the task back to `approved`. With the new boot-remote permission, this is a missed coordination opportunity. When PM detects a dead agent with in-progress work, the logical sequence should be: **(1) try to boot the dead agent** (stall recovery per the new policy), **(2) if boot fails or agent remains dead**, then transition the task. The current text jumps straight to task re-queuing.
+- **Evidence**: Pipeline sentinel 4f Tier 1 action: *"Transition the task back to approved so another agent (or the same agent after restart) can pick it up."* The newly permitted `boot_remote.py --role <name>` path is not mentioned as a first-resort action, even though a dead agent with in-progress work is exactly the stall scenario the new policy authorizes PM to address.
+- **Suggested fix**: Add a step before the Tier 1 transition: *"If auto-boot is unavailable or the agent remained dead after auto-boot, invoke `python references/scripts/boot_remote.py --role <name>` to attempt stall recovery. Only if boot fails (or the agent remains unhealthy on next check), then transition the task back to approved."*
+
+---
+
+### `--all` Constraint Assessment
+
+The constraint **"Use `--all` only on explicit human request"** is appropriately tight. Reasoning:
+- `--all` boots every agent simultaneously — in a harness-down scenario, this could race with harness recovery or create duplicate processes.
+- The single-role path (`--role <name>`) gives PM surgical precision: boot only the agent that's actually stalled.
+- If multiple agents are dead during a harness outage, the human can assess the situation holistically before authorizing a mass boot. This gate is proportionate to the blast radius — no change needed.
+
+---
+
+## Summary
+
+| # | Severity | What | Where |
+|---|----------|------|-------|
+| 1 | **error** | `health-check` says PM never touches lifecycle; `boot-remote-agents` now permits it | All 3 CLAUDE.md files |
+| 2 | **error** | `agent-lifecycle` says agents never manage processes directly; PM now does | All 3 CLAUDE.md files |
+| 3 | **warning** | Pipeline sentinel 4f skips boot attempt before re-queuing dead-agent tasks | All 3 CLAUDE.md files |
+
+All three findings apply to `.squidsquad/pm/CLAUDE.md`, `pm_events_CLAUDE.md`, and `pm_polling_CLAUDE.md` — they share the same sub-skill fragments. The source file `references/sub-skills/common/boot-remote-agents.md` is internally consistent and well-scoped; the contradictions arise from other sub-skills that were not updated to acknowledge the new policy.

--- a/references/sub-skills/common/agent-lifecycle.md
+++ b/references/sub-skills/common/agent-lifecycle.md
@@ -1,7 +1,7 @@
 <!-- sub-skill: agent-lifecycle -->
 ### Agent Lifecycle
 
-Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly.
+Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly during normal operation. **Stall-recovery exception (#9272)**: PM may invoke `python references/scripts/boot_remote.py --role <name>` directly to spawn a stalled agent when the harness is unreachable (#9242) or when an agent stays dead despite auto-boot — see the `boot-remote-agents` sub-skill for the full policy. No other role boots agents directly.
 
 **Three guarantees**:
 1. **Singleton**: Only one instance per role runs at a time (harness process table).

--- a/references/sub-skills/common/boot-remote-agents.md
+++ b/references/sub-skills/common/boot-remote-agents.md
@@ -13,5 +13,5 @@ If any agents were spawned, print: `[🦑 HH:MM:SS] Booted: [role1, role2, ...]`
 
 If all agents alive or stopped, print nothing — silent pass.
 
-**PM does not boot agents directly.** Agent lifecycle is managed by the harness (`harness.py`) and `start_team.py` (#4966). If PM detects a stalled or dead agent, report to the human — do not attempt to spawn or restart agents.
+**Manual boot is permitted on stall.** Routine agent lifecycle (start/stop on demand, restart on healthy cycles) belongs to the harness (`harness.py`) and `start_team.py` (#4966) — and the auto-boot path in `cycle_pre.py` runs before every PM cycle. When auto-boot is unavailable (harness down — see #9242) or insufficient (a specific agent stayed dead), PM may invoke `python references/scripts/boot_remote.py --role <name>` directly to spawn the stalled agent. Use `--all` only on explicit human request. Manual PM intervention is reserved for stall recovery — do NOT pre-emptively boot healthy agents (#9272, memory rule `feedback_manual_agents`).
 <!-- /sub-skill: boot-remote-agents -->

--- a/references/sub-skills/roles/pm/health-check.md
+++ b/references/sub-skills/roles/pm/health-check.md
@@ -16,7 +16,7 @@ Log the script's output in `pm/qa-log.md`. For any agent reporting stalled (👻
 1. Append a Discussion note to that agent's latest open tracker item.
 2. If no open item exists, log in `qa-log.md` only.
 
-**Context pressure monitoring**: Check each agent's context pressure file. If any agent exceeds threshold, report to the human with the agent role and pressure percentage. **PM does not execute reboots directly** — agent lifecycle is managed by the harness; operators use `squidsquad_cli.py` (or the backward-compatible `start_team.py` shim) (#4966).
+**Context pressure monitoring**: Check each agent's context pressure file. If any agent exceeds threshold, report to the human with the agent role and pressure percentage. **PM does not execute reboots for healthy agents** — graceful restart belongs to the harness via `squidsquad_cli.py` (or the backward-compatible `start_team.py` shim) (#4966). **On stall (harness down per #9242, or a specific agent stays dead despite auto-boot), PM may invoke `python references/scripts/boot_remote.py --role <name>` directly** — see the `boot-remote-agents` sub-skill for the full stall-recovery policy.
 
 For programmatic use, the script accepts `--json` for structured output.
 <!-- /sub-skill: health-check -->

--- a/references/sub-skills/roles/pm/pipeline-sentinel.md
+++ b/references/sub-skills/roles/pm/pipeline-sentinel.md
@@ -124,6 +124,7 @@ For each `in-progress` item, extract the `role:*` label. Cross-reference with ag
 python references/scripts/health_check.py --json
 ```
 Parse the JSON output. If the assigned agent's health is `stalled`, `stopped`, or `unknown`:
+- **Tier 0** (#9272 — try recovery first): if auto-boot in `cycle_pre.py` did not recover the agent, attempt manual stall recovery via `python references/scripts/boot_remote.py --role <name>` (see `boot-remote-agents` sub-skill). Only if the boot fails OR the agent remains unhealthy on the next health check, proceed to Tier 1. Skip this tier if the agent's intent is `stopping` or `stopped` (genuinely shut down on operator request, not a stall).
 - **Tier 1**: Transition the task back to `approved` so another agent (or the same agent after restart) can pick it up:
   ```bash
   python references/scripts/tracker.py transition [NUMBER] in-progress approved --role pm-lead

--- a/tests/comprehension/8697_fixtures/dm_events_CLAUDE.md
+++ b/tests/comprehension/8697_fixtures/dm_events_CLAUDE.md
@@ -938,7 +938,7 @@ At the end of a **normal** cycle (no exit-42 imminent), write `idle|` to `curren
 <!-- sub-skill: agent-lifecycle -->
 ### Agent Lifecycle
 
-Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly.
+Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly during normal operation. **Stall-recovery exception (#9272)**: PM may invoke `python references/scripts/boot_remote.py --role <name>` directly to spawn a stalled agent when the harness is unreachable (#9242) or when an agent stays dead despite auto-boot — see the `boot-remote-agents` sub-skill for the full policy. No other role boots agents directly.
 
 **Three guarantees**:
 1. **Singleton**: Only one instance per role runs at a time (harness process table).

--- a/tests/comprehension/8697_fixtures/dm_polling_CLAUDE.md
+++ b/tests/comprehension/8697_fixtures/dm_polling_CLAUDE.md
@@ -713,7 +713,7 @@ At the end of a **normal** cycle (no exit-42 imminent), write `idle|` to `curren
 <!-- sub-skill: agent-lifecycle -->
 ### Agent Lifecycle
 
-Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly.
+Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly during normal operation. **Stall-recovery exception (#9272)**: PM may invoke `python references/scripts/boot_remote.py --role <name>` directly to spawn a stalled agent when the harness is unreachable (#9242) or when an agent stays dead despite auto-boot — see the `boot-remote-agents` sub-skill for the full policy. No other role boots agents directly.
 
 **Three guarantees**:
 1. **Singleton**: Only one instance per role runs at a time (harness process table).

--- a/tests/comprehension/8697_fixtures/pm_events_CLAUDE.md
+++ b/tests/comprehension/8697_fixtures/pm_events_CLAUDE.md
@@ -706,6 +706,7 @@ For each `in-progress` item, extract the `role:*` label. Cross-reference with ag
 python references/scripts/health_check.py --json
 ```
 Parse the JSON output. If the assigned agent's health is `stalled`, `stopped`, or `unknown`:
+- **Tier 0** (#9272 — try recovery first): if auto-boot in `cycle_pre.py` did not recover the agent, attempt manual stall recovery via `python references/scripts/boot_remote.py --role <name>` (see `boot-remote-agents` sub-skill). Only if the boot fails OR the agent remains unhealthy on the next health check, proceed to Tier 1. Skip this tier if the agent's intent is `stopping` or `stopped` (genuinely shut down on operator request, not a stall).
 - **Tier 1**: Transition the task back to `approved` so another agent (or the same agent after restart) can pick it up:
   ```bash
   python references/scripts/tracker.py transition [NUMBER] in-progress approved --role pm-lead
@@ -757,7 +758,7 @@ Log the script's output in `pm/qa-log.md`. For any agent reporting stalled (👻
 1. Append a Discussion note to that agent's latest open tracker item.
 2. If no open item exists, log in `qa-log.md` only.
 
-**Context pressure monitoring**: Check each agent's context pressure file. If any agent exceeds threshold, report to the human with the agent role and pressure percentage. **PM does not execute reboots directly** — agent lifecycle is managed by the harness; operators use `squidsquad_cli.py` (or the backward-compatible `start_team.py` shim) (#4966).
+**Context pressure monitoring**: Check each agent's context pressure file. If any agent exceeds threshold, report to the human with the agent role and pressure percentage. **PM does not execute reboots for healthy agents** — graceful restart belongs to the harness via `squidsquad_cli.py` (or the backward-compatible `start_team.py` shim) (#4966). **On stall (harness down per #9242, or a specific agent stays dead despite auto-boot), PM may invoke `python references/scripts/boot_remote.py --role <name>` directly** — see the `boot-remote-agents` sub-skill for the full stall-recovery policy.
 
 For programmatic use, the script accepts `--json` for structured output.
 <!-- /sub-skill: health-check -->
@@ -806,7 +807,7 @@ If any agents were spawned, print: `[🦑 HH:MM:SS] Booted: [role1, role2, ...]`
 
 If all agents alive or stopped, print nothing — silent pass.
 
-**PM does not boot agents directly.** Agent lifecycle is managed by the harness (`harness.py`) and `start_team.py` (#4966). If PM detects a stalled or dead agent, report to the human — do not attempt to spawn or restart agents.
+**Manual boot is permitted on stall.** Routine agent lifecycle (start/stop on demand, restart on healthy cycles) belongs to the harness (`harness.py`) and `start_team.py` (#4966) — and the auto-boot path in `cycle_pre.py` runs before every PM cycle. When auto-boot is unavailable (harness down — see #9242) or insufficient (a specific agent stayed dead), PM may invoke `python references/scripts/boot_remote.py --role <name>` directly to spawn the stalled agent. Use `--all` only on explicit human request. Manual PM intervention is reserved for stall recovery — do NOT pre-emptively boot healthy agents (#9272, memory rule `feedback_manual_agents`).
 <!-- /sub-skill: boot-remote-agents -->
 
 <!-- sub-skill: soul-shepherd -->
@@ -1201,7 +1202,7 @@ At the end of a **normal** cycle (no exit-42 imminent), write `idle|` to `curren
 <!-- sub-skill: agent-lifecycle -->
 ### Agent Lifecycle
 
-Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly.
+Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly during normal operation. **Stall-recovery exception (#9272)**: PM may invoke `python references/scripts/boot_remote.py --role <name>` directly to spawn a stalled agent when the harness is unreachable (#9242) or when an agent stays dead despite auto-boot — see the `boot-remote-agents` sub-skill for the full policy. No other role boots agents directly.
 
 **Three guarantees**:
 1. **Singleton**: Only one instance per role runs at a time (harness process table).
@@ -1926,7 +1927,7 @@ These instructions apply to the PM agent on this project.
 - **NEVER modify dev agent branches.** If a PR has merge conflicts, comment on the issue telling the dev agent to merge main and re-push. The dev agent owns their branch — conflict resolution is their responsibility, not PM's.
 - **QA handles all verification**: PM holds QA accountable but never verifies directly.
 - **Post-merge recompose**: when merged branches touch `references/`, run `compose.py deploy-all`.
-- **Agent lifecycle via `start_team.py`** — PM does not boot agents directly. Report stalled agents to human.
+- **Agent lifecycle via `start_team.py`** — routine start/stop/restart belongs to the harness + `cycle_pre.py` auto-boot. On stall (auto-boot unavailable or specific agent stays dead), PM may invoke `python references/scripts/boot_remote.py --role <name>` directly per #9272 + memory rule `feedback_manual_agents`; otherwise leave lifecycle to the harness.
 
 ### Task Lifecycle
 

--- a/tests/comprehension/8697_fixtures/pm_polling_CLAUDE.md
+++ b/tests/comprehension/8697_fixtures/pm_polling_CLAUDE.md
@@ -558,6 +558,7 @@ For each `in-progress` item, extract the `role:*` label. Cross-reference with ag
 python references/scripts/health_check.py --json
 ```
 Parse the JSON output. If the assigned agent's health is `stalled`, `stopped`, or `unknown`:
+- **Tier 0** (#9272 — try recovery first): if auto-boot in `cycle_pre.py` did not recover the agent, attempt manual stall recovery via `python references/scripts/boot_remote.py --role <name>` (see `boot-remote-agents` sub-skill). Only if the boot fails OR the agent remains unhealthy on the next health check, proceed to Tier 1. Skip this tier if the agent's intent is `stopping` or `stopped` (genuinely shut down on operator request, not a stall).
 - **Tier 1**: Transition the task back to `approved` so another agent (or the same agent after restart) can pick it up:
   ```bash
   python references/scripts/tracker.py transition [NUMBER] in-progress approved --role pm-lead
@@ -609,7 +610,7 @@ Log the script's output in `pm/qa-log.md`. For any agent reporting stalled (👻
 1. Append a Discussion note to that agent's latest open tracker item.
 2. If no open item exists, log in `qa-log.md` only.
 
-**Context pressure monitoring**: Check each agent's context pressure file. If any agent exceeds threshold, report to the human with the agent role and pressure percentage. **PM does not execute reboots directly** — agent lifecycle is managed by the harness; operators use `squidsquad_cli.py` (or the backward-compatible `start_team.py` shim) (#4966).
+**Context pressure monitoring**: Check each agent's context pressure file. If any agent exceeds threshold, report to the human with the agent role and pressure percentage. **PM does not execute reboots for healthy agents** — graceful restart belongs to the harness via `squidsquad_cli.py` (or the backward-compatible `start_team.py` shim) (#4966). **On stall (harness down per #9242, or a specific agent stays dead despite auto-boot), PM may invoke `python references/scripts/boot_remote.py --role <name>` directly** — see the `boot-remote-agents` sub-skill for the full stall-recovery policy.
 
 For programmatic use, the script accepts `--json` for structured output.
 <!-- /sub-skill: health-check -->
@@ -658,7 +659,7 @@ If any agents were spawned, print: `[🦑 HH:MM:SS] Booted: [role1, role2, ...]`
 
 If all agents alive or stopped, print nothing — silent pass.
 
-**PM does not boot agents directly.** Agent lifecycle is managed by the harness (`harness.py`) and `start_team.py` (#4966). If PM detects a stalled or dead agent, report to the human — do not attempt to spawn or restart agents.
+**Manual boot is permitted on stall.** Routine agent lifecycle (start/stop on demand, restart on healthy cycles) belongs to the harness (`harness.py`) and `start_team.py` (#4966) — and the auto-boot path in `cycle_pre.py` runs before every PM cycle. When auto-boot is unavailable (harness down — see #9242) or insufficient (a specific agent stayed dead), PM may invoke `python references/scripts/boot_remote.py --role <name>` directly to spawn the stalled agent. Use `--all` only on explicit human request. Manual PM intervention is reserved for stall recovery — do NOT pre-emptively boot healthy agents (#9272, memory rule `feedback_manual_agents`).
 <!-- /sub-skill: boot-remote-agents -->
 
 <!-- sub-skill: soul-shepherd -->
@@ -1053,7 +1054,7 @@ At the end of a **normal** cycle (no exit-42 imminent), write `idle|` to `curren
 <!-- sub-skill: agent-lifecycle -->
 ### Agent Lifecycle
 
-Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly.
+Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly during normal operation. **Stall-recovery exception (#9272)**: PM may invoke `python references/scripts/boot_remote.py --role <name>` directly to spawn a stalled agent when the harness is unreachable (#9242) or when an agent stays dead despite auto-boot — see the `boot-remote-agents` sub-skill for the full policy. No other role boots agents directly.
 
 **Three guarantees**:
 1. **Singleton**: Only one instance per role runs at a time (harness process table).
@@ -1778,7 +1779,7 @@ These instructions apply to the PM agent on this project.
 - **NEVER modify dev agent branches.** If a PR has merge conflicts, comment on the issue telling the dev agent to merge main and re-push. The dev agent owns their branch — conflict resolution is their responsibility, not PM's.
 - **QA handles all verification**: PM holds QA accountable but never verifies directly.
 - **Post-merge recompose**: when merged branches touch `references/`, run `compose.py deploy-all`.
-- **Agent lifecycle via `start_team.py`** — PM does not boot agents directly. Report stalled agents to human.
+- **Agent lifecycle via `start_team.py`** — routine start/stop/restart belongs to the harness + `cycle_pre.py` auto-boot. On stall (auto-boot unavailable or specific agent stays dead), PM may invoke `python references/scripts/boot_remote.py --role <name>` directly per #9272 + memory rule `feedback_manual_agents`; otherwise leave lifecycle to the harness.
 
 ### Task Lifecycle
 

--- a/tests/comprehension/8697_fixtures/qa_events_CLAUDE.md
+++ b/tests/comprehension/8697_fixtures/qa_events_CLAUDE.md
@@ -939,7 +939,7 @@ At the end of a **normal** cycle (no exit-42 imminent), write `idle|` to `curren
 <!-- sub-skill: agent-lifecycle -->
 ### Agent Lifecycle
 
-Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly.
+Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly during normal operation. **Stall-recovery exception (#9272)**: PM may invoke `python references/scripts/boot_remote.py --role <name>` directly to spawn a stalled agent when the harness is unreachable (#9242) or when an agent stays dead despite auto-boot — see the `boot-remote-agents` sub-skill for the full policy. No other role boots agents directly.
 
 **Three guarantees**:
 1. **Singleton**: Only one instance per role runs at a time (harness process table).

--- a/tests/comprehension/8697_fixtures/qa_polling_CLAUDE.md
+++ b/tests/comprehension/8697_fixtures/qa_polling_CLAUDE.md
@@ -791,7 +791,7 @@ At the end of a **normal** cycle (no exit-42 imminent), write `idle|` to `curren
 <!-- sub-skill: agent-lifecycle -->
 ### Agent Lifecycle
 
-Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly.
+Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly during normal operation. **Stall-recovery exception (#9272)**: PM may invoke `python references/scripts/boot_remote.py --role <name>` directly to spawn a stalled agent when the harness is unreachable (#9242) or when an agent stays dead despite auto-boot — see the `boot-remote-agents` sub-skill for the full policy. No other role boots agents directly.
 
 **Three guarantees**:
 1. **Singleton**: Only one instance per role runs at a time (harness process table).

--- a/tests/comprehension/8697_fixtures/skill_events_CLAUDE.md
+++ b/tests/comprehension/8697_fixtures/skill_events_CLAUDE.md
@@ -1086,7 +1086,7 @@ At the end of a **normal** cycle (no exit-42 imminent), write `idle|` to `curren
 <!-- sub-skill: agent-lifecycle -->
 ### Agent Lifecycle
 
-Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly.
+Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly during normal operation. **Stall-recovery exception (#9272)**: PM may invoke `python references/scripts/boot_remote.py --role <name>` directly to spawn a stalled agent when the harness is unreachable (#9242) or when an agent stays dead despite auto-boot — see the `boot-remote-agents` sub-skill for the full policy. No other role boots agents directly.
 
 **Three guarantees**:
 1. **Singleton**: Only one instance per role runs at a time (harness process table).

--- a/tests/comprehension/8697_fixtures/skill_polling_CLAUDE.md
+++ b/tests/comprehension/8697_fixtures/skill_polling_CLAUDE.md
@@ -951,7 +951,7 @@ At the end of a **normal** cycle (no exit-42 imminent), write `idle|` to `curren
 <!-- sub-skill: agent-lifecycle -->
 ### Agent Lifecycle
 
-Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly.
+Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). Agents do not manage their own or other agents' processes directly during normal operation. **Stall-recovery exception (#9272)**: PM may invoke `python references/scripts/boot_remote.py --role <name>` directly to spawn a stalled agent when the harness is unreachable (#9242) or when an agent stays dead despite auto-boot — see the `boot-remote-agents` sub-skill for the full policy. No other role boots agents directly.
 
 **Three guarantees**:
 1. **Singleton**: Only one instance per role runs at a time (harness process table).


### PR DESCRIPTION
Closes #9272

### Summary
Codify the manual-boot-on-stall policy that `feedback_manual_agents` and live user practice already established. The `boot-remote-agents` fragment previously told PM "do not attempt to spawn or restart agents" — contradicting both memory and the user's explicit cycle-1497 directive to boot stalled agents during the #9242 harness outage.

### Acceptance
- [x] `references/sub-skills/common/boot-remote-agents.md` updated to reflect manual-boot-on-stall policy.
- [x] PM CLAUDE.md regenerated.
- [x] Memory rule `feedback_manual_agents` codified — PR copies the policy into composed templates so future sessions don't rely on memory alone.

### Changes
- **`references/sub-skills/common/boot-remote-agents.md`**: replaced "PM does not boot agents directly" with the stall-recovery policy. PM may invoke `boot_remote.py --role <name>` when auto-boot is unavailable (harness down per #9242) or insufficient; `--all` requires explicit human request; no pre-emptive booting of healthy agents.
- **`.squidsquad/project/pm-instructions.md`**: short L4 lifecycle bullet rewritten to point at the new policy.
- **`references/sub-skills/common/agent-lifecycle.md`** (deepseek R1 finding): added the #9272 stall-recovery carve-out to the blanket "agents do not manage other agents' processes" rule, otherwise that rule contradicted the new permission inside the same composed file.
- **`references/sub-skills/roles/pm/health-check.md`** (deepseek R1 finding): qualified "PM does not execute reboots" to "for healthy agents" + added stall-recovery clause.
- **`references/sub-skills/roles/pm/pipeline-sentinel.md`** (deepseek R1 finding): pipeline-sentinel 4f gained a **Tier 0** step — try `boot_remote.py --role <name>` before re-queuing the task. Skip Tier 0 when intent is `stopping`/`stopped` (genuine shutdown, not stall).
- **`.squidsquad/{pm,qa,dm,skill}/CLAUDE.md`**: recomposed via `compose.py deploy-all`.
- **`tests/comprehension/8697_fixtures/*_CLAUDE.md`** (8 files): pre-composed test snapshots updated to match the new sub-skill text.

### Out of scope
- `start_team.py` vs `squidsquad_cli.py` mention parity (deepseek R2 noted this; minor wording variance, no incorrect behavior).
- Memory rule `feedback_manual_agents` — kept as historical note since this PR codifies its policy in templates; safe to deprecate later if PM cycles confirm the new wording is sufficient.

### QA Status
- [x] `python tests/run_tests.py` — passes, no regressions.
- [x] Self-review clean.
- [x] External code review (deepseek-v4-pro, **2 rounds**): R1 = 3 real findings (agent-lifecycle contradiction, health-check contradiction, pipeline-sentinel missed Tier 0). All addressed. R2 = **NO_FINDINGS** after cross-file consistency audit.

### Setup/Upgrade Sync Check
- [x] New config values: N/A
- [x] New files/directories: 2 review artifacts (test-only)
- [x] Modified template structure: yes — `boot-remote-agents.md`, `agent-lifecycle.md`, `health-check.md`, `pipeline-sentinel.md` are composed into PM CLAUDE.md; the 8697 fixtures are pre-composed test snapshots regenerated to match
- [x] Added/removed sub-skills: N/A
- [x] Changed role composition: N/A (text changes only; no compose graph changes)
