### PR TITLE
skill: #9744 — DM pr-merge-wait per-wake label + status pre-check

### DIFF
--- a/references/sub-skills/roles/dm/events/pr-merge-wait.md
+++ b/references/sub-skills/roles/dm/events/pr-merge-wait.md
@@ -36,7 +36,14 @@ The reaction window for a comment that arrives during the wait is "the moment th
 
 The wait is implemented as a **bounded periodic forge-read**, NOT as event-driven action. Events arriving on the stream during the wait are handled per [[l1-base]] Case D (noted, not acted on) — they are NOT what triggers DM to recheck the PR.
 
-On each Monitor wake (the persistent `event_poll.py` heartbeat at the role's wait cadence), DM forge-reads the PR exactly once and inspects:
+On each Monitor wake (the persistent `event_poll.py` heartbeat at the role's wait cadence), DM performs two cheap tracker checks **before** the PR forge-read so an operator redirect lands in one wake interval rather than waiting for PR terminal state (#9744):
+
+1. **Label re-check** — `python references/scripts/tracker.py get-labels <issue-number>`. If ANY label name starts with `pending-human-` (covers `pending-human-review`, `pending-human-approval`, `pending-human-setup` — the three taxonomy variants), the wait ends immediately; fall through to End-Of-Task Re-Read, where outcome (a) will trigger because the label is present.
+2. **Status re-check** — `python references/scripts/tracker.py get-state <issue-number>`. If the status is no longer `pending-ship` (operator transitioned the item elsewhere mid-wait), the wait ends immediately; fall through to End-Of-Task Re-Read, where outcome (b) will trigger.
+
+Use prefix matching (`name.startswith("pending-human-")`) so any future `pending-human-*` label added to the taxonomy is honored automatically. Do NOT hard-code the three current variants — the prefix match is the contract.
+
+If neither tracker check triggers an abort, DM forge-reads the PR exactly once and inspects:
 
 - **PR state == merged** → the wait ends, fall through to End-Of-Task Re-Read.
 - **PR state == closed and not merged** → the wait ends with a rollback; fall through to End-Of-Task Re-Read.
@@ -45,6 +52,8 @@ On each Monitor wake (the persistent `event_poll.py` heartbeat at the role's wai
 - **PR state == open and (`MERGEABLE` or `UNKNOWN`) and wait has not exceeded the ceiling** → wait is not over; return to wait.
 
 Event payloads about the PR are hints; the forge is authoritative ([[forge-read-pattern]]).
+
+The two pre-check tracker calls cost one round-trip each per wake — equivalent in shape to the PR forge-read that already runs, so the per-wake cost roughly doubles but stays bounded by the wake cadence. The trade-off vs the prior behavior (operator redirect could be delayed indefinitely if the PR never reached a terminal state) is intentional per CONTEXT-9744 Risk 3.
 
 ### End-Of-Task Re-Read
 

--- a/tests/comprehension/9744_spec.json
+++ b/tests/comprehension/9744_spec.json
@@ -1,0 +1,24 @@
+{
+  "issue": 9744,
+  "title": "DM pr-merge-wait per-wake label and status pre-check",
+  "files": [
+    "references/sub-skills/roles/dm/events/pr-merge-wait.md"
+  ],
+  "questions": [
+    {
+      "id": "1",
+      "question": "Per pr-merge-wait.md, what does DM do on each Monitor wake BEFORE forge-reading the PR? List the cheap tracker checks DM runs first.",
+      "expected": "Before the PR forge-read, DM runs two tracker checks: (1) tracker.py get-labels <issue-number> to detect any pending-human-* label, and (2) tracker.py get-state <issue-number> to detect a status transition away from pending-ship. Either of these aborts the wait immediately so an operator redirect lands in one wake interval rather than waiting for PR terminal state."
+    },
+    {
+      "id": "2",
+      "question": "Per pr-merge-wait.md, which exact label name(s) cause DM to abort the wait when found via the get-labels check? How does DM match them?",
+      "expected": "DM aborts on any label whose name starts with the prefix pending-human- (using prefix/startswith matching, not a hard-coded list). This covers the three current taxonomy variants pending-human-review, pending-human-approval, pending-human-setup, and is forward-compatible with any future pending-human-* labels added to the taxonomy."
+    },
+    {
+      "id": "3",
+      "question": "Per pr-merge-wait.md, when the label check finds a pending-human-* label mid-wait, which End-Of-Task Re-Read outcome applies, and does DM transition the issue?",
+      "expected": "Outcome (a) applies: DM leaves the item where the operator put it and does NOT transition. The human handoff wins regardless of PR state. The label that appeared during the wait is the trigger; the End-Of-Task Re-Read evaluates this rule with highest precedence (before the rollback or merged-pr outcomes)."
+    }
+  ]
+}


### PR DESCRIPTION
Closes #9744

> **AUTHORITATIVE SCOPE**: `.squidsquad/pm/planning/CONTEXT-9744.md` — 6 locked decisions + 5 ACs.

## Summary

Add a per-wake pre-check to DM's PR-merge-wait so an operator's `pending-human-*` label or status transition lands in **one wake interval** instead of waiting for the PR to reach terminal state. Before this change, an operator redirect could be delayed indefinitely if the PR never merged / never conflicted / never closed.

## Implementation (CONTEXT D1)

In `references/sub-skills/roles/dm/events/pr-merge-wait.md`, the "How DM Detects The Merge" section now runs two cheap tracker checks BEFORE the PR forge-read on each Monitor wake:

1. `tracker.py get-labels <issue-number>` → abort on any label name starting with `pending-human-` (prefix match per D2/AC-4 — covers the 3 current variants and any future additions)
2. `tracker.py get-state <issue-number>` → abort if status is no longer `pending-ship` (operator transitioned the item elsewhere)

Aborts fall through to End-Of-Task Re-Read where outcome (a) handles labels and outcome (b) handles status transitions. The End-Of-Task Re-Read section itself is **unchanged** (D6/AC-5) — its precedence rules already correctly handle operator redirect vs PR terminal state.

## Cost

Two extra tracker round-trips per wake, equivalent in shape to the existing PR forge-read. Per-wake cost roughly doubles but stays bounded by the wake cadence. Trade-off vs prior behavior (indefinite delay): intentional per Risk 3.

## Acceptance

- [x] **AC-1** — per-wake section has label pre-check + abort to outcome (a); `compose.py deploy dm` ran; no fixture diff (pr-merge-wait is a runtime-Read fragment per `compose.py:51 RUNTIME_READ_FRAGMENTS`)
- [x] **AC-2** — CQ spec at `tests/comprehension/9744_spec.json` with 3 questions covering (a) per-wake checks, (b) prefix-match strategy, (c) outcome (a) precedence
- [ ] **AC-3** — live-system QA test (QA's responsibility per CONTEXT D5; not in this PR)
- [x] **AC-4** — prefix match `name.startswith("pending-human-")` (forward-compatible)
- [x] **AC-5** — End-Of-Task Re-Read section (lines 49-62 in pre-edit file) unchanged

## Tests

- `python tests/run_tests.py` (smoke gate) — **50/50 passing**
- CQ spec is a planning artifact — QA executes it during verification

## Code Review

Skipped DS this cycle — placeholder-only 5-for-5 this session. Went direct to Claude subagent. Subagent verdict: **No BLOCKER/MAJOR findings**; 2 MINORs + 2 NITs all acknowledged as non-blocking (precedence wording variations, optional paragraph placement).

## Post-Ship

Effective on next DM reboot. Deferred to fleet reset per CONTEXT-9478 D9 pattern — do NOT drive an immediate DM reboot after merge.