### PR TITLE
skill: #9357 — EventLifecycleManager.load() lock-guarded idempotency

### DIFF
--- a/.squidsquad/skill/planning/CODE-REVIEW-9357.md
+++ b/.squidsquad/skill/planning/CODE-REVIEW-9357.md
@@ -1,0 +1,36 @@
+After thoroughly analyzing the changed files — `references/scripts/harness.py` and the new test file — I traced through all three questions posed by the task. Here is my verdict.
+
+## Analysis
+
+### 1. Race the claim doesn't cover
+
+The `_loaded` check-and-set is wrapped in `with self._lock:` (lines ~678–682 in `load()`). The lock is held only for the atomic check+claim, then immediately released. The claim sets `_loaded=True` BEFORE any body work (file-exists check, read, parse, state restoration, event appends). This means a concurrent caller observes `_loaded=True` and returns without doing any work.
+
+**No uncovered race**: The only TOCTOU is the `EVENT_STATE_FILE.exists()` → `read_text()` gap (outside the lock), but `read_text` failures are caught by the existing `except (JSONDecodeError, OSError)` handler, and `_loaded` is already `True` at that point — matching the prior semantics where error paths also marked the manager as loaded. The event-append loop at the end acquires only `EventStream._lock` (not `self._lock`), so there's no window where an untimely `_persist()` call could corrupt the manager's in-flight state mid-restore: the second `self._lock` block (lines ~700–712) fully restores in-flight state before any events are appended.
+
+### 2. Lock-ordering regression with `EventStream._lock`
+
+The invariant is `self._lock → EventStream._lock`. Verified:
+
+- `_persist()`: acquires `self._lock`, then calls `self._stream.get_recent()` which acquires `EventStream._lock`. ✓
+- `load()` first block: acquires `self._lock` only, releases it. ✓
+- `load()` second block: acquires `self._lock` only, releases it. ✓
+- `load()` append loop: acquires `EventStream._lock` only (via `self._stream.append()`). ✓
+
+`load()` never holds both locks simultaneously. The append loop (`EventStream._lock`) and `_persist()` (`self._lock → EventStream._lock`) cannot deadlock — the worst case is `_persist()` blocks briefly on `EventStream._lock` while an append is in flight. No regression.
+
+### 3. Test assertions passing for wrong reason
+
+- **`test_concurrent_load_double_dispatch_does_not_double_append`** — 8 threads + `Barrier`, then all call `load()`. Asserts stream length and `_total_emitted_count` are exactly 3. Genuinely exercises the lock-guarded idempotency; if the check-and-set were not atomic, multiple threads would pass the guard and double-append. Passes for the right reason.
+
+- **`test_loaded_flag_set_before_body_runs`** — Blocks first caller inside `read_text` (patched), verifies second caller returns in <1s. If `_loaded=True` were set AFTER the body, the second caller would also block on `read_text` and the test would fail (timeout). Correctly validates claim-before-body timing.
+
+- **`test_loaded_check_is_inside_lock`** — Static source inspection checking that `load()`'s first executable line is `with self._lock:`. A refactor could theoretically put `with self._lock:` first but move `_loaded` check outside it — but this is a defense-in-depth check, not the sole verification. The runtime tests cover actual behavior.
+
+- **`test_single_load_appends_events_once`** and **`test_second_load_is_silent_noop`** — Straightforward sanity checks. No wrong-reason risk.
+
+## Verdict
+
+**NO_FINDINGS**
+
+I checked: (1) all `_loaded` check-and-set paths are covered by `self._lock`; concurrent callers observe True and return without re-appending events; the TOCTOU between file-exists and read is handled by the existing exception handler with `_loaded` already True, preserving prior semantics. (2) Lock ordering `self._lock → EventStream._lock` is maintained — `load()` never holds both locks simultaneously, and the append loop outside `self._lock` cannot deadlock with `_persist()`. (3) All five test assertions exercise genuine invariants (atomic claim, claim-before-body timing, single-load, double-call no-op, static lock guard) and none passes for a wrong or accidental reason.

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -660,17 +660,39 @@ class EventLifecycleManager:
                 pass  # Best-effort — don't crash harness on persist failure
 
     def load(self):
-        """Restore event state from disk on harness restart. Idempotent."""
-        if self._loaded:
-            return
-        if not EVENT_STATE_FILE.exists():
+        """Restore event state from disk on harness restart. Idempotent.
+
+        Thread-safety (#9357): the ``_loaded`` check-and-set is wrapped
+        in ``self._lock`` so concurrent callers cannot both pass the
+        idempotency guard and double-load the event stream. Once a
+        thread claims the load (sets ``_loaded=True``), any concurrent
+        caller observes True and returns immediately — matching the
+        existing semantics where any prior load attempt (including
+        missing-file or parse-error fast paths) marks the manager as
+        loaded so the next call is a silent no-op.
+
+        Today ``load()`` is only called from ``_deferred_init`` on the
+        lifespan thread, but the guard is the only defense against a
+        future refactor that fans the call out across multiple threads
+        (which would otherwise re-append events into ``EventStream``
+        and inflate ``_total_emitted_count`` introduced in #9331).
+        """
+        # Claim the load atomically. Mark _loaded BEFORE doing any work
+        # so a concurrent caller can't slip in between the check and the
+        # state mutations below. If we crash mid-load, the existing
+        # fast-path semantics (set _loaded=True on missing file or parse
+        # error → next call returns silently) are preserved.
+        with self._lock:
+            if self._loaded:
+                return
             self._loaded = True
+
+        if not EVENT_STATE_FILE.exists():
             return
         try:
             raw = EVENT_STATE_FILE.read_text(encoding="utf-8")
             data = json.loads(raw)
         except (json.JSONDecodeError, OSError):
-            self._loaded = True
             return
 
         # Restore in-flight/dispatch state under lock, then load events outside
@@ -690,7 +712,6 @@ class EventLifecycleManager:
         # Append events outside self._lock (acquires EventStream._lock)
         for event in events_to_load:
             self._stream.append(event)
-        self._loaded = True
 
     def timeout_scan(self):
         """Check for overdue in-flight events and escalate (#7630 2-3).

--- a/tests/test_9357_eventlifecycle_load_thread_safety.py
+++ b/tests/test_9357_eventlifecycle_load_thread_safety.py
@@ -1,0 +1,271 @@
+"""Tests for #9357 — EventLifecycleManager.load() lock-guarded idempotency.
+
+Before #9357 the ``_loaded`` flag was read and written without holding
+``self._lock``. Single-threaded use was fine (today the only caller is
+``_deferred_init`` on the harness lifespan thread), but a future
+refactor that fanned ``load()`` out across multiple threads could let
+both threads pass the early-return guard, run the event-loading loop
+twice, and double-append events into ``EventStream`` — inflating
+``_total_emitted_count`` (the #9331 lifetime counter).
+
+The fix wraps the check-and-set in ``self._lock``, claiming
+``_loaded = True`` BEFORE any state mutation so a concurrent caller
+observes True and returns immediately.
+
+These tests pin both the source-level invariant and the runtime
+behavior under thread contention.
+"""
+
+import importlib.util
+import json
+import sys
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO_ROOT / "references" / "scripts"
+
+
+def _load_module(name: str, source: Path):
+    spec = importlib.util.spec_from_file_location(name, source)
+    if not (spec and spec.loader):
+        raise ImportError(f"cannot build spec for {source}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+try:
+    _harness = _load_module("_harness_for_9357", SCRIPTS / "harness.py")
+    HARNESS_AVAILABLE = True
+except Exception as _e:
+    print(
+        f"[test_9357] harness import failed: {type(_e).__name__}: {_e}",
+        file=sys.stderr,
+    )
+    HARNESS_AVAILABLE = False
+    _harness = None  # type: ignore
+
+
+@unittest.skipUnless(HARNESS_AVAILABLE, "harness module not importable")
+class TestLoadIdempotencyGuardLockProtected(unittest.TestCase):
+    """``EventLifecycleManager.load()`` must hold ``self._lock`` when
+    reading or writing the ``_loaded`` flag (#9357)."""
+
+    def setUp(self):
+        # Use a temp state file so the test doesn't touch the real
+        # `.event-state.json`.
+        import tempfile
+        self.tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8",
+        )
+        # Seed a small state file so the load path exercises the
+        # full body, not just the missing-file fast path.
+        payload = {
+            "events": [
+                {"id": "ev1", "event_type": "status-transition", "role": "skill",
+                 "timestamp": 1.0, "payload": {}},
+                {"id": "ev2", "event_type": "status-transition", "role": "skill",
+                 "timestamp": 2.0, "payload": {}},
+                {"id": "ev3", "event_type": "status-transition", "role": "skill",
+                 "timestamp": 3.0, "payload": {}},
+            ],
+            "in_flight": {},
+            "dispatched": {},
+            "dispatch_times": {},
+            "retry_counts": {},
+        }
+        self.tmp.write(json.dumps(payload))
+        self.tmp.close()
+        self.state_path = Path(self.tmp.name)
+
+        self._patch = mock.patch.object(_harness, "EVENT_STATE_FILE", self.state_path)
+        self._patch.start()
+
+        self.stream = _harness.EventStream(maxlen=1000)
+        self.mgr = _harness.EventLifecycleManager(self.stream)
+
+    def tearDown(self):
+        self._patch.stop()
+        try:
+            self.state_path.unlink()
+        except FileNotFoundError:
+            pass
+
+    def test_single_load_appends_events_once(self):
+        """Sanity check: a single load() call appends the seeded
+        events exactly once."""
+        self.mgr.load()
+        self.assertEqual(len(self.stream), 3)
+        self.assertEqual(self.stream._total_emitted_count, 3)
+
+    def test_second_load_is_silent_noop(self):
+        """Calling load() twice from one thread is the idempotency
+        contract — second call returns immediately, no re-append."""
+        self.mgr.load()
+        self.mgr.load()
+        # Still exactly 3 events; counter not double-incremented.
+        self.assertEqual(len(self.stream), 3)
+        self.assertEqual(self.stream._total_emitted_count, 3)
+
+    def test_concurrent_load_double_dispatch_does_not_double_append(self):
+        """The real regression: spawn N threads all calling load()
+        simultaneously. With the #9357 lock-guarded claim, exactly one
+        thread runs the body; the others return immediately. Stream
+        contents must reflect a single load, not N loads."""
+        barrier = threading.Barrier(8)
+        errors = []
+
+        def worker():
+            try:
+                barrier.wait()  # release all threads at once
+                self.mgr.load()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        self.assertEqual(errors, [], msg=f"workers raised: {errors}")
+        # If the guard were broken, multiple workers would each append
+        # the seeded 3 events into the stream.
+        self.assertEqual(
+            len(self.stream), 3,
+            msg=f"event stream has {len(self.stream)} events after "
+                f"concurrent load — expected 3. The _loaded guard was "
+                f"not lock-protected and multiple workers double-appended.",
+        )
+        self.assertEqual(
+            self.stream._total_emitted_count, 3,
+            msg="lifetime emit counter was inflated by concurrent "
+                "double-load — #9331's hint computation would be wrong.",
+        )
+
+    def test_loaded_flag_set_before_body_runs(self):
+        """The fix claims `_loaded = True` BEFORE the body runs (read +
+        parse + state mutation), so a concurrent caller observes True
+        immediately and returns. Verify by patching the file read to
+        block on an event; while it's blocked, a second thread's
+        load() must return without doing any work."""
+        body_started = threading.Event()
+        body_may_continue = threading.Event()
+
+        original_read = Path.read_text
+
+        def slow_read_text(self, *args, **kwargs):
+            # Only stall when the code under test reads the event-state
+            # file; other Path.read_text callers (unrelated mocks,
+            # logging, etc.) pass straight through to the real method.
+            if str(self) == str(_harness.EVENT_STATE_FILE):
+                body_started.set()
+                body_may_continue.wait(timeout=5)
+            return original_read(self, *args, **kwargs)
+
+        results = {"second_caller_returned": False}
+
+        def first_caller():
+            with mock.patch.object(Path, "read_text", slow_read_text):
+                self.mgr.load()
+
+        def second_caller():
+            body_started.wait(timeout=5)
+            # First caller is now blocked inside the body (after
+            # claiming _loaded=True). Our load() call must return
+            # immediately without doing any disk I/O.
+            t0 = time.monotonic()
+            self.mgr.load()
+            elapsed = time.monotonic() - t0
+            results["elapsed"] = elapsed
+            results["second_caller_returned"] = True
+            # Release the first caller so it can finish.
+            body_may_continue.set()
+
+        t1 = threading.Thread(target=first_caller)
+        t2 = threading.Thread(target=second_caller)
+        t1.start()
+        t2.start()
+        t2.join(timeout=10)
+        t1.join(timeout=10)
+
+        self.assertTrue(
+            results["second_caller_returned"],
+            msg="second concurrent load() did not return — the lock "
+                "claim is not freeing the second caller, suggesting "
+                "the guard still serializes the entire body.",
+        )
+        self.assertLess(
+            results.get("elapsed", 99), 1.0,
+            msg=f"second load() took {results.get('elapsed')}s — should "
+                f"have been ~immediate (the claim path exits before "
+                f"the slow body). Implies the lock is held through "
+                f"the body, defeating the purpose of the claim.",
+        )
+
+
+@unittest.skipUnless(HARNESS_AVAILABLE, "harness module not importable")
+class TestLoadStaticInvariant(unittest.TestCase):
+    """Static check against the source: the ``_loaded`` check-and-set
+    must happen inside a ``with self._lock:`` block. Catches regressions
+    where a refactor moves the check back out of the lock."""
+
+    def test_loaded_check_is_inside_lock(self):
+        source = (SCRIPTS / "harness.py").read_text(encoding="utf-8")
+
+        # Locate the load() function body.
+        marker = "    def load(self):"
+        idx = source.find(marker)
+        self.assertGreaterEqual(idx, 0, msg="EventLifecycleManager.load() not found")
+
+        # Read forward until the next top-level def or class boundary.
+        sig_end = source.find("\n", idx) + 1
+        next_def = source.find("\n    def ", sig_end)
+        next_class = source.find("\nclass ", sig_end)
+        end_candidates = [n for n in (next_def, next_class) if n > 0]
+        end = min(end_candidates) if end_candidates else len(source)
+        body = source[sig_end:end]
+
+        # The very first non-comment, non-docstring, non-blank line of
+        # logic must be `with self._lock:` so the _loaded check is
+        # under the lock. Walk forward past the docstring (triple-quoted)
+        # and any leading comments to find the first executable line.
+        lines = body.splitlines()
+        in_docstring = False
+        first_logic = None
+        for line in lines:
+            s = line.strip()
+            if not s:
+                continue
+            if s.startswith('"""') or s.startswith("'''"):
+                # Toggle docstring; handle one-liners.
+                quote = s[:3]
+                if s.count(quote) >= 2 and len(s) > 3:
+                    continue  # single-line docstring
+                in_docstring = not in_docstring
+                continue
+            if in_docstring:
+                continue
+            if s.startswith("#"):
+                continue
+            first_logic = s
+            break
+
+        self.assertIsNotNone(first_logic, msg="no executable line in load() body")
+        self.assertTrue(
+            first_logic.startswith("with self._lock"),
+            msg=(
+                f"load()'s first executable line is {first_logic!r} — "
+                f"must be `with self._lock:` so the _loaded check-and-set "
+                f"is lock-protected (#9357). If you refactored, ensure "
+                f"the new shape still claims _loaded atomically."
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #9357

### Summary
Wrap `EventLifecycleManager.load()`'s `_loaded` idempotency check-and-set in `self._lock` so concurrent callers can't both pass the early-return guard and double-append events into `EventStream` (which would also inflate the #9331 lifetime emit counter — relied on by the eviction-signal hint).

### Acceptance
- [x] `EventLifecycleManager.load()` `_loaded` check-and-set is lock-protected.
- [x] Tests pin the contract: 4 runtime tests (sanity, single-thread idempotency, 8-thread contention, claim-before-body timing) + 1 static source guard.

### Approach
Picked Option 1 from the issue body (lock-guarded check-and-set) over Option 2 (document not-thread-safe + contract test). Cheaper to enforce at runtime than to depend on documentation; matches the pattern every other `self._lock`-using method in this class already follows.

Key invariant: claim `_loaded = True` BEFORE any state mutation, so even if `load()` crashes mid-body, the manager is marked loaded and a retry returns silently. This matches the prior semantics where lines 667/673 set `_loaded = True` on missing-file and parse-error fast paths.

### Changes
- **`references/scripts/harness.py:662-714`** — `load()` rewritten:
  - Top of function: `with self._lock: if self._loaded: return; self._loaded = True`.
  - Existing body unchanged (file read, parse, second `self._lock` block for in-flight state restore, append events outside both locks).
- **`tests/test_9357_eventlifecycle_load_thread_safety.py`** (new): 5 tests across `TestLoadIdempotencyGuardLockProtected` (4 runtime) and `TestLoadStaticInvariant` (1 source-level).

### Out of scope
- Refactoring the rest of `EventLifecycleManager` for thread-safety. Other methods (e.g. `_persist`, `dispatch`, `ack`) already use `self._lock`; this PR only closes the gap in `load()`.

### QA Status
- [x] `python tests/run_tests.py` — passes, no regressions.
- [x] `python -m pytest tests/test_9357_eventlifecycle_load_thread_safety.py` — 5/5 pass.
- [x] Self-review clean.
- [x] External code review (deepseek-v4-pro): **NO_FINDINGS**. Reviewer traced all `_loaded` paths under `self._lock`, verified TOCTOU between `exists()` and `read_text()` is handled by the existing exception handler with `_loaded` already True, confirmed lock-ordering invariant `self._lock → EventStream._lock` is maintained (load() never holds both simultaneously), and audited each test assertion against the invariant it claims to test.

### Setup/Upgrade Sync Check
- [x] New config values: N/A
- [x] New files/directories: 1 test file + 1 review artifact
- [x] Modified template structure: N/A
- [x] Added/removed sub-skills: N/A
- [x] Changed role composition: N/A
