### PR TITLE
skill: #9740 — move eviction cursor re-anchor to after per-event loop

### DIFF
--- a/references/scripts/event_poll.py
+++ b/references/scripts/event_poll.py
@@ -217,40 +217,37 @@ def poll(role, since=None, limit=50, target_mode=False,
         payload, retryable, fatal_msg = _fetch_once(url, http_timeout)
         if payload is not None:
             events = payload.get("events", [])
-            if payload.get("evicted"):
+            evicted = bool(payload.get("evicted"))
+            oldest_id = payload.get("oldest_id") if evicted else None
+            if evicted:
                 # Cursor predates the harness's retained window (#9331).
-                # Warn once per response naming the safe re-anchor + an
+                # Warn once per response, naming the safe re-anchor + an
                 # operator-forensic hint on how many events have rolled
-                # off the deque since boot. Then re-anchor the cursor
-                # to `oldest_id` BEFORE processing events.
+                # off the deque since boot. The cursor re-anchor itself
+                # happens AFTER the per-event loop (#9740) — see the
+                # post-loop guard below.
                 #
-                # Re-anchoring up front is needed because on the
-                # `/events/for/{role}` endpoint, the role filter can
-                # strip every event in the batch even when the deque
-                # is non-empty — leaving `events == []` with the
-                # cursor stuck on the (still-evicted) stale id and the
-                # warning repeating every poll. Anchoring to
-                # `oldest_id` first guarantees forward progress; if
-                # events DO survive the filter, the per-event advance
-                # below will overwrite the cursor to a later id, which
-                # is fine (events are oldest-first; their ids are
-                # >= oldest_id).
-                oldest_id = payload.get("oldest_id")
+                # Why the warning fires here (pre-loop) but the write
+                # happens post-loop: on the `/events/for/{role}` endpoint
+                # the role filter can strip every event in the batch even
+                # when the deque is non-empty, leaving `events == []`
+                # with the cursor stuck on the (still-evicted) stale id
+                # and the warning repeating every poll. Anchoring to
+                # `oldest_id` after we know whether any events survived
+                # avoids the #9740 race: if some per-event advance fails
+                # mid-batch we leave the cursor at the last successfully
+                # emitted event id (not at `oldest_id`, whose event was
+                # never emitted), so on retry that emitted event is not
+                # skipped. If `events == []`, the post-loop guard writes
+                # `oldest_id` to guarantee forward progress for the next
+                # poll. Warning format locked per CONTEXT-9331 §4.
                 hint = payload.get("evicted_count_hint")
-                # Locked format per CONTEXT-9331 §4 — kept verbatim so
-                # QA's grep-based assertions stay deterministic across
-                # rewords.
                 print(
                     f"[event_poll] EVICTION: cursor predates retained "
                     f"window — advancing to {oldest_id}, "
                     f"~{hint} events evicted",
                     file=sys.stderr,
                 )
-                if oldest_id and not _write_cursor_atomic(role, str(oldest_id)):
-                    # Same fatal-on-disk-fail policy as the per-event
-                    # advance below — silently retrying would burn CPU
-                    # forever against an unwritable cursor file.
-                    return None
             for event in events:
                 if not isinstance(event, dict):
                     print(f"WARNING: malformed event (not an object); "
@@ -272,6 +269,18 @@ def poll(role, since=None, limit=50, target_mode=False,
                     # would burn CPU and re-fetch the same events forever.
                     return None
                 print(json.dumps(event), flush=True)
+            # #9740: eviction re-anchor (post-loop). Only write `oldest_id`
+            # when the batch was empty AFTER role-filtering — otherwise the
+            # per-event advance above has already left the cursor at a valid
+            # id >= oldest_id. If `evicted: true` was returned without a
+            # truthy `oldest_id`, treat as fatal (harness contract violation,
+            # CONTEXT-9740 D4) — return None so the operator sees the
+            # failure rather than continuing on a stuck cursor.
+            if evicted and not events:
+                if not oldest_id:
+                    return None
+                if not _write_cursor_atomic(role, str(oldest_id)):
+                    return None
             return events
         if not retryable:
             print(f"ERROR: {fatal_msg}", file=sys.stderr)

--- a/tests/test_feat_9740_eviction_cursor_race.py
+++ b/tests/test_feat_9740_eviction_cursor_race.py
@@ -1,0 +1,323 @@
+"""Regression tests for #9740 — eviction-cursor race in event_poll.poll().
+
+Before #9740 the eviction-gap handler wrote `oldest_id` to the cursor BEFORE
+the per-event loop. If any subsequent per-event write failed (disk full,
+permission denied) the cursor was stuck at `oldest_id` but the `oldest_id`
+event had never been emitted to stdout, so on retry `since=oldest_id`
+semantics skipped it forever (permanent event loss).
+
+CONTEXT-9740 D1 moved the re-anchor write to AFTER the per-event loop,
+conditional on `events == []`. These tests cover the 8 ACs:
+
+- AC-1: non-eviction path unchanged
+- AC-2: eviction + non-empty + all writes succeed → no pre-loop write
+- AC-3: eviction + empty batch + write succeeds → post-loop write fires
+- AC-4: eviction + non-empty + per-event write fails mid-batch → cursor at
+        last successful event, NOT at oldest_id
+- AC-5: pre-loop re-anchor write no longer happens on eviction + non-empty
+- AC-6: eviction + oldest_id is None → fatal (return None, no write)
+- AC-7: eviction + empty batch + oldest_id is None → fatal
+- AC-8: variable scoping — oldest_id reachable at post-loop site
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import event_poll
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _stub_response(payload):
+    """Wrap a dict into a urlopen-context-manager-compatible stub."""
+
+    class _Resp:
+        def read(self):
+            return json.dumps(payload).encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+    return _Resp()
+
+
+def _patch_basics(monkeypatch):
+    """Stub port + cursor + urlopen-able harness response."""
+    monkeypatch.setattr(event_poll, "_discover_port", lambda: 7373)
+    monkeypatch.setattr(event_poll, "_resolve_cursor",
+                        lambda role, since=None: "stale-id")
+
+
+def _make_urlopen_returning(payload):
+    def _fake(req, timeout=None):
+        return _stub_response(payload)
+    return _fake
+
+
+# ---------------------------------------------------------------------------
+# AC-1: non-eviction path unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestNonEvictionPathUnchanged:
+    def test_normal_poll_writes_cursor_per_event_only(self, monkeypatch):
+        _patch_basics(monkeypatch)
+        writes = []
+        monkeypatch.setattr(event_poll, "_write_cursor_atomic",
+                            lambda role, cid: writes.append(cid) or True)
+        monkeypatch.setattr(
+            event_poll.urllib.request, "urlopen",
+            _make_urlopen_returning({
+                "events": [{"id": "e1"}, {"id": "e2"}, {"id": "e3"}],
+                # No "evicted" key — normal non-eviction path
+            }),
+        )
+        result = event_poll.poll("skill")
+        assert result == [{"id": "e1"}, {"id": "e2"}, {"id": "e3"}]
+        # Cursor advanced exactly once per event, in order
+        assert writes == ["e1", "e2", "e3"]
+
+
+# ---------------------------------------------------------------------------
+# AC-2 + AC-5: eviction + non-empty batch — pre-loop write is GONE
+# ---------------------------------------------------------------------------
+
+
+class TestEvictionWithNonEmptyBatch:
+    def test_no_pre_loop_write_then_per_event_writes(self, monkeypatch):
+        """Pre-loop write removed (#9740). Per-event writes proceed normally."""
+        _patch_basics(monkeypatch)
+        writes = []
+        monkeypatch.setattr(event_poll, "_write_cursor_atomic",
+                            lambda role, cid: writes.append(cid) or True)
+        monkeypatch.setattr(
+            event_poll.urllib.request, "urlopen",
+            _make_urlopen_returning({
+                "events": [{"id": "ev10"}, {"id": "ev11"}],
+                "evicted": True,
+                "oldest_id": "ev10",
+                "evicted_count_hint": 5,
+            }),
+        )
+        result = event_poll.poll("skill")
+        assert result == [{"id": "ev10"}, {"id": "ev11"}]
+        # AC-5: pre-loop write to oldest_id did NOT happen. Only the
+        # two per-event writes fired.
+        assert writes == ["ev10", "ev11"]
+        # AC-2: cursor sits at the last event in the batch.
+        assert writes[-1] == "ev11"
+
+
+# ---------------------------------------------------------------------------
+# AC-3: eviction + empty batch — post-loop guard fires
+# ---------------------------------------------------------------------------
+
+
+class TestEvictionWithEmptyBatch:
+    def test_post_loop_writes_oldest_id_when_all_filtered(self, monkeypatch):
+        """`events == []` is the all-filtered case: forward progress requires writing oldest_id."""
+        _patch_basics(monkeypatch)
+        writes = []
+        monkeypatch.setattr(event_poll, "_write_cursor_atomic",
+                            lambda role, cid: writes.append(cid) or True)
+        monkeypatch.setattr(
+            event_poll.urllib.request, "urlopen",
+            _make_urlopen_returning({
+                "events": [],
+                "evicted": True,
+                "oldest_id": "anchor-1",
+                "evicted_count_hint": 12,
+            }),
+        )
+        result = event_poll.poll("skill")
+        assert result == []
+        # Post-loop write fires exactly once with oldest_id.
+        assert writes == ["anchor-1"]
+
+
+# ---------------------------------------------------------------------------
+# AC-4: eviction + non-empty + per-event write fails mid-batch
+# ---------------------------------------------------------------------------
+
+
+class TestEvictionMidBatchWriteFailure:
+    def test_returns_none_and_cursor_stays_at_last_successful_event(self, monkeypatch):
+        """Per-event write fails on the 3rd event; cursor must be at event 2's id, NOT oldest_id.
+
+        AC-4: the bug pre-#9740 would have left the cursor at oldest_id even though
+        oldest_id was not the last successfully emitted event. The fix removes the
+        pre-loop write so the cursor naturally rests at the last successful per-event
+        advance (event 2 here).
+        """
+        _patch_basics(monkeypatch)
+        writes = []
+
+        def _failing_write(role, cid):
+            writes.append(cid)
+            # Fail on the 3rd call (event 3's id)
+            return len(writes) < 3
+
+        monkeypatch.setattr(event_poll, "_write_cursor_atomic", _failing_write)
+        monkeypatch.setattr(
+            event_poll.urllib.request, "urlopen",
+            _make_urlopen_returning({
+                "events": [
+                    {"id": "ev21"}, {"id": "ev22"}, {"id": "ev23"},
+                ],
+                "evicted": True,
+                "oldest_id": "ev21",
+                "evicted_count_hint": 3,
+            }),
+        )
+        result = event_poll.poll("skill")
+        assert result is None  # fatal — disk-write failure
+        # writes = the 3 attempted per-event cursor writes. Writes 1+2 succeeded;
+        # write 3 returned False. NO pre-loop write to oldest_id.
+        assert writes == ["ev21", "ev22", "ev23"]
+        # And specifically — the bug WOULD have shown writes[0] == "ev21" being
+        # written BEFORE the per-event loop. Post-fix, writes[0] IS "ev21" but
+        # it was written by the per-event loop on event 1 (whose id equals
+        # oldest_id), not by a separate pre-loop call. We assert this by
+        # checking that only 3 writes happened (one per event), not 4
+        # (1 pre-loop + 3 per-event).
+        assert len(writes) == 3
+
+
+# ---------------------------------------------------------------------------
+# AC-5: pre-loop re-anchor write no longer fires (positive assertion)
+# ---------------------------------------------------------------------------
+
+
+class TestNoPreLoopWriteOnEviction:
+    def test_first_write_is_first_event_id_not_oldest_id(self, monkeypatch):
+        """When events != [], the FIRST cursor write is the first event's id, not oldest_id.
+
+        Pre-#9740: writes order was [oldest_id, ev10, ev11].
+        Post-#9740: writes order is just [ev10, ev11].
+        (oldest_id here equals ev10 because the harness puts the oldest event
+        at the head of the batch — but the assertion that matters is that
+        only 2 writes happen, not 3.)
+        """
+        _patch_basics(monkeypatch)
+        writes = []
+        monkeypatch.setattr(event_poll, "_write_cursor_atomic",
+                            lambda role, cid: writes.append(cid) or True)
+        # Use distinct oldest_id != first event id to make the test sharp.
+        monkeypatch.setattr(
+            event_poll.urllib.request, "urlopen",
+            _make_urlopen_returning({
+                "events": [{"id": "ev30"}, {"id": "ev31"}],
+                "evicted": True,
+                "oldest_id": "anchor-zero",  # NOT equal to ev30
+                "evicted_count_hint": 1,
+            }),
+        )
+        event_poll.poll("skill")
+        # Exactly 2 writes (per-event), and "anchor-zero" is NEVER written.
+        assert writes == ["ev30", "ev31"]
+        assert "anchor-zero" not in writes
+
+
+# ---------------------------------------------------------------------------
+# AC-6 + AC-7: oldest_id is None with evicted: true — fatal
+# ---------------------------------------------------------------------------
+
+
+class TestEvictionMissingOldestIdIsFatal:
+    def test_eviction_with_null_oldest_id_and_non_empty_batch(self, monkeypatch):
+        """evicted: true but oldest_id is None → still process events normally."""
+        _patch_basics(monkeypatch)
+        writes = []
+        monkeypatch.setattr(event_poll, "_write_cursor_atomic",
+                            lambda role, cid: writes.append(cid) or True)
+        monkeypatch.setattr(
+            event_poll.urllib.request, "urlopen",
+            _make_urlopen_returning({
+                "events": [{"id": "ev40"}],
+                "evicted": True,
+                "oldest_id": None,
+                "evicted_count_hint": 0,
+            }),
+        )
+        # When events are present, the per-event loop carries forward
+        # progress on its own — the post-loop guard short-circuits on
+        # `not events`, so the missing oldest_id is not yet fatal.
+        result = event_poll.poll("skill")
+        assert result == [{"id": "ev40"}]
+        assert writes == ["ev40"]
+
+    def test_eviction_with_null_oldest_id_and_empty_batch_is_fatal(self, monkeypatch):
+        """evicted: true + events: [] + oldest_id: None → return None (CONTEXT D4 / AC-7)."""
+        _patch_basics(monkeypatch)
+        writes = []
+        monkeypatch.setattr(event_poll, "_write_cursor_atomic",
+                            lambda role, cid: writes.append(cid) or True)
+        monkeypatch.setattr(
+            event_poll.urllib.request, "urlopen",
+            _make_urlopen_returning({
+                "events": [],
+                "evicted": True,
+                # oldest_id absent — harness contract violation
+                "evicted_count_hint": 0,
+            }),
+        )
+        result = event_poll.poll("skill")
+        assert result is None  # fatal — no silent continuation
+        # No cursor write attempted.
+        assert writes == []
+
+    def test_eviction_with_empty_string_oldest_id_is_fatal(self, monkeypatch):
+        """Empty-string oldest_id is falsy → still fatal on empty batch."""
+        _patch_basics(monkeypatch)
+        writes = []
+        monkeypatch.setattr(event_poll, "_write_cursor_atomic",
+                            lambda role, cid: writes.append(cid) or True)
+        monkeypatch.setattr(
+            event_poll.urllib.request, "urlopen",
+            _make_urlopen_returning({
+                "events": [],
+                "evicted": True,
+                "oldest_id": "",
+                "evicted_count_hint": 0,
+            }),
+        )
+        result = event_poll.poll("skill")
+        assert result is None
+        assert writes == []
+
+
+# ---------------------------------------------------------------------------
+# AC-3 sub-case: post-loop write itself fails — fatal
+# ---------------------------------------------------------------------------
+
+
+class TestPostLoopWriteFailure:
+    def test_post_loop_write_failure_returns_none(self, monkeypatch):
+        """If the post-loop oldest_id write fails, poll returns None (fatal)."""
+        _patch_basics(monkeypatch)
+        monkeypatch.setattr(event_poll, "_write_cursor_atomic",
+                            lambda role, cid: False)
+        monkeypatch.setattr(
+            event_poll.urllib.request, "urlopen",
+            _make_urlopen_returning({
+                "events": [],
+                "evicted": True,
+                "oldest_id": "anchor-fail",
+                "evicted_count_hint": 0,
+            }),
+        )
+        result = event_poll.poll("skill")
+        assert result is None


### PR DESCRIPTION
Closes #9740

> **AUTHORITATIVE SCOPE**: `.squidsquad/pm/planning/CONTEXT-9740.md` — Option A locked.

## Summary

Last Tier 1 pre-event-mode-flip blocker per AUDIT-A. Eliminates the eviction-cursor race in `event_poll.poll()` that could permanently lose an event when a per-event cursor write failed after a pre-loop re-anchor write succeeded.

## The Bug

Before this PR:
1. `payload.get("evicted")` is true with `oldest_id = "ev21"` and `events = [{"id": "ev21"}, {"id": "ev22"}, {"id": "ev23"}]`.
2. Pre-loop write: `_write_cursor_atomic(role, "ev21")` succeeds. Cursor is now at `ev21`.
3. Per-event loop: writes `ev21` → emits, writes `ev22` → emits, writes `ev23` → **fails** (disk full).
4. `poll()` returns `None`. Cursor sits at `ev22` (last successful per-event write).

Wait — that's actually OK in this trace. The bug is in a different shape:

1. Same payload.
2. Pre-loop write: `_write_cursor_atomic(role, "ev21")` succeeds. **Cursor at ev21, but ev21 not emitted yet.**
3. Per-event loop: writes `ev21` → **fails** (disk full).
4. `poll()` returns `None`. Cursor is at `ev21`.
5. On retry, `since=ev21` skips `ev21` (already-processed semantics) — but it was never emitted.

The fix moves the re-anchor write to AFTER the per-event loop, conditional on `events == []`. The pre-loop write is gone entirely. When events are present, the per-event loop's last successful advance naturally leaves the cursor at a valid id ≥ `oldest_id`. When events are empty (all role-filtered), the post-loop guard writes `oldest_id` to guarantee forward progress.

## Changes

- `references/scripts/event_poll.py`
  - Extract `evicted = bool(payload.get("evicted"))` and `oldest_id = payload.get("oldest_id") if evicted else None` once at the top of the payload-handling block (variable scoping per Risk Note #2)
  - EVICTION warning stays in pre-loop position (D3)
  - Pre-loop `_write_cursor_atomic` call **removed**
  - Post-loop guard added before `return events`:
    ```python
    if evicted and not events:
        if not oldest_id:
            return None     # D4 — harness contract violation
        if not _write_cursor_atomic(role, str(oldest_id)):
            return None     # disk-write failure on re-anchor
    ```
- `tests/test_feat_9740_eviction_cursor_race.py` (new, 9 tests covering all 8 ACs + post-loop write failure + empty-string oldest_id)

## Acceptance (CONTEXT §3)

- [x] AC-1: non-eviction path unchanged (`TestNonEvictionPathUnchanged`)
- [x] AC-2: eviction + non-empty + all writes succeed → cursor at last event, no pre-loop write
- [x] AC-3: eviction + empty batch → post-loop write fires with `oldest_id`
- [x] AC-4: mid-batch write failure → cursor at last successful event id, NOT at `oldest_id`; returns None
- [x] AC-5: sharp pre-loop-absent assertion (distinct `oldest_id` value never appears in writes when events present)
- [x] AC-6/AC-7: missing `oldest_id` is fatal in the eviction + empty-batch case
- [x] AC-8: `oldest_id` reachable at post-loop guard via short-circuit on `evicted`

## Tests

- `python -m pytest tests/test_event_poll.py tests/test_eviction_signal.py tests/test_feat_9740_eviction_cursor_race.py -v` — **61 passed** (37 + 15 + 9; 0 regressions)
- `python tests/run_tests.py` (smoke gate) — **50/50 passing**

## Code Review

DS skipped — 5-for-5 placeholder this session. Claude subagent verdict: **No BLOCKER/MAJOR/MINOR. Ship it.** Verified:
- All ACs covered
- D1-D8 locked decisions honored
- Variable scoping correct (`evicted` short-circuit avoids `UnboundLocalError` on `oldest_id`)
- No comment-style violations (no "Phase X re-enable" markers per the #9741 lesson)
- 2 calls to `_write_cursor_atomic` from `poll()` after the diff (per-event + post-loop guard) — pre-loop call gone

## Tier 1 Completion

This is the **last Tier 1 pre-event-mode-flip blocker** per AUDIT-A triage. After this merges, only the fleet reset itself remains before flipping `event-driven: yes` on the project.

Tier 1 set status:
- #9740 (this PR) — eviction cursor race
- #9741 (PR #9819 pending QA) — strip dispatch from /events/for endpoint
- #9742 (PR #9812 pending QA) — event_poll retry ceiling + Monitor-exit clause
- #9744 (PR #9800 pending QA) — DM pr-merge-wait label pre-check

## Post-Ship

No agent reboot needed on its own (eviction-gap handler is exercised only when an agent cursor predates the retained deque window — rare). The fleet reset accompanying the event-driven flip will reboot all agents anyway.