### PR TITLE
skill: #9747 — eliminate [ROLE] placeholder in dev polling fragment via status-bar-self helper

### DIFF
--- a/references/scripts/cycle.py
+++ b/references/scripts/cycle.py
@@ -8,6 +8,7 @@ Usage:
     python scripts/cycle.py timestamp-short        # HH:MM:SS
     python scripts/cycle.py step-marker <message>   # Print step marker
     python scripts/cycle.py status-bar <role> <phase> <desc>  # Write current-state
+    python scripts/cycle.py status-bar-self <phase> <desc>    # Write current-state for SQUIDSQUAD_ROLE
     python scripts/cycle.py get-counter <role>      # Read quiet cycle counter
     python scripts/cycle.py inc-counter <role>      # Increment quiet cycle counter
     python scripts/cycle.py reset-counter <role>    # Reset counter to 0
@@ -16,6 +17,7 @@ Usage:
     python scripts/cycle.py --help
 """
 
+import os
 import re
 import sys
 from datetime import datetime
@@ -71,6 +73,27 @@ def status_bar(role, phase, description=""):
     tmp_path.write_text(content, encoding="utf-8")
     tmp_path.replace(final_path)
     return content
+
+
+def status_bar_self(phase, description=""):
+    """Write current-state for the agent's own role (#9747).
+
+    Reads the role from the ``SQUIDSQUAD_ROLE`` environment variable, which
+    every agent process has set at spawn time (thin_launcher.py:135). This
+    eliminates the ``[ROLE]`` placeholder from the runtime-loaded dev polling
+    fragment, removing the LLM-substitution dependency flagged by AUDIT-B
+    Risk 3.
+
+    Exits non-zero with a clear message if ``SQUIDSQUAD_ROLE`` is unset (which
+    should never happen for a normally-spawned agent — fail loudly rather
+    than silently writing to an unexpected location).
+    """
+    role = os.environ.get("SQUIDSQUAD_ROLE", "").strip()
+    if not role:
+        print("ERROR: status-bar-self requires SQUIDSQUAD_ROLE env var "
+              "(set by thin_launcher at spawn time)", file=sys.stderr)
+        sys.exit(1)
+    return status_bar(role, phase, description)
 
 
 def _get_working_state_path(role):
@@ -235,6 +258,11 @@ def main():
             print("Usage: cycle.py status-bar <role> <phase> [desc]", file=sys.stderr)
             sys.exit(1)
         status_bar(pos[0], pos[1], pos[2] if len(pos) > 2 else "")
+    elif cmd == "status-bar-self":
+        if len(pos) < 1:
+            print("Usage: cycle.py status-bar-self <phase> [desc]", file=sys.stderr)
+            sys.exit(1)
+        status_bar_self(pos[0], pos[1] if len(pos) > 1 else "")
     elif cmd == "get-counter":
         if not pos:
             print("Usage: cycle.py get-counter <role>", file=sys.stderr)

--- a/references/sub-skills/roles/dev/ralph-loop-overview.md
+++ b/references/sub-skills/roles/dev/ralph-loop-overview.md
@@ -20,10 +20,10 @@ At the end of each cycle, print:
 
 **Step markers**: At the start of each step, print a one-line `[🦑 HH:MM:SS]` timestamped status so the human can scan scrollback. Key sub-actions (filing bugs, committing) also get markers. Keep each marker to one concise line. **All timestamps** (`HH:MM:SS`, `YYYY-MM-DD HH:MM`) must come from `python references/scripts/cycle.py timestamp-short` — see Timestamps in Tracker Protocol. Never guess or fabricate times.
 
-**Status bar state**: At each step marker, also write your current state to `.squidsquad/[ROLE]/current-state` so the status bar can display it. **Use atomic writes** (write to `.tmp` then `mv`) to avoid file locking races with the statusline script on Windows:
+**Status bar state**: At each step marker, also write your current state so the status bar can display it. The helper below derives your role from the `SQUIDSQUAD_ROLE` environment variable (set by `thin_launcher.py` at spawn time) and writes to your own `.squidsquad/<your-role>/current-state` file atomically — you do not pass the role yourself and you do not write the file directly (#9747):
 
 ```bash
-python references/scripts/cycle.py status-bar [ROLE] "phase" "sub-skill — description"
+python references/scripts/cycle.py status-bar-self "phase" "sub-skill — description"
 ```
 
 Phase is one of: `pulling`, `triaging`, `implementing`, `committing`, `idle`. The sub-skill is the short name of the active sub-skill (e.g., `pull-latest`, `tracker-protocol`, `dev-agent`, `git-commit`). The description is a short (≤60 char) human-readable label. **Include the GitHub Issue number** (e.g. `#29`, `#37`) in all item-specific phases. Put the issue number near the start of the description so it survives truncation. Examples:

--- a/tests/test_cycle.py
+++ b/tests/test_cycle.py
@@ -57,6 +57,49 @@ class TestStatusBar:
         assert result == "idle|"
 
 
+class TestStatusBarSelf:
+    """#9747: status-bar-self derives role from SQUIDSQUAD_ROLE env."""
+
+    def test_uses_squidsquad_role_env(self, tmp_path, monkeypatch):
+        role_dir = tmp_path / "skill"
+        role_dir.mkdir()
+        monkeypatch.setenv("SQUIDSQUAD_ROLE", "skill")
+        with patch.object(cycle, "SQUIDSQUAD_DIR", tmp_path):
+            result = cycle.status_bar_self("implementing", "#42 working...")
+        assert result == "implementing|#42 working..."
+        assert (role_dir / "current-state").read_text(encoding="utf-8") == "implementing|#42 working..."
+
+    def test_routes_to_role_specific_dir(self, tmp_path, monkeypatch):
+        """qa role writes to .squidsquad/qa/current-state, not skill's."""
+        (tmp_path / "skill").mkdir()
+        qa_dir = tmp_path / "qa"
+        qa_dir.mkdir()
+        monkeypatch.setenv("SQUIDSQUAD_ROLE", "qa")
+        with patch.object(cycle, "SQUIDSQUAD_DIR", tmp_path):
+            cycle.status_bar_self("verifying", "#100")
+        assert (qa_dir / "current-state").read_text(encoding="utf-8") == "verifying|#100"
+        assert not (tmp_path / "skill" / "current-state").exists()
+
+    def test_missing_env_exits_nonzero(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.delenv("SQUIDSQUAD_ROLE", raising=False)
+        with pytest.raises(SystemExit) as exc:
+            cycle.status_bar_self("phase")
+        assert exc.value.code == 1
+        assert "SQUIDSQUAD_ROLE" in capsys.readouterr().err
+
+    def test_empty_env_exits_nonzero(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("SQUIDSQUAD_ROLE", "")
+        with pytest.raises(SystemExit) as exc:
+            cycle.status_bar_self("phase")
+        assert exc.value.code == 1
+
+    def test_whitespace_env_exits_nonzero(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("SQUIDSQUAD_ROLE", "   ")
+        with pytest.raises(SystemExit) as exc:
+            cycle.status_bar_self("phase")
+        assert exc.value.code == 1
+
+
 class TestCounters:
     def _setup_working_state(self, tmp_path, role, counter=0):
         role_dir = tmp_path / role

--- a/tests/test_feat_9747_role_placeholder_elimination_live.py
+++ b/tests/test_feat_9747_role_placeholder_elimination_live.py
@@ -1,0 +1,115 @@
+"""Live-system pytest for #9747 — eliminate [ROLE] placeholder in dev polling fragment.
+
+AC: "Either polling fragments no longer contain placeholders needing runtime
+LLM substitution, OR documented as accepted technical debt with a follow-up
+issue." PR took option (a): eliminate the placeholder via a script helper
+that reads SQUIDSQUAD_ROLE.
+
+TC mapping:
+  TC-1 → polling fragments have ZERO [ROLE] placeholders (dev + pm + qa + dm)
+  TC-2 → cycle.py exposes `status-bar-self` subcommand
+  TC-3 → status_bar_self() reads SQUIDSQUAD_ROLE env and writes current-state
+  TC-4 → status_bar_self() fails loudly when SQUIDSQUAD_ROLE is missing/empty
+  TC-5 → dev's tests/test_cycle.py 24/24 PASS
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _find_repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "references" / "scripts" / "compose.py").exists():
+            return parent
+    raise RuntimeError(f"Could not locate repo root from {here}")
+
+
+REPO_ROOT = _find_repo_root()
+SCRIPTS_DIR = REPO_ROOT / "references" / "scripts"
+SUB_SKILLS = REPO_ROOT / "references" / "sub-skills"
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+import cycle  # noqa: E402
+
+
+# TC-1
+@pytest.mark.parametrize("role", ["dev", "pm", "qa", "dm"])
+def test_tc_01_polling_fragment_has_no_role_placeholder(role):
+    text = (SUB_SKILLS / "roles" / role / "ralph-loop-overview.md").read_text(
+        encoding="utf-8"
+    )
+    assert "[ROLE]" not in text, (
+        f"{role}/ralph-loop-overview.md still contains a [ROLE] placeholder; "
+        f"#9747 requires elimination via the cycle.py status-bar-self helper "
+        f"or equivalent."
+    )
+
+
+# TC-2
+def test_tc_02_cycle_py_exposes_status_bar_self_subcommand():
+    r = subprocess.run(
+        [sys.executable, str(SCRIPTS_DIR / "cycle.py"), "--help"],
+        capture_output=True, text=True, timeout=30,
+    )
+    # Command should be listed in the help/docstring
+    assert "status-bar-self" in (r.stdout + r.stderr), (
+        "cycle.py --help does not advertise the status-bar-self subcommand"
+    )
+    # And the function exists
+    assert callable(getattr(cycle, "status_bar_self", None)), (
+        "cycle.py is missing the status_bar_self function"
+    )
+
+
+# TC-3
+def test_tc_03_status_bar_self_uses_env_role_and_writes_current_state(
+    monkeypatch, tmp_path
+):
+    role = "qa"
+    monkeypatch.setenv("SQUIDSQUAD_ROLE", role)
+    # status_bar() (which status_bar_self delegates to) writes under
+    # SQUIDSQUAD_DIR / role. Redirect that to tmp.
+    monkeypatch.setattr(cycle, "SQUIDSQUAD_DIR", tmp_path)
+    (tmp_path / role).mkdir(parents=True, exist_ok=True)
+    cycle.status_bar_self("testing", "qa-verify-9747")
+    state = (tmp_path / role / "current-state").read_text(encoding="utf-8")
+    assert "testing" in state
+    assert "qa-verify-9747" in state
+
+
+# TC-4
+def test_tc_04_status_bar_self_fails_loudly_on_missing_env(monkeypatch):
+    monkeypatch.delenv("SQUIDSQUAD_ROLE", raising=False)
+    with pytest.raises(SystemExit) as exc:
+        cycle.status_bar_self("idle", "no-env")
+    assert exc.value.code != 0, (
+        "status_bar_self must exit non-zero when SQUIDSQUAD_ROLE is missing"
+    )
+
+    # Also empty / whitespace
+    monkeypatch.setenv("SQUIDSQUAD_ROLE", "   ")
+    with pytest.raises(SystemExit) as exc:
+        cycle.status_bar_self("idle", "whitespace-env")
+    assert exc.value.code != 0
+
+
+# TC-5
+def test_tc_05_dev_cycle_suite_green():
+    r = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "--tb=short",
+         str(REPO_ROOT / "tests" / "test_cycle.py")],
+        cwd=str(REPO_ROOT),
+        capture_output=True, encoding="utf-8", errors="replace",
+        timeout=120,
+    )
+    assert r.returncode == 0, (
+        f"test_cycle.py failed:\n{r.stdout}\n{r.stderr}"
+    )


### PR DESCRIPTION
Closes #9747

## Summary

Per the issue body's Option B (script-level helper), add `cycle.py status-bar-self` subcommand that reads `SQUIDSQUAD_ROLE` from env (set by `thin_launcher.py:135` at spawn time) and routes to the existing `status_bar()`. Then rewrite `references/sub-skills/roles/dev/ralph-loop-overview.md` lines 23-26 to use it — eliminating the `[ROLE]` placeholder from the runtime-loaded dev polling fragment.

This removes the LLM-substitution dependency flagged in AUDIT-B Risk 3.

## Why Option B (not A)

- (a) compose-time per-role copies — touches `compose.py` + multiplies fragment count; high blast radius for a Tier 3 issue.
- (b) script-level helper — single new function + single subcommand + minimal fragment edit. Backward-compatible (existing `status-bar <role>` subcommand untouched). Chose B.

## Scope

- `references/scripts/cycle.py` — `+status_bar_self()` (delegates to `status_bar`), `+"status-bar-self"` subcommand dispatch
- `references/sub-skills/roles/dev/ralph-loop-overview.md` — L23-26 rewrite; `[ROLE]` placeholder eliminated from the status-bar section
- `tests/test_cycle.py` — 5 new `TestStatusBarSelf` cases

Not touched: pm/qa/dm polling fragments (they already have pre-substituted role names, not placeholders); compose machinery; other `[ROLE]` placeholders in `implement-tasks.md` / `triage-issues.md` (separate concerns, out of scope for this issue).

## Acceptance

- [x] Polling fragment no longer contains placeholders needing runtime LLM substitution (verified: `grep "\[ROLE\]" references/sub-skills/roles/dev/ralph-loop-overview.md` → 0 matches)
- [x] Helper handles missing/empty/whitespace `SQUIDSQUAD_ROLE` (exits non-zero with clear error)
- [x] Backward compat: existing `status-bar <role> <phase> <desc>` subcommand and function unchanged
- [x] Regression tests cover env routing, role-isolation, all 3 failure modes

## Tests

- `python -m pytest tests/test_cycle.py -v` — **24 passed**
- `python tests/run_tests.py` (smoke gate) — **50/50 passing**

## Code Review

- DeepSeek returned placeholder-only after timeout (3rd consecutive degenerate output this session) — auto-fallback to Claude subagent per memory rule `feedback_model_router_auto_fallback`
- Subagent verdict: **No BLOCKER / MAJOR / MINOR findings — ready to ship**
- 2 NITs: unrelated unstaged files filtered out at commit (per-path commit); optional docstring rephrase deferred

## Inline mode

The fragment's inline-mode caveat (L7) already covers the edge case: when a human drives the session directly without `/loop`, `cycle_pre`/`cycle_post` are not invoked, so the status-bar helper isn't called either. Inline-mode sessions started directly by humans may not have `SQUIDSQUAD_ROLE` set — that's fine, the helper isn't invoked.