### PR TITLE
skill: #9741 — strip dispatch() from GET /events/for/{role}

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -1672,11 +1672,11 @@ async def get_events_for_role(
     else:
         filtered = filtered[-limit:] if len(filtered) > limit else filtered
 
-    # Mark dispatched in lifecycle manager
-    for e in filtered:
-        eid = e.get("id")
-        if eid:
-            event_lifecycle.dispatch(eid, role, e)
+    # #9741: dispatch() call stripped — endpoint is a pure filtered-read
+    # with no lifecycle side effects. There is no ack consumer (event_bus.ack
+    # is a dormant stub, tracked separately as #9813), so dispatching here
+    # was accumulating in-flight entries that always timed out, producing
+    # log spam and growing .event-state.json indefinitely.
 
     response = {"events": filtered, "total": len(filtered)}
     if eviction is not None:

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1948,8 +1948,15 @@ class TestGetEventsForRole(unittest.TestCase):
         self.assertEqual(len(data["events"]), 1)
         self.assertEqual(data["events"][0]["id"], "e1")
 
-    def test_marks_dispatched(self):
-        """GET /events/for/skill marks returned events as dispatched."""
+    def test_does_not_dispatch(self):
+        """#9741: GET /events/for/skill must NOT add events to in-flight.
+
+        Before #9741 the endpoint called event_lifecycle.dispatch() on every
+        delivered event, but there is no ack consumer wired yet — every
+        event would eventually time out, growing .event-state.json and
+        spamming the timeout-scanner log. CONTEXT-9741 D1 strips the call;
+        the endpoint is a pure filtered-read with no lifecycle side effects.
+        """
         from harness import event_stream, event_lifecycle
 
         event_stream.append({
@@ -1960,7 +1967,8 @@ class TestGetEventsForRole(unittest.TestCase):
         with patch("harness._validate_role"):
             self.client.get("/events/for/skill")
 
-        self.assertIn("e3", event_lifecycle.get_in_flight("skill"))
+        # Endpoint delivers the event but does not touch in-flight state.
+        self.assertNotIn("e3", event_lifecycle.get_in_flight("skill"))
 
     def test_since_cursor_filters_events(self):
         """GET /events/for/skill?since=X returns only events after cursor."""
@@ -1983,8 +1991,15 @@ class TestGetEventsForRole(unittest.TestCase):
         self.assertNotIn("old1", ids)
         self.assertIn("new1", ids)
 
-    def test_does_not_redispatch_already_dispatched(self):
-        """GET /events/for/skill does not re-dispatch already dispatched events."""
+    def test_endpoint_does_not_touch_lifecycle_state(self):
+        """#9741: with dispatch stripped, the endpoint must not mutate in-flight.
+
+        Even when an event was pre-dispatched by some other path, calling
+        the read endpoint must not re-dispatch, re-add, or otherwise mutate
+        the lifecycle state. CONTEXT-9741 D2 — the idempotency guard test
+        is irrelevant once dispatch is stripped; this test instead verifies
+        the read-only invariant.
+        """
         from harness import event_stream, event_lifecycle
 
         event_stream.append({
@@ -1992,14 +2007,20 @@ class TestGetEventsForRole(unittest.TestCase):
             "payload": {"target_role": "skill"},
         })
 
-        # Pre-dispatch the event
+        # Pre-dispatch via the lifecycle manager directly (NOT via the endpoint).
         event_lifecycle.dispatch("e4", "skill", {"id": "e4"})
+        before = list(event_lifecycle.get_in_flight("skill"))
 
         with patch("harness._validate_role"):
             self.client.get("/events/for/skill")
 
-        # Should still be dispatched exactly once (not duplicated in in_flight)
-        self.assertEqual(event_lifecycle.get_in_flight("skill").count("e4"), 1)
+        # In-flight state must be identical — endpoint touched nothing.
+        after = list(event_lifecycle.get_in_flight("skill"))
+        self.assertEqual(before, after)
+        # And specifically: e4 still appears exactly once (the pre-dispatch),
+        # not zero (would mean endpoint cleared it) or two (would mean
+        # endpoint re-dispatched).
+        self.assertEqual(after.count("e4"), 1)
 
 
 class TestCompleteEventEndpoint(unittest.TestCase):


### PR DESCRIPTION
Closes #9741

> **AUTHORITATIVE SCOPE**: `.squidsquad/pm/planning/CONTEXT-9741.md` — Option A locked.

## Summary

`GET /events/for/{role}` was calling `event_lifecycle.dispatch()` on every delivered event, marking it in-flight. Agents never ack (`event_bus.ack` is a dormant stub) so every dispatched event eventually hit the 10-minute timeout, producing "Event overdue" / "Event TIMED OUT" log spam and unbounded `.event-state.json` growth.

Per CONTEXT-9741 D1+D5: clean delete of the dispatch call loop. Endpoint is now a pure filtered-read with no lifecycle side effects.

## Changes

- `references/scripts/harness.py` — 5-line `for e in filtered: ... event_lifecycle.dispatch(eid, role, e)` loop deleted from `GET /events/for/{role}`. Brief comment in its place referencing #9741 + #9813 (no "Phase 4 re-enable" marker per D5).
- `tests/test_harness.py` — 2 tests inverted per D2:
  - `test_marks_dispatched` → `test_does_not_dispatch` (asserts e3 NOT in `get_in_flight("skill")` after delivery)
  - `test_does_not_redispatch_already_dispatched` → `test_endpoint_does_not_touch_lifecycle_state` (pre-dispatches e4 directly via `event_lifecycle.dispatch()`, then asserts `before == after` — stronger read-only invariant than the original count check)

## Follow-up (CONTEXT D4 / AC-6)

Filed **#9813** — `event_bus.ack()` is a dead stub. Phase 4 work to either wire it to `POST /events/{event_id}/complete` (option a) or delete it in favor of cursor-advance-as-implicit-ack (option b). Out of scope here.

## Acceptance

- [x] **AC-1**: `grep "event_lifecycle.dispatch" references/scripts/harness.py` shows only the `def dispatch` definition; no callsite from the endpoint
- [x] **AC-2**: by construction — no `dispatch()` call means zero new in-flight entries in `.event-state.json` from this endpoint
- [x] **AC-3**: by construction — timeout scanner has nothing to scan for events delivered via this endpoint
- [x] **AC-4**: both rewritten tests pass
- [x] **AC-5**: full `tests/test_harness.py` suite 161/161 pass; no regressions in `TestEventLifecycleManager` / `TestTimeoutScanner` / `TestCompleteEventEndpoint` / `TestBootupCompleteFlag`
- [x] **AC-6**: follow-up #9813 filed and referenced

## Tests

- `python -m pytest tests/test_harness.py -v` — **161 passed**
- `python tests/run_tests.py` (smoke gate) — **50/50 passing**

## Code Review

DS skipped — 5-for-5 placeholder this session. Claude subagent verdict: **No BLOCKER/MAJOR**. 1 MINOR caught — explanatory comment's "Phase 4 will re-add" trailing clause flirted with D5's "no re-enable marker" rule; tightened to drop the clause and reference the #9813 follow-up issue instead.

## Latent Semantic Coherence Note (CONTEXT Risk 4)

After this PR, `POST /events/{event_id}/complete` will return 410 for ALL events delivered via the polling endpoint (because the endpoint no longer marks them in-flight). This is deliberate semantic coherence with the new state, not a runtime error. Phase 4 will re-add dispatch alongside the ack consumer to restore the full lifecycle.

## Post-Ship

No agent reboot needed. Server-side side effect only. Agents do not observe the removal.