### PR TITLE
skill: #9319 — clean up dead test-plan infrastructure (reclaim for QA)

### DIFF
--- a/.squidsquad/pm/CLAUDE.md
+++ b/.squidsquad/pm/CLAUDE.md
@@ -239,7 +239,11 @@ At the end of each cycle, print:
 echo "phase|sub-skill — description" > .squidsquad/pm/current-state.tmp && mv -f .squidsquad/pm/current-state.tmp .squidsquad/pm/current-state
 ```
 
-Phase is one of: `pulling`, `checkin`, `testing`, `verifying`, `planning`, `researching`, `discussing`, `test-planning`, `health`, `idle`. The sub-skill is the short name of the active sub-skill (e.g., `pull-latest`, `verification`, `feature-intake`). The description is a short (≤60 char) human-readable label. **Include the GitHub Issue number** (e.g. `#29`, `#37`) in all item-specific phases. Put the issue number near the start of the description so it survives truncation. Examples:
+Phase is one of: `pulling`, `checkin`, `testing`, `verifying`, `planning`, `researching`, `discussing`, `health`, `idle`. The sub-skill is the short name of the active sub-skill (e.g., `pull-latest`, `verification`, `feature-intake`). The description is a short (≤60 char) human-readable label. **Include the GitHub Issue number** (e.g. `#29`, `#37`) in all item-specific phases. Put the issue number near the start of the description so it survives truncation.
+
+> Note: `test-planning` was dropped from this enum on #9319. Under the #9184 workflow PM no longer authors test plans; QA writes its own `TEST-PLAN-<NUMBER>.md` at verification time and uses the `test-plan` external-model route from its own sub-skill.
+
+Examples:
 
 - `pulling|pull-latest — Syncing with remote...`
 - `testing|verification — Running E2E tests...`
@@ -247,7 +251,6 @@ Phase is one of: `pulling`, `checkin`, `testing`, `verifying`, `planning`, `rese
 - `planning|feature-intake — #37 intake...`
 - `researching|feature-intake — Researching #35...`
 - `discussing|feature-intake — Discussion for #35...`
-- `test-planning|feature-intake — Test plan for #35...`
 - `idle|`
 
 Write `idle|` at cycle end so the status bar shows rotating hints between cycles.

--- a/.squidsquad/qa/CLAUDE.md
+++ b/.squidsquad/qa/CLAUDE.md
@@ -547,6 +547,19 @@ python references/scripts/git_ops.py task-end [role] [number]
 
    Resume logic mirrors PM's: if `TEST-PLAN-<NUMBER>.md` already exists under `.squidsquad/qa/planning/` and the issue body's ACs have not changed since the file was committed, reuse it; otherwise re-derive.
 
+   **Optional: route test-plan drafting to an external model** (#9319 — was orphaned PM infrastructure, reclaimed for QA):
+
+   ```bash
+   python references/scripts/model_router.py route \
+     --task-type test-plan \
+     --task-id <NUMBER> \
+     --input-files "<issue body export>,<CONTEXT artifact if any>" \
+     --output-file ".squidsquad/qa/planning/TEST-PLAN-<NUMBER>.md" \
+     --context "Draft live-system test plan for #<NUMBER> from the AC list."
+   ```
+
+   The router uses the `Test Plan Model` config setting and falls back to a Claude subagent on failure (same fallback contract PM uses for research/discussion-prep). QA reviews the draft, adjusts as needed, and saves the final version. This is optional — QA can also write the plan directly without routing.
+
    **Test plan structure**:
 
    ```markdown

--- a/.squidsquad/skill/planning/CODE-REVIEW-9319.md
+++ b/.squidsquad/skill/planning/CODE-REVIEW-9319.md
@@ -1,0 +1,15 @@
+Now I have a complete picture. Let me compile my analysis.
+
+---
+
+**Summary of review**: I examined all six changed files for correctness, regressions, contradictions in the QA path, and issues with the deferred-fixture decision. Here are my findings:
+
+**Change 1 (PM ralph-loop-overview.md source)**: ✅ Phase enum has `test-planning` removed (line 37). The 'Test plan for #35' example is absent from the examples list (lines 43-49). The explanatory note on line 39 correctly references #9319 and explains QA now owns test plans. The composed PM CLAUDE.md (line 242) matches the source.
+
+**Change 2 (QA verification.md source)**: ✅ The model_router.py route section (lines 157-168) correctly invokes `route --task-type test-plan` with the right arguments. The router script (`references/scripts/model_router.py`) supports this: `test-plan` is a valid task type (line 16), maps to `test-plan-model` config key (line 140), uses `test-plan.md.j2` template (line 541), and the `route()` function handles it (line 634). The composed QA CLAUDE.md (lines 550-561) matches the source. The instruction makes clear this is optional.
+
+**Change 3 (PM fixture snapshots)**: ✅ The `pm_polling_CLAUDE.md` fixture has the phase enum updated on line 233 — no `test-planning`. The `pm_events_CLAUDE.md` fixture has no ralph-loop-overview section (event-driven), so no phase enum to update.
+
+**Deferred-fixture decision**: The task explicitly excludes the pre-#9184 task-intake `test-planning` references in the fixtures (pm_polling line 1384, pm_events line 1533) as "separate hygiene issue." This is a reasonable scoping choice — those lines belong to the entire task-intake section that was rewritten by #9184 but the fixtures weren't refreshed. Changing them would require a full fixture refresh (not just the phase enum), which is correctly deferred. No contradiction found.
+
+NO_FINDINGS

--- a/references/sub-skills/roles/pm/ralph-loop-overview.md
+++ b/references/sub-skills/roles/pm/ralph-loop-overview.md
@@ -34,7 +34,11 @@ At the end of each cycle, print:
 echo "phase|sub-skill — description" > .squidsquad/pm/current-state.tmp && mv -f .squidsquad/pm/current-state.tmp .squidsquad/pm/current-state
 ```
 
-Phase is one of: `pulling`, `checkin`, `testing`, `verifying`, `planning`, `researching`, `discussing`, `test-planning`, `health`, `idle`. The sub-skill is the short name of the active sub-skill (e.g., `pull-latest`, `verification`, `feature-intake`). The description is a short (≤60 char) human-readable label. **Include the GitHub Issue number** (e.g. `#29`, `#37`) in all item-specific phases. Put the issue number near the start of the description so it survives truncation. Examples:
+Phase is one of: `pulling`, `checkin`, `testing`, `verifying`, `planning`, `researching`, `discussing`, `health`, `idle`. The sub-skill is the short name of the active sub-skill (e.g., `pull-latest`, `verification`, `feature-intake`). The description is a short (≤60 char) human-readable label. **Include the GitHub Issue number** (e.g. `#29`, `#37`) in all item-specific phases. Put the issue number near the start of the description so it survives truncation.
+
+> Note: `test-planning` was dropped from this enum on #9319. Under the #9184 workflow PM no longer authors test plans; QA writes its own `TEST-PLAN-<NUMBER>.md` at verification time and uses the `test-plan` external-model route from its own sub-skill.
+
+Examples:
 
 - `pulling|pull-latest — Syncing with remote...`
 - `testing|verification — Running E2E tests...`
@@ -42,7 +46,6 @@ Phase is one of: `pulling`, `checkin`, `testing`, `verifying`, `planning`, `rese
 - `planning|feature-intake — #37 intake...`
 - `researching|feature-intake — Researching #35...`
 - `discussing|feature-intake — Discussion for #35...`
-- `test-planning|feature-intake — Test plan for #35...`
 - `idle|`
 
 Write `idle|` at cycle end so the status bar shows rotating hints between cycles.

--- a/references/sub-skills/roles/qa/verification.md
+++ b/references/sub-skills/roles/qa/verification.md
@@ -154,6 +154,19 @@ python references/scripts/git_ops.py task-end [role] [number]
 
    Resume logic mirrors PM's: if `TEST-PLAN-<NUMBER>.md` already exists under `.squidsquad/qa/planning/` and the issue body's ACs have not changed since the file was committed, reuse it; otherwise re-derive.
 
+   **Optional: route test-plan drafting to an external model** (#9319 — was orphaned PM infrastructure, reclaimed for QA):
+
+   ```bash
+   python references/scripts/model_router.py route \
+     --task-type test-plan \
+     --task-id <NUMBER> \
+     --input-files "<issue body export>,<CONTEXT artifact if any>" \
+     --output-file ".squidsquad/qa/planning/TEST-PLAN-<NUMBER>.md" \
+     --context "Draft live-system test plan for #<NUMBER> from the AC list."
+   ```
+
+   The router uses the `Test Plan Model` config setting and falls back to a Claude subagent on failure (same fallback contract PM uses for research/discussion-prep). QA reviews the draft, adjusts as needed, and saves the final version. This is optional — QA can also write the plan directly without routing.
+
    **Test plan structure**:
 
    ```markdown

--- a/tests/comprehension/8697_fixtures/pm_polling_CLAUDE.md
+++ b/tests/comprehension/8697_fixtures/pm_polling_CLAUDE.md
@@ -230,7 +230,7 @@ At the end of each cycle, print:
 echo "phase|sub-skill — description" > .squidsquad/pm/current-state.tmp && mv -f .squidsquad/pm/current-state.tmp .squidsquad/pm/current-state
 ```
 
-Phase is one of: `pulling`, `checkin`, `testing`, `verifying`, `planning`, `researching`, `discussing`, `test-planning`, `health`, `idle`. The sub-skill is the short name of the active sub-skill (e.g., `pull-latest`, `verification`, `feature-intake`). The description is a short (≤60 char) human-readable label. **Include the GitHub Issue number** (e.g. `#29`, `#37`) in all item-specific phases. Put the issue number near the start of the description so it survives truncation. Examples:
+Phase is one of: `pulling`, `checkin`, `testing`, `verifying`, `planning`, `researching`, `discussing`, `health`, `idle`. The sub-skill is the short name of the active sub-skill (e.g., `pull-latest`, `verification`, `feature-intake`). The description is a short (≤60 char) human-readable label. **Include the GitHub Issue number** (e.g. `#29`, `#37`) in all item-specific phases. Put the issue number near the start of the description so it survives truncation. Examples:
 
 - `pulling|pull-latest — Syncing with remote...`
 - `testing|verification — Running E2E tests...`
@@ -238,7 +238,6 @@ Phase is one of: `pulling`, `checkin`, `testing`, `verifying`, `planning`, `rese
 - `planning|feature-intake — #37 intake...`
 - `researching|feature-intake — Researching #35...`
 - `discussing|feature-intake — Discussion for #35...`
-- `test-planning|feature-intake — Test plan for #35...`
 - `idle|`
 
 Write `idle|` at cycle end so the status bar shows rotating hints between cycles.


### PR DESCRIPTION
Closes #9319

### Summary
Reclaim the orphaned test-plan infrastructure for QA (Option 1 per the issue body's recommendation). PM's status-bar phase enum and example loses the dead `test-planning` entry; QA's verification.md gains an optional route to `model_router.py route --task-type test-plan` so QA can use the existing infrastructure (Jinja template, model config setting, task-type registration) when drafting `TEST-PLAN-<NUMBER>.md`.

### Acceptance
- [x] `references/sub-skills/roles/pm/ralph-loop-overview.md:37,45` — `test-planning` phase + "Test plan for #35" example removed.
- [x] `references/prompts/test-plan.md.j2` — kept, now invoked by QA via `model_router`.
- [x] `references/scripts/model_router.py` — `test-plan` task type registrations kept, now have a real caller (QA verification).
- [x] `.squidsquad/config.md` `Test Plan Model` setting — kept, now consumed by QA.
- [x] PM CLAUDE.md regenerated; phase-enum reflects the new wording.
- [x] QA CLAUDE.md regenerated with the optional `model_router test-plan` invocation.

### Changes
- **`references/sub-skills/roles/pm/ralph-loop-overview.md`**: dropped `test-planning` from the phase enum + dropped the example line. Added inline note pointing at #9184/#9319.
- **`references/sub-skills/roles/qa/verification.md`**: new "Optional: route test-plan drafting to an external model" subsection. Optional path — QA can also write directly without routing. Uses the existing Claude-fallback contract (same as PM's research/discussion-prep flow).
- **`.squidsquad/{pm,qa,dm,skill}/CLAUDE.md`**: recomposed.
- **`tests/comprehension/8697_fixtures/pm_polling_CLAUDE.md`**: phase-enum snapshot updated to match new source.

### Out of scope
- Deeper pre-#9184 PM Phase 3 fragment in `pm_polling_CLAUDE.md:1384` and `pm_events_CLAUDE.md:1533` (`Test plan for FEAT-...`). That content was already removed from source by #9184 but fixtures weren't refreshed at the time — refreshing them now would require regenerating the full PM-side fixtures, not just dropping these two lines. Not in #9319 body's enumerated orphans. Separate hygiene task.
- Option 2 (delete the entire test-plan infrastructure) — picked Option 1 per the issue body's recommendation.

### QA Status
- [x] `python tests/run_tests.py` — passes, no regressions.
- [x] `python -m pytest tests/test_model_router.py` — 83/83 pass.
- [x] Self-review clean.
- [x] External code review (deepseek-v4-pro, single round): **NO_FINDINGS**. Reviewer verified the `model_router` test-plan task type is fully wired (task-type registration, config key mapping, template path, `route()` handler), the optional-routing language is correct, and the deferred-fixture decision is reasonable scoping.

### Setup/Upgrade Sync Check
- [x] New config values: N/A (kept `Test Plan Model`)
- [x] New files/directories: 1 review artifact (test-only)
- [x] Modified template structure: yes — composed PM/QA CLAUDE.md regenerated to match source changes
- [x] Added/removed sub-skills: N/A
- [x] Changed role composition: N/A
