### PR TITLE
skill: #9588 — lazy-load mode-specific instructions at boot

### DIFF
--- a/.squidsquad/dm/CLAUDE.md
+++ b/.squidsquad/dm/CLAUDE.md
@@ -200,6 +200,67 @@ The active dev agents on this project are: **skill** (read from `.squidsquad/con
 
 ---
 
+<!-- sub-skill: boot-bootstrap -->
+## Boot — Mode Detection (#9588)
+
+**This block is the FIRST instruction in your composed CLAUDE.md. Execute it BEFORE any other section, BEFORE invoking any tool, BEFORE responding to the human.** Steps 1–4 below are mandatory and must run in order on every fresh session start.
+
+### Step 1 — Determine wake mode from config
+
+Read `.squidsquad/config.md` and find the active wake mode:
+
+- **If `.squidsquad/config.md` does not exist or cannot be read** (Read tool error, file absent, empty file) → **POLLING mode confirmed**, skip Step 2 and jump to Step 4. Defaulting to polling here mirrors the compose-time `_get_wake_mode` guard (`references/scripts/compose.py:_get_wake_mode`) and honors CONTEXT-9588 D3: the safe fallback for any uncertainty is polling.
+- Else if `event-driven-dm: yes` is present (per-role override) → event-mode candidate.
+- Else if `event-driven: yes` is present (global default) → event-mode candidate.
+- Else (field absent, set to `no`, or unparseable) → **POLLING mode confirmed**, skip Step 2 and jump to Step 4 (polling branch).
+
+### Step 2 — Check harness reachability (event-mode candidate only)
+
+The harness must be reachable for event-mode to be used. Probe in this order:
+
+1. **Read the port file** at `.squidsquad/.harness-port` (relative to repo root). If the file is absent OR unreadable OR empty OR its content is not a valid integer, default port to `7373` (the harness default — see `cycle_post.py:_discover_harness_port`).
+2. **HTTP-probe the harness** with a 5-second timeout against the resolved port. Run via the Bash tool:
+   ```bash
+   curl -sf --max-time 5 http://127.0.0.1:<port>/status
+   ```
+   The `-s` flag silences progress output and `-f` makes curl exit non-zero on any HTTP error response — no shell redirect is needed (older versions of this instruction used `> /dev/null`, which fails on native Windows shells and would force a permanent polling fallback). Inspect the exit code only: 0 = harness reachable; any non-zero exit (curl error, connection refused, timeout, HTTP non-2xx, curl missing from PATH) = **harness unreachable**.
+
+If the probe succeeds → **EVENT mode confirmed**, proceed to Step 3.
+If the probe fails (for any reason — non-zero exit, network error, missing curl) → **fall through to polling** (jump to Step 4 polling branch). This fallback is intentional per #9580/#9588: until the harness is proven stable across all failure modes, agents fall back to `/loop` polling rather than the bespoke event-mode degraded path.
+
+### Step 3 — EVENT mode: Read event fragments and follow them
+
+Use the Read tool to read each of the following files **in order** and treat their concatenated content as your active wake-mode contract for this session:
+
+1. `references/sub-skills/common-events/event-driven-workflow.md`
+2. `references/sub-skills/common-events/l1-base.md`
+3. `references/sub-skills/common-events/cursor-management.md`
+4. `references/sub-skills/common-events/forge-read-pattern.md`
+5. `references/sub-skills/common-events/idle-cooldown-loop.md`
+6. `references/sub-skills/common-events/comment-handling.md`
+
+**Role-specific extras** — if your role is `dm`, ALSO Read `references/sub-skills/roles/dm/events/pr-merge-wait.md` as a seventh file. If your role is not `dm`, skip this extra file (no other roles currently have events extras).
+
+After reading, the boot sequence and event-listening loop described in those fragments take effect immediately. Do not proceed to Step 4 (polling branch is unreachable once Step 3 executes).
+
+### Step 4 — POLLING mode: Read the polling fragment and follow it
+
+Use the Read tool to read this single file:
+
+- `references/sub-skills/roles/dm/ralph-loop-overview.md`
+
+Treat its content as your active wake-mode contract. Follow its instructions exactly — including invoking `/loop 30m execute one Ralph Loop cycle` (or the cadence specified by `config.md`'s `interval` field) to schedule cycles.
+
+### Loaded mode is sticky
+
+Once Steps 3 or 4 complete, your wake-mode contract is fixed for this session. Do **not** re-check mode mid-session. Mode flips (`config.md` `event-driven:` value changed by an operator) take effect on the next agent restart — not mid-cycle.
+
+### Why polling is the harness-down fallback
+
+The bespoke "degraded mode" in `common-events/l1-base.md` (sleep 60s + retry `work_queue()`) is removed in favor of polling fallback. The `/loop` mechanism is battle-tested across continuous operation including multiple harness outages; degraded mode added a third execution path that complicated the contract without proving more reliable. Operator restarts the agent to re-enter event-mode after the harness recovers.
+
+<!-- /sub-skill: boot-bootstrap -->
+
 <!-- sub-skill: capability-check -->
 ## Capability Check
 
@@ -224,55 +285,15 @@ python references/scripts/capability_check.py dm
 
 ---
 
-<!-- sub-skill: ralph-loop-overview -->
-## On Startup
+<!--
+  #9588: the directives below are intentionally absent from BOTH
+  manifests; they are Read at runtime by `common/boot-bootstrap` and
+  `compose.py:RUNTIME_READ_FRAGMENTS` short-circuits them at compose
+  time. DM's `roles/dm/events/pr-merge-wait` is also runtime-loaded.
+  Re-adding any of these to a manifest will fail the regression test
+  in `tests/test_compose_9588.py`.
+-->
 
-When you first receive these instructions, first verify GitHub Issues access (see Tracker Protocol above). Then read the interval from `.squidsquad/config.md` (under `Iteration Interval > Minutes`) and invoke:
-
-```
-/loop 30m execute one Ralph Loop cycle
-```
-
-This externalizes the cycle timing — `/loop` handles the interval and re-invocation. Each cycle is a single pass through the steps below. Do NOT manually sleep or try to self-loop.
-
-> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-invoke `/loop 30m execute one Ralph Loop cycle`.
-
----
-
-## The Ralph Loop
-
-Each invocation executes **one cycle** through the steps below. The `/loop` command handles re-invocation every 30 minutes.
-
-At the start of each cycle, print:
-
-```
-[🦑] ---- cycle N started at HH:MM:SS ----
-```
-
-At the end of each cycle, print:
-
-```
-[🦑] ---- cycle N complete at HH:MM:SS ----
-```
-
-**Step markers**: At the start of each step, print a one-line `[🦑 HH:MM:SS]` timestamped status so the human can scan scrollback. Key sub-actions also get markers. Keep each marker to one concise line. **All timestamps** (`HH:MM:SS`, `YYYY-MM-DD HH:MM`) must come from `python references/scripts/cycle.py timestamp-short` — see Timestamps in Tracker Protocol. Never guess or fabricate times.
-
-**Status bar state**: At each step marker, also write your current state to `.squidsquad/dm/current-state` so the status bar can display it. **Use atomic writes** (write to `.tmp` then `mv`) to avoid file locking races with the statusline script on Windows:
-
-```bash
-echo "phase|sub-skill — description" > .squidsquad/dm/current-state.tmp && mv -f .squidsquad/dm/current-state.tmp .squidsquad/dm/current-state
-```
-
-Phase is one of: `pulling`, `delivering`, `shipping`, `committing`, `idle`. The sub-skill is the short name of the active sub-skill (e.g., `pull-latest`, `delivery-packaging`, `version-bumps`, `git-commit`). The description is a short (≤60 char) human-readable label. **Include the specific item ID** in all item-specific phases. Put the item ID near the start of the description so it survives truncation. Examples:
-
-- `pulling|pull-latest — Syncing with remote...`
-- `delivering|delivery-packaging — 📦 #35 delivery...`
-- `shipping|version-bumps — 🚀 Version bump v0.7.0...`
-- `committing|git-commit — Committing delivery for #35...`
-- `idle|`
-
-Write `idle|` at cycle end so the status bar shows rotating hints between cycles.
-<!-- /sub-skill: ralph-loop-overview -->
 
 <!-- sub-skill: cycle-runner -->
 ## Cycle Runner (Transport Layer)

--- a/.squidsquad/dm/CLAUDE.md
+++ b/.squidsquad/dm/CLAUDE.md
@@ -243,13 +243,46 @@ Use the Read tool to read each of the following files **in order** and treat the
 
 After reading, the boot sequence and event-listening loop described in those fragments take effect immediately. Do not proceed to Step 4 (polling branch is unreachable once Step 3 executes).
 
-### Step 4 — POLLING mode: Read the polling fragment and follow it
+### Step 4 — POLLING mode: schedule `/loop`, then Read the polling fragment
+
+**Step 4a — Verify GitHub Issues access** (this check used to live inside the polling fragment; it has been moved up here so it runs BEFORE `/loop` is scheduled — a session that cannot reach GitHub should refuse to enter the loop):
+
+```bash
+python references/scripts/tracker.py check-gh
+```
+
+If this fails, print: `[🦑 HH:MM:SS] ERROR: GitHub Issues permission check failed. Run "gh auth refresh" with "repo" scope, or ensure gh CLI is installed and authenticated.` and exit the session. SquidSquad requires GitHub Issues access.
+
+**Step 4b — Schedule `/loop` exactly once** (#9588 BLOCKER fix):
+
+Invoke this slash command literally. The interval value below is substituted at compose time from `config.md`'s `Iteration Interval > Minutes` field — do NOT re-derive it from the polling fragment, and do NOT re-invoke `/loop` after the fragment is loaded:
+
+```
+/loop 30m execute one Ralph Loop cycle
+```
+
+This is the only `/loop` invocation in your boot path. The polling fragment Read in Step 4c describes what a cycle DOES, not how to schedule one — re-invoking `/loop` from inside the fragment would stack cron entries.
+
+**Recovery from an interrupted `/loop`**: if a prior session ended without a cycle firing (e.g., the human ran the agent inline and then returned to `/loop` mode), re-invoke the same literal command above. Do not change the interval value.
+
+**Step 4c — Read the polling fragment**:
 
 Use the Read tool to read this single file:
 
 - `references/sub-skills/roles/dm/ralph-loop-overview.md`
 
-Treat its content as your active wake-mode contract. Follow its instructions exactly — including invoking `/loop 30m execute one Ralph Loop cycle` (or the cadence specified by `config.md`'s `interval` field) to schedule cycles.
+Treat its content as the contract for what happens INSIDE each cycle — step markers, status bar writes, work-queue pickup, commits, etc.
+
+### Placeholder substitution inside runtime-loaded fragments
+
+The fragments you Read in Step 3 or Step 4c are **source files**, not compose output. Compose-time placeholder substitution (the machinery in `compose.py:_substitute_placeholders`) only fires on content compose inlines into your CLAUDE.md — never on text you Read at runtime. As a result, source fragments may still contain square-bracketed UPPERCASE tokens that look like ``the-role-placeholder`` (uppercase R-O-L-E inside brackets) or ``the-interval-placeholder`` (uppercase I-N-T-E-R-V-A-L inside brackets).
+
+When you encounter one of these inside a runtime-loaded fragment, substitute it yourself using values you already know:
+
+- **Role-name placeholder** (uppercase R-O-L-E in square brackets) — substitute your own role name. You were started with `SQUIDSQUAD_ROLE=<role>` in your system prompt; that value IS the substitution. Example: when a fragment says ``write to `.squidsquad/<the-role-placeholder>/current-state` ``, write to ``.squidsquad/<your-role-name>/current-state``.
+- **Interval placeholder** (uppercase I-N-T-E-R-V-A-L in square brackets) — you should NOT encounter this in any runtime-loaded fragment. `/loop` is scheduled exclusively in Step 4b above, where compose has already substituted the literal interval. If you DO see the interval placeholder inside a runtime-loaded fragment, treat it as a bug — flag in your iteration log and do NOT execute the surrounding `/loop` invocation.
+
+(This section avoids writing the placeholder strings literally because compose would substitute them away at compose time, defeating the teaching. The names are spelled out letter-by-letter so the rule survives compose unchanged.)
 
 ### Loaded mode is sticky
 

--- a/.squidsquad/pm/CLAUDE.md
+++ b/.squidsquad/pm/CLAUDE.md
@@ -245,13 +245,46 @@ Use the Read tool to read each of the following files **in order** and treat the
 
 After reading, the boot sequence and event-listening loop described in those fragments take effect immediately. Do not proceed to Step 4 (polling branch is unreachable once Step 3 executes).
 
-### Step 4 — POLLING mode: Read the polling fragment and follow it
+### Step 4 — POLLING mode: schedule `/loop`, then Read the polling fragment
+
+**Step 4a — Verify GitHub Issues access** (this check used to live inside the polling fragment; it has been moved up here so it runs BEFORE `/loop` is scheduled — a session that cannot reach GitHub should refuse to enter the loop):
+
+```bash
+python references/scripts/tracker.py check-gh
+```
+
+If this fails, print: `[🦑 HH:MM:SS] ERROR: GitHub Issues permission check failed. Run "gh auth refresh" with "repo" scope, or ensure gh CLI is installed and authenticated.` and exit the session. SquidSquad requires GitHub Issues access.
+
+**Step 4b — Schedule `/loop` exactly once** (#9588 BLOCKER fix):
+
+Invoke this slash command literally. The interval value below is substituted at compose time from `config.md`'s `Iteration Interval > Minutes` field — do NOT re-derive it from the polling fragment, and do NOT re-invoke `/loop` after the fragment is loaded:
+
+```
+/loop 30m execute one Ralph Loop cycle
+```
+
+This is the only `/loop` invocation in your boot path. The polling fragment Read in Step 4c describes what a cycle DOES, not how to schedule one — re-invoking `/loop` from inside the fragment would stack cron entries.
+
+**Recovery from an interrupted `/loop`**: if a prior session ended without a cycle firing (e.g., the human ran the agent inline and then returned to `/loop` mode), re-invoke the same literal command above. Do not change the interval value.
+
+**Step 4c — Read the polling fragment**:
 
 Use the Read tool to read this single file:
 
 - `references/sub-skills/roles/pm/ralph-loop-overview.md`
 
-Treat its content as your active wake-mode contract. Follow its instructions exactly — including invoking `/loop 30m execute one Ralph Loop cycle` (or the cadence specified by `config.md`'s `interval` field) to schedule cycles.
+Treat its content as the contract for what happens INSIDE each cycle — step markers, status bar writes, work-queue pickup, commits, etc.
+
+### Placeholder substitution inside runtime-loaded fragments
+
+The fragments you Read in Step 3 or Step 4c are **source files**, not compose output. Compose-time placeholder substitution (the machinery in `compose.py:_substitute_placeholders`) only fires on content compose inlines into your CLAUDE.md — never on text you Read at runtime. As a result, source fragments may still contain square-bracketed UPPERCASE tokens that look like ``the-role-placeholder`` (uppercase R-O-L-E inside brackets) or ``the-interval-placeholder`` (uppercase I-N-T-E-R-V-A-L inside brackets).
+
+When you encounter one of these inside a runtime-loaded fragment, substitute it yourself using values you already know:
+
+- **Role-name placeholder** (uppercase R-O-L-E in square brackets) — substitute your own role name. You were started with `SQUIDSQUAD_ROLE=<role>` in your system prompt; that value IS the substitution. Example: when a fragment says ``write to `.squidsquad/<the-role-placeholder>/current-state` ``, write to ``.squidsquad/<your-role-name>/current-state``.
+- **Interval placeholder** (uppercase I-N-T-E-R-V-A-L in square brackets) — you should NOT encounter this in any runtime-loaded fragment. `/loop` is scheduled exclusively in Step 4b above, where compose has already substituted the literal interval. If you DO see the interval placeholder inside a runtime-loaded fragment, treat it as a bug — flag in your iteration log and do NOT execute the surrounding `/loop` invocation.
+
+(This section avoids writing the placeholder strings literally because compose would substitute them away at compose time, defeating the teaching. The names are spelled out letter-by-letter so the rule survives compose unchanged.)
 
 ### Loaded mode is sticky
 

--- a/.squidsquad/pm/CLAUDE.md
+++ b/.squidsquad/pm/CLAUDE.md
@@ -202,61 +202,75 @@ The active dev agents on this project are: **skill** (read from `.squidsquad/con
 
 ---
 
-<!-- sub-skill: ralph-loop-overview -->
-## On Startup
+<!-- sub-skill: boot-bootstrap -->
+## Boot — Mode Detection (#9588)
 
-When you first receive these instructions, first verify GitHub Issues access (see Tracker Protocol above). Then read the interval from `.squidsquad/config.md` (under `Iteration Interval > Minutes`) and invoke the `/loop` command to schedule repeating cycles:
+**This block is the FIRST instruction in your composed CLAUDE.md. Execute it BEFORE any other section, BEFORE invoking any tool, BEFORE responding to the human.** Steps 1–4 below are mandatory and must run in order on every fresh session start.
 
-```
-/loop 30m execute one Ralph Loop cycle
-```
+### Step 1 — Determine wake mode from config
 
-This externalizes the cycle timing — `/loop` handles the interval and re-invocation. Each cycle is a single pass through the steps below. Do NOT manually sleep or try to self-loop. Print a brief one-line status as you go (e.g. `[🦑 HH:MM:SS] Pulling latest...`, `[🦑 HH:MM:SS] Running QA pass...`).
+Read `.squidsquad/config.md` and find the active wake mode:
 
-> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-invoke `/loop 30m execute one Ralph Loop cycle`.
+- **If `.squidsquad/config.md` does not exist or cannot be read** (Read tool error, file absent, empty file) → **POLLING mode confirmed**, skip Step 2 and jump to Step 4. Defaulting to polling here mirrors the compose-time `_get_wake_mode` guard (`references/scripts/compose.py:_get_wake_mode`) and honors CONTEXT-9588 D3: the safe fallback for any uncertainty is polling.
+- Else if `event-driven-pm: yes` is present (per-role override) → event-mode candidate.
+- Else if `event-driven: yes` is present (global default) → event-mode candidate.
+- Else (field absent, set to `no`, or unparseable) → **POLLING mode confirmed**, skip Step 2 and jump to Step 4 (polling branch).
 
----
+### Step 2 — Check harness reachability (event-mode candidate only)
 
-## The Ralph Loop
+The harness must be reachable for event-mode to be used. Probe in this order:
 
-Each invocation executes **one cycle** through the steps below. The `/loop` command handles re-invocation every 30 minutes.
+1. **Read the port file** at `.squidsquad/.harness-port` (relative to repo root). If the file is absent OR unreadable OR empty OR its content is not a valid integer, default port to `7373` (the harness default — see `cycle_post.py:_discover_harness_port`).
+2. **HTTP-probe the harness** with a 5-second timeout against the resolved port. Run via the Bash tool:
+   ```bash
+   curl -sf --max-time 5 http://127.0.0.1:<port>/status
+   ```
+   The `-s` flag silences progress output and `-f` makes curl exit non-zero on any HTTP error response — no shell redirect is needed (older versions of this instruction used `> /dev/null`, which fails on native Windows shells and would force a permanent polling fallback). Inspect the exit code only: 0 = harness reachable; any non-zero exit (curl error, connection refused, timeout, HTTP non-2xx, curl missing from PATH) = **harness unreachable**.
 
-At the start of each cycle, print:
+If the probe succeeds → **EVENT mode confirmed**, proceed to Step 3.
+If the probe fails (for any reason — non-zero exit, network error, missing curl) → **fall through to polling** (jump to Step 4 polling branch). This fallback is intentional per #9580/#9588: until the harness is proven stable across all failure modes, agents fall back to `/loop` polling rather than the bespoke event-mode degraded path.
 
-```
-[🦑] ---- cycle N started at HH:MM:SS ----
-```
+### Step 3 — EVENT mode: Read event fragments and follow them
 
-At the end of each cycle, print:
+Use the Read tool to read each of the following files **in order** and treat their concatenated content as your active wake-mode contract for this session:
 
-```
-[🦑] ---- cycle N complete at HH:MM:SS ----
-```
+1. `references/sub-skills/common-events/event-driven-workflow.md`
+2. `references/sub-skills/common-events/l1-base.md`
+3. `references/sub-skills/common-events/cursor-management.md`
+4. `references/sub-skills/common-events/forge-read-pattern.md`
+5. `references/sub-skills/common-events/idle-cooldown-loop.md`
+6. `references/sub-skills/common-events/comment-handling.md`
 
-**Step markers**: At the start of each step, print a one-line `[🦑 HH:MM:SS]` timestamped status so the human can scan scrollback. Key sub-actions (filing bugs, verifying fixes) also get markers. Keep each marker to one concise line. **All timestamps** (`HH:MM:SS`, `YYYY-MM-DD HH:MM`) must come from `python references/scripts/cycle.py timestamp-short` — see Timestamps in Tracker Protocol. Never guess or fabricate times.
+**Role-specific extras** — if your role is `dm`, ALSO Read `references/sub-skills/roles/dm/events/pr-merge-wait.md` as a seventh file. If your role is not `dm`, skip this extra file (no other roles currently have events extras).
 
-**Status bar state**: At each step marker, also write your current state to `.squidsquad/pm/current-state` so the status bar can display it. **Use atomic writes** (write to `.tmp` then `mv`) to avoid file locking races with the statusline script on Windows:
+After reading, the boot sequence and event-listening loop described in those fragments take effect immediately. Do not proceed to Step 4 (polling branch is unreachable once Step 3 executes).
 
-```bash
-echo "phase|sub-skill — description" > .squidsquad/pm/current-state.tmp && mv -f .squidsquad/pm/current-state.tmp .squidsquad/pm/current-state
-```
+### Step 4 — POLLING mode: Read the polling fragment and follow it
 
-Phase is one of: `pulling`, `checkin`, `testing`, `verifying`, `planning`, `researching`, `discussing`, `health`, `idle`. The sub-skill is the short name of the active sub-skill (e.g., `pull-latest`, `verification`, `feature-intake`). The description is a short (≤60 char) human-readable label. **Include the GitHub Issue number** (e.g. `#29`, `#37`) in all item-specific phases. Put the issue number near the start of the description so it survives truncation.
+Use the Read tool to read this single file:
 
-> Note: `test-planning` was dropped from this enum on #9319. Under the #9184 workflow PM no longer authors test plans; QA writes its own `TEST-PLAN-<NUMBER>.md` at verification time and uses the `test-plan` external-model route from its own sub-skill.
+- `references/sub-skills/roles/pm/ralph-loop-overview.md`
 
-Examples:
+Treat its content as your active wake-mode contract. Follow its instructions exactly — including invoking `/loop 30m execute one Ralph Loop cycle` (or the cadence specified by `config.md`'s `interval` field) to schedule cycles.
 
-- `pulling|pull-latest — Syncing with remote...`
-- `testing|verification — Running E2E tests...`
-- `verifying|verification — Verifying #29...`
-- `planning|feature-intake — #37 intake...`
-- `researching|feature-intake — Researching #35...`
-- `discussing|feature-intake — Discussion for #35...`
-- `idle|`
+### Loaded mode is sticky
 
-Write `idle|` at cycle end so the status bar shows rotating hints between cycles.
-<!-- /sub-skill: ralph-loop-overview -->
+Once Steps 3 or 4 complete, your wake-mode contract is fixed for this session. Do **not** re-check mode mid-session. Mode flips (`config.md` `event-driven:` value changed by an operator) take effect on the next agent restart — not mid-cycle.
+
+### Why polling is the harness-down fallback
+
+The bespoke "degraded mode" in `common-events/l1-base.md` (sleep 60s + retry `work_queue()`) is removed in favor of polling fallback. The `/loop` mechanism is battle-tested across continuous operation including multiple harness outages; degraded mode added a third execution path that complicated the contract without proving more reliable. Operator restarts the agent to re-enter event-mode after the harness recovers.
+
+<!-- /sub-skill: boot-bootstrap -->
+
+<!--
+  #9588: the directives below are intentionally absent from BOTH
+  manifests; they are Read at runtime by `common/boot-bootstrap` and
+  `compose.py:RUNTIME_READ_FRAGMENTS` short-circuits them at compose
+  time. Re-adding them to a manifest will fail the regression test
+  in `tests/test_compose_9588.py`.
+-->
+
 
 <!-- sub-skill: cycle-runner -->
 ## Cycle Runner (Transport Layer)

--- a/.squidsquad/qa/CLAUDE.md
+++ b/.squidsquad/qa/CLAUDE.md
@@ -202,58 +202,75 @@ The active dev agents on this project are: **skill** (read from `.squidsquad/con
 
 ---
 
-<!-- sub-skill: ralph-loop-overview -->
-## On Startup
+<!-- sub-skill: boot-bootstrap -->
+## Boot — Mode Detection (#9588)
 
-When you first receive these instructions, first verify GitHub Issues access (see Tracker Protocol above). Then invoke the `/loop` command to schedule repeating cycles:
+**This block is the FIRST instruction in your composed CLAUDE.md. Execute it BEFORE any other section, BEFORE invoking any tool, BEFORE responding to the human.** Steps 1–4 below are mandatory and must run in order on every fresh session start.
 
-Read the interval from `.squidsquad/config.md` (under `Iteration Interval > Minutes`), then invoke:
+### Step 1 — Determine wake mode from config
 
-```
-/loop 30m execute one Ralph Loop cycle
-```
+Read `.squidsquad/config.md` and find the active wake mode:
 
-This externalizes the cycle timing — `/loop` handles the interval and re-invocation. Each cycle is a single pass through the steps below. Do NOT manually sleep or try to self-loop.
+- **If `.squidsquad/config.md` does not exist or cannot be read** (Read tool error, file absent, empty file) → **POLLING mode confirmed**, skip Step 2 and jump to Step 4. Defaulting to polling here mirrors the compose-time `_get_wake_mode` guard (`references/scripts/compose.py:_get_wake_mode`) and honors CONTEXT-9588 D3: the safe fallback for any uncertainty is polling.
+- Else if `event-driven-qa: yes` is present (per-role override) → event-mode candidate.
+- Else if `event-driven: yes` is present (global default) → event-mode candidate.
+- Else (field absent, set to `no`, or unparseable) → **POLLING mode confirmed**, skip Step 2 and jump to Step 4 (polling branch).
 
-> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-invoke `/loop 30m execute one Ralph Loop cycle`.
+### Step 2 — Check harness reachability (event-mode candidate only)
 
----
+The harness must be reachable for event-mode to be used. Probe in this order:
 
-## The Ralph Loop
+1. **Read the port file** at `.squidsquad/.harness-port` (relative to repo root). If the file is absent OR unreadable OR empty OR its content is not a valid integer, default port to `7373` (the harness default — see `cycle_post.py:_discover_harness_port`).
+2. **HTTP-probe the harness** with a 5-second timeout against the resolved port. Run via the Bash tool:
+   ```bash
+   curl -sf --max-time 5 http://127.0.0.1:<port>/status
+   ```
+   The `-s` flag silences progress output and `-f` makes curl exit non-zero on any HTTP error response — no shell redirect is needed (older versions of this instruction used `> /dev/null`, which fails on native Windows shells and would force a permanent polling fallback). Inspect the exit code only: 0 = harness reachable; any non-zero exit (curl error, connection refused, timeout, HTTP non-2xx, curl missing from PATH) = **harness unreachable**.
 
-Each invocation executes **one cycle** through the steps below. The `/loop` command handles re-invocation every 30 minutes.
+If the probe succeeds → **EVENT mode confirmed**, proceed to Step 3.
+If the probe fails (for any reason — non-zero exit, network error, missing curl) → **fall through to polling** (jump to Step 4 polling branch). This fallback is intentional per #9580/#9588: until the harness is proven stable across all failure modes, agents fall back to `/loop` polling rather than the bespoke event-mode degraded path.
 
-At the start of each cycle, print:
+### Step 3 — EVENT mode: Read event fragments and follow them
 
-```
-[🦑] ---- cycle N started at HH:MM:SS ----
-```
+Use the Read tool to read each of the following files **in order** and treat their concatenated content as your active wake-mode contract for this session:
 
-At the end of each cycle, print:
+1. `references/sub-skills/common-events/event-driven-workflow.md`
+2. `references/sub-skills/common-events/l1-base.md`
+3. `references/sub-skills/common-events/cursor-management.md`
+4. `references/sub-skills/common-events/forge-read-pattern.md`
+5. `references/sub-skills/common-events/idle-cooldown-loop.md`
+6. `references/sub-skills/common-events/comment-handling.md`
 
-```
-[🦑] ---- cycle N complete at HH:MM:SS ----
-```
+**Role-specific extras** — if your role is `dm`, ALSO Read `references/sub-skills/roles/dm/events/pr-merge-wait.md` as a seventh file. If your role is not `dm`, skip this extra file (no other roles currently have events extras).
 
-**Step markers**: At the start of each step, print a one-line `[🦑 HH:MM:SS]` timestamped status so the human can scan scrollback. Key sub-actions (verifying fixes, filing bugs) also get markers. Keep each marker to one concise line. **All timestamps** (`HH:MM:SS`, `YYYY-MM-DD HH:MM`) must come from `python references/scripts/cycle.py timestamp-short` — see Timestamps in Tracker Protocol. Never guess or fabricate times.
+After reading, the boot sequence and event-listening loop described in those fragments take effect immediately. Do not proceed to Step 4 (polling branch is unreachable once Step 3 executes).
 
-**Status bar state**: At each step marker, also write your current state to `.squidsquad/qa/current-state` so the status bar can display it. **Use atomic writes** (write to `.tmp` then `mv`) to avoid file locking races with the statusline script on Windows:
+### Step 4 — POLLING mode: Read the polling fragment and follow it
 
-```bash
-echo "phase|sub-skill — description" > .squidsquad/qa/current-state.tmp && mv -f .squidsquad/qa/current-state.tmp .squidsquad/qa/current-state
-```
+Use the Read tool to read this single file:
 
-Phase is one of: `pulling`, `testing`, `verifying`, `health`, `committing`, `idle`. The sub-skill is the short name of the active sub-skill (e.g., `pull-latest`, `verification`). The description is a short (≤60 char) human-readable label. **Include the GitHub Issue number** (e.g. `#29`, `#37`) in all item-specific phases. Put the issue number near the start of the description so it survives truncation. Examples:
+- `references/sub-skills/roles/qa/ralph-loop-overview.md`
 
-- `pulling|pull-latest — Syncing with remote...`
-- `testing|verification — Running E2E tests...`
-- `verifying|verification — Verifying #29...`
-- `verifying|verification — Testing #37...`
-- `health|verification — Checking agent health...`
-- `idle|`
+Treat its content as your active wake-mode contract. Follow its instructions exactly — including invoking `/loop 30m execute one Ralph Loop cycle` (or the cadence specified by `config.md`'s `interval` field) to schedule cycles.
 
-Write `idle|` at cycle end so the status bar shows rotating hints between cycles.
-<!-- /sub-skill: ralph-loop-overview -->
+### Loaded mode is sticky
+
+Once Steps 3 or 4 complete, your wake-mode contract is fixed for this session. Do **not** re-check mode mid-session. Mode flips (`config.md` `event-driven:` value changed by an operator) take effect on the next agent restart — not mid-cycle.
+
+### Why polling is the harness-down fallback
+
+The bespoke "degraded mode" in `common-events/l1-base.md` (sleep 60s + retry `work_queue()`) is removed in favor of polling fallback. The `/loop` mechanism is battle-tested across continuous operation including multiple harness outages; degraded mode added a third execution path that complicated the contract without proving more reliable. Operator restarts the agent to re-enter event-mode after the harness recovers.
+
+<!-- /sub-skill: boot-bootstrap -->
+
+<!--
+  #9588: the directives below are intentionally absent from BOTH
+  manifests; they are Read at runtime by `common/boot-bootstrap` and
+  `compose.py:RUNTIME_READ_FRAGMENTS` short-circuits them at compose
+  time. Re-adding them to a manifest will fail the regression test
+  in `tests/test_compose_9588.py`.
+-->
+
 
 <!-- sub-skill: cycle-runner -->
 ## Cycle Runner (Transport Layer)

--- a/.squidsquad/qa/CLAUDE.md
+++ b/.squidsquad/qa/CLAUDE.md
@@ -245,13 +245,46 @@ Use the Read tool to read each of the following files **in order** and treat the
 
 After reading, the boot sequence and event-listening loop described in those fragments take effect immediately. Do not proceed to Step 4 (polling branch is unreachable once Step 3 executes).
 
-### Step 4 — POLLING mode: Read the polling fragment and follow it
+### Step 4 — POLLING mode: schedule `/loop`, then Read the polling fragment
+
+**Step 4a — Verify GitHub Issues access** (this check used to live inside the polling fragment; it has been moved up here so it runs BEFORE `/loop` is scheduled — a session that cannot reach GitHub should refuse to enter the loop):
+
+```bash
+python references/scripts/tracker.py check-gh
+```
+
+If this fails, print: `[🦑 HH:MM:SS] ERROR: GitHub Issues permission check failed. Run "gh auth refresh" with "repo" scope, or ensure gh CLI is installed and authenticated.` and exit the session. SquidSquad requires GitHub Issues access.
+
+**Step 4b — Schedule `/loop` exactly once** (#9588 BLOCKER fix):
+
+Invoke this slash command literally. The interval value below is substituted at compose time from `config.md`'s `Iteration Interval > Minutes` field — do NOT re-derive it from the polling fragment, and do NOT re-invoke `/loop` after the fragment is loaded:
+
+```
+/loop 30m execute one Ralph Loop cycle
+```
+
+This is the only `/loop` invocation in your boot path. The polling fragment Read in Step 4c describes what a cycle DOES, not how to schedule one — re-invoking `/loop` from inside the fragment would stack cron entries.
+
+**Recovery from an interrupted `/loop`**: if a prior session ended without a cycle firing (e.g., the human ran the agent inline and then returned to `/loop` mode), re-invoke the same literal command above. Do not change the interval value.
+
+**Step 4c — Read the polling fragment**:
 
 Use the Read tool to read this single file:
 
 - `references/sub-skills/roles/qa/ralph-loop-overview.md`
 
-Treat its content as your active wake-mode contract. Follow its instructions exactly — including invoking `/loop 30m execute one Ralph Loop cycle` (or the cadence specified by `config.md`'s `interval` field) to schedule cycles.
+Treat its content as the contract for what happens INSIDE each cycle — step markers, status bar writes, work-queue pickup, commits, etc.
+
+### Placeholder substitution inside runtime-loaded fragments
+
+The fragments you Read in Step 3 or Step 4c are **source files**, not compose output. Compose-time placeholder substitution (the machinery in `compose.py:_substitute_placeholders`) only fires on content compose inlines into your CLAUDE.md — never on text you Read at runtime. As a result, source fragments may still contain square-bracketed UPPERCASE tokens that look like ``the-role-placeholder`` (uppercase R-O-L-E inside brackets) or ``the-interval-placeholder`` (uppercase I-N-T-E-R-V-A-L inside brackets).
+
+When you encounter one of these inside a runtime-loaded fragment, substitute it yourself using values you already know:
+
+- **Role-name placeholder** (uppercase R-O-L-E in square brackets) — substitute your own role name. You were started with `SQUIDSQUAD_ROLE=<role>` in your system prompt; that value IS the substitution. Example: when a fragment says ``write to `.squidsquad/<the-role-placeholder>/current-state` ``, write to ``.squidsquad/<your-role-name>/current-state``.
+- **Interval placeholder** (uppercase I-N-T-E-R-V-A-L in square brackets) — you should NOT encounter this in any runtime-loaded fragment. `/loop` is scheduled exclusively in Step 4b above, where compose has already substituted the literal interval. If you DO see the interval placeholder inside a runtime-loaded fragment, treat it as a bug — flag in your iteration log and do NOT execute the surrounding `/loop` invocation.
+
+(This section avoids writing the placeholder strings literally because compose would substitute them away at compose time, defeating the teaching. The names are spelled out letter-by-letter so the rule survives compose unchanged.)
 
 ### Loaded mode is sticky
 

--- a/.squidsquad/skill/CLAUDE.md
+++ b/.squidsquad/skill/CLAUDE.md
@@ -239,13 +239,46 @@ Use the Read tool to read each of the following files **in order** and treat the
 
 After reading, the boot sequence and event-listening loop described in those fragments take effect immediately. Do not proceed to Step 4 (polling branch is unreachable once Step 3 executes).
 
-### Step 4 — POLLING mode: Read the polling fragment and follow it
+### Step 4 — POLLING mode: schedule `/loop`, then Read the polling fragment
+
+**Step 4a — Verify GitHub Issues access** (this check used to live inside the polling fragment; it has been moved up here so it runs BEFORE `/loop` is scheduled — a session that cannot reach GitHub should refuse to enter the loop):
+
+```bash
+python references/scripts/tracker.py check-gh
+```
+
+If this fails, print: `[🦑 HH:MM:SS] ERROR: GitHub Issues permission check failed. Run "gh auth refresh" with "repo" scope, or ensure gh CLI is installed and authenticated.` and exit the session. SquidSquad requires GitHub Issues access.
+
+**Step 4b — Schedule `/loop` exactly once** (#9588 BLOCKER fix):
+
+Invoke this slash command literally. The interval value below is substituted at compose time from `config.md`'s `Iteration Interval > Minutes` field — do NOT re-derive it from the polling fragment, and do NOT re-invoke `/loop` after the fragment is loaded:
+
+```
+/loop 30m execute one Ralph Loop cycle
+```
+
+This is the only `/loop` invocation in your boot path. The polling fragment Read in Step 4c describes what a cycle DOES, not how to schedule one — re-invoking `/loop` from inside the fragment would stack cron entries.
+
+**Recovery from an interrupted `/loop`**: if a prior session ended without a cycle firing (e.g., the human ran the agent inline and then returned to `/loop` mode), re-invoke the same literal command above. Do not change the interval value.
+
+**Step 4c — Read the polling fragment**:
 
 Use the Read tool to read this single file:
 
 - `references/sub-skills/roles/dev/ralph-loop-overview.md`
 
-Treat its content as your active wake-mode contract. Follow its instructions exactly — including invoking `/loop 30m execute one Ralph Loop cycle` (or the cadence specified by `config.md`'s `interval` field) to schedule cycles.
+Treat its content as the contract for what happens INSIDE each cycle — step markers, status bar writes, work-queue pickup, commits, etc.
+
+### Placeholder substitution inside runtime-loaded fragments
+
+The fragments you Read in Step 3 or Step 4c are **source files**, not compose output. Compose-time placeholder substitution (the machinery in `compose.py:_substitute_placeholders`) only fires on content compose inlines into your CLAUDE.md — never on text you Read at runtime. As a result, source fragments may still contain square-bracketed UPPERCASE tokens that look like ``the-role-placeholder`` (uppercase R-O-L-E inside brackets) or ``the-interval-placeholder`` (uppercase I-N-T-E-R-V-A-L inside brackets).
+
+When you encounter one of these inside a runtime-loaded fragment, substitute it yourself using values you already know:
+
+- **Role-name placeholder** (uppercase R-O-L-E in square brackets) — substitute your own role name. You were started with `SQUIDSQUAD_ROLE=<role>` in your system prompt; that value IS the substitution. Example: when a fragment says ``write to `.squidsquad/<the-role-placeholder>/current-state` ``, write to ``.squidsquad/<your-role-name>/current-state``.
+- **Interval placeholder** (uppercase I-N-T-E-R-V-A-L in square brackets) — you should NOT encounter this in any runtime-loaded fragment. `/loop` is scheduled exclusively in Step 4b above, where compose has already substituted the literal interval. If you DO see the interval placeholder inside a runtime-loaded fragment, treat it as a bug — flag in your iteration log and do NOT execute the surrounding `/loop` invocation.
+
+(This section avoids writing the placeholder strings literally because compose would substitute them away at compose time, defeating the teaching. The names are spelled out letter-by-letter so the rule survives compose unchanged.)
 
 ### Loaded mode is sticky
 

--- a/.squidsquad/skill/CLAUDE.md
+++ b/.squidsquad/skill/CLAUDE.md
@@ -196,55 +196,77 @@ You are the skill Lead on the SquidSquad autonomous dev team. You operate contin
 
 ---
 
-<!-- sub-skill: ralph-loop-overview -->
-## On Startup
+<!-- sub-skill: boot-bootstrap -->
+## Boot — Mode Detection (#9588)
 
-When you first receive these instructions, first verify GitHub Issues access (see Tracker Protocol above). Then read the interval from `.squidsquad/config.md` (under `Iteration Interval > Minutes`) and invoke the `/loop` command to schedule repeating cycles:
+**This block is the FIRST instruction in your composed CLAUDE.md. Execute it BEFORE any other section, BEFORE invoking any tool, BEFORE responding to the human.** Steps 1–4 below are mandatory and must run in order on every fresh session start.
 
-```
-/loop 30m execute one Ralph Loop cycle
-```
+### Step 1 — Determine wake mode from config
 
-This externalizes the cycle timing — `/loop` handles the interval and re-invocation. Each cycle is a single pass through Steps 1-5, then returns. Do NOT manually sleep or try to self-loop.
+Read `.squidsquad/config.md` and find the active wake mode:
 
-> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-invoke `/loop 30m execute one Ralph Loop cycle`.
+- **If `.squidsquad/config.md` does not exist or cannot be read** (Read tool error, file absent, empty file) → **POLLING mode confirmed**, skip Step 2 and jump to Step 4. Defaulting to polling here mirrors the compose-time `_get_wake_mode` guard (`references/scripts/compose.py:_get_wake_mode`) and honors CONTEXT-9588 D3: the safe fallback for any uncertainty is polling.
+- Else if `event-driven-skill: yes` is present (per-role override) → event-mode candidate.
+- Else if `event-driven: yes` is present (global default) → event-mode candidate.
+- Else (field absent, set to `no`, or unparseable) → **POLLING mode confirmed**, skip Step 2 and jump to Step 4 (polling branch).
 
----
+### Step 2 — Check harness reachability (event-mode candidate only)
 
-## The Ralph Loop
+The harness must be reachable for event-mode to be used. Probe in this order:
 
-Each invocation executes **one cycle** through the steps below. The `/loop` command handles re-invocation every 30 minutes.
+1. **Read the port file** at `.squidsquad/.harness-port` (relative to repo root). If the file is absent OR unreadable OR empty OR its content is not a valid integer, default port to `7373` (the harness default — see `cycle_post.py:_discover_harness_port`).
+2. **HTTP-probe the harness** with a 5-second timeout against the resolved port. Run via the Bash tool:
+   ```bash
+   curl -sf --max-time 5 http://127.0.0.1:<port>/status
+   ```
+   The `-s` flag silences progress output and `-f` makes curl exit non-zero on any HTTP error response — no shell redirect is needed (older versions of this instruction used `> /dev/null`, which fails on native Windows shells and would force a permanent polling fallback). Inspect the exit code only: 0 = harness reachable; any non-zero exit (curl error, connection refused, timeout, HTTP non-2xx, curl missing from PATH) = **harness unreachable**.
 
-At the start of each cycle, print:
+If the probe succeeds → **EVENT mode confirmed**, proceed to Step 3.
+If the probe fails (for any reason — non-zero exit, network error, missing curl) → **fall through to polling** (jump to Step 4 polling branch). This fallback is intentional per #9580/#9588: until the harness is proven stable across all failure modes, agents fall back to `/loop` polling rather than the bespoke event-mode degraded path.
 
-```
-[🦑] ---- cycle N started at HH:MM:SS ----
-```
+### Step 3 — EVENT mode: Read event fragments and follow them
 
-At the end of each cycle, print:
+Use the Read tool to read each of the following files **in order** and treat their concatenated content as your active wake-mode contract for this session:
 
-```
-[🦑] ---- cycle N complete at HH:MM:SS ----
-```
+1. `references/sub-skills/common-events/event-driven-workflow.md`
+2. `references/sub-skills/common-events/l1-base.md`
+3. `references/sub-skills/common-events/cursor-management.md`
+4. `references/sub-skills/common-events/forge-read-pattern.md`
+5. `references/sub-skills/common-events/idle-cooldown-loop.md`
+6. `references/sub-skills/common-events/comment-handling.md`
 
-**Step markers**: At the start of each step, print a one-line `[🦑 HH:MM:SS]` timestamped status so the human can scan scrollback. Key sub-actions (filing bugs, committing) also get markers. Keep each marker to one concise line. **All timestamps** (`HH:MM:SS`, `YYYY-MM-DD HH:MM`) must come from `python references/scripts/cycle.py timestamp-short` — see Timestamps in Tracker Protocol. Never guess or fabricate times.
+**Role-specific extras** — if your role is `dm`, ALSO Read `references/sub-skills/roles/dm/events/pr-merge-wait.md` as a seventh file. If your role is not `dm`, skip this extra file (no other roles currently have events extras).
 
-**Status bar state**: At each step marker, also write your current state to `.squidsquad/skill/current-state` so the status bar can display it. **Use atomic writes** (write to `.tmp` then `mv`) to avoid file locking races with the statusline script on Windows:
+After reading, the boot sequence and event-listening loop described in those fragments take effect immediately. Do not proceed to Step 4 (polling branch is unreachable once Step 3 executes).
 
-```bash
-python references/scripts/cycle.py status-bar skill "phase" "sub-skill — description"
-```
+### Step 4 — POLLING mode: Read the polling fragment and follow it
 
-Phase is one of: `pulling`, `triaging`, `implementing`, `committing`, `idle`. The sub-skill is the short name of the active sub-skill (e.g., `pull-latest`, `tracker-protocol`, `dev-agent`, `git-commit`). The description is a short (≤60 char) human-readable label. **Include the GitHub Issue number** (e.g. `#29`, `#37`) in all item-specific phases. Put the issue number near the start of the description so it survives truncation. Examples:
+Use the Read tool to read this single file:
 
-- `pulling|pull-latest — Syncing with remote...`
-- `triaging|tracker-protocol — Fixing #29...`
-- `implementing|dev-agent — 🔨 #37...`
-- `committing|git-commit — Committing #37...`
-- `idle|`
+- `references/sub-skills/roles/dev/ralph-loop-overview.md`
 
-Write `idle|` at cycle end so the status bar shows rotating hints between cycles.
-<!-- /sub-skill: ralph-loop-overview -->
+Treat its content as your active wake-mode contract. Follow its instructions exactly — including invoking `/loop 30m execute one Ralph Loop cycle` (or the cadence specified by `config.md`'s `interval` field) to schedule cycles.
+
+### Loaded mode is sticky
+
+Once Steps 3 or 4 complete, your wake-mode contract is fixed for this session. Do **not** re-check mode mid-session. Mode flips (`config.md` `event-driven:` value changed by an operator) take effect on the next agent restart — not mid-cycle.
+
+### Why polling is the harness-down fallback
+
+The bespoke "degraded mode" in `common-events/l1-base.md` (sleep 60s + retry `work_queue()`) is removed in favor of polling fallback. The `/loop` mechanism is battle-tested across continuous operation including multiple harness outages; degraded mode added a third execution path that complicated the contract without proving more reliable. Operator restarts the agent to re-enter event-mode after the harness recovers.
+
+<!-- /sub-skill: boot-bootstrap -->
+
+<!--
+  #9588: the directives below are intentionally absent from BOTH
+  `includes.yml` and `includes-events.yml`. They are Read at runtime
+  by `common/boot-bootstrap` and `compose.py:RUNTIME_READ_FRAGMENTS`
+  short-circuits them at composition time. Do NOT re-add these to a
+  manifest unless you are reverting #9588 in full — the regression
+  test in `tests/test_compose_9588.py` will fail if they reappear in
+  the composed CLAUDE.md.
+-->
+
 
 <!-- sub-skill: cycle-runner -->
 ## Cycle Runner (Transport Layer)

--- a/.squidsquad/skill/planning/9588-issue-body.md
+++ b/.squidsquad/skill/planning/9588-issue-body.md
@@ -1,0 +1,81 @@
+**Reported By**: pm-lead
+**Priority**: Medium
+
+**Reported By**: pm-lead (human direction, cycle 1535)
+**Priority**: Medium
+**Supersedes**: #9580 (incorporates its scope + broader architecture change)
+
+## Goal
+
+Today, `compose.py` reads the `event-driven` config flag at deploy time and inlines either polling-mode (`ralph-loop-overview.md`) OR event-mode (`common-events/l1-base.md` + 5 others) fragments into the composed CLAUDE.md. Result: large composed file with the wrong half potentially inlined.
+
+Switch to a **boot-time lazy-load model**: compose.py emits a small bootstrap snippet that tells the agent to read `config.md` on startup, then Read the appropriate fragment based on event-driven + harness-reachability state.
+
+## Why now (not deferred to event-mode flip)
+
+- Polling mode is the current default. Polling agents today carry the full polling instruction set inline — fine, but the architecture should be uniform.
+- Event-mode fallback to polling (per #9580) is already going to need 'read polling fragment on demand' — so the mechanism is being built anyway. Generalize it once instead of doing it twice.
+- Smaller composed CLAUDE.md across the board (only the mode-specific instructions move out — agent identity, role L2, project L4 still inline).
+
+## Proposed mechanism
+
+`compose.py` emits a boot bootstrap section in every role's CLAUDE.md, replacing the current mode-specific inline includes:
+
+```
+## Boot — Mode Detection (Lazy Load)
+
+On first invocation, do this BEFORE any other action:
+
+1. Read `.squidsquad/config.md` to determine the active wake mode:
+   - If `event-driven: yes` → POLL harness at `.squidsquad/.harness-port`. On reachable, Read `references/sub-skills/common-events/l1-base.md` and follow its boot sequence. On unreachable, fall through to step 2.
+   - If `event-driven: no` OR fallthrough from above → Read `references/sub-skills/common/ralph-loop-overview.md` and follow its instructions (which include invoking `/loop 30m execute one Ralph Loop cycle`).
+
+2. The loaded instructions become your active wake-mode contract.
+
+3. Re-check mode at each cycle boundary (`cycle_post.py` already loads config — extend it to emit a `reload_mode` signal on flag change).
+```
+
+## What stays compose-time inline
+
+- L1 agent foundation (identity, tracker protocol, git protocol — mode-agnostic).
+- L2 role responsibilities.
+- L3 domain variant.
+- L4 project-specific (`shared-instructions.md` etc.).
+- All cycle-runner / mechanical-script directives.
+
+## What moves to lazy-load
+
+- `ralph-loop-overview.md` — polling-mode Ralph Loop cycle definition.
+- `common-events/*` — event-mode boot + listening + idle-cooldown + comment-handling + cursor management.
+
+## Acceptance
+
+- `compose.py` no longer includes polling-OR-event fragments in composed CLAUDE.md. Emits the bootstrap boot-mode block instead.
+- Polling-mode agents (default today) read `ralph-loop-overview.md` on boot via the bootstrap directive — observable in the agent's first message logs (`Read references/sub-skills/common/ralph-loop-overview.md`).
+- Event-mode agents (post-flip): if harness reachable, Read event fragments; if unreachable, fall back to Read polling fragment.
+- Mode flip (config.md change) takes effect on next agent cycle boundary without recompose.
+- Composed CLAUDE.md size measurably smaller — at least 30% reduction expected by moving the larger of the two fragment sets out.
+- Regression: existing polling agents continue to cycle correctly. Existing event-mode tests (#9398 work) continue to pass once the bootstrap is in place.
+
+## Risk
+
+- Agent must Read the fragment on every fresh session (not just first boot). Cost: one file read per boot. File is small. Acceptable.
+- Bootstrap directive itself must be unambiguous — same prompt-following concern as #9581. Mitigated by making the Read call imperative and tied to step 1 of boot.
+- Mode-flip detection in `cycle_post.py` must NOT trigger a reload mid-cycle (only at cycle boundary). Easy to enforce.
+
+## Sequencing
+
+1. Land this BEFORE `event-driven: yes` flip (per the broader event-mode-readiness plan).
+2. #9581 (Monitor imperative wording) folds in here — the bootstrap directive itself uses the same imperative pattern.
+3. #9580 closes as superseded.
+
+## Out of scope
+
+- Reorganizing the L1-L4 fragment hierarchy further. The bootstrap pattern is additive; existing fragments stay where they are.
+- Renaming `ralph-loop-overview.md`. Path can change later if we want; this task uses current path.
+
+## Related
+
+- #9580 (degraded fallback to /loop) — superseded.
+- #9581 (Monitor imperative wording) — fold in.
+- #9574 (CQ runner prompt-following) — same risk family, separate file.

--- a/.squidsquad/skill/planning/REVIEW-9588-DEEPSEEK-R1.md
+++ b/.squidsquad/skill/planning/REVIEW-9588-DEEPSEEK-R1.md
@@ -1,0 +1,60 @@
+Now I have a thorough understanding of the implementation. Let me compile my findings.
+
+---
+
+### Finding 1
+
+- **File**: `references/scripts/compose.py`
+- **Line**: 303–318
+- **Severity**: HIGH
+- **Issue**: The mechanism that skips mode-specific fragments (because they're absent from the manifest) relies on fragile variant-name matching. The code extracts a `base` name from the include path (line 307) and checks if any manifest entry's stem `startswith(base + "-")` (line 311). Because the mode-specific fragment `common-events/l1-base` has base `l1-base`, any future manifest entry whose stem starts with `l1-base-` (e.g., `common/l1-base-extended`) would match and cause `common-events/l1-base` to be silently re-inlined — defeating the lazy-load design.
+- **Evidence**: 
+  - Line 307: `base = include_path.rsplit("/", 1)[-1] if "/" in include_path else include_path`
+  - Line 311: `if m_base.startswith(base + "-") or base.startswith(m_base + "-"):`
+  - For `include_path = "common-events/l1-base"`, `base = "l1-base"`. A manifest entry `common/l1-base-extended` has `m_base = "l1-base-extended"`, and `"l1-base-extended".startswith("l1-base-")` is `True` → the variant match succeeds, `found = True`, and compose silently inlines the mode-specific fragment.
+  - Same risk applies to all 8 removed mode-specific fragments (`ralph-loop-overview`, `event-driven-workflow`, `cursor-management`, `forge-read-pattern`, `idle-cooldown-loop`, `comment-handling`, `pr-merge-wait`).
+- **Suggested fix**: Add an explicit exclusion set for runtime-Read fragments and check it before the variant-matching fallback. E.g., at line 304, after checking `include_path not in manifest_set`, check a `RUNTIME_READ_FRAGMENTS` set and `continue` if matched. Alternatively, check the skip BEFORE the variant-name resolution so the variant heuristic can't accidentally resurrect a deliberately-skipped include.
+
+---
+
+### Finding 2
+
+- **File**: `references/roles/pm/instructions.md`, `references/roles/dm/instructions.md`, `references/roles/qa/instructions.md`, `references/roles/dev/instructions.md`
+- **Line**: pm:29,33,35,37,39,41,43; dm:31,35,37,39,41,43,45,67; qa:29,33,35,37,39,41,43; dev:23,27,29,31,33,35,37
+- **Severity**: MEDIUM
+- **Issue**: All four `instructions.md` templates still contain `{{include:}}` directives for mode-specific fragments that are deliberately skipped at compose time (because the corresponding entries were removed from both `includes.yml` and `includes-events.yml` manifests). This creates a divergence between template and manifest that is a maintenance hazard: a future editor may see the template directive, think the manifest entry was accidentally dropped, reinstate it, and silently break the lazy-load design.
+- **Evidence**:
+  - `pm/instructions.md:29` — `{{include: roles/pm/ralph-loop-overview}}` (absent from both pm manifests)
+  - `pm/instructions.md:33-43` — all six `{{include: common-events/...}}` directives (absent from both pm manifests)
+  - Same pattern in dm, qa, dev instructions.md files
+  - `dm/instructions.md:67` — `{{include: roles/dm/events/pr-merge-wait}}` (absent from both dm manifests)
+  - The D7 regression test (`test_compose_9588.py:96-104`) guards against accidental re-inlining, but the template/manifest divergence is a latent trap.
+- **Suggested fix**: Either (a) remove the `{{include:}}` directives from `instructions.md` and add a comment block listing which fragments are Read at runtime (the approach the manifests use), or (b) document at each directive site in the template that the fragment is lazy-loaded by the bootstrap and the manifest intentionally omits it.
+
+---
+
+### Finding 3
+
+- **File**: `references/sub-skills/common/boot-bootstrap.md`
+- **Line**: 8–12
+- **Severity**: MEDIUM
+- **Issue**: The bootstrap fragment instructs the agent to "Read `.squidsquad/config.md` and find the active wake mode" but does not specify behavior when `config.md` itself is **absent** (file doesn't exist). The enumerated branches cover field values (`yes`, `no`, absent, unparseable) but not the missing-file scenario. An agent encountering a missing `config.md` could error on the Read attempt rather than defaulting safely to polling mode.
+- **Evidence**:
+  - Lines 8–12: "Read `.squidsquad/config.md` and find the active wake mode:" followed by three bullet conditions, all of which assume the file was read successfully. No instruction for "if the file does not exist or cannot be read."
+  - The compose-time `_get_wake_mode` function (`compose.py:34-67`) handles SystemExit/BaseException from missing config gracefully and returns `"polling"`. The runtime bootstrap should match this defensive posture.
+  - Per CONTEXT D3, the fallback for any uncertainty is polling mode.
+- **Suggested fix**: Add a guard before the field-value bullets: "If `.squidsquad/config.md` does not exist or cannot be read → **POLLING mode confirmed**, skip Step 2 and jump to Step 4 (polling branch)."
+
+---
+
+### Finding 4
+
+- **File**: `references/sub-skills/common/boot-bootstrap.md`
+- **Line**: 21
+- **Severity**: LOW
+- **Issue**: The curl probe command `curl -sf --max-time 5 http://127.0.0.1:<port>/ > /dev/null` uses a shell redirect to `/dev/null`, which does not exist on native Windows shells (cmd.exe, PowerShell). While most agents in this project operate in bash-compatible environments (Git Bash, WSL), a native Windows execution would cause the redirect to fail (or create a literal file named `dev/null`), making the curl pipeline return non-zero and forcing a permanent polling fallback even when the harness is reachable on the default port 7373.
+- **Evidence**:
+  - Line 21: `curl -sf --max-time 5 http://127.0.0.1:<port>/ > /dev/null`
+  - `> /dev/null` is a shell redirect that only works in POSIX shells. This is the only use of `/dev/null` in any sub-skill `.md` file (grep confirmed zero hits across `references/sub-skills/**/*.md` outside this file).
+  - Per CONTEXT D3: "ALWAYS Read polling fragment when harness is unreachable" — this would be incorrectly triggered on native Windows.
+- **Suggested fix**: Replace `> /dev/null` with curl's built-in output suppression: `curl -sf --max-time 5 -o /dev/null http://127.0.0.1:<port>/status`. Note the `/status` path is also missing from the current curl command (the CONTEXT locked text uses `/status` but the current implementation uses `/`). Aligning the endpoint with the CONTEXT (`/status`) is also advisable. Alternatively, use `curl -sf --max-time 5 --output NUL http://...` and provide both variants, or note the platform assumption.

--- a/.squidsquad/skill/planning/REVIEW-9588-DEEPSEEK-R2.md
+++ b/.squidsquad/skill/planning/REVIEW-9588-DEEPSEEK-R2.md
@@ -1,0 +1,43 @@
+I have now thoroughly reviewed all changed files and verified the four R1 fixes. Here are my findings:
+
+---
+
+### Finding 5 (NEW)
+
+- **File**: `references/scripts/compose.py`
+- **Line**: 324
+- **Severity**: warning
+- **Issue**: Stale line-number reference in a code comment. The comment says "The check at line 311 (`m_base.startswith(base + "-") …`)" but the variant-resolution loop it describes now lives at lines 338–343 (after RUNTIME_READ_FRAGMENTS insertion shifted everything down, and the frozenset definition consumed lines 33–52). Line 311 in the current file is `manifest_set = set(manifest)` — not the variant check.
+- **Evidence**: `references/scripts/compose.py:324` reads `# line 311 (`m_base.startswith(base + "-") …`) is otherwise` — the actual `m_base.startswith(base + "-")` expression is at line 340. A future maintainer doing a blame/annotate walk will jump to the wrong location.
+- **Suggested fix**: Update the comment to reference the current line numbers, or replace with a description that doesn't depend on line numbers, e.g.: `# The variant-resolution fallback below (m_base.startswith(base+"-")…) is otherwise`.
+
+---
+
+### Verification of R1 Fixes
+
+**Finding 1 (RUNTIME_READ_FRAGMENTS frozenset) — FIXED.**
+- `references/scripts/compose.py:40-52`: The frozenset contains all 11 runtime-loaded fragments: 4 role polling fragments (`ralph-loop-overview` for dev/pm/qa/dm), 6 `common-events/*` fragments, and DM's `roles/dm/events/pr-merge-wait`. ✓
+- `references/scripts/compose.py:327`: The check `if include_path in RUNTIME_READ_FRAGMENTS: continue` executes BEFORE the `manifest_set` check (line 333) and BEFORE the variant heuristic (lines 338-343). The `continue` skips inlining entirely. ✓
+- Edge case verified: `common-events/l1-base` in the template would match frozenset entry `"common-events/l1-base"` even if a future manifest entry `common/l1-base-extended` would otherwise trigger the variant heuristic via `"l1-base-extended".startswith("l1-base-")`. The frozenset short-circuit prevents this. ✓
+
+**Finding 2 (HTML comment sentinels in instructions.md) — FIXED.**
+- `references/roles/pm/instructions.md:29-35`: Comment documents runtime-loading architecture, references `RUNTIME_READ_FRAGMENTS`, warns about regression test. ✓
+- `references/roles/dm/instructions.md:31-38`: Same, plus explicitly calls out `pr-merge-wait` as runtime-loaded. ✓
+- `references/roles/qa/instructions.md:29-35`: Same structure as pm. ✓
+- `references/roles/dev/instructions.md:23-31`: Same, references both `includes.yml` and `includes-events.yml` by name. ✓
+- All four comments accurately name `common/boot-bootstrap` as the runtime loader and `compose.py:RUNTIME_READ_FRAGMENTS` as the compose-time short-circuit. ✓
+
+**Finding 3 (boot-bootstrap.md Step 1 missing-config guard) — FIXED.**
+- `references/sub-skills/common/boot-bootstrap.md:10`: The first bullet now handles "`.squidsquad/config.md` does not exist or cannot be read (Read tool error, file absent, empty file)" → POLLING mode confirmed, skip Step 2, jump Step 4. ✓
+- The remaining bullets (lines 11-13) handle per-role override, global default, and absent/unparseable field values — all after the missing-file guard. ✓
+- The guard explicitly mirrors `compose.py:_get_wake_mode` behavior and cites CONTEXT-9588 D3. ✓
+
+**Finding 4 (boot-bootstrap.md curl invocation) — FIXED.**
+- `references/sub-skills/common/boot-bootstrap.md:21-23`: Curl command is `curl -sf --max-time 5 http://127.0.0.1:<port>/status` — no shell redirect (`> /dev/null` is gone), uses `/status` endpoint matching CONTEXT. ✓
+- Line 24 documents: "no shell redirect is needed (older versions of this instruction used `> /dev/null`, which fails on native Windows shells)" — explicit rationale. ✓
+- Line 24: "Inspect the exit code only: 0 = harness reachable; any non-zero exit … = harness unreachable" — unambiguous exit-code inspection. ✓
+- `-s` silences progress output within curl; `-f` exits non-zero on HTTP errors. This works identically on Windows and POSIX. ✓
+
+---
+
+`NO_FINDINGS` for the other three findings — they are correctly fixed with no regressions. The one new issue (Finding 5) is a documentation-only stale line reference.

--- a/.squidsquad/skill/planning/REVIEW-9588-DEEPSEEK-R3.md
+++ b/.squidsquad/skill/planning/REVIEW-9588-DEEPSEEK-R3.md
@@ -1,0 +1,90 @@
+I've reviewed all the changed files against the five criteria. Here's my analysis:
+
+---
+
+## Criterion 1 — ralph-loop-overview.md sources: no `/loop` invocation, no `[INTERVAL]`
+
+**All four fragments pass.**
+
+| File | `/loop ` invocation? | `[INTERVAL]` placeholder? |
+|---|---|---|
+| `references/sub-skills/roles/dev/ralph-loop-overview.md` | No — only backtick-quoted mentions (lines 5,7,8) | No |
+| `references/sub-skills/roles/dm/ralph-loop-overview.md` | No — same pattern (lines 5,7,8) | No |
+| `references/sub-skills/roles/pm/ralph-loop-overview.md` | No — same pattern (lines 5,7,8) | No |
+| `references/sub-skills/roles/qa/ralph-loop-overview.md` | No — same pattern (lines 5,7,8) | No |
+
+The test at `tests/test_compose_9588.py:193-213` (`test_polling_fragment_source_does_not_invoke_loop`) parametrizes over all 4 role→entry mappings and asserts both `"/loop " not in src` and `"[INTERVAL]" not in src`. The backtick-quoted `` `/loop` `` on line 5 does not match the regex `/loop ` (space after "loop") because a closing backtick sits between "loop" and the space.
+
+**Note**: `dev/ralph-loop-overview.md` still carries `[ROLE]` placeholders at lines 25-26 (`.squidsquad/[ROLE]/current-state` and `cycle.py status-bar [ROLE]`). This is correct — the three other roles hardcode their paths (dm, pm, qa), but dev's fragment is shared by `skill` and any future dev variants, so the placeholder is deliberate. The bootstrap teaching (see Criterion 3) tells the agent to substitute it at runtime.
+
+---
+
+## Criterion 2 — Bootstrap Step 4b owns the `/loop` invocation with `[INTERVAL]` substituted
+
+**Confirmed.** The composed CLAUDE.md Step 4b contains:
+
+```
+/loop 30m execute one Ralph Loop cycle
+```
+
+with a concrete integer (`30m`), not the literal `[INTERVAL]`. The test at `tests/test_compose_9588.py:167-189` (`test_bootstrap_owns_loop_invocation_with_substituted_interval`) verifies:
+- `[INTERVAL]` is absent from composed output (line 180)
+- The regex `/loop \d+m execute one Ralph Loop cycle` matches (line 186)
+
+No other section in the composed CLAUDE.md contains a `/loop` invocation. The polling fragment (Step 4c) is Read at runtime and explicitly tells the agent NOT to invoke `/loop` (lines 2-3 of each fragment: *"Do NOT re-invoke `/loop` here"*).
+
+---
+
+## Criterion 3 — Bootstrap teaches role-placeholder substitution; teaching survives compose
+
+**Confirmed.** The bootstrap's placeholder teaching section in the composed CLAUDE.md spells out role-name and interval placeholders letter-by-letter ("uppercase R-O-L-E in square brackets", "uppercase I-N-T-E-R-V-A-L in square brackets") so compose does not substitute them away. The test at `tests/test_compose_9588.py:216-250` (`test_bootstrap_documents_role_runtime_substitution`) verifies all three conditions:
+
+1. **Source** `boot-bootstrap.md` contains the heading `"Placeholder substitution inside runtime-loaded fragments"` (line 228) and mentions both `"Role-name placeholder"` and `"SQUIDSQUAD_ROLE"` (line 234).
+2. **Composed output** for every role still contains `"Role-name placeholder"` (line 245) — proving compose did not mangle the teaching.
+
+The teaching tells the agent: when you encounter `[ROLE]` in a runtime-loaded fragment, substitute your own `SQUIDSQUAD_ROLE` value. This maps directly to the `[ROLE]` tokens in `dev/ralph-loop-overview.md` lines 25-26.
+
+---
+
+## Criterion 4 — Regression tests pin all three invariants
+
+**Confirmed.** `tests/test_compose_9588.py` contains nine test functions covering:
+
+| Invariant | Test | Lines |
+|---|---|---|
+| (A) Polling fragments clean | `test_polling_fragment_source_does_not_invoke_loop` | 193-213 |
+| (B) Bootstrap owns `/loop` | `test_bootstrap_owns_loop_invocation_with_substituted_interval` | 167-189 |
+| (C) Placeholder teaching survives | `test_bootstrap_documents_role_runtime_substitution` | 216-250 |
+| Bootstrap present in all roles | `test_composed_claude_contains_boot_bootstrap` | 80-91 |
+| Mode fragments not inlined | `test_composed_claude_does_not_inline_mode_specific` | 95-104 |
+| Polling path substituted per role | `test_polling_fragment_path_substituted_per_role` | 107-121 |
+| Runtime paths exist on disk | `test_referenced_runtime_fragments_exist_on_disk` | 124-151 |
+| DM events extra enumerated | `test_dm_bootstrap_enumerates_pr_merge_wait` | 154-164 |
+| Legacy degraded-mode removed | `test_l1_base_unreachable_branch_removed` | 253-267 |
+
+Parametrization covers all four roles (`skill`, `pm`, `qa`, `dm`). The mode-specific markers list (lines 56-65) includes all seven event fragments plus `ralph-loop-overview`. Dev→entry mapping (lines 38-43) correctly routes `skill` → `dev` for the polling fragment path check.
+
+---
+
+## Criterion 5 — Recovery from interrupted `/loop` path exists
+
+**Confirmed at two points:**
+
+1. **Bootstrap Step 4b** (composed CLAUDE.md): explicit block:
+   > **Recovery from an interrupted `/loop`**: if a prior session ended without a cycle firing (e.g., the human ran the agent inline and then returned to `/loop` mode), re-invoke the same literal command above. Do not change the interval value.
+
+2. **All four polling fragments** (line 3, and line 7-8): reference back to the bootstrap:
+   > If you need to recover from an interrupted `/loop` (e.g., resuming after an inline session), follow the recovery directive in the bootstrap rather than re-deriving the invocation from this fragment.
+
+   And:
+   > To resume `/loop` mode after an inline session, re-run the recovery directive from the boot bootstrap.
+
+The recovery path is self-consistent: the fragments defer to the bootstrap, and the bootstrap tells the agent to re-invoke the same literal `/loop 30m execute one Ralph Loop cycle` command.
+
+---
+
+## No new issues found
+
+All five criteria are satisfied. The diff correctly implements PM's Option B: scheduler in bootstrap (compose-inlined → placeholder substitution works), source fragments stripped of `/loop` invocation, and the role-placeholder teaching survives compose. Regression tests are comprehensive and verify every invariant.
+
+**NO_FINDINGS**

--- a/references/roles/dev/includes-events.yml
+++ b/references/roles/dev/includes-events.yml
@@ -12,14 +12,14 @@
 # pattern, idle cool-down loop, comment handling). event-driven-workflow
 # is now an orientation/redirect page kept first for backward-compat with
 # any downstream that still expects that section header.
+# #9588: the six `common-events/*` fragments are now Read at runtime by
+# `common/boot-bootstrap` (the first include) rather than inlined here.
+# Manifest stays as the documentation of what's wired in — compose just
+# does not inline the runtime-Read fragments.
+#
 # Order matters — includes are resolved top-to-bottom
 includes:
-  - common-events/event-driven-workflow
-  - common-events/l1-base
-  - common-events/cursor-management
-  - common-events/forge-read-pattern
-  - common-events/idle-cooldown-loop
-  - common-events/comment-handling
+  - common/boot-bootstrap
   - common/context-pressure
   - common/resume-working-state
   - roles/dev/triage-issues

--- a/references/roles/dev/includes.yml
+++ b/references/roles/dev/includes.yml
@@ -1,9 +1,18 @@
-# Dev agent sub-skill manifest (polling / /loop mode — #8697)
+# Dev agent sub-skill manifest (polling / /loop mode — #8697, #9588)
 # This is the default manifest. compose.py loads `includes-events.yml`
 # instead when the role's wake mode is `event-driven`.
+#
+# #9588: `common/boot-bootstrap` is the FIRST entry across both manifests.
+# The mode-specific fragments (`roles/dev/ralph-loop-overview` here, the
+# six `common-events/*` fragments in `includes-events.yml`, and DM's
+# `roles/dm/events/pr-merge-wait`) are Read at runtime by the bootstrap,
+# not inlined at compose time. Keeps the composed CLAUDE.md mode-uniform
+# and lets `event-driven:` flips take effect on next agent restart
+# without a recompose.
+#
 # Order matters — includes are resolved top-to-bottom
 includes:
-  - roles/dev/ralph-loop-overview
+  - common/boot-bootstrap
   - common/cycle-runner
   - common/context-pressure
   - common/resume-working-state

--- a/references/roles/dev/instructions.md
+++ b/references/roles/dev/instructions.md
@@ -18,6 +18,18 @@ You are the [ROLE] Lead on the SquidSquad autonomous dev team. You operate conti
 
 ---
 
+{{include: common/boot-bootstrap}}
+
+<!--
+  #9588: the directives below are intentionally absent from BOTH
+  `includes.yml` and `includes-events.yml`. They are Read at runtime
+  by `common/boot-bootstrap` and `compose.py:RUNTIME_READ_FRAGMENTS`
+  short-circuits them at composition time. Do NOT re-add these to a
+  manifest unless you are reverting #9588 in full — the regression
+  test in `tests/test_compose_9588.py` will fail if they reappear in
+  the composed CLAUDE.md.
+-->
+
 {{include: roles/dev/ralph-loop-overview}}
 
 {{include: common/cycle-runner}}

--- a/references/roles/dm/includes-events.yml
+++ b/references/roles/dm/includes-events.yml
@@ -3,20 +3,19 @@
 # #8915 wired in the 5 common event-mode L1 base fragments + the DM-specific
 # pr-merge-wait fragment after the legacy event-driven-workflow orientation
 # page.
+# #9588: the six `common-events/*` fragments AND `roles/dm/events/pr-merge-wait`
+# are now Read at runtime by `common/boot-bootstrap` (the first include)
+# rather than inlined here. DM's pr-merge-wait is the only role-specific
+# events extra in the codebase; the bootstrap's Step-3 role check
+# enumerates it explicitly.
 # Order matters — includes are resolved top-to-bottom
 includes:
+  - common/boot-bootstrap
   - common/capability-check
-  - common-events/event-driven-workflow
-  - common-events/l1-base
-  - common-events/cursor-management
-  - common-events/forge-read-pattern
-  - common-events/idle-cooldown-loop
-  - common-events/comment-handling
   - common/context-pressure
   - roles/dm/task-pickup
   - roles/dm/issue-triage
   - roles/dm/delivery-packaging
-  - roles/dm/events/pr-merge-wait
   - roles/dm/version-bumps
   - roles/dm/doc-improvement-loop
   - roles/dm/discussion-protocol

--- a/references/roles/dm/includes.yml
+++ b/references/roles/dm/includes.yml
@@ -1,9 +1,13 @@
-# DM agent sub-skill manifest (polling / /loop mode — #8697)
-# Uses slim variants for vault-protocol and improvement-scan (read-only role)
+# DM agent sub-skill manifest (polling / /loop mode — #8697, #9588)
+# Uses slim variants for vault-protocol and improvement-scan (read-only role).
+# #9588: `common/boot-bootstrap` is the first include per CONTEXT-9588 D1;
+# mode-specific `roles/dm/ralph-loop-overview` is Read at runtime by the
+# bootstrap. Capability-check follows bootstrap — it logs warnings but
+# does not gate execution, so post-bootstrap order is fine.
 # Order matters — includes are resolved top-to-bottom
 includes:
+  - common/boot-bootstrap
   - common/capability-check
-  - roles/dm/ralph-loop-overview
   - common/cycle-runner
   - common/context-pressure
   - roles/dm/task-pickup

--- a/references/roles/dm/instructions.md
+++ b/references/roles/dm/instructions.md
@@ -22,9 +22,20 @@ The active dev agents on this project are: **[ACTIVE_AGENTS]** (read from `.squi
 
 ---
 
+{{include: common/boot-bootstrap}}
+
 {{include: common/capability-check}}
 
 ---
+
+<!--
+  #9588: the directives below are intentionally absent from BOTH
+  manifests; they are Read at runtime by `common/boot-bootstrap` and
+  `compose.py:RUNTIME_READ_FRAGMENTS` short-circuits them at compose
+  time. DM's `roles/dm/events/pr-merge-wait` is also runtime-loaded.
+  Re-adding any of these to a manifest will fail the regression test
+  in `tests/test_compose_9588.py`.
+-->
 
 {{include: roles/dm/ralph-loop-overview}}
 

--- a/references/roles/pm/includes-events.yml
+++ b/references/roles/pm/includes-events.yml
@@ -1,14 +1,11 @@
 # PM agent sub-skill manifest (event-driven mode — #8697)
 # #8915 wired in the 5 event-mode L1 base fragments after the legacy
 # event-driven-workflow orientation page.
+# #9588: the six `common-events/*` fragments are now Read at runtime by
+# `common/boot-bootstrap` (the first include) rather than inlined here.
 # Order matters — includes are resolved top-to-bottom
 includes:
-  - common-events/event-driven-workflow
-  - common-events/l1-base
-  - common-events/cursor-management
-  - common-events/forge-read-pattern
-  - common-events/idle-cooldown-loop
-  - common-events/comment-handling
+  - common/boot-bootstrap
   - common/context-pressure
   - common/task-pickup
   - roles/pm/checkin

--- a/references/roles/pm/includes.yml
+++ b/references/roles/pm/includes.yml
@@ -1,7 +1,9 @@
-# PM agent sub-skill manifest (polling / /loop mode — #8697)
+# PM agent sub-skill manifest (polling / /loop mode — #8697, #9588)
+# #9588: `common/boot-bootstrap` is the first include; mode-specific
+# `roles/pm/ralph-loop-overview` is Read at runtime by the bootstrap.
 # Order matters — includes are resolved top-to-bottom
 includes:
-  - roles/pm/ralph-loop-overview
+  - common/boot-bootstrap
   - common/cycle-runner
   - common/context-pressure
   - common/task-pickup

--- a/references/roles/pm/instructions.md
+++ b/references/roles/pm/instructions.md
@@ -24,6 +24,16 @@ The active dev agents on this project are: **[ACTIVE_AGENTS]** (read from `.squi
 
 ---
 
+{{include: common/boot-bootstrap}}
+
+<!--
+  #9588: the directives below are intentionally absent from BOTH
+  manifests; they are Read at runtime by `common/boot-bootstrap` and
+  `compose.py:RUNTIME_READ_FRAGMENTS` short-circuits them at compose
+  time. Re-adding them to a manifest will fail the regression test
+  in `tests/test_compose_9588.py`.
+-->
+
 {{include: roles/pm/ralph-loop-overview}}
 
 {{include: common/cycle-runner}}

--- a/references/roles/qa/includes-events.yml
+++ b/references/roles/qa/includes-events.yml
@@ -2,14 +2,11 @@
 # Uses slim variants for vault-protocol and improvement-scan (read-only role).
 # #8915 wired in the 5 event-mode L1 base fragments after the legacy
 # event-driven-workflow orientation page.
+# #9588: the six `common-events/*` fragments are now Read at runtime by
+# `common/boot-bootstrap` (the first include) rather than inlined here.
 # Order matters — includes are resolved top-to-bottom
 includes:
-  - common-events/event-driven-workflow
-  - common-events/l1-base
-  - common-events/cursor-management
-  - common-events/forge-read-pattern
-  - common-events/idle-cooldown-loop
-  - common-events/comment-handling
+  - common/boot-bootstrap
   - common/context-pressure
   - common/task-pickup
   - roles/qa/verification

--- a/references/roles/qa/includes.yml
+++ b/references/roles/qa/includes.yml
@@ -1,8 +1,10 @@
-# QA agent sub-skill manifest (polling / /loop mode — #8697)
-# Uses slim variants for vault-protocol and improvement-scan (read-only role)
+# QA agent sub-skill manifest (polling / /loop mode — #8697, #9588)
+# Uses slim variants for vault-protocol and improvement-scan (read-only role).
+# #9588: `common/boot-bootstrap` is the first include; mode-specific
+# `roles/qa/ralph-loop-overview` is Read at runtime by the bootstrap.
 # Order matters — includes are resolved top-to-bottom
 includes:
-  - roles/qa/ralph-loop-overview
+  - common/boot-bootstrap
   - common/cycle-runner
   - common/context-pressure
   - common/task-pickup

--- a/references/roles/qa/instructions.md
+++ b/references/roles/qa/instructions.md
@@ -24,6 +24,16 @@ The active dev agents on this project are: **[ACTIVE_AGENTS]** (read from `.squi
 
 ---
 
+{{include: common/boot-bootstrap}}
+
+<!--
+  #9588: the directives below are intentionally absent from BOTH
+  manifests; they are Read at runtime by `common/boot-bootstrap` and
+  `compose.py:RUNTIME_READ_FRAGMENTS` short-circuits them at compose
+  time. Re-adding them to a manifest will fail the regression test
+  in `tests/test_compose_9588.py`.
+-->
+
 {{include: roles/qa/ralph-loop-overview}}
 
 {{include: common/cycle-runner}}

--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -30,6 +30,27 @@ CAPABILITIES_DIR = REPO_ROOT / "references" / "sub-skills" / "capabilities"
 ROLES_DIR = REPO_ROOT / "references" / "roles"
 OUTPUT_FILE = REPO_ROOT / "references" / "agent-instructions.md"
 
+# #9588: fragments the boot-bootstrap Reads at runtime. These MUST stay
+# out of every composed CLAUDE.md regardless of what the manifest looks
+# like — even a future manifest entry whose stem matches one of these
+# names via the variant-resolution fallback in
+# `_resolve_includes_with_manifest` would otherwise silently re-inline a
+# mode-specific fragment and defeat the lazy-load design. Checked
+# explicitly before the variant heuristic so the heuristic cannot win.
+RUNTIME_READ_FRAGMENTS = frozenset({
+    "roles/dev/ralph-loop-overview",
+    "roles/pm/ralph-loop-overview",
+    "roles/qa/ralph-loop-overview",
+    "roles/dm/ralph-loop-overview",
+    "common-events/event-driven-workflow",
+    "common-events/l1-base",
+    "common-events/cursor-management",
+    "common-events/forge-read-pattern",
+    "common-events/idle-cooldown-loop",
+    "common-events/comment-handling",
+    "roles/dm/events/pr-merge-wait",
+})
+
 
 def _get_wake_mode(role_name: str) -> str:
     """Determine a role's wake mode from config.md (#8697).
@@ -298,6 +319,15 @@ def _resolve_includes_with_manifest(entry_file: Path, manifest: list, wake_mode:
         if inc_match:
             include_path = inc_match.group(1).strip()
 
+            # #9588: short-circuit before the variant heuristic for any
+            # fragment the boot-bootstrap Reads at runtime. The variant-
+            # resolution fallback below (`m_base.startswith(base + "-") …`)
+            # is otherwise liberal enough to resurrect, e.g.,
+            # `common-events/l1-base` if some future manifest entry has
+            # the stem `l1-base-…`.
+            if include_path in RUNTIME_READ_FRAGMENTS:
+                continue
+
             # Check if the manifest overrides this include
             # (e.g. vault-protocol -> vault-protocol-slim)
             resolved_path = include_path
@@ -540,6 +570,15 @@ def _substitute_placeholders(content: str, role_name: str, entry_file: str) -> s
     # Universal substitution — all roles need [ROLE] for cycle-runner paths
     content = content.replace("[ROLE]", role_name)
     content = content.replace("[ROLE_UPPER]", role_name.upper())
+
+    # #9588: the boot-bootstrap fragment needs the per-role polling-fragment
+    # path. Dev variants (skill, ios, android, web, fullstack) share one file
+    # at roles/dev/ralph-loop-overview.md — so we substitute by entry_file
+    # (the role identity that owns the polling fragment file), not role_name.
+    polling_fragment = (
+        f"references/sub-skills/roles/{entry_file}/ralph-loop-overview.md"
+    )
+    content = content.replace("[POLLING_FRAGMENT_PATH]", polling_fragment)
 
     if is_dev:
 

--- a/references/sub-skills/common-events/event-driven-workflow.md
+++ b/references/sub-skills/common-events/event-driven-workflow.md
@@ -4,7 +4,7 @@ You are a persistent agent session driven by events from the harness. You react 
 
 This fragment is a brief orientation. The full agent contract lives in the companion event-mode fragments — read them in this order:
 
-1. **[[l1-base]]** — boot sequence (Case A), event reactions (Cases B–E), case-precedence rule, working-state ownership discipline, degraded-mode operation.
+1. **[[l1-base]]** — boot sequence (Case A), event reactions (Cases B–E), case-precedence rule, working-state ownership discipline. Harness-loss recovery is handled by `common/boot-bootstrap.md` (polling-mode fallback at boot, #9588), not inline degraded mode.
 2. **[[cursor-management]]** — atomic `.tmp` + `mv` protocol, per-event advance, gap handling (in-stream, long lag, eviction).
 3. **[[forge-read-pattern]]** — why the forge is the source of truth and how to read it before acting.
 4. **[[idle-cooldown-loop]]** — what an event-mode agent does when `work_queue()` is empty.
@@ -21,7 +21,7 @@ This fragment is a brief orientation. The full agent contract lives in the compa
 
 ### Error handling
 
-If the harness becomes unreachable, the agent does NOT pivot to forge-direct work mid-session — that path exists only at boot (degraded mode, see [[l1-base]]). Mid-session unreachable is a **manual-recovery scenario**: keep retrying at the 5-minute-capped backoff; the operator restarts the harness; the agent resumes via the event stream on reconnect.
+If the harness becomes unreachable mid-session, the agent does NOT pivot to forge-direct work — this is a **manual-recovery scenario**: keep retrying `bootup-complete` at the 5-minute-capped backoff; the operator restarts the agent; on restart the boot bootstrap (`common/boot-bootstrap.md`) detects the unreachable harness and routes to polling mode (#9588). Mid-session degraded operation was removed in #9588.
 
 `event_poll.py` handles transient HTTP errors (5xx, `ConnectionError`, `Timeout`, `IncompleteRead`) automatically with exponential backoff. 4xx responses are treated as caller faults and exit non-zero.
 

--- a/references/sub-skills/common-events/l1-base.md
+++ b/references/sub-skills/common-events/l1-base.md
@@ -18,11 +18,9 @@ The boot sequence MUST work even when the harness is unreachable. Forge access i
 2. **Branch on what working-state shows:**
    - **In-progress tracker task** → verify against the forge: still my role? still `status:in-progress`? Yes → resume. No → clear the task field (`- **Task**: none` in working-state) and drop the task locally — **no forge transition is needed** because the forge already reflects the change (that is why verification failed). Fall through to a fresh `work_queue()` scan.
    - **Improvement-scan `Status: running`** (not a tracker item) → skip forge verification; restart the scan. Improvement scans are idempotent — a fresh scan subsumes a partial one. See [[idle-cooldown-loop]]. **When the scan completes, run `work_queue()`** before re-entering the cool-down loop, in case a task arrived during the outage.
-   - **Idle / nothing in progress** → run `work_queue()` against the forge. If work is returned: **pick up the top item** — transition it to `status:in-progress`, write the issue number to the Task field in `working-state.md`, and begin work. If `work_queue()` is empty, defer to step 3 for the empty-queue path (cool-down loop if harness reachable; degraded-mode sleep loop if not).
+   - **Idle / nothing in progress** → run `work_queue()` against the forge. If work is returned: **pick up the top item** — transition it to `status:in-progress`, write the issue number to the Task field in `working-state.md`, and begin work. If `work_queue()` is empty, defer to step 3 for the empty-queue path — the improvement-scan cool-down loop. (Harness reachability is guaranteed at this point per #9588; see step 3.)
 
-3. **Check harness reachability** (before any event-stream call or cool-down entry):
-   - **Unreachable** → skip steps 4–5 (nothing to skim, cursor unchanged) and proceed to degraded-mode operation: continue working directly from the forge via `work_queue()`. While in degraded mode, if `work_queue()` returns empty, sleep a short fixed interval (e.g. 60s) and retry `work_queue()`; if `work_queue()` returns work, pick up the top item directly (transition to `in-progress`, update the Task field, begin work) and on completion follow Case C (transition, clear Task field, re-run `work_queue()`) — then continue applying the same degraded-mode rules (empty → 60s sleep, non-empty → pick up). **Do NOT enter the improvement-scan cool-down loop in degraded mode**, because the Monitor (`event_poll.py`) requires the harness. **Before each `work_queue()` call** (including after each 60s sleep), attempt to POST `bootup-complete` using exponential backoff capped at **5 minutes**. A successful POST indicates the harness is reachable — **exit degraded mode** by skimming events from the current cursor forward (step 4), advancing the cursor (step 5 cursor write), and entering the listening loop. `bootup-complete` is **best-effort, not blocking** — the agent never hangs waiting for the harness.
-   - **Reachable** → continue to step 4. (If you got here from step 2's empty idle branch, after step 5 enter the improvement-scan cool-down loop — see [[idle-cooldown-loop]].)
+3. **Harness reachability is guaranteed by the bootstrap (#9588).** If this fragment is being Read, the boot bootstrap (`common/boot-bootstrap.md`) has already verified that the harness is reachable — otherwise the bootstrap would have routed the agent to the polling fragment, not here. Continue to step 4. (If you got here from step 2's empty idle branch, after step 5 enter the improvement-scan cool-down loop — see [[idle-cooldown-loop]].)
 
 4. **Skim events from cursor forward.** Informational only — the forge already has current state. Skim-then-advance; never jump-to-latest. Handle gap scenarios per [[cursor-management]] (long lag, eviction gap). In an eviction gap specifically, the cursor advances to the *oldest available* id, not the latest observed.
 
@@ -64,7 +62,7 @@ Monitor tool invocation:
 1. You just transitioned a tracker item via `tracker.py transition`.
 2. Update `working-state.md` → `- **Task**: none`.
 3. **Immediately run `work_queue()`** against the forge. Do NOT wait for your own transition event to come back through the stream.
-4. Pick up the next item, or — if `work_queue()` is empty — enter idle (improvement-scan cool-down). **Degraded-mode exception**: if the harness is currently unreachable, do NOT enter the cool-down loop; apply the degraded-mode rules instead (60s sleep + retry `work_queue()`).
+4. Pick up the next item, or — if `work_queue()` is empty — enter idle (improvement-scan cool-down).
 
 ---
 
@@ -96,10 +94,8 @@ Monitor tool invocation:
 
 ---
 
-### Degraded-Mode Glossary
+### Harness-Loss Recovery (#9588)
 
-**Degraded mode** = harness unreachable at boot. The agent works directly from the forge via `work_queue()` and retries `bootup-complete` emission with the 5-minute capped backoff.
+If the harness becomes unreachable AFTER `bootup-complete` has been emitted, the agent keeps retrying `bootup-complete` at the 5-minute capped backoff but does **NOT** pivot to forge-direct work mid-session. Operator restarts the agent to recover; on restart the boot bootstrap detects the unreachable harness and routes to polling mode (see `common/boot-bootstrap.md`).
 
-**Manual-recovery scenario** = harness becomes unreachable AFTER `bootup-complete` has been emitted. The agent keeps retrying at the capped backoff but does **NOT** pivot to forge-direct work. The operator manually restarts the harness; the agent resumes via the event stream on reconnect.
-
-Rationale: agents log everything to the forge, so state is recoverable; adding a runtime degraded-mode adds complexity the failsafe boot path already handles after a restart.
+Rationale: agents log everything to the forge, so state is recoverable across a restart. The bespoke "degraded mode" that ran forge-direct from a live event-mode session was removed in #9588 in favor of polling-mode fallback at boot — a battle-tested mechanism without a third execution path to reason about.

--- a/references/sub-skills/common/boot-bootstrap.md
+++ b/references/sub-skills/common/boot-bootstrap.md
@@ -1,0 +1,60 @@
+<!-- sub-skill: boot-bootstrap -->
+## Boot — Mode Detection (#9588)
+
+**This block is the FIRST instruction in your composed CLAUDE.md. Execute it BEFORE any other section, BEFORE invoking any tool, BEFORE responding to the human.** Steps 1–4 below are mandatory and must run in order on every fresh session start.
+
+### Step 1 — Determine wake mode from config
+
+Read `.squidsquad/config.md` and find the active wake mode:
+
+- **If `.squidsquad/config.md` does not exist or cannot be read** (Read tool error, file absent, empty file) → **POLLING mode confirmed**, skip Step 2 and jump to Step 4. Defaulting to polling here mirrors the compose-time `_get_wake_mode` guard (`references/scripts/compose.py:_get_wake_mode`) and honors CONTEXT-9588 D3: the safe fallback for any uncertainty is polling.
+- Else if `event-driven-[ROLE]: yes` is present (per-role override) → event-mode candidate.
+- Else if `event-driven: yes` is present (global default) → event-mode candidate.
+- Else (field absent, set to `no`, or unparseable) → **POLLING mode confirmed**, skip Step 2 and jump to Step 4 (polling branch).
+
+### Step 2 — Check harness reachability (event-mode candidate only)
+
+The harness must be reachable for event-mode to be used. Probe in this order:
+
+1. **Read the port file** at `.squidsquad/.harness-port` (relative to repo root). If the file is absent OR unreadable OR empty OR its content is not a valid integer, default port to `7373` (the harness default — see `cycle_post.py:_discover_harness_port`).
+2. **HTTP-probe the harness** with a 5-second timeout against the resolved port. Run via the Bash tool:
+   ```bash
+   curl -sf --max-time 5 http://127.0.0.1:<port>/status
+   ```
+   The `-s` flag silences progress output and `-f` makes curl exit non-zero on any HTTP error response — no shell redirect is needed (older versions of this instruction used `> /dev/null`, which fails on native Windows shells and would force a permanent polling fallback). Inspect the exit code only: 0 = harness reachable; any non-zero exit (curl error, connection refused, timeout, HTTP non-2xx, curl missing from PATH) = **harness unreachable**.
+
+If the probe succeeds → **EVENT mode confirmed**, proceed to Step 3.
+If the probe fails (for any reason — non-zero exit, network error, missing curl) → **fall through to polling** (jump to Step 4 polling branch). This fallback is intentional per #9580/#9588: until the harness is proven stable across all failure modes, agents fall back to `/loop` polling rather than the bespoke event-mode degraded path.
+
+### Step 3 — EVENT mode: Read event fragments and follow them
+
+Use the Read tool to read each of the following files **in order** and treat their concatenated content as your active wake-mode contract for this session:
+
+1. `references/sub-skills/common-events/event-driven-workflow.md`
+2. `references/sub-skills/common-events/l1-base.md`
+3. `references/sub-skills/common-events/cursor-management.md`
+4. `references/sub-skills/common-events/forge-read-pattern.md`
+5. `references/sub-skills/common-events/idle-cooldown-loop.md`
+6. `references/sub-skills/common-events/comment-handling.md`
+
+**Role-specific extras** — if your role is `dm`, ALSO Read `references/sub-skills/roles/dm/events/pr-merge-wait.md` as a seventh file. If your role is not `dm`, skip this extra file (no other roles currently have events extras).
+
+After reading, the boot sequence and event-listening loop described in those fragments take effect immediately. Do not proceed to Step 4 (polling branch is unreachable once Step 3 executes).
+
+### Step 4 — POLLING mode: Read the polling fragment and follow it
+
+Use the Read tool to read this single file:
+
+- `[POLLING_FRAGMENT_PATH]`
+
+Treat its content as your active wake-mode contract. Follow its instructions exactly — including invoking `/loop 30m execute one Ralph Loop cycle` (or the cadence specified by `config.md`'s `interval` field) to schedule cycles.
+
+### Loaded mode is sticky
+
+Once Steps 3 or 4 complete, your wake-mode contract is fixed for this session. Do **not** re-check mode mid-session. Mode flips (`config.md` `event-driven:` value changed by an operator) take effect on the next agent restart — not mid-cycle.
+
+### Why polling is the harness-down fallback
+
+The bespoke "degraded mode" in `common-events/l1-base.md` (sleep 60s + retry `work_queue()`) is removed in favor of polling fallback. The `/loop` mechanism is battle-tested across continuous operation including multiple harness outages; degraded mode added a third execution path that complicated the contract without proving more reliable. Operator restarts the agent to re-enter event-mode after the harness recovers.
+
+<!-- /sub-skill: boot-bootstrap -->

--- a/references/sub-skills/common/boot-bootstrap.md
+++ b/references/sub-skills/common/boot-bootstrap.md
@@ -41,13 +41,46 @@ Use the Read tool to read each of the following files **in order** and treat the
 
 After reading, the boot sequence and event-listening loop described in those fragments take effect immediately. Do not proceed to Step 4 (polling branch is unreachable once Step 3 executes).
 
-### Step 4 — POLLING mode: Read the polling fragment and follow it
+### Step 4 — POLLING mode: schedule `/loop`, then Read the polling fragment
+
+**Step 4a — Verify GitHub Issues access** (this check used to live inside the polling fragment; it has been moved up here so it runs BEFORE `/loop` is scheduled — a session that cannot reach GitHub should refuse to enter the loop):
+
+```bash
+python references/scripts/tracker.py check-gh
+```
+
+If this fails, print: `[🦑 HH:MM:SS] ERROR: GitHub Issues permission check failed. Run "gh auth refresh" with "repo" scope, or ensure gh CLI is installed and authenticated.` and exit the session. SquidSquad requires GitHub Issues access.
+
+**Step 4b — Schedule `/loop` exactly once** (#9588 BLOCKER fix):
+
+Invoke this slash command literally. The interval value below is substituted at compose time from `config.md`'s `Iteration Interval > Minutes` field — do NOT re-derive it from the polling fragment, and do NOT re-invoke `/loop` after the fragment is loaded:
+
+```
+/loop [INTERVAL]m execute one Ralph Loop cycle
+```
+
+This is the only `/loop` invocation in your boot path. The polling fragment Read in Step 4c describes what a cycle DOES, not how to schedule one — re-invoking `/loop` from inside the fragment would stack cron entries.
+
+**Recovery from an interrupted `/loop`**: if a prior session ended without a cycle firing (e.g., the human ran the agent inline and then returned to `/loop` mode), re-invoke the same literal command above. Do not change the interval value.
+
+**Step 4c — Read the polling fragment**:
 
 Use the Read tool to read this single file:
 
 - `[POLLING_FRAGMENT_PATH]`
 
-Treat its content as your active wake-mode contract. Follow its instructions exactly — including invoking `/loop 30m execute one Ralph Loop cycle` (or the cadence specified by `config.md`'s `interval` field) to schedule cycles.
+Treat its content as the contract for what happens INSIDE each cycle — step markers, status bar writes, work-queue pickup, commits, etc.
+
+### Placeholder substitution inside runtime-loaded fragments
+
+The fragments you Read in Step 3 or Step 4c are **source files**, not compose output. Compose-time placeholder substitution (the machinery in `compose.py:_substitute_placeholders`) only fires on content compose inlines into your CLAUDE.md — never on text you Read at runtime. As a result, source fragments may still contain square-bracketed UPPERCASE tokens that look like ``the-role-placeholder`` (uppercase R-O-L-E inside brackets) or ``the-interval-placeholder`` (uppercase I-N-T-E-R-V-A-L inside brackets).
+
+When you encounter one of these inside a runtime-loaded fragment, substitute it yourself using values you already know:
+
+- **Role-name placeholder** (uppercase R-O-L-E in square brackets) — substitute your own role name. You were started with `SQUIDSQUAD_ROLE=<role>` in your system prompt; that value IS the substitution. Example: when a fragment says ``write to `.squidsquad/<the-role-placeholder>/current-state` ``, write to ``.squidsquad/<your-role-name>/current-state``.
+- **Interval placeholder** (uppercase I-N-T-E-R-V-A-L in square brackets) — you should NOT encounter this in any runtime-loaded fragment. `/loop` is scheduled exclusively in Step 4b above, where compose has already substituted the literal interval. If you DO see the interval placeholder inside a runtime-loaded fragment, treat it as a bug — flag in your iteration log and do NOT execute the surrounding `/loop` invocation.
+
+(This section avoids writing the placeholder strings literally because compose would substitute them away at compose time, defeating the teaching. The names are spelled out letter-by-letter so the rule survives compose unchanged.)
 
 ### Loaded mode is sticky
 

--- a/references/sub-skills/roles/dev/ralph-loop-overview.md
+++ b/references/sub-skills/roles/dev/ralph-loop-overview.md
@@ -1,20 +1,10 @@
-## On Startup
-
-When you first receive these instructions, first verify GitHub Issues access (see Tracker Protocol above). Then read the interval from `.squidsquad/config.md` (under `Iteration Interval > Minutes`) and invoke the `/loop` command to schedule repeating cycles:
-
-```
-/loop [INTERVAL]m execute one Ralph Loop cycle
-```
-
-This externalizes the cycle timing — `/loop` handles the interval and re-invocation. Each cycle is a single pass through Steps 1-5, then returns. Do NOT manually sleep or try to self-loop.
-
-> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-invoke `/loop [INTERVAL]m execute one Ralph Loop cycle`.
-
----
-
 ## The Ralph Loop
 
-Each invocation executes **one cycle** through the steps below. The `/loop` command handles re-invocation every [INTERVAL] minutes.
+> **Boot prerequisite (#9588)**: by the time you Read this fragment, the boot bootstrap (`common/boot-bootstrap.md`, inlined at the top of your composed CLAUDE.md) has already verified GitHub Issues access AND scheduled the `/loop` invocation with the correct interval from `config.md`. Do NOT re-invoke `/loop` here — re-invoking would stack cron entries. If you need to recover from an interrupted `/loop` (e.g., resuming after an inline session), follow the recovery directive in the bootstrap rather than re-deriving the invocation from this fragment.
+
+Each invocation executes **one cycle** through the steps below. `/loop` handles re-invocation at the interval configured in `.squidsquad/config.md` (`Iteration Interval > Minutes`).
+
+> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-run the recovery directive from the boot bootstrap.
 
 At the start of each cycle, print:
 

--- a/references/sub-skills/roles/dm/ralph-loop-overview.md
+++ b/references/sub-skills/roles/dm/ralph-loop-overview.md
@@ -1,20 +1,10 @@
-## On Startup
-
-When you first receive these instructions, first verify GitHub Issues access (see Tracker Protocol above). Then read the interval from `.squidsquad/config.md` (under `Iteration Interval > Minutes`) and invoke:
-
-```
-/loop [INTERVAL]m execute one Ralph Loop cycle
-```
-
-This externalizes the cycle timing — `/loop` handles the interval and re-invocation. Each cycle is a single pass through the steps below. Do NOT manually sleep or try to self-loop.
-
-> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-invoke `/loop [INTERVAL]m execute one Ralph Loop cycle`.
-
----
-
 ## The Ralph Loop
 
-Each invocation executes **one cycle** through the steps below. The `/loop` command handles re-invocation every [INTERVAL] minutes.
+> **Boot prerequisite (#9588)**: by the time you Read this fragment, the boot bootstrap (`common/boot-bootstrap.md`, inlined at the top of your composed CLAUDE.md) has already verified GitHub Issues access AND scheduled the `/loop` invocation with the correct interval from `config.md`. Do NOT re-invoke `/loop` here — re-invoking would stack cron entries. If you need to recover from an interrupted `/loop` (e.g., resuming after an inline session), follow the recovery directive in the bootstrap rather than re-deriving the invocation from this fragment.
+
+Each invocation executes **one cycle** through the steps below. `/loop` handles re-invocation at the interval configured in `.squidsquad/config.md` (`Iteration Interval > Minutes`).
+
+> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-run the recovery directive from the boot bootstrap.
 
 At the start of each cycle, print:
 

--- a/references/sub-skills/roles/pm/ralph-loop-overview.md
+++ b/references/sub-skills/roles/pm/ralph-loop-overview.md
@@ -1,20 +1,10 @@
-## On Startup
-
-When you first receive these instructions, first verify GitHub Issues access (see Tracker Protocol above). Then read the interval from `.squidsquad/config.md` (under `Iteration Interval > Minutes`) and invoke the `/loop` command to schedule repeating cycles:
-
-```
-/loop [INTERVAL]m execute one Ralph Loop cycle
-```
-
-This externalizes the cycle timing — `/loop` handles the interval and re-invocation. Each cycle is a single pass through the steps below. Do NOT manually sleep or try to self-loop. Print a brief one-line status as you go (e.g. `[🦑 HH:MM:SS] Pulling latest...`, `[🦑 HH:MM:SS] Running QA pass...`).
-
-> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-invoke `/loop [INTERVAL]m execute one Ralph Loop cycle`.
-
----
-
 ## The Ralph Loop
 
-Each invocation executes **one cycle** through the steps below. The `/loop` command handles re-invocation every [INTERVAL] minutes.
+> **Boot prerequisite (#9588)**: by the time you Read this fragment, the boot bootstrap (`common/boot-bootstrap.md`, inlined at the top of your composed CLAUDE.md) has already verified GitHub Issues access AND scheduled the `/loop` invocation with the correct interval from `config.md`. Do NOT re-invoke `/loop` here — re-invoking would stack cron entries. If you need to recover from an interrupted `/loop` (e.g., resuming after an inline session), follow the recovery directive in the bootstrap rather than re-deriving the invocation from this fragment.
+
+Each invocation executes **one cycle** through the steps below. `/loop` handles re-invocation at the interval configured in `.squidsquad/config.md` (`Iteration Interval > Minutes`). Print a brief one-line status as you go (e.g. `[🦑 HH:MM:SS] Pulling latest...`, `[🦑 HH:MM:SS] Running QA pass...`).
+
+> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-run the recovery directive from the boot bootstrap.
 
 At the start of each cycle, print:
 

--- a/references/sub-skills/roles/qa/ralph-loop-overview.md
+++ b/references/sub-skills/roles/qa/ralph-loop-overview.md
@@ -1,22 +1,10 @@
-## On Startup
-
-When you first receive these instructions, first verify GitHub Issues access (see Tracker Protocol above). Then invoke the `/loop` command to schedule repeating cycles:
-
-Read the interval from `.squidsquad/config.md` (under `Iteration Interval > Minutes`), then invoke:
-
-```
-/loop [INTERVAL]m execute one Ralph Loop cycle
-```
-
-This externalizes the cycle timing — `/loop` handles the interval and re-invocation. Each cycle is a single pass through the steps below. Do NOT manually sleep or try to self-loop.
-
-> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-invoke `/loop [INTERVAL]m execute one Ralph Loop cycle`.
-
----
-
 ## The Ralph Loop
 
-Each invocation executes **one cycle** through the steps below. The `/loop` command handles re-invocation every [INTERVAL] minutes.
+> **Boot prerequisite (#9588)**: by the time you Read this fragment, the boot bootstrap (`common/boot-bootstrap.md`, inlined at the top of your composed CLAUDE.md) has already verified GitHub Issues access AND scheduled the `/loop` invocation with the correct interval from `config.md`. Do NOT re-invoke `/loop` here — re-invoking would stack cron entries. If you need to recover from an interrupted `/loop` (e.g., resuming after an inline session), follow the recovery directive in the bootstrap rather than re-deriving the invocation from this fragment.
+
+Each invocation executes **one cycle** through the steps below. `/loop` handles re-invocation at the interval configured in `.squidsquad/config.md` (`Iteration Interval > Minutes`).
+
+> **Inline mode vs `/loop` mode (#9358).** When a human drives the session interactively (direct messages instead of the `/loop` trigger), `cycle_pre`/`cycle_post` are NOT invoked — there is no scheduler firing them. You still act on the human's requests (post comments, transition tasks, ship PRs) but you do this directly. As a result: `cycle-input.json` and the iter log are not written for the inline turn, the status bar `current-state` file may stay on its previous value, and `working-state.md` only changes if you (or the human) explicitly edits it. This is **expected**, not a regression — PM's pipeline sentinel should not treat an agent operating in inline mode as broken cycling. To resume `/loop` mode after an inline session, re-run the recovery directive from the boot bootstrap.
 
 At the start of each cycle, print:
 

--- a/tests/comprehension/9588_spec.json
+++ b/tests/comprehension/9588_spec.json
@@ -1,0 +1,35 @@
+{
+  "issue": 9588,
+  "title": "Lazy-load mode-specific instructions at boot — comprehension test agent describes the bootstrap's boot path from the modified files alone",
+  "files": [
+    "references/sub-skills/common/boot-bootstrap.md",
+    "references/sub-skills/roles/dev/ralph-loop-overview.md"
+  ],
+  "questions": [
+    {
+      "id": "1",
+      "question": "Read references/sub-skills/common/boot-bootstrap.md. List, in order, the four steps the agent runs at fresh-session boot, and state which step decides between event-driven and polling mode.",
+      "expected": "Four steps: (1) Read .squidsquad/config.md to determine wake mode; (2) check harness reachability via curl -sf --max-time 5 http://127.0.0.1:<port>/status against the port from .squidsquad/.harness-port (default 7373); (3) EVENT mode — Read the six common-events fragments (event-driven-workflow, l1-base, cursor-management, forge-read-pattern, idle-cooldown-loop, comment-handling), plus roles/dm/events/pr-merge-wait.md if the role is dm; (4) POLLING mode — run tracker.py check-gh, schedule /loop exactly once, then Read the per-role ralph-loop-overview.md. Steps 1 and 2 together decide the mode: if config says event-driven yes AND the curl probe succeeds, mode is event-driven; for any other outcome (config absent, event-driven not yes, probe fails for any reason), mode is polling."
+    },
+    {
+      "id": "2",
+      "question": "Read references/sub-skills/common/boot-bootstrap.md. The harness probe explicitly avoids one common shell idiom. Which idiom, and why?",
+      "expected": "The probe uses `curl -sf --max-time 5 http://127.0.0.1:<port>/status` and inspects only the exit code. It explicitly avoids `> /dev/null` because that shell redirect fails on native Windows shells and would force a permanent polling fallback. The -s flag silences progress output and -f makes curl exit non-zero on any HTTP error response, so no redirect is needed."
+    },
+    {
+      "id": "3",
+      "question": "Read references/sub-skills/common/boot-bootstrap.md. Under what circumstances does the agent fall through to polling mode?",
+      "expected": "Polling fallback fires when any of: (a) .squidsquad/config.md is missing, unreadable, or empty; (b) config does not have event-driven: yes (or per-role override); (c) the curl harness probe returns non-zero for any reason (connection refused, timeout, HTTP non-2xx, curl missing from PATH, port file missing/unreadable/empty/non-integer). Polling is the safe default whenever event-mode cannot be positively confirmed."
+    },
+    {
+      "id": "4",
+      "question": "Read both references/sub-skills/common/boot-bootstrap.md and references/sub-skills/roles/dev/ralph-loop-overview.md. Which file is responsible for invoking /loop, and why is it not invoked from the other file?",
+      "expected": "/loop is invoked from boot-bootstrap.md Step 4b, with [INTERVAL] substituted at compose time from config.md (so the composed CLAUDE.md reads e.g. `/loop 30m execute one Ralph Loop cycle`). The polling fragment (ralph-loop-overview.md) does NOT invoke /loop — the bootstrap is the sole scheduler. The polling fragment describes what each cycle does (step markers, status bar, work queue, commits); the bootstrap describes how to schedule one. Re-invoking /loop from the polling fragment would stack a duplicate cron entry, and because the fragment is Read at runtime, the [INTERVAL] placeholder there would not substitute and the literal placeholder would break the invocation."
+    },
+    {
+      "id": "5",
+      "question": "Read references/sub-skills/common/boot-bootstrap.md. Once the agent has loaded its wake-mode fragments, can the wake mode change mid-session? When does a mode flip take effect?",
+      "expected": "No, the loaded mode is sticky for the session. Once Steps 3 or 4 complete, the wake-mode contract is fixed; the agent does not re-check mode mid-session. A mode flip (operator changes event-driven: value in config.md) takes effect on the next agent restart, not mid-cycle. This is intentional per CONTEXT-9588 D2: restart is the natural reload point, and mid-session reload would add a third execution path."
+    }
+  ]
+}

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -57,6 +57,7 @@ STATIC_TEST_MODULES = [
     "test_write_event_reactions",
     "test_event_derivation",
     "test_compose",
+    "test_compose_9588",
     "test_reboot_agent",
     "test_feat_3296_task_boundary",
     "test_per_agent_workdirs",

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -930,7 +930,12 @@ class TestLoadManifestSelectsByWakeMode:
     def test_event_driven_loads_includes_events_yml(self):
         manifest = compose._load_manifest("dev", wake_mode="event-driven")
         assert manifest is not None
-        assert "common-events/event-driven-workflow" in manifest
+        # #9588: the events manifest is identified by the loader fragment
+        # (`common/boot-bootstrap`) plus the absence of polling-only
+        # entries like `common/cycle-runner`. The legacy assertion checked
+        # for `common-events/event-driven-workflow` — that fragment is now
+        # Read at runtime via the bootstrap, not listed in the manifest.
+        assert "common/boot-bootstrap" in manifest
         # cycle-runner is polling-only, should NOT appear in events manifest
         assert "common/cycle-runner" not in manifest
 
@@ -959,9 +964,19 @@ class TestLoadManifestSelectsByWakeMode:
             event = compose._load_manifest(role, wake_mode="event-driven")
             assert poll is not None, f"{role}: missing includes.yml"
             assert event is not None, f"{role}: missing includes-events.yml"
-            # Both must reference at least one common-events/ or common/ entry
-            assert any("common-events/" in p for p in event), (
-                f"{role}: includes-events.yml has no common-events/ entries"
+            # #9588: under the boot-bootstrap architecture, the mark that a
+            # manifest is wired correctly is the presence of the loader
+            # itself (`common/boot-bootstrap`) — the legacy check looked
+            # for `common-events/` entries directly in the events manifest,
+            # but those fragments are now Read at runtime by the bootstrap
+            # rather than listed in the manifest.
+            assert "common/boot-bootstrap" in poll, (
+                f"{role}: includes.yml missing `common/boot-bootstrap` "
+                f"loader entry"
+            )
+            assert "common/boot-bootstrap" in event, (
+                f"{role}: includes-events.yml missing `common/boot-bootstrap` "
+                f"loader entry"
             )
 
 

--- a/tests/test_compose_9588.py
+++ b/tests/test_compose_9588.py
@@ -1,0 +1,181 @@
+"""Regression tests for #9588 — lazy-load mode-specific instructions at boot.
+
+CONTEXT-9588.md D7 locks the regression contract:
+
+  - Composed CLAUDE.md contains the boot-bootstrap snippet (a single marker
+    check is enough — the bootstrap is shipped as a sub-skill fragment so
+    its outer marker is deterministic).
+  - Composed CLAUDE.md does NOT inline the mode-specific fragments
+    (`ralph-loop-overview` or any `common-events/*`). Per CONTEXT §2.4 the
+    agent Reads those at runtime via the bootstrap, so finding their
+    marker in compose output would mean compose-time leakage came back.
+  - Each runtime Read target referenced by the bootstrap actually exists
+    on disk — broken paths in the bootstrap silently degrade an agent to
+    a no-op at boot.
+  - The polling-fragment path placeholder is substituted per role so dev
+    variants (skill etc.) get the dev base path rather than a nonexistent
+    `roles/skill/ralph-loop-overview.md`.
+"""
+
+from pathlib import Path
+import re
+import sys
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO_ROOT / "references" / "scripts"
+SUB_SKILLS = REPO_ROOT / "references" / "sub-skills"
+
+sys.path.insert(0, str(SCRIPTS))
+import compose  # noqa: E402
+
+
+ROLES = ["skill", "pm", "qa", "dm"]
+
+# (role, entry_file) — entry_file is the directory under references/sub-skills/roles
+# that owns the polling fragment for this role. Dev variants share dev's.
+ROLE_TO_ENTRY = {
+    "skill": "dev",
+    "pm": "pm",
+    "qa": "qa",
+    "dm": "dm",
+}
+
+# Marker the bootstrap fragment writes at the top of its content. Comes
+# from references/sub-skills/common/boot-bootstrap.md's `## Boot — Mode
+# Detection (#9588)` heading, which compose preserves verbatim under its
+# `<!-- sub-skill: boot-bootstrap -->` wrapper.
+BOOT_BOOTSTRAP_MARKER = "<!-- sub-skill: boot-bootstrap -->"
+BOOT_BOOTSTRAP_HEADING = "## Boot — Mode Detection (#9588)"
+
+# Mode-specific sub-skill markers that MUST NOT appear in composed output
+# after #9588. compose strips the outer markers from the source fragment
+# but re-wraps with these — if the wrapper marker shows up in the deployed
+# CLAUDE.md, the fragment was inlined at compose time.
+MODE_SPECIFIC_MARKERS = [
+    "<!-- sub-skill: ralph-loop-overview -->",
+    "<!-- sub-skill: event-driven-workflow -->",
+    "<!-- sub-skill: l1-base -->",
+    "<!-- sub-skill: cursor-management -->",
+    "<!-- sub-skill: forge-read-pattern -->",
+    "<!-- sub-skill: idle-cooldown-loop -->",
+    "<!-- sub-skill: comment-handling -->",
+    "<!-- sub-skill: pr-merge-wait -->",
+]
+
+
+def _compose_for(role: str) -> str:
+    """Compose a role end-to-end, including placeholder substitution.
+
+    Mirrors what `deploy_role` does up to (but not including) writing the
+    composed text to .squidsquad/<role>/CLAUDE.md. Skipping the disk write
+    keeps the test hermetic on a clean checkout.
+    """
+    entry_file = compose._get_entry_file_for_role(role)
+    composed = compose.compose_role(role)
+    return compose._substitute_placeholders(composed, role, entry_file)
+
+
+@pytest.mark.parametrize("role", ROLES)
+def test_composed_claude_contains_boot_bootstrap(role):
+    """Every role's composed CLAUDE.md inlines `common/boot-bootstrap`."""
+    text = _compose_for(role)
+    assert BOOT_BOOTSTRAP_MARKER in text, (
+        f"{role}: composed CLAUDE.md is missing the boot-bootstrap sub-skill "
+        f"marker. Either the manifest dropped the include or the L2 "
+        f"instructions.md no longer references it."
+    )
+    assert BOOT_BOOTSTRAP_HEADING in text, (
+        f"{role}: bootstrap marker present but heading missing — fragment "
+        f"content may have drifted."
+    )
+
+
+@pytest.mark.parametrize("role", ROLES)
+@pytest.mark.parametrize("marker", MODE_SPECIFIC_MARKERS)
+def test_composed_claude_does_not_inline_mode_specific(role, marker):
+    """Mode-specific fragments are Read at runtime, never inlined at compose."""
+    text = _compose_for(role)
+    assert marker not in text, (
+        f"{role}: composed CLAUDE.md contains mode-specific marker "
+        f"`{marker}` — this fragment should be Read at runtime by the "
+        f"bootstrap, not inlined at compose time (#9588)."
+    )
+
+
+@pytest.mark.parametrize("role,entry", ROLE_TO_ENTRY.items())
+def test_polling_fragment_path_substituted_per_role(role, entry):
+    """Bootstrap's [POLLING_FRAGMENT_PATH] resolves to the role's entry-file path."""
+    text = _compose_for(role)
+    expected = f"references/sub-skills/roles/{entry}/ralph-loop-overview.md"
+    assert expected in text, (
+        f"{role}: composed CLAUDE.md should reference `{expected}` after "
+        f"placeholder substitution. Dev variants (skill) must resolve to "
+        f"the dev base path, not their own role name."
+    )
+    # And the unsubstituted placeholder must not leak through.
+    assert "[POLLING_FRAGMENT_PATH]" not in text, (
+        f"{role}: raw [POLLING_FRAGMENT_PATH] placeholder leaked into "
+        f"composed output — _substitute_placeholders did not run."
+    )
+
+
+@pytest.mark.parametrize("role", ROLES)
+def test_referenced_runtime_fragments_exist_on_disk(role):
+    """Every fragment path the bootstrap tells the agent to Read must exist."""
+    text = _compose_for(role)
+
+    # Extract every references/sub-skills/... .md path mentioned inside the
+    # boot-bootstrap section. Constrain the scan to the bootstrap block so
+    # we don't trip on unrelated path mentions elsewhere in CLAUDE.md.
+    start = text.find(BOOT_BOOTSTRAP_MARKER)
+    end = text.find("<!-- /sub-skill: boot-bootstrap -->", start)
+    assert start != -1 and end != -1, (
+        f"{role}: bootstrap markers missing — earlier tests should have "
+        f"caught this; aborting."
+    )
+    block = text[start:end]
+
+    paths = re.findall(r"`(references/sub-skills/[^`]+\.md)`", block)
+    assert paths, (
+        f"{role}: bootstrap block names zero runtime-Read paths — that "
+        f"would mean the agent has nothing to Read, which is a regression."
+    )
+
+    for rel in paths:
+        full = REPO_ROOT / rel
+        assert full.exists(), (
+            f"{role}: bootstrap references `{rel}` but the file does not "
+            f"exist on disk. Broken Read targets silently no-op at boot."
+        )
+
+
+def test_dm_bootstrap_enumerates_pr_merge_wait():
+    """DM's bootstrap must call out the role-specific events extra."""
+    text = _compose_for("dm")
+    start = text.find(BOOT_BOOTSTRAP_MARKER)
+    end = text.find("<!-- /sub-skill: boot-bootstrap -->", start)
+    block = text[start:end]
+    assert "roles/dm/events/pr-merge-wait.md" in block, (
+        "DM's bootstrap must enumerate `pr-merge-wait.md` — it is the only "
+        "role-specific events extra in the codebase and the bootstrap is "
+        "the sole loader for it after #9588."
+    )
+
+
+def test_l1_base_unreachable_branch_removed():
+    """l1-base.md §3 no longer carries the bespoke degraded-mode block."""
+    text = (SUB_SKILLS / "common-events" / "l1-base.md").read_text(encoding="utf-8")
+    # The old block had this distinctive sequence — its presence would mean
+    # we re-introduced the unreachable branch the bootstrap now subsumes.
+    assert "proceed to degraded-mode operation" not in text, (
+        "l1-base.md still contains the legacy degraded-mode block; #9588 "
+        "deletes it because the boot bootstrap routes harness-unreachable "
+        "to polling-mode before l1-base is ever Read."
+    )
+    # Also: the Degraded-Mode Glossary section is gone.
+    assert "### Degraded-Mode Glossary" not in text, (
+        "l1-base.md still has the Degraded-Mode Glossary section — replace "
+        "it with the Harness-Loss Recovery block per CONTEXT §2.6."
+    )

--- a/tests/test_compose_9588.py
+++ b/tests/test_compose_9588.py
@@ -164,6 +164,92 @@ def test_dm_bootstrap_enumerates_pr_merge_wait():
     )
 
 
+@pytest.mark.parametrize("role", ROLES)
+def test_bootstrap_owns_loop_invocation_with_substituted_interval(role):
+    """#9588 BLOCKER fix: `/loop` is invoked from the bootstrap (which compose
+    inlines, so `[INTERVAL]` substitutes correctly), NOT from any runtime-Read
+    fragment (where the placeholder would not substitute and the agent would
+    try to invoke `/loop [INTERVAL]m …` literally).
+
+    Composed CLAUDE.md must contain `/loop <N>m execute one Ralph Loop cycle`
+    with a concrete integer N — and must NOT contain the literal placeholder
+    `[INTERVAL]`. Pulls the expected interval from config to keep the test
+    honest if someone changes the default cadence.
+    """
+    text = _compose_for(role)
+    assert "[INTERVAL]" not in text, (
+        f"{role}: composed CLAUDE.md still contains the literal `[INTERVAL]` "
+        f"placeholder — compose-time substitution failed somewhere."
+    )
+    # The /loop directive must be substituted. We don't pin the exact integer
+    # so the test survives config interval changes; we just require digits.
+    assert re.search(r"/loop \d+m execute one Ralph Loop cycle", text), (
+        f"{role}: composed CLAUDE.md should contain a substituted `/loop <N>m "
+        f"execute one Ralph Loop cycle` directive in the boot bootstrap."
+    )
+
+
+@pytest.mark.parametrize("role,entry", ROLE_TO_ENTRY.items())
+def test_polling_fragment_source_does_not_invoke_loop(role, entry):
+    """#9588 BLOCKER fix: source `ralph-loop-overview.md` fragments must NOT
+    contain a `/loop` invocation or the `[INTERVAL]` placeholder. Those moved
+    into the bootstrap (where compose substitutes `[INTERVAL]`). If a polling
+    fragment ever regains a literal `/loop [INTERVAL]m …`, an agent in
+    polling mode will Read the placeholder verbatim and the loop will never
+    fire — exactly the bug PM caught in cycle ~1537.
+    """
+    path = SUB_SKILLS / "roles" / entry / "ralph-loop-overview.md"
+    assert path.exists(), f"{role}: polling fragment missing at {path}"
+    src = path.read_text(encoding="utf-8")
+    assert "[INTERVAL]" not in src, (
+        f"{role}: source fragment {path.name} still has the [INTERVAL] "
+        f"placeholder — compose-time substitution does not fire on runtime-"
+        f"loaded fragments. Move any /loop references to boot-bootstrap.md."
+    )
+    assert "/loop " not in src, (
+        f"{role}: source fragment {path.name} still invokes `/loop` — boot "
+        f"bootstrap is now the sole scheduler. Strip the invocation from "
+        f"the source so a runtime Read cannot stack a duplicate cron entry."
+    )
+
+
+def test_bootstrap_documents_role_runtime_substitution():
+    """#9588 BLOCKER follow-on: role-placeholder still appears in the polling
+    fragment source (dev's, lines 33/36 — status-bar and current-state refs).
+    The bootstrap must tell the agent to substitute it at runtime using its
+    own role identity; otherwise the agent reads the literal placeholder
+    and writes a broken path / runs a broken arg.
+
+    The bootstrap source can't contain the literal placeholder string because
+    compose would substitute it away at compose time (the very bug we're
+    avoiding). So we check for the teaching marker + the role-name guidance.
+    """
+    text = (SUB_SKILLS / "common" / "boot-bootstrap.md").read_text(encoding="utf-8")
+    assert "Placeholder substitution inside runtime-loaded fragments" in text, (
+        "boot-bootstrap.md must carry the placeholder-substitution rule so "
+        "the agent knows what to do with role/interval placeholders inside "
+        "a runtime-loaded fragment. Without this rule, the literal "
+        "placeholder breaks path/arg construction in the polling fragment."
+    )
+    assert "Role-name placeholder" in text and "SQUIDSQUAD_ROLE" in text, (
+        "boot-bootstrap.md placeholder section must call out the role-name "
+        "placeholder and tell the agent to substitute its own SQUIDSQUAD_ROLE."
+    )
+    # And critically: the section must survive compose unchanged — i.e., the
+    # teaching itself must still be in the *composed* CLAUDE.md, not just
+    # the source. If compose were substituting the placeholder names away,
+    # the teaching section would render mangled (the original draft of this
+    # fragment had exactly that bug).
+    for role in ROLES:
+        composed = _compose_for(role)
+        assert "Role-name placeholder" in composed, (
+            f"{role}: composed CLAUDE.md is missing the placeholder-teaching "
+            f"section. Either compose mangled it (placeholder names spelled "
+            f"literally and substituted away) or the bootstrap was excluded "
+            f"from this role's compose."
+        )
+
+
 def test_l1_base_unreachable_branch_removed():
     """l1-base.md §3 no longer carries the bespoke degraded-mode block."""
     text = (SUB_SKILLS / "common-events" / "l1-base.md").read_text(encoding="utf-8")

--- a/tests/test_event_mode_fragments.py
+++ b/tests/test_event_mode_fragments.py
@@ -158,12 +158,17 @@ class TestAc7TopicCoverage:
 
 
 class TestAc6M62ManifestWiring:
-    """AC-6 M-6.2: every event-mode role manifest must reference the
-    L1 base fragment + its four supporting common-events fragments so
-    `compose.py deploy <role>` renders the boot sequence + Cases A–E
-    into the composed CLAUDE.md. QA cycle-1140 rejection on #8915 hung
-    on this — the fragments existed but were not wired, so a fresh
-    agent in event-driven mode would not see them.
+    """AC-6 M-6.2 (post-#9588): the event-mode L1 base fragment + its four
+    supporting common-events fragments must reach the agent at runtime via
+    the boot bootstrap, NOT via compose-time inlining.
+
+    #9588 swapped the wiring mechanism: instead of every event-mode manifest
+    listing all six common-events fragments and the template having matching
+    `{{include:}}` directives, the manifest now contains `common/boot-bootstrap`
+    only, and the bootstrap's content carries `Read references/sub-skills/
+    common-events/<name>.md` directives that fire when the agent boots in
+    event mode. The previous compose-time-inline contract (#8915) is the old
+    contract; this class enforces the new one.
     """
 
     REQUIRED_COMMON_EVENTS = [
@@ -187,47 +192,48 @@ class TestAc6M62ManifestWiring:
             out[role] = data.get("includes", [])
         return out
 
+    @pytest.fixture(scope="class")
+    def bootstrap_text(self):
+        path = SUB_SKILLS / "common" / "boot-bootstrap.md"
+        assert path.exists(), (
+            "common/boot-bootstrap.md must exist — #9588 made it the single "
+            "loader for both polling and event-mode entry fragments."
+        )
+        return path.read_text(encoding="utf-8")
+
     @pytest.mark.parametrize("role", ROLES)
-    @pytest.mark.parametrize("required", REQUIRED_COMMON_EVENTS)
-    def test_role_manifest_includes_required_event_fragment(
-        self, includes_by_role, role, required,
+    def test_role_manifest_includes_boot_bootstrap(
+        self, includes_by_role, role,
     ):
+        """Manifests reference `common/boot-bootstrap` as the loader. The
+        six legacy `common-events/*` entries are no longer present — they
+        are Read at runtime by the bootstrap instead."""
         includes = includes_by_role[role]
-        assert required in includes, (
-            f"references/roles/{role}/includes-events.yml must reference "
-            f"{required!r} per AC-6 M-6.2 — the manifest allow-lists which "
-            f"fragments compose.py will resolve when the template includes "
-            f"them. Without this manifest entry, compose.py would skip the "
-            f"corresponding `{{{{include:}}}}` directive in the role template."
+        assert "common/boot-bootstrap" in includes, (
+            f"references/roles/{role}/includes-events.yml must list "
+            f"`common/boot-bootstrap` — #9588 made it the manifest entry "
+            f"that gets the agent into event mode (or fallback polling)."
         )
 
-    @pytest.mark.parametrize("role", ROLES)
     @pytest.mark.parametrize("required", REQUIRED_COMMON_EVENTS)
-    def test_role_template_has_include_directive(
-        self, role, required,
+    def test_bootstrap_references_common_events_fragment(
+        self, bootstrap_text, required,
     ):
-        """compose.py is template-driven (#8697) — manifest membership alone
-        does not render a fragment. The role `instructions.md` template must
-        carry the matching `{{include: ...}}` directive too."""
-        path = REPO_ROOT / "references" / "roles" / role / "instructions.md"
-        text = path.read_text(encoding="utf-8")
-        directive = "{{include: " + required + "}}"
-        assert directive in text, (
-            f"{path} must contain `{directive}` for compose.py to render "
-            f"{required!r} into the composed CLAUDE.md when event-driven."
+        """The bootstrap fragment must Read each common-events fragment at
+        runtime so a fresh event-mode agent loads the full event contract."""
+        rel = f"references/sub-skills/{required}.md"
+        assert rel in bootstrap_text, (
+            f"boot-bootstrap.md must reference `{rel}` so event-mode agents "
+            f"Read it at boot. Removing the runtime Read here breaks the "
+            f"same wiring AC-6 M-6.2 was originally written to enforce."
         )
 
-    def test_dm_template_includes_pr_merge_wait_directive(self):
-        path = REPO_ROOT / "references" / "roles" / "dm" / "instructions.md"
-        text = path.read_text(encoding="utf-8")
-        assert "{{include: roles/dm/events/pr-merge-wait}}" in text, (
-            "DM template must include the pr-merge-wait directive."
-        )
-
-    def test_dm_manifest_includes_pr_merge_wait(self, includes_by_role):
-        assert "roles/dm/events/pr-merge-wait" in includes_by_role["dm"], (
-            "DM's event-mode manifest must include the per-role "
-            "pr-merge-wait fragment called out in CONTEXT.md §5.1."
+    def test_bootstrap_references_pr_merge_wait_for_dm(self, bootstrap_text):
+        """DM's role-specific events extra is loaded by the bootstrap too."""
+        rel = "references/sub-skills/roles/dm/events/pr-merge-wait.md"
+        assert rel in bootstrap_text, (
+            f"boot-bootstrap.md must reference `{rel}` in its DM-only "
+            f"branch — it is the sole loader for the per-role events extra."
         )
 
 

--- a/tests/test_feat_9588_lazy_load_bootstrap.py
+++ b/tests/test_feat_9588_lazy_load_bootstrap.py
@@ -1,0 +1,352 @@
+"""Live-system pytest for #9588 — lazy-load mode-specific instructions at boot.
+
+Maps 1:1 to TC-1…TC-14 in TEST-PLAN-9588.md. Tests run against the *deployed*
+state of the repo: the composed CLAUDE.md files in .squidsquad/<role>/, the
+source fragments under references/sub-skills/, the manifests, and config.md.
+This is the verification gate — not a sanity check of dev's hermetic tests.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Walk up until we find references/scripts/compose.py — works from both
+# .squidsquad/qa/planning/ (where this was originally authored) and tests/
+# (where it was promoted as a regression test).
+def _find_repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "references" / "scripts" / "compose.py").exists():
+            return parent
+    raise RuntimeError(f"Could not locate repo root from {here}")
+
+REPO_ROOT = _find_repo_root()
+SQUID_DIR = REPO_ROOT / ".squidsquad"
+SUB_SKILLS = REPO_ROOT / "references" / "sub-skills"
+ROLES_DIR = REPO_ROOT / "references" / "roles"
+SCRIPTS_DIR = REPO_ROOT / "references" / "scripts"
+
+ROLES = ["skill", "pm", "qa", "dm"]
+ROLE_TO_ENTRY = {"skill": "dev", "pm": "pm", "qa": "qa", "dm": "dm"}
+
+MODE_SPECIFIC_MARKERS = [
+    "<!-- sub-skill: ralph-loop-overview -->",
+    "<!-- sub-skill: event-driven-workflow -->",
+    "<!-- sub-skill: l1-base -->",
+    "<!-- sub-skill: cursor-management -->",
+    "<!-- sub-skill: forge-read-pattern -->",
+    "<!-- sub-skill: idle-cooldown-loop -->",
+    "<!-- sub-skill: comment-handling -->",
+    "<!-- sub-skill: pr-merge-wait -->",
+]
+
+EVENT_FRAGMENTS = [
+    "common-events/event-driven-workflow",
+    "common-events/l1-base",
+    "common-events/cursor-management",
+    "common-events/forge-read-pattern",
+    "common-events/idle-cooldown-loop",
+    "common-events/comment-handling",
+]
+
+
+def _composed(role: str) -> str:
+    p = SQUID_DIR / role / "CLAUDE.md"
+    assert p.exists(), f"Deployed CLAUDE.md missing for {role}: {p}"
+    return p.read_text(encoding="utf-8")
+
+
+def _bootstrap_block(text: str) -> str:
+    """Slice the boot-bootstrap section from a composed CLAUDE.md."""
+    start = text.find("<!-- sub-skill: boot-bootstrap -->")
+    end = text.find("<!-- /sub-skill: boot-bootstrap -->", start)
+    assert start != -1 and end != -1, "boot-bootstrap markers missing"
+    return text[start:end]
+
+
+# TC-1
+@pytest.mark.parametrize("role", ROLES)
+@pytest.mark.parametrize("marker", MODE_SPECIFIC_MARKERS)
+def test_tc_01_no_mode_specific_markers_inlined(role, marker):
+    text = _composed(role)
+    assert marker not in text, (
+        f"{role}: deployed CLAUDE.md contains {marker!r} — mode-specific "
+        f"fragment was inlined at compose time, breaking #9588's lazy-load."
+    )
+
+
+# TC-2
+@pytest.mark.parametrize("role", ROLES)
+def test_tc_02_bootstrap_present(role):
+    text = _composed(role)
+    assert "<!-- sub-skill: boot-bootstrap -->" in text
+    assert "## Boot — Mode Detection (#9588)" in text
+
+
+# TC-3
+@pytest.mark.parametrize("role,entry", ROLE_TO_ENTRY.items())
+def test_tc_03_polling_fragment_substituted_per_role(role, entry):
+    text = _composed(role)
+    expected = f"references/sub-skills/roles/{entry}/ralph-loop-overview.md"
+    assert expected in text, (
+        f"{role}: bootstrap should reference {expected} after substitution"
+    )
+    assert "[POLLING_FRAGMENT_PATH]" not in text
+    assert (REPO_ROOT / expected).exists(), (
+        f"{role}: polling fragment {expected} does not exist on disk"
+    )
+
+
+# TC-4
+@pytest.mark.parametrize("role", ROLES)
+def test_tc_04_event_fragments_referenced_in_bootstrap(role):
+    block = _bootstrap_block(_composed(role))
+    for frag in EVENT_FRAGMENTS:
+        path = f"references/sub-skills/{frag}.md"
+        assert path in block, (
+            f"{role}: bootstrap missing reference to {path}"
+        )
+        assert (REPO_ROOT / path).exists(), (
+            f"{role}: event fragment {path} does not exist on disk"
+        )
+
+
+def test_tc_04_dm_pr_merge_wait_present_only_in_dm():
+    dm_block = _bootstrap_block(_composed("dm"))
+    assert "roles/dm/events/pr-merge-wait.md" in dm_block
+    assert (REPO_ROOT / "references/sub-skills/roles/dm/events/pr-merge-wait.md").exists()
+    for r in ("skill", "pm", "qa"):
+        block = _bootstrap_block(_composed(r))
+        # Non-DM roles still mention "role is dm" in conditional text, but should
+        # not be telling themselves to Read the file. Check the file path appears
+        # only inside a conditional pointing at dm role.
+        # The bootstrap text says: "if your role is `dm`, ALSO Read ... pr-merge-wait.md"
+        # Non-DM roles inherit this conditional verbatim, which is fine — the
+        # check that matters is they do not unconditionally Read it. We verify by
+        # confirming the conditional wording is preserved.
+        if "pr-merge-wait.md" in block:
+            assert "if your role is `dm`" in block.lower() or "role is `dm`" in block, (
+                f"{r}: pr-merge-wait.md mentioned without DM conditional"
+            )
+
+
+# TC-5
+def test_tc_05_bootstrap_uses_127_0_0_1_and_no_dev_null():
+    src = (SUB_SKILLS / "common" / "boot-bootstrap.md").read_text(encoding="utf-8")
+    assert "127.0.0.1" in src, "Bootstrap must probe 127.0.0.1 (not localhost)"
+    assert "/status" in src
+    assert "--max-time 5" in src
+    # Critical: no `> /dev/null` in the probe instruction (Windows-incompat).
+    # Match the curl line and ensure no shell redirect to /dev/null.
+    curl_lines = [ln for ln in src.splitlines() if "curl" in ln and "-sf" in ln]
+    assert curl_lines, "Bootstrap missing curl probe instruction"
+    for ln in curl_lines:
+        assert "/dev/null" not in ln, (
+            f"Bootstrap curl instruction uses /dev/null which breaks on Windows: {ln}"
+        )
+
+
+# TC-6
+def test_tc_06_l1_base_degraded_branch_removed():
+    src = (SUB_SKILLS / "common-events" / "l1-base.md").read_text(encoding="utf-8")
+    assert "proceed to degraded-mode operation" not in src
+    assert "### Degraded-Mode Glossary" not in src
+
+
+# TC-7
+@pytest.mark.parametrize("role", ROLES)
+def test_tc_07_bootstrap_reads_config_at_runtime(role):
+    block = _bootstrap_block(_composed(role))
+    assert "Read `.squidsquad/config.md`" in block, (
+        f"{role}: bootstrap must instruct agent to Read config.md at runtime"
+    )
+    assert "Loaded mode is sticky" in block, (
+        f"{role}: bootstrap must declare the loaded-mode-is-sticky contract"
+    )
+    assert "next agent restart" in block, (
+        f"{role}: bootstrap must say mode flips take effect on next agent restart"
+    )
+
+
+# TC-8
+@pytest.mark.parametrize("role", ROLES)
+def test_tc_08_loop_invocation_in_bootstrap_with_substituted_interval(role):
+    text = _composed(role)
+    assert "[INTERVAL]" not in text, (
+        f"{role}: composed CLAUDE.md still contains literal [INTERVAL]"
+    )
+    m = re.search(r"/loop (\d+)m execute one Ralph Loop cycle", text)
+    assert m, f"{role}: composed CLAUDE.md missing substituted /loop directive"
+    # Sanity: the interval should match config.md
+    interval = subprocess.check_output(
+        [sys.executable, str(SCRIPTS_DIR / "config.py"), "get", "interval"],
+        cwd=str(REPO_ROOT),
+        text=True,
+    ).strip()
+    assert m.group(1) == interval, (
+        f"{role}: /loop interval {m.group(1)} does not match config.md ({interval})"
+    )
+
+
+@pytest.mark.parametrize("role,entry", ROLE_TO_ENTRY.items())
+def test_tc_08_polling_fragment_source_has_no_loop(role, entry):
+    src = (SUB_SKILLS / "roles" / entry / "ralph-loop-overview.md").read_text(encoding="utf-8")
+    assert "/loop " not in src, (
+        f"{role}: source ralph-loop-overview.md still has `/loop ` invocation"
+    )
+    assert "[INTERVAL]" not in src, (
+        f"{role}: source ralph-loop-overview.md still has [INTERVAL] placeholder"
+    )
+
+
+# TC-9
+def test_tc_09_composed_size_within_locked_tolerance():
+    """Polling-mode CLAUDE.md size changes vs main are bounded (CONTEXT §5).
+    Event-mode reduction is established structurally by TC-4 (no inlining).
+    """
+    deltas = {}
+    for role in ROLES:
+        head = (SQUID_DIR / role / "CLAUDE.md").read_text(encoding="utf-8").count("\n")
+        main_bytes = subprocess.check_output(
+            ["git", "show", f"main:.squidsquad/{role}/CLAUDE.md"],
+            cwd=str(REPO_ROOT),
+        )
+        base = main_bytes.decode("utf-8", errors="replace").count("\n")
+        deltas[role] = head - base
+    # CONTEXT-9588 §5: polling roles accept a small net increase (bootstrap >
+    # ralph-loop-overview). Bound at +200 lines per role to catch egregious
+    # bloat regressions; PR-reported delta is ~+55 lines.
+    for role, d in deltas.items():
+        assert d <= 200, (
+            f"{role}: composed CLAUDE.md grew by {d} lines vs main — exceeds "
+            f"locked tolerance for polling-mode bootstrap swap. Deltas: {deltas}"
+        )
+
+
+# TC-10
+def test_tc_10_regression_suite_green():
+    r = subprocess.run(
+        [sys.executable, "-m", "pytest", "tests/test_compose_9588.py", "-q"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert r.returncode == 0, (
+        f"tests/test_compose_9588.py failed:\nSTDOUT:\n{r.stdout}\nSTDERR:\n{r.stderr}"
+    )
+
+
+# TC-11
+def test_tc_11_changed_area_test_suites_green():
+    """The suites directly exercising #9588's changed area must be green.
+
+    Rationale: the full repo suite (run_tests.py static) exceeds 10 min on
+    Windows because of unrelated subprocess fan-out. The PR body documents
+    that dev ran the full static suite with the 4 known #9724 baseline
+    failures (test_run_comprehension*) as the only failures. QA's gate is
+    the live AC walk (TCs 1-10, 12-14) plus the changed-area suites
+    enumerated below — every test module touched or directly related to
+    the lazy-load contract.
+    """
+    suites = [
+        "tests/test_compose.py",
+        "tests/test_compose_9588.py",
+        "tests/test_manifest.py",
+        "tests/test_event_mode_fragments.py",
+    ]
+    r = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "--tb=short", *suites],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=300,
+    )
+    if r.returncode != 0:
+        print("STDOUT:\n", r.stdout)
+        print("STDERR:\n", r.stderr)
+    assert r.returncode == 0, (
+        f"Changed-area suites are not all green. Exit code: {r.returncode}"
+    )
+
+
+# TC-12
+@pytest.mark.parametrize("role", ROLES)
+def test_tc_12_bootstrap_teaches_runtime_substitution(role):
+    text = _composed(role)
+    assert "Placeholder substitution inside runtime-loaded fragments" in text, (
+        f"{role}: bootstrap missing the placeholder-substitution teaching section"
+    )
+    assert "SQUIDSQUAD_ROLE" in text, (
+        f"{role}: bootstrap must cite SQUIDSQUAD_ROLE for role substitution"
+    )
+
+
+# TC-13
+@pytest.mark.parametrize("role", ROLES)
+@pytest.mark.parametrize("manifest_file", ["includes.yml", "includes-events.yml"])
+def test_tc_13_manifest_no_runtime_read_entries(role, manifest_file):
+    entry = ROLE_TO_ENTRY[role]
+    manifest_path = ROLES_DIR / entry / manifest_file
+    if not manifest_path.exists():
+        pytest.skip(f"{manifest_path.name} not present for {entry}")
+    data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    includes = data.get("includes", [])
+    assert includes, f"{manifest_path}: empty includes list"
+    assert includes[0] == "common/boot-bootstrap", (
+        f"{manifest_path}: boot-bootstrap must be the first include"
+    )
+    forbidden = {
+        f"roles/{entry}/ralph-loop-overview",
+        *EVENT_FRAGMENTS,
+        "roles/dm/events/pr-merge-wait",
+    }
+    for inc in includes:
+        assert inc not in forbidden, (
+            f"{manifest_path}: includes {inc!r} but that fragment is "
+            f"Read at runtime by the bootstrap — must not be inlined."
+        )
+
+
+# TC-14
+def test_tc_14_compose_runtime_read_frozenset_present():
+    src = (SCRIPTS_DIR / "compose.py").read_text(encoding="utf-8")
+    assert "RUNTIME_READ_FRAGMENTS = frozenset" in src
+    required = [
+        "roles/dev/ralph-loop-overview",
+        "roles/pm/ralph-loop-overview",
+        "roles/qa/ralph-loop-overview",
+        "roles/dm/ralph-loop-overview",
+        "common-events/event-driven-workflow",
+        "common-events/l1-base",
+        "common-events/cursor-management",
+        "common-events/forge-read-pattern",
+        "common-events/idle-cooldown-loop",
+        "common-events/comment-handling",
+        "roles/dm/events/pr-merge-wait",
+    ]
+    for entry in required:
+        assert f'"{entry}"' in src, (
+            f"RUNTIME_READ_FRAGMENTS missing {entry!r}"
+        )
+    # Short-circuit check: the `if include_path in RUNTIME_READ_FRAGMENTS: continue`
+    # must precede the variant-resolution heuristic. Match the actual code
+    # line (not the comment that also mentions m_base.startswith).
+    short_circuit_idx = src.find("if include_path in RUNTIME_READ_FRAGMENTS")
+    variant_idx = src.find(
+        'if m_base.startswith(base + "-") or base.startswith(m_base + "-"):'
+    )
+    assert short_circuit_idx != -1, "Missing RUNTIME_READ_FRAGMENTS short-circuit"
+    assert variant_idx != -1, "Missing variant-resolution heuristic code line"
+    assert short_circuit_idx < variant_idx, (
+        f"RUNTIME_READ_FRAGMENTS short-circuit (byte {short_circuit_idx}) must "
+        f"run BEFORE variant heuristic (byte {variant_idx})"
+    )

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -120,6 +120,33 @@ class TestManifestIntegrity:
         except Exception:
             pass
 
+        # #9588: mode-specific fragments are Read at runtime by
+        # `common/boot-bootstrap.md` instead of being inlined via manifest.
+        # Treat any fragment whose path appears inside the bootstrap text
+        # as referenced — broken paths there are caught by a dedicated
+        # test in test_compose_9588.py, so duplicating that check here
+        # would just couple the orphan-scan to bootstrap formatting.
+        bootstrap_path = self.sub_skills_dir / "common" / "boot-bootstrap.md"
+        if bootstrap_path.exists():
+            bootstrap_text = bootstrap_path.read_text(encoding="utf-8")
+            for rel_str in re.findall(
+                r"references/sub-skills/([^\s`)]+\.md)", bootstrap_text
+            ):
+                referenced.add(rel_str)
+            # The polling-fragment path is templated via the
+            # `[POLLING_FRAGMENT_PATH]` placeholder so the bootstrap
+            # text itself never spells out each role's polling fragment
+            # literally. Compose substitutes per role — see
+            # compose._substitute_placeholders. Mark every shipped
+            # role's polling fragment as referenced if the placeholder
+            # is in the bootstrap.
+            if "[POLLING_FRAGMENT_PATH]" in bootstrap_text:
+                roles_dir = self.sub_skills_dir / "roles"
+                for ralph in roles_dir.rglob("ralph-loop-overview.md"):
+                    referenced.add(
+                        ralph.relative_to(self.sub_skills_dir).as_posix()
+                    )
+
         # #8697: common/event-reactions.md exists but isn't referenced by
         # any current role manifest. It's a sub-skill that may be wired in
         # for future event-driven needs; explicitly tolerate its
@@ -247,7 +274,29 @@ class TestIncludesYml:
                 "common/improvement-scan",
                 "common/vault-protocol",
             }
-            unexpected = uncovered - known_exclusions
+
+            # #9588: mode-specific includes are intentionally NOT in any
+            # manifest. compose skips them; the agent Reads them at runtime
+            # via `common/boot-bootstrap`. The directives stay in the
+            # template as architectural documentation of the fragments
+            # involved on each mode branch. Add them to the exclusion set
+            # so this coverage test does not flag them as orphans —
+            # test_compose_9588.py asserts the bootstrap actually wires
+            # them up at runtime.
+            mode_specific_runtime_loaded = {
+                "common-events/event-driven-workflow",
+                "common-events/l1-base",
+                "common-events/cursor-management",
+                "common-events/forge-read-pattern",
+                "common-events/idle-cooldown-loop",
+                "common-events/comment-handling",
+                "roles/dev/ralph-loop-overview",
+                "roles/pm/ralph-loop-overview",
+                "roles/qa/ralph-loop-overview",
+                "roles/dm/ralph-loop-overview",
+                "roles/dm/events/pr-merge-wait",
+            }
+            unexpected = uncovered - known_exclusions - mode_specific_runtime_loaded
             assert not unexpected, (
                 f"{role}: template includes not covered by ANY manifest "
                 f"(polling+events), and not slim/role-override/excluded: "
@@ -317,6 +366,12 @@ class TestComposeManifestIntegration:
             "idle-cooldown-loop",
             "comment-handling",
             "pr-merge-wait",
+            # #9588: the polling-mode ralph-loop-overview is now Read at
+            # runtime via boot-bootstrap rather than inlined via manifest.
+            # The inline path still renders it (the directive is in the
+            # template); strip it so the comparison stays apples-to-apples
+            # with the post-#9588 polling manifest output.
+            "ralph-loop-overview",
         )
         for name in events_only_names:
             inline_result = re.sub(


### PR DESCRIPTION
Closes #9588

## Summary

`compose.py` no longer inlines mode-specific instruction fragments (polling-mode `roles/<role>/ralph-loop-overview.md`, the six `common-events/*.md` fragments, and DM's `roles/dm/events/pr-merge-wait.md`). Instead, every role's composed CLAUDE.md starts with a new `common/boot-bootstrap.md` fragment that detects wake mode at session start, probes harness reachability when relevant, and uses the Read tool to pull in the appropriate mode-specific fragments at runtime.

Result: one mode-uniform composed CLAUDE.md per role. `event-driven:` flag flips take effect on next agent restart without a recompose. Event-mode role files shrink by the size of the six common-events fragments (~280 lines) once event mode is enabled; polling-mode files swap a 47-line ralph-loop-overview for a 70-line bootstrap (net +23 lines while polling, but with the architectural uniformity needed for clean event-mode flips later).

## Locked decisions implemented (CONTEXT-9588.md D1–D7)

- **D1** — bootstrap is a new fragment `references/sub-skills/common/boot-bootstrap.md`, first include in every manifest.
- **D2** — no mid-session config-change detection; restart is the reload mechanism.
- **D3** — harness-unreachable always falls back to polling at boot (no bespoke degraded mode).
- **D4** — DM's `pr-merge-wait` is enumerated explicitly in the bootstrap's role-specific events branch; no other roles currently need extras.
- **D5** — hard cutover; this single PR ships the fragment + compose change + l1-base trim + manifest edits + recompose of all 4 roles.
- **D6** — bootstrap's polling branch is lexically separable for the Phase 6 (#8698) polling-removal cleanup.
- **D7** — regression test `tests/test_compose_9588.py` (46 cases) asserts bootstrap present + no mode-specific inline + runtime-Read paths resolve + per-role placeholder substitution.

## Skill-discretion decisions called out

- **Compose-level skip + manifest cleanup, both** (CONTEXT §2.5 gave skill discretion). Manifests no longer list the mode-specific entries, AND `compose.py:RUNTIME_READ_FRAGMENTS` short-circuits them in case a future variant-resolution heuristic match tries to resurrect them.
- **Polling-fragment path substitution at compose time** rather than runtime agent substitution. CONTEXT §2.4's `<your-role>` placeholder would have routed skill to a nonexistent `roles/skill/ralph-loop-overview.md`; compose now substitutes a new `[POLLING_FRAGMENT_PATH]` placeholder per role's entry_file so dev variants resolve to `roles/dev/...`.
- **CONTEXT §2.4 literal-text corrections**: `.harness-port` path corrected to `.squidsquad/.harness-port` (CONTEXT said `references/scripts/.harness-port`, the harness reads `SQUID_DIR / .harness-port`); host `localhost` → `127.0.0.1` to match the rest of the codebase; endpoint kept at `/status` per CONTEXT (both `/` and `/status` are post-#9665 safe).

## DM-bootstrap-order deliberate deviation

CONTEXT D1 says bootstrap is the FIRST include in every manifest. DM's `includes.yml` originally had `common/capability-check` first. I kept bootstrap first per the lock; capability-check now runs second. Capability-check is non-gating (warnings only), so post-bootstrap order is functionally fine.

## Acceptance Criteria (from #9588 issue body)

- [x] `compose.py` no longer inlines mode-specific fragments. Bootstrap is the only mode-relevant content in composed CLAUDE.md.
- [x] Polling-mode agents Read `ralph-loop-overview.md` on boot via the bootstrap.
- [x] Event-mode agents: harness reachable → Read event fragments; unreachable → Read polling fragment.
- [x] Mode flip (config.md change) takes effect on next agent cycle boundary without recompose. (D2: restart = next boundary)
- [x] Composed CLAUDE.md size reduction: ~22% for event-mode roles (per #9588 estimate, kicks in when `event-driven: yes`); polling roles see a small net increase from bootstrap > ralph-loop, accepted per locked design.
- [x] Regression test added (`tests/test_compose_9588.py`).
- [x] Existing polling agents continue cycling correctly (existing 219 tests still green; 4 pre-existing failures in `test_run_comprehension*` filed as #9724, confirmed unrelated).

## Changes

- **New**: `references/sub-skills/common/boot-bootstrap.md` (70 lines) — imperative mode-detection text, missing-config guard, exit-code-only curl probe, role-specific extras for DM.
- **Modified**: `references/scripts/compose.py` — `RUNTIME_READ_FRAGMENTS` frozenset (defensive skip), `[POLLING_FRAGMENT_PATH]` placeholder substitution.
- **Modified**: 8 manifests (4 roles × 2 modes) — boot-bootstrap prepended; ralph-loop-overview + common-events + pr-merge-wait removed.
- **Modified**: 4 `instructions.md` — `{{include: common/boot-bootstrap}}` added with sentinel comment documenting why the directives below are intentionally manifest-absent.
- **Modified**: `references/sub-skills/common-events/l1-base.md` — §3 unreachable branch deleted (subsumed by bootstrap); Degraded-Mode Glossary rewritten to Harness-Loss Recovery.
- **Modified**: `references/sub-skills/common-events/event-driven-workflow.md` — orientation page updated to reference the bootstrap-as-loader architecture.
- **Modified**: `tests/test_compose.py`, `tests/test_event_mode_fragments.py`, `tests/test_manifest.py` — assertions updated for the new contract (bootstrap loader + runtime Read instead of compose-time inline).
- **New**: `tests/test_compose_9588.py` — 46 cases enforcing the D7 contract.
- **Regenerated**: `.squidsquad/{skill,pm,qa,dm}/CLAUDE.md`.

## QA Status

- [x] Unit tests passing — 224/224 in affected suites; full static suite green except 4 pre-existing #9724 failures.
- [x] Acceptance criteria met (see checklist above).
- [x] DeepSeek code review — R1 returned 4 findings (1 HIGH, 2 MEDIUM, 1 LOW), all addressed; R2 verified all 4 fixes clean, returned 1 doc-only warning, addressed. Audit trail: `.squidsquad/skill/planning/REVIEW-9588-DEEPSEEK-R{1,2}.md`.

QA: please verify the `event-driven: yes` flip behavior end-to-end by toggling `.squidsquad/config.md` and restarting an agent; the bootstrap branch should route to event fragments if harness is up, fall through to polling otherwise. Cold/warm probes against `127.0.0.1:7373/status` should both succeed on the live install.