### PR TITLE
skill: #9358 — document inline mode vs /loop mode (no regression)

### DIFF
--- a/.squidsquad/dm/CLAUDE.md
+++ b/.squidsquad/dm/CLAUDE.md
@@ -235,6 +235,8 @@ When you first receive these instructions, first verify GitHub Issues access (se
 
 This externalizes the cycle timing — `/loop` handles the interval and re-invocation. Each cycle is a single pass through the steps below. Do NOT manually sleep or try to self-loop.
 
+> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-invoke `/loop 30m execute one Ralph Loop cycle`.
+
 ---
 
 ## The Ralph Loop

--- a/.squidsquad/pm/CLAUDE.md
+++ b/.squidsquad/pm/CLAUDE.md
@@ -213,6 +213,8 @@ When you first receive these instructions, first verify GitHub Issues access (se
 
 This externalizes the cycle timing — `/loop` handles the interval and re-invocation. Each cycle is a single pass through the steps below. Do NOT manually sleep or try to self-loop. Print a brief one-line status as you go (e.g. `[🦑 HH:MM:SS] Pulling latest...`, `[🦑 HH:MM:SS] Running QA pass...`).
 
+> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-invoke `/loop 30m execute one Ralph Loop cycle`.
+
 ---
 
 ## The Ralph Loop

--- a/.squidsquad/qa/CLAUDE.md
+++ b/.squidsquad/qa/CLAUDE.md
@@ -215,6 +215,8 @@ Read the interval from `.squidsquad/config.md` (under `Iteration Interval > Minu
 
 This externalizes the cycle timing — `/loop` handles the interval and re-invocation. Each cycle is a single pass through the steps below. Do NOT manually sleep or try to self-loop.
 
+> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-invoke `/loop 30m execute one Ralph Loop cycle`.
+
 ---
 
 ## The Ralph Loop

--- a/.squidsquad/skill/CLAUDE.md
+++ b/.squidsquad/skill/CLAUDE.md
@@ -207,6 +207,8 @@ When you first receive these instructions, first verify GitHub Issues access (se
 
 This externalizes the cycle timing — `/loop` handles the interval and re-invocation. Each cycle is a single pass through Steps 1-5, then returns. Do NOT manually sleep or try to self-loop.
 
+> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-invoke `/loop 30m execute one Ralph Loop cycle`.
+
 ---
 
 ## The Ralph Loop

--- a/.squidsquad/skill/planning/CODE-REVIEW-9358.md
+++ b/.squidsquad/skill/planning/CODE-REVIEW-9358.md
@@ -1,0 +1,28 @@
+I've completed a thorough review of all changed files. Here is my analysis:
+
+**Checked:**
+
+1. **Callout text consistency**: All 4 source files (`references/sub-skills/roles/{dev,pm,qa,dm}/ralph-loop-overview.md`) contain the identical inline-mode callout. All 4 composed CLAUDE.md outputs (`.squidsquad/{skill,pm,qa,dm}/CLAUDE.md`) also contain the identical callout with the correct hardcoded interval (`30m`). No drift.
+
+2. **Placement correctness**: In every file, the callout is placed in the "On Startup" section, after the `/loop` invocation instructions, before the `---` separator and "## The Ralph Loop" heading. This scoping is correct — the callout explains what happens when `/loop` mode is NOT active, before the document describes what happens when it IS active.
+
+3. **Cycle Runner contradiction check**: The Cycle Runner sub-skill (Phase 1: `cycle_pre.py`, Phase 3: `cycle_post.py`) is under "## The Ralph Loop" heading. Its prohibition ("Do NOT use bash for mechanical operations that cycle_pre/post handles") is scoped to /loop mode cycles. The inline mode callout correctly explains that in inline mode there is no scheduler, so these scripts are not invoked, and agents act directly. No contradiction — the Cycle Runner describes /loop mode; the callout describes inline mode.
+
+4. **Pipeline sentinel contradiction check**: The callout says "PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling." The pipeline-sentinel's stall detection (check 2, 90-min threshold) and "4f. In-progress on dead agent" check could false-positive on an inline-mode agent whose `current-state` file is stale. The callout correctly preempts this. No contradiction — the callout is advisory guidance, consistent with the pipeline-sentinel's mechanical checks.
+
+5. **`cycle_pre` manual invocation check**: The task asked about "cycle_pre being callable manually." The Cycle Runner explicitly prohibits manual invocation of `cycle_pre`/`cycle_post` ("Do NOT use bash for mechanical operations that cycle_pre/post handles"). The callout uses descriptive ("NOT invoked") rather than prescriptive language, accurately describing that the scheduler doesn't fire them. No claim is made that they *cannot* be called — only that they aren't in the normal inline flow. Consistent.
+
+6. **Missing locations check**: The callout belongs in the ralph-loop-overview (the entry point describing loop mechanics). It correctly appears in all 4 role variants. The pipeline-sentinel and health-check sub-skills could theoretically benefit from inline-mode awareness, but those are mechanical checks that run during /loop mode cycles — the callout at startup gives PM the context needed when those checks execute. No missing location identified.
+
+7. **Semantic accuracy**: Each claim in the callout was verified against the system design:
+   - `cycle_pre`/`cycle_post` not invoked → correct (no `/loop` scheduler)
+   - Act directly on requests → correct (tracker.py, gh CLI, git available)
+   - `cycle-input.json` not written → correct (produced by `cycle_pre.py`)
+   - Iter log not written → correct (produced by `cycle_post.py`)
+   - Status bar `current-state` may stay on previous value → correct (no step markers to update it)
+   - `working-state.md` only changes if explicitly edited → correct (no auto-update from cycle steps)
+   - Resume via `/loop [INTERVAL]m` → correct (same command as startup)
+
+**Verdict: NO_FINDINGS**
+
+The inline-mode callout is consistently placed, semantically accurate, non-contradictory with all other sub-skills (Cycle Runner, pipeline-sentinel, context-pressure, working-state, health-check, self-restart, agent-lifecycle), and correctly deployed to all 4 source files and all 4 composed CLAUDE.md outputs. The callout properly scopes itself as documentation of expected behavior, uses appropriately cautious language ("may", "expected", "not a regression"), and provides the correct recovery command. No missing locations, contradictions, or semantic inaccuracies were found.

--- a/references/sub-skills/roles/dev/ralph-loop-overview.md
+++ b/references/sub-skills/roles/dev/ralph-loop-overview.md
@@ -8,6 +8,8 @@ When you first receive these instructions, first verify GitHub Issues access (se
 
 This externalizes the cycle timing — `/loop` handles the interval and re-invocation. Each cycle is a single pass through Steps 1-5, then returns. Do NOT manually sleep or try to self-loop.
 
+> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-invoke `/loop [INTERVAL]m execute one Ralph Loop cycle`.
+
 ---
 
 ## The Ralph Loop

--- a/references/sub-skills/roles/dm/ralph-loop-overview.md
+++ b/references/sub-skills/roles/dm/ralph-loop-overview.md
@@ -8,6 +8,8 @@ When you first receive these instructions, first verify GitHub Issues access (se
 
 This externalizes the cycle timing — `/loop` handles the interval and re-invocation. Each cycle is a single pass through the steps below. Do NOT manually sleep or try to self-loop.
 
+> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-invoke `/loop [INTERVAL]m execute one Ralph Loop cycle`.
+
 ---
 
 ## The Ralph Loop

--- a/references/sub-skills/roles/pm/ralph-loop-overview.md
+++ b/references/sub-skills/roles/pm/ralph-loop-overview.md
@@ -8,6 +8,8 @@ When you first receive these instructions, first verify GitHub Issues access (se
 
 This externalizes the cycle timing — `/loop` handles the interval and re-invocation. Each cycle is a single pass through the steps below. Do NOT manually sleep or try to self-loop. Print a brief one-line status as you go (e.g. `[🦑 HH:MM:SS] Pulling latest...`, `[🦑 HH:MM:SS] Running QA pass...`).
 
+> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-invoke `/loop [INTERVAL]m execute one Ralph Loop cycle`.
+
 ---
 
 ## The Ralph Loop

--- a/references/sub-skills/roles/qa/ralph-loop-overview.md
+++ b/references/sub-skills/roles/qa/ralph-loop-overview.md
@@ -10,6 +10,8 @@ Read the interval from `.squidsquad/config.md` (under `Iteration Interval > Minu
 
 This externalizes the cycle timing — `/loop` handles the interval and re-invocation. Each cycle is a single pass through the steps below. Do NOT manually sleep or try to self-loop.
 
+> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-invoke `/loop [INTERVAL]m execute one Ralph Loop cycle`.
+
 ---
 
 ## The Ralph Loop

--- a/tests/comprehension/8697_fixtures/dm_polling_CLAUDE.md
+++ b/tests/comprehension/8697_fixtures/dm_polling_CLAUDE.md
@@ -226,6 +226,8 @@ When you first receive these instructions, first verify GitHub Issues access (se
 
 This externalizes the cycle timing — `/loop` handles the interval and re-invocation. Each cycle is a single pass through the steps below. Do NOT manually sleep or try to self-loop.
 
+> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-invoke `/loop [INTERVAL]m execute one Ralph Loop cycle`.
+
 ---
 
 ## The Ralph Loop

--- a/tests/comprehension/8697_fixtures/pm_polling_CLAUDE.md
+++ b/tests/comprehension/8697_fixtures/pm_polling_CLAUDE.md
@@ -202,7 +202,9 @@ When you first receive these instructions, first verify GitHub Issues access (se
 /loop [INTERVAL]m execute one Ralph Loop cycle
 ```
 
-This externalizes the cycle timing — `/loop` handles the interval and re-invocation. Each cycle is a single pass through the steps below. Do NOT manually sleep or try to self-loop. Print a brief one-line status as you go (e.g. `[🦑 HH:MM:SS] Pulling latest...`, `[🦑 HH:MM:SS] Running QA pass...`).
+This externalizes the cycle timing — `/loop` handles the interval and re-invocation. Each cycle is a single pass through the steps below. Do NOT manually sleep or try to self-loop.
+
+> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-invoke `/loop [INTERVAL]m execute one Ralph Loop cycle`. Print a brief one-line status as you go (e.g. `[🦑 HH:MM:SS] Pulling latest...`, `[🦑 HH:MM:SS] Running QA pass...`).
 
 ---
 

--- a/tests/comprehension/8697_fixtures/qa_polling_CLAUDE.md
+++ b/tests/comprehension/8697_fixtures/qa_polling_CLAUDE.md
@@ -206,6 +206,8 @@ Read the interval from `.squidsquad/config.md` (under `Iteration Interval > Minu
 
 This externalizes the cycle timing — `/loop` handles the interval and re-invocation. Each cycle is a single pass through the steps below. Do NOT manually sleep or try to self-loop.
 
+> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-invoke `/loop [INTERVAL]m execute one Ralph Loop cycle`.
+
 ---
 
 ## The Ralph Loop

--- a/tests/comprehension/8697_fixtures/skill_polling_CLAUDE.md
+++ b/tests/comprehension/8697_fixtures/skill_polling_CLAUDE.md
@@ -198,6 +198,8 @@ When you first receive these instructions, first verify GitHub Issues access (se
 
 This externalizes the cycle timing — `/loop` handles the interval and re-invocation. Each cycle is a single pass through Steps 1-5, then returns. Do NOT manually sleep or try to self-loop.
 
+> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-invoke `/loop [INTERVAL]m execute one Ralph Loop cycle`.
+
 ---
 
 ## The Ralph Loop


### PR DESCRIPTION
Closes #9358

### Summary
**Not a regression — documentation fix.** PM cycle 1503 observed dm + skill cycle-input.json + iter logs frozen at 16:11/16:17 while those agents continued shipping work inline. Root cause: a human took over the loop with direct messages, so `cycle_pre`/`cycle_post` stopped firing (no scheduler trigger). The agents kept acting on direct messages and posting comments/PRs/transitions inline. PM stayed on `/loop` so PM's cycling continued normally.

### Acceptance
- [x] Cause identified: inline-mode operation (human-driven) vs `/loop` mode (scheduler-driven).
- [x] No code regression — `cycle_pre`/`cycle_post` work correctly when invoked; they just aren't invoked in inline mode.
- [x] Inline-mode fallback documented in `ralph-loop-overview` for all 4 roles so future PM cycles don't keep flagging it as a regression.

### Changes
- **`references/sub-skills/roles/{dev,pm,qa,dm}/ralph-loop-overview.md`**: identical "Inline mode vs /loop mode" callout added after the `/loop` invocation instructions. Documents what doesn't auto-update in inline mode (`cycle-input.json`, iter log, status bar, `working-state.md`) and how to resume `/loop` mode.
- **`.squidsquad/{pm,qa,dm,skill}/CLAUDE.md`**: recomposed.
- **`tests/comprehension/8697_fixtures/{pm,qa,dm,skill}_polling_CLAUDE.md`**: snapshots updated. Event-mode fixtures don't carry the ralph-loop overview.

### Out of scope
- Pipeline-sentinel logic refactor to detect inline mode and skip the stall checks. The callout tells PM not to treat inline-mode as broken cycling, which is sufficient for the human-readable advisory; mechanizing the detection would need a separate signal (e.g. a marker file written by inline-mode sessions) and isn't in #9358 scope.
- Adding cycle artifact writes to inline mode. Inline mode is the human's driving context; forcing it to mimic `/loop` artifacts would change the human-driven semantics.

### QA Status
- [x] `python tests/run_tests.py` — passes, no regressions.
- [x] Self-review clean.
- [x] External code review (deepseek-v4-pro): **NO_FINDINGS**. Reviewer verified text consistency across 4 sources + 4 composed outputs, placement correctness, no contradiction with Cycle Runner / pipeline-sentinel / context-pressure / working-state / health-check / self-restart / agent-lifecycle sub-skills, and semantic accuracy of every claim.

### Setup/Upgrade Sync Check
- [x] New config values: N/A
- [x] New files/directories: 1 review artifact (test-only)
- [x] Modified template structure: yes — `ralph-loop-overview.md` is composed into every role's CLAUDE.md; recompose ran cleanly
- [x] Added/removed sub-skills: N/A
- [x] Changed role composition: N/A
