### PR TITLE
skill: #9474 — stop dropping DM edits to SKILL.md and config.md

### DIFF
--- a/.squidsquad/skill/planning/CODE-REVIEW-9474-R2.md
+++ b/.squidsquad/skill/planning/CODE-REVIEW-9474-R2.md
@@ -1,0 +1,11 @@
+NO_FINDINGS
+
+After thorough review of both changed files (`references/scripts/git_ops.py` and `tests/test_git_ops.py`), the #9474 changes are correct and complete:
+
+- **`_role_owned_patterns`**: The DM role's allowlist now includes `SKILL.md` (for doc-improvement-loop rotation scanning + line-level corrections) and `.squidsquad/config.md` (for Shipped Since Last Bump counter increments and feature-flag toggles). The 12-line KNOWN LIMITATION comment documents the `config.md merge=ours` race hazard with escape hatches. No other role's patterns were altered.
+
+- **`commit_role_scoped`**: Unchanged — it already calls `push(role=role)`, propagating the role kwarg.
+
+- **Tests**: `test_dm_stages_skill_md_and_config_md` verifies both files are staged and, critically, asserts `mock_push.assert_called_once_with(role='dm')` (the R1-identified gap). `test_pm_does_not_pick_up_dm_extras` confirms the boundary between PM and DM patterns is clean. `test_qa_has_no_extras_beyond_common` confirms QA doesn't inherit `SKILL.md`.
+
+No regressions, no edge-case gaps, no integration issues, and no philosophy violations. The changes address both R1 warnings directly.

--- a/.squidsquad/skill/planning/CODE-REVIEW-9474.md
+++ b/.squidsquad/skill/planning/CODE-REVIEW-9474.md
@@ -1,0 +1,32 @@
+### Finding 1
+
+- **File**: `references/scripts/git_ops.py`
+- **Line**: 399–416 (the `role_specific` dict in `_role_owned_patterns`)
+- **Severity**: warning
+- **Issue**: Co-ownership of `.squidsquad/config.md` by both PM and DM introduces a silent-data-loss race window. Both roles now independently stage and push `config.md` via `commit_role_scoped`. The `.gitattributes` entry `config.md merge=ours` (confirmed at test_git_ops.py line ~760) means that on any push rejection (non-fast-forward), the subsequent `pull` keeps the *local* version and discards the remote version — the first pusher's config.md edits are silently overwritten.
+- **Evidence**: 
+  - Before this change, only PM owned `config.md` in `commit_role_scoped`. With DM added as a co-owner, two roles in the same cycle can now both mutate different fields (PM: housekeeping; DM: ship-counter + flags) and both will attempt to push. 
+  - In single-clone sequential execution, this is safe because the second role's commit is a fast-forward child of the first's. But the project's own comment at line ~376 states *"A single clone can have multiple agents and parallel processes writing files"* — parallel processes in one clone, or multiple clones running cycles, can produce a push race.
+  - The `merge=ours` strategy means the loser's pull silently accepts the local (loser's) version and drops the winner's remote changes. There is no merge-conflict marker or warning surfaced to either agent.
+- **Suggested fix**: Either (a) document that `config.md` co-ownership requires strictly serialized cycle execution and add a guard in `commit_role_scoped` (e.g., pull-before-commit for co-owned files), or (b) split the DM-only fields into a separate file (e.g., `.squidsquad/dm-ship-state.md`) so each role has exclusive ownership and `merge=ours` can't cross-erase. If co-ownership is kept, consider switching `config.md` to `merge=union` so both sides' lines are preserved, at the cost of requiring the file format to tolerate duplicate/accumulated keys.
+
+---
+
+### Finding 2
+
+- **File**: `tests/test_git_ops.py`
+- **Line**: ~570–600 (the `test_dm_stages_skill_md_and_config_md` test)
+- **Severity**: warning
+- **Issue**: The test mocks `push` at the module level (`@patch("git_ops.push", return_value=True)`) but `commit_role_scoped` passes `role=role` to `push`. The mock ignores arguments, so the test cannot detect a regression where `push` is called without the `role` keyword (which would drop the `git-push` event emission for DM). The test passes regardless of whether the role is correctly threaded to the push event.
+- **Evidence**: At lines ~535–540 the test patches `git_ops.push` with a generic `return_value=True`. The real `push(role=role)` at line ~477 calls `_emit("git-push", ...)` with the role. The mock replaces the entire function, so the event is never emitted and the role propagation is never verified. Compare with `TestPushEmitsRole` (line ~180–210) which explicitly tests that `push(role=...)` calls `_emit` with the correct role kwargs — the runtime integration test for DM staging doesn't replicate this check.
+- **Suggested fix**: Add an assertion that `mock_push` was called with the expected role keyword, e.g.:
+  ```python
+  mock_push.assert_called_once_with(role="dm")
+  ```
+  This verifies the role reaches the push event without needing to mock `_emit` in the integration-style test.
+
+---
+
+### Verdict
+
+**One genuine race-condition finding (warning severity) and one test-gap finding (warning severity).** The pattern boundaries are correct — DM's new ownership of `SKILL.md` and co-ownership of `.squidsquad/config.md` are properly isolated from QA and PM extras, and the new tests validly exercise the allowlist. However, the config.md co-ownership combined with the existing `merge=ours` strategy creates a silent-data-loss hazard under any concurrent execution, and the integration test for DM staging doesn't validate that the role is propagated to the push event. Neither is a correctness blocker for strictly-serial single-clone operation, but both warrant attention before production deployment of parallel cycles.

--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -588,7 +588,37 @@ def _role_owned_patterns(role):
     ]
     role_specific = {
         "pm": [".squidsquad/config.md", ".squidsquad/project/"],
-        "dm": ["README.md", "CHANGELOG.md", "docs/"],
+        # DM also legitimately writes SKILL.md (doc-improvement-loop
+        # rotation scanning + line-level corrections) and
+        # .squidsquad/config.md (Shipped Since Last Bump counter
+        # increments, feature-flag toggles post-delivery). Before #9474
+        # those edits were treated as foreign and left dirty in the
+        # working tree — they either rotted for cycles or got
+        # overwritten when a sibling commit re-staged the same file
+        # from a stale base. Co-ownership of config.md with PM is
+        # intentional: both roles legitimately mutate different fields
+        # (PM: own-domain housekeeping; DM: ship counter + flags).
+        #
+        # KNOWN LIMITATION (#9474 follow-up): config.md has
+        # `merge=ours` set in `.gitattributes`. Concurrent edits from
+        # PM and DM can silently overwrite each other's changes via
+        # the "ours" merge driver. The same hazard already existed
+        # under PM-only ownership (PM cycles in parallel clones, plus
+        # compose.py deploy contamination on feature branches —
+        # already guarded by `commit_code`'s checkout-from-working-
+        # branch step). The current single-clone, serial-cycle setup
+        # in `.local-config` makes the race unlikely. If parallel
+        # multi-clone execution is enabled later, split the DM-only
+        # fields (ship-counter + flags) into a separate file with
+        # exclusive ownership, OR convert config.md to a structured
+        # format that tolerates `merge=union`.
+        "dm": [
+            "README.md",
+            "CHANGELOG.md",
+            "docs/",
+            "SKILL.md",
+            ".squidsquad/config.md",
+        ],
         # qa: nothing beyond common
     }
     return common + role_specific.get(role, [])

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -646,12 +646,30 @@ class TestRoleOwnedPatterns:
         assert "README.md" in pats
         assert "CHANGELOG.md" in pats
         assert "docs/" in pats
+        # #9474: DM also owns SKILL.md (doc-improvement-loop) and
+        # co-owns .squidsquad/config.md (ship-counter + flag toggles).
+        # Pre-#9474 these were treated as foreign and left dirty.
+        assert "SKILL.md" in pats
+        assert ".squidsquad/config.md" in pats
 
     def test_qa_has_no_extras_beyond_common(self):
         pats = git_ops._role_owned_patterns("qa")
         # QA must NOT pick up config or delivery docs
         assert ".squidsquad/config.md" not in pats
         assert "README.md" not in pats
+        # #9474 sanity check: QA also must NOT pick up SKILL.md —
+        # the DM-extras additions don't bleed into other roles.
+        assert "SKILL.md" not in pats
+
+    def test_pm_does_not_pick_up_dm_extras(self):
+        """#9474: PM and DM co-own .squidsquad/config.md, but PM must
+        NOT inherit DM's SKILL.md ownership (skill owns its own file
+        through the branch+PR workflow). Sanity check on the pattern
+        boundary between PM and DM."""
+        pats = git_ops._role_owned_patterns("pm")
+        assert "SKILL.md" not in pats
+        assert "README.md" not in pats
+        assert "CHANGELOG.md" not in pats
 
 
 class TestPathMatches:
@@ -728,6 +746,48 @@ class TestCommitRoleScoped:
         assert "CHANGELOG.md" in staged
         assert "docs/release-notes.md" in staged
         assert ".squidsquad/dm/working-state.md" in staged
+
+    @patch("git_ops.push", return_value=True)
+    @patch("git_ops.commit", return_value=True)
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_dm_stages_skill_md_and_config_md(
+        self, mock_run, mock_run_list, mock_commit, mock_push
+    ):
+        """#9474 regression: DM's cycle commit must include SKILL.md
+        (doc-improvement-loop) and .squidsquad/config.md (Shipped Since
+        Last Bump counter + feature-flag toggles). Before the fix these
+        files were treated as foreign and either rotted in the working
+        tree across cycles or got overwritten by sibling commits."""
+        mock_run.return_value = _mock_result(stdout=(
+            " M SKILL.md\n"
+            " M .squidsquad/config.md\n"
+            " M .squidsquad/dm/working-state.md\n"
+        ))
+        mock_run_list.return_value = _mock_result()
+
+        result = git_ops.commit_role_scoped("dm", "dm: ship #9474 + counter")
+        assert result is True
+
+        staged = [c[0][0][-1] for c in mock_run_list.call_args_list
+                  if c[0][0][:2] == ["git", "add"]]
+        assert "SKILL.md" in staged, (
+            "DM cycle commit must stage SKILL.md when dirty — "
+            "doc-improvement-loop fixes were silently rotting "
+            "in the working tree before #9474."
+        )
+        assert ".squidsquad/config.md" in staged, (
+            "DM cycle commit must stage .squidsquad/config.md when "
+            "dirty — the Shipped Since Last Bump counter was being "
+            "silently dropped before #9474."
+        )
+        assert ".squidsquad/dm/working-state.md" in staged
+
+        # Ensure the role kwarg propagates to the push call — without
+        # it the git-push event would be emitted with role=None and
+        # the audit trail would lose the DM attribution. Tightening
+        # this assertion was the deepseek R1 finding on this PR.
+        mock_push.assert_called_once_with(role="dm")
 
     @patch("git_ops.commit", return_value=True)
     @patch("git_ops.push", return_value=True)


### PR DESCRIPTION
Closes #9474

### Summary
Add `SKILL.md` and `.squidsquad/config.md` to DM's `_role_owned_patterns` allowlist so `cycle_post`'s commit-role-scoped path stages them instead of leaving them dirty. DM's doc-improvement-loop fixes to `SKILL.md` and ship-counter/feature-flag edits to `config.md` were silently rotting in the working tree or getting overwritten by sibling commits before this fix.

### Acceptance
- [x] `cycle_post.py dm` stages `SKILL.md` when dirty.
- [x] `cycle_post.py dm` stages `.squidsquad/config.md` when dirty.
- [x] `CHANGELOG.md` already covered (preserved from prior pattern).
- [x] `docs/` already covered (preserved from prior pattern).
- [x] No bleed into PM or QA patterns.

### Approach
Conservative — DM owns files documented in the role doc, not `git add -A`. The existing `_role_owned_patterns()` mechanism is the right place; just add the two missing entries to the `dm` role-specific list. config.md becomes co-owned with PM since both legitimately mutate different fields.

### Changes
- **`references/scripts/git_ops.py`** — `_role_owned_patterns("dm")` now includes `SKILL.md` and `.squidsquad/config.md` alongside the existing `README.md` / `CHANGELOG.md` / `docs/`. 12-line inline comment documents the rationale + known limitation around `config.md merge=ours` race (deepseek R1).
- **`tests/test_git_ops.py`** — 4 test additions:
  - `test_dm_extras` extended to assert the new patterns.
  - `test_qa_has_no_extras_beyond_common` extended to assert QA does NOT inherit SKILL.md.
  - `test_pm_does_not_pick_up_dm_extras` — new boundary sanity check.
  - `test_dm_stages_skill_md_and_config_md` — runtime integration test that the commit flow stages both files and propagates the role kwarg to `push` (the deepseek R1 test-gap finding).

### Out of scope
- Splitting DM-only fields out of `config.md` to a separate file. The current single-clone serial-cycle setup makes the `merge=ours` race unlikely; if parallel multi-clone execution is ever enabled, the inline comment documents the escape hatches.
- Auditing PM/QA `cycle_post` patterns for analogous gaps. The issue body recommended this; QA has no extras today (deliberate); PM already owns config.md and project/. No gap found.
- Changing `.gitattributes` `merge=ours` on `config.md`. Out of scope; documented as known limitation.

### QA Status
- [x] `python tests/run_tests.py` — passes, no regressions.
- [x] `python -m pytest tests/test_git_ops.py` — 110/110 pass.
- [x] Self-review clean.
- [x] External code review (deepseek-v4-pro, 2 rounds): R1 = 2 warnings (config.md race documented inline + escape hatches; test gap on role kwarg propagation fixed with `mock_push.assert_called_once_with(role='dm')`). R2 = **NO_FINDINGS**.

### Setup/Upgrade Sync Check
- [x] New config values: N/A
- [x] New files/directories: 2 review artifacts (test-only)
- [x] Modified template structure: N/A (script + tests only)
- [x] Added/removed sub-skills: N/A
- [x] Changed role composition: N/A
