### PR TITLE
skill: #9665 — extend #9481 fix; remove inline update_health from /agents endpoints

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -1188,9 +1188,14 @@ async def get_root():
 
 @app.get("/agents")
 async def list_agents():
-    """List agents with state."""
-    # #9481: see get_status — keep sync subprocess off the event loop.
-    await asyncio.to_thread(state.update_health)
+    """List agents with state.
+
+    #9665: no inline update_health() call (extends #9481). On warm
+    Windows runs the call exceeds 30s even off the event loop, which
+    timed out callers like the #9398 real-subprocess tests. The
+    background health poller (HEALTH_POLL_INTERVAL) is the
+    authoritative freshness budget for this endpoint.
+    """
     return {"agents": state.all_agents()}
 
 
@@ -1267,10 +1272,12 @@ async def stop_all():
 
 @app.get("/agents/{role}")
 async def get_agent(role: str):
-    """Get single agent state."""
+    """Get single agent state.
+
+    #9665: no inline update_health() call (extends #9481). See
+    list_agents — same freshness rationale.
+    """
     _validate_role(role)
-    # #9481: see get_status — keep sync subprocess off the event loop.
-    await asyncio.to_thread(state.update_health)
     agent = state.get_agent(role)
     if agent is None:
         return {"role": role, "status": "unknown", "message": "No health data yet"}
@@ -1319,10 +1326,12 @@ async def start_agent(role: str):
 
 @app.get("/agents/{role}/health")
 async def get_agent_health(role: str):
-    """Agent health endpoint — process status, last cycle, phase, context pressure (#4966)."""
+    """Agent health endpoint — process status, last cycle, phase, context pressure (#4966).
+
+    #9665: no inline update_health() call (extends #9481). See
+    list_agents — same freshness rationale.
+    """
     _validate_role(role)
-    # #9481: see get_status — keep sync subprocess off the event loop.
-    await asyncio.to_thread(state.update_health)
     agent = state.get_agent(role)
 
     result = {

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -103,6 +103,7 @@ STATIC_TEST_MODULES = [
     "test_vault_synthesis",
     "test_work_queue",
     "test_9481_update_health_off_event_loop",
+    "test_9665_no_inline_update_health_on_agents_endpoints",
     # #9398 Phase A unit tests
     "test_9398_squidsquad_dir_env_var",
     "test_9398_gh_shim",

--- a/tests/test_9481_update_health_off_event_loop.py
+++ b/tests/test_9481_update_health_off_event_loop.py
@@ -25,12 +25,16 @@ The fix has two parts:
    refreshes state every ``HEALTH_POLL_INTERVAL`` seconds; ``/status``
    returns cached state in milliseconds.
 
-2. The other three read-only handlers wrap ``update_health()`` in
-   ``await asyncio.to_thread(...)`` so the slow probe runs in a
-   worker thread instead of freezing the loop.
+2. The other three read-only handlers wrapped ``update_health()`` in
+   ``await asyncio.to_thread(...)`` so the slow probe ran in a worker
+   thread instead of freezing the loop.
 
-Same anti-pattern, same fix shape, as #9242's ``save_state`` wraps —
-just on a different function.
+   **Superseded by #9665.** On warm Windows runs the probe exceeds
+   30s even off the event loop, which timed out the #9398
+   real-subprocess integration tests. #9665 removed the inline call
+   from those three handlers as well — same treatment ``/status``
+   already got. The positive assertion for that new invariant lives
+   in ``test_9665_no_inline_update_health_on_agents_endpoints.py``.
 """
 
 import importlib.util
@@ -121,58 +125,13 @@ class TestStatusEndpointNoInlineUpdateHealth(unittest.TestCase):
         )
 
 
-class TestReadOnlyHandlersUpdateHealthOffEventLoop(unittest.TestCase):
-    """Other read-only async handlers may still want fresh data on each
-    call (e.g. ``/agents/{role}/health`` is a deliberate probe). They
-    MUST wrap ``state.update_health()`` in ``await asyncio.to_thread(...)``
-    so the subprocess storm runs in a worker thread instead of freezing
-    the asyncio loop. Same shape as #9242's ``save_state`` wraps."""
-
-    HANDLERS = [
-        "async def list_agents",          # GET /agents
-        "async def get_agent",            # GET /agents/{role}
-        "async def get_agent_health",     # GET /agents/{role}/health
-    ]
-
-    def setUp(self):
-        self.source = HARNESS_PATH.read_text(encoding="utf-8")
-
-    def test_no_bare_update_health_in_async_handlers(self):
-        for handler in self.HANDLERS:
-            with self.subTest(handler=handler):
-                body = _extract_handler_body(self.source, handler)
-                bare = [
-                    line for line in body.splitlines()
-                    if line.strip().startswith("state.update_health(")
-                ]
-                self.assertEqual(
-                    bare, [],
-                    msg=(
-                        f"{handler}: found bare state.update_health() call(s) "
-                        "on the asyncio event loop. Wrap in "
-                        "`await asyncio.to_thread(state.update_health)` per "
-                        "#9481. Offending lines:\n" + "\n".join(bare)
-                    ),
-                )
-
-    def test_to_thread_wrap_present_in_each_handler(self):
-        """Positive check: each handler still updates health, just via
-        ``to_thread``. Guards against a refactor that drops the call
-        without leaving a wrap behind."""
-        for handler in self.HANDLERS:
-            with self.subTest(handler=handler):
-                body = _extract_handler_body(self.source, handler)
-                self.assertIn(
-                    "asyncio.to_thread(state.update_health)", body,
-                    msg=(
-                        f"{handler}: expected "
-                        "`await asyncio.to_thread(state.update_health)` so "
-                        "the slow Windows tasklist probe runs off the event "
-                        "loop. If the call was deliberately removed (like "
-                        "/status), move the handler out of HANDLERS in this "
-                        "test and add a no-inline-call assertion instead."
-                    ),
-                )
+# NOTE: ``TestReadOnlyHandlersUpdateHealthOffEventLoop`` lived here in
+# the original #9481 commit and asserted that ``list_agents``,
+# ``get_agent``, and ``get_agent_health`` wrapped ``update_health`` in
+# ``asyncio.to_thread``. #9665 superseded that — those handlers no
+# longer call ``update_health`` at all (same treatment ``/status`` got
+# above). See ``test_9665_no_inline_update_health_on_agents_endpoints.py``
+# for the new invariant.
 
 
 class TestUpdateHealthStillCalledFromPoller(unittest.TestCase):

--- a/tests/test_9665_no_inline_update_health_on_agents_endpoints.py
+++ b/tests/test_9665_no_inline_update_health_on_agents_endpoints.py
@@ -1,0 +1,112 @@
+"""Tests for the #9665 follow-on to #9481.
+
+#9481 moved ``state.update_health()`` off the asyncio event loop in
+four read-only handlers — ``/status`` lost the call entirely, while
+``/agents``, ``/agents/{role}``, and ``/agents/{role}/health`` wrapped
+it in ``await asyncio.to_thread(...)``. That fixed the event-loop
+wedge.
+
+QA's re-verification of #9398 surfaced a deeper symptom: on warm
+back-to-back Windows runs the wrapped call still exceeds the 30s
+client-side timeout the #9398 helper bumped to (originally 10s →
+30s in cycle 1198). Root cause: ``state.update_health()`` shells
+out to ``tasklist`` per registered agent under ``state._lock``,
+and on a hot machine with TIME_WAIT pressure from a prior test
+suite the per-call latency can sustain 30s+ even off the event
+loop. Bumping the test-helper timeout again would just escalate
+the duct tape.
+
+#9665 fix: extend the ``/status`` treatment to the other three
+handlers. None of them may call ``state.update_health()`` inline
+on the request path — neither bare nor wrapped. Freshness is the
+background health poller's job (``HEALTH_POLL_INTERVAL = 5s``);
+that contract was already documented in the #9481 commit and the
+poller-invariant test in ``test_9481_update_health_off_event_loop.py``
+still pins it.
+
+What the #9398 test that surfaced this needs: the AgentState
+record exists with ``bootup_complete=True`` after the agent
+subprocess emits the event. That flag is set by the ``/events``
+POST handler at receipt — not by ``update_health`` — so removing
+the inline probe from ``/agents/{role}`` cannot affect the
+assertion.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HARNESS_PATH = REPO_ROOT / "references" / "scripts" / "harness.py"
+
+
+def _extract_handler_body(source: str, handler_signature: str) -> str:
+    """Return the source between ``handler_signature`` and the next
+    ``@app.``, ``def``, ``async def``, or ``class`` boundary."""
+    idx = source.find(handler_signature)
+    if idx < 0:
+        raise AssertionError(
+            f"handler '{handler_signature}' not found in harness.py — "
+            f"if it was renamed, update this test too."
+        )
+    sig_end = source.find("\n", idx) + 1
+    candidates = [
+        source.find("\n@app.", sig_end),
+        source.find("\nasync def ", sig_end),
+        source.find("\ndef ", sig_end),
+        source.find("\nclass ", sig_end),
+    ]
+    candidates = [c for c in candidates if c > 0]
+    end = min(candidates) if candidates else len(source)
+    return source[sig_end:end]
+
+
+class TestAgentsEndpointsNoInlineUpdateHealth(unittest.TestCase):
+    """``/agents``, ``/agents/{role}``, and ``/agents/{role}/health``
+    must NOT call ``state.update_health()`` on the request path —
+    neither bare nor wrapped in ``asyncio.to_thread``. On warm Windows
+    runs the call exceeds 30s, which is the documented client-side
+    budget the #9398 helper bumped to. The background health poller
+    is the only authoritative freshness path."""
+
+    HANDLERS = [
+        "async def list_agents",          # GET /agents
+        "async def get_agent",            # GET /agents/{role}
+        "async def get_agent_health",     # GET /agents/{role}/health
+    ]
+
+    def setUp(self):
+        self.source = HARNESS_PATH.read_text(encoding="utf-8")
+
+    def test_no_update_health_call_in_each_handler(self):
+        """A real call has the form ``state.update_health(`` with a
+        literal open-paren. Comments and backtick-quoted docstring
+        references are ignored — they're documentation, not call
+        sites."""
+        for handler in self.HANDLERS:
+            with self.subTest(handler=handler):
+                body = _extract_handler_body(self.source, handler)
+                offending = []
+                for line in body.splitlines():
+                    stripped = line.lstrip()
+                    if stripped.startswith("#"):
+                        continue
+                    cleaned = re.sub(r"``[^`]*``", "", line)
+                    if "state.update_health(" in cleaned:
+                        offending.append(line)
+                self.assertEqual(
+                    offending, [],
+                    msg=(
+                        f"{handler}: must NOT call state.update_health() "
+                        "(neither bare nor wrapped in asyncio.to_thread). "
+                        "The background poller refreshes state every "
+                        "HEALTH_POLL_INTERVAL seconds; on warm Windows "
+                        "runs the inline call exceeds 30s and times out "
+                        "callers (#9665, surfaced by #9398). Offending "
+                        "lines:\n" + "\n".join(offending)
+                    ),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Extends #9481's `/status` fix to `/agents`, `/agents/{role}`, and `/agents/{role}/health`. After #9481, those three handlers wrapped `state.update_health()` in `await asyncio.to_thread(...)` to keep the slow Windows-tasklist subprocess storm off the asyncio event loop. QA's re-verification of #9398 found that on warm back-to-back runs the call still exceeds the 30s client-side timeout (the helper that #9398 bumped from 10s→30s), because the per-call latency itself sustains 30s+ under TIME_WAIT socket pressure. Bumping the test-helper timeout again would just escalate the duct tape.

The background health poller (`HEALTH_POLL_INTERVAL = 5s`) already refreshes `AgentState` — same authoritative-freshness contract `/status` got under #9481. The `bootup_complete` flag the #9398 real-subprocess tests assert is set by the `/events` POST handler at receipt, not by `update_health`, so removing the inline probe cannot affect that assertion.

## Changes

- `references/scripts/harness.py` — drop the inline `update_health` call from `list_agents`, `get_agent`, `get_agent_health`. Docstrings updated with #9665 rationale.
- `tests/test_9665_no_inline_update_health_on_agents_endpoints.py` — new. Pins that those three handlers do not call `state.update_health(` on the request path.
- `tests/test_9481_update_health_off_event_loop.py` — `TestReadOnlyHandlersUpdateHealthOffEventLoop` removed (its expectation that those handlers wrap `update_health` is superseded). Top docstring notes the #9665 follow-on. Poller-invariant test still pins `_poll_loop` as the freshness path.
- `tests/run_tests.py` — registered `test_9665_*`.

## Test plan

- [x] `python -m unittest test_9665_no_inline_update_health_on_agents_endpoints test_9481_update_health_off_event_loop` — 4/4 OK.
- [x] Full suite cold run on Windows: 50/50 OK in 79.452s (faster than 99.996s pre-fix — fewer tasklist storms).
- [x] Full suite warm back-to-back run on Windows: 50/50 OK in 81.492s. The `_get_agent` `TimeoutError` QA filed is gone.

## Freshness trade-off

`/agents/{role}` and friends now report process status as stale by up to `HEALTH_POLL_INTERVAL` (5s). Same contract `/status` got under #9481 — operators get a millisecond response; freshness comes from the poller. Documented in handler docstrings.