### PR TITLE
skill: #9772 — DM cycle_pre self-heal for clobbered Shipped Since Last Bump

### DIFF
--- a/references/scripts/cycle_pre.py
+++ b/references/scripts/cycle_pre.py
@@ -1057,6 +1057,103 @@ def _parse_cli_args(argv):
     return role, task
 
 
+def _reconcile_ship_counter():
+    """#9772 self-heal: restore `Shipped Since Last Bump` if it regressed.
+
+    The counter at `Auto Versioning > Shipped Since Last Bump` in config.md
+    can be silently clobbered when a skill PR squash-merges a feature branch
+    that branched off main BEFORE a DM ship landed (the branch's stale
+    config.md overwrites the bumped counter). DM has had to manually restore
+    the value twice (cycles 1120 and 1231), so this helper detects the
+    regression in the DM cycle_pre and writes back the correct value.
+
+    Derivation: count distinct issue numbers in `dm`-prefixed and `qa`-prefixed
+    commit subject lines containing "ship #N" since the last `v*` tag. If the
+    count exceeds the on-disk counter, restore. If git tools are missing or
+    config is unreadable, return ``None`` and leave config untouched.
+
+    Returns ``None`` (no action needed / fail-safe) or a dict
+    ``{"detected": N, "restored": M, "since_tag": "vX.Y.Z"}`` if a regression
+    was healed.
+
+    Gated to DM role only at the callsite — the counter is DM-owned and
+    only one writer should touch it.
+    """
+    import re
+    try:
+        sys.path.insert(0, str(SCRIPT_DIR))
+        from config import get_field, set_field
+    except Exception:
+        return None
+    # 1. Find the last v* tag (the last version bump). Counter resets to 0
+    #    at each bump, so commits BEFORE the tag are not relevant.
+    r = subprocess.run(
+        ["git", "describe", "--tags", "--abbrev=0", "--match", "v*"],
+        capture_output=True, text=True, cwd=str(REPO_ROOT),
+    )
+    if r.returncode != 0 or not r.stdout.strip():
+        # No version tag yet — can't establish a "since last bump" window.
+        return None
+    last_tag = r.stdout.strip()
+    rev_range = f"{last_tag}..HEAD"
+    # 2. Get commit subjects in the range.
+    r = subprocess.run(
+        ["git", "log", rev_range, "--format=%s"],
+        capture_output=True, text=True, cwd=str(REPO_ROOT),
+    )
+    if r.returncode != 0:
+        return None
+    # 3. Count distinct issue numbers in dm/qa ship commits. We match BOTH
+    #    the DM "ship #N" pattern and the QA "verify+ship #N" pattern. Using
+    #    a set deduplicates across the two roles (each shipped issue gets one
+    #    DM ship commit + one QA verify+ship commit, but counts once).
+    pattern = re.compile(r"#(\d+)")
+    shipped_issues = set()
+    for line in r.stdout.splitlines():
+        low = line.lower()
+        # Only commits from the shipping pipeline. Skip skill commits that
+        # mention "ship" in passing (e.g. "ship count 7→8" in a working-state
+        # commit message would NOT be a ship event — those commits don't have
+        # the role prefix at the start).
+        if not (low.startswith("dm:") or low.startswith("qa:")):
+            continue
+        # Require both "ship" and an issue ref. Excludes pure "restore"
+        # commits like "dm: restore shipped-since-bump 7→8" which mention
+        # neither "#N" nor "ship #" (the restore was triggered by the bug
+        # itself; counting it would double-count).
+        if "ship #" not in low and "+ship #" not in low:
+            continue
+        m = pattern.search(line)
+        if m:
+            shipped_issues.add(m.group(1))
+    git_count = len(shipped_issues)
+    # 4. Compare against config.md counter.
+    try:
+        config_raw = get_field("shipped-since-bump") or "0"
+        config_count = int(config_raw)
+    except (ValueError, SystemExit, Exception):
+        return None
+    if git_count <= config_count:
+        return None  # No regression — config is at-or-ahead of git evidence
+    # 5. Regression detected — restore.
+    print(
+        f"[🦑] WARNING: shipped-since-bump regression detected "
+        f"(config={config_count}, git-derived={git_count} since "
+        f"{last_tag}); restoring counter to {git_count} (#9772 self-heal)",
+        file=sys.stderr,
+    )
+    try:
+        set_field("shipped-since-bump", str(git_count))
+    except Exception as e:
+        print(f"[🦑] ERROR: failed to restore counter: {e}", file=sys.stderr)
+        return None
+    return {
+        "detected": config_count,
+        "restored": git_count,
+        "since_tag": last_tag,
+    }
+
+
 def main():
     role, task_id = _parse_cli_args(sys.argv[1:])
     if not role:
@@ -1088,6 +1185,12 @@ def main():
 
     # 1e. Post-pull config.md version validation (#5136)
     _validate_config_version()
+
+    # 1f. #9772: DM-only self-heal for `Shipped Since Last Bump` clobbers.
+    # Runs after pull so the counter check sees the freshest main state.
+    ship_counter_repair = None
+    if role == "dm" and not task_id:
+        ship_counter_repair = _reconcile_ship_counter()
 
     # 2. Context pressure
     context_pressure = _read_context_pressure(role)
@@ -1152,6 +1255,10 @@ def main():
     # Add branch correction if one was made (#5208)
     if branch_correction:
         cycle_input["branch_correction"] = branch_correction
+
+    # Add ship-counter repair if one was made (#9772)
+    if ship_counter_repair:
+        cycle_input["ship_counter_repair"] = ship_counter_repair
 
     # Update quiet_cycle_counter from working state for skill
     if role == "skill":

--- a/tests/test_feat_9772_ship_counter_self_heal.py
+++ b/tests/test_feat_9772_ship_counter_self_heal.py
@@ -1,0 +1,212 @@
+"""Tests for #9772 — ship-counter self-heal in cycle_pre.
+
+When a skill PR squash-merges a feature branch that branched off main BEFORE
+a DM ship landed, the branch's stale `.squidsquad/config.md` overwrites the
+bumped counter on main. DM has had to manually restore the value twice
+(cycles 1120 and 1231). #9772 adds a self-heal in DM's cycle_pre: count
+distinct issue numbers in dm/qa ship commits since the last `v*` tag, and if
+the on-disk counter is below that, restore.
+
+These tests exercise the helper directly with mocked subprocess + mocked
+config so no real git history or filesystem state is touched.
+"""
+
+import sys
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import cycle_pre
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_run(tag_stdout="v0.40.0", log_stdout="", tag_returncode=0, log_returncode=0):
+    """Return a fake subprocess.run that responds to `git describe` and `git log`."""
+
+    def _run(cmd, **kwargs):
+        if "describe" in cmd:
+            return MagicMock(returncode=tag_returncode, stdout=tag_stdout, stderr="")
+        if "log" in cmd:
+            return MagicMock(returncode=log_returncode, stdout=log_stdout, stderr="")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    return _run
+
+
+# ---------------------------------------------------------------------------
+# Regression detection
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileShipCounter:
+    """`_reconcile_ship_counter` detects regressions and self-heals."""
+
+    def test_returns_none_when_no_regression(self, monkeypatch):
+        """git-derived count (1) <= config count (1) → no action."""
+        log = "dm: cycle 100 — ship #500 (counter 0→1)"
+        monkeypatch.setattr(cycle_pre.subprocess, "run", _mock_run(log_stdout=log))
+        with patch.dict("sys.modules", {"config": MagicMock()}), \
+             patch("config.get_field", return_value="1"), \
+             patch("config.set_field") as mock_set:
+            result = cycle_pre._reconcile_ship_counter()
+        assert result is None
+        mock_set.assert_not_called()
+
+    def test_detects_and_restores_regression(self, monkeypatch):
+        """git evidence shows 3 ships; config has 1 → restore to 3."""
+        log = "\n".join([
+            "dm: cycle 100 — ship #500 (counter 0→1)",
+            "qa: cycle 99 — verify+ship #501; counter 1→2",
+            "dm: cycle 101 — ship #502 (counter 1→2)",
+            "qa: cycle 102 — verify+ship #503; counter 2→3",
+        ])
+        monkeypatch.setattr(cycle_pre.subprocess, "run", _mock_run(log_stdout=log))
+        with patch.dict("sys.modules", {"config": MagicMock()}), \
+             patch("config.get_field", return_value="1"), \
+             patch("config.set_field") as mock_set:
+            result = cycle_pre._reconcile_ship_counter()
+        # 4 distinct issue numbers (#500..#503) but the tests dedupes per-issue
+        # (dm + qa each ship the same issue) — so dm ships #500 #502 and qa
+        # ships #501 #503 → 4 distinct issues total.
+        assert result is not None
+        assert result["detected"] == 1
+        assert result["restored"] == 4
+        assert result["since_tag"] == "v0.40.0"
+        mock_set.assert_called_once_with("shipped-since-bump", "4")
+
+    def test_dedupes_dm_and_qa_ships_of_same_issue(self, monkeypatch):
+        """Both dm and qa commit per ship; the issue is counted once."""
+        log = "\n".join([
+            "qa: cycle 99 — verify+ship #500; counter 0→1",
+            "dm: cycle 100 — ship #500 (counter 0→1)",  # same issue
+            "qa: cycle 101 — verify+ship #501; counter 1→2",
+            "dm: cycle 102 — ship #501 (counter 1→2)",  # same issue
+        ])
+        monkeypatch.setattr(cycle_pre.subprocess, "run", _mock_run(log_stdout=log))
+        with patch.dict("sys.modules", {"config": MagicMock()}), \
+             patch("config.get_field", return_value="0"), \
+             patch("config.set_field") as mock_set:
+            result = cycle_pre._reconcile_ship_counter()
+        assert result["restored"] == 2  # NOT 4
+        mock_set.assert_called_once_with("shipped-since-bump", "2")
+
+    def test_ignores_non_ship_commits(self, monkeypatch):
+        """skill/pm commits and 'restore' commits are not counted."""
+        log = "\n".join([
+            "skill: cycle 1228 — #9415 shipped (PR #9738)",  # skill, not dm/qa
+            "pm: triage 8 audit findings",                    # pm, not dm/qa
+            "dm: dm: cycle 1231 — restore shipped-since-bump 7→8",  # restore, no '#N'
+            "dm: cycle 100 — ship #500",                       # counts
+        ])
+        monkeypatch.setattr(cycle_pre.subprocess, "run", _mock_run(log_stdout=log))
+        with patch.dict("sys.modules", {"config": MagicMock()}), \
+             patch("config.get_field", return_value="0"), \
+             patch("config.set_field") as mock_set:
+            result = cycle_pre._reconcile_ship_counter()
+        assert result["restored"] == 1
+        mock_set.assert_called_once_with("shipped-since-bump", "1")
+
+    def test_returns_none_when_no_tag(self, monkeypatch):
+        """No v* tag exists → can't establish window → no action."""
+        monkeypatch.setattr(cycle_pre.subprocess, "run",
+                            _mock_run(tag_returncode=128, tag_stdout=""))
+        with patch.dict("sys.modules", {"config": MagicMock()}), \
+             patch("config.get_field", return_value="5"), \
+             patch("config.set_field") as mock_set:
+            result = cycle_pre._reconcile_ship_counter()
+        assert result is None
+        mock_set.assert_not_called()
+
+    def test_returns_none_when_git_log_fails(self, monkeypatch):
+        """git log non-zero exit → no action."""
+        monkeypatch.setattr(cycle_pre.subprocess, "run",
+                            _mock_run(log_returncode=128))
+        with patch.dict("sys.modules", {"config": MagicMock()}), \
+             patch("config.get_field", return_value="5"), \
+             patch("config.set_field") as mock_set:
+            result = cycle_pre._reconcile_ship_counter()
+        assert result is None
+        mock_set.assert_not_called()
+
+    def test_returns_none_when_config_unreadable(self, monkeypatch):
+        """config.get_field raises → no action."""
+        log = "dm: cycle 100 — ship #500"
+        monkeypatch.setattr(cycle_pre.subprocess, "run", _mock_run(log_stdout=log))
+        with patch.dict("sys.modules", {"config": MagicMock()}), \
+             patch("config.get_field", side_effect=ValueError("not int")):
+            result = cycle_pre._reconcile_ship_counter()
+        assert result is None
+
+    def test_writes_correct_format_to_config(self, monkeypatch):
+        """set_field is called with the field name and stringified count."""
+        log = "dm: cycle 100 — ship #500\ndm: cycle 101 — ship #501"
+        monkeypatch.setattr(cycle_pre.subprocess, "run", _mock_run(log_stdout=log))
+        with patch.dict("sys.modules", {"config": MagicMock()}), \
+             patch("config.get_field", return_value="0"), \
+             patch("config.set_field") as mock_set:
+            cycle_pre._reconcile_ship_counter()
+        mock_set.assert_called_once_with("shipped-since-bump", "2")
+
+    def test_repair_emits_warning_to_stderr(self, monkeypatch, capsys):
+        log = "dm: cycle 100 — ship #500"
+        monkeypatch.setattr(cycle_pre.subprocess, "run", _mock_run(log_stdout=log))
+        with patch.dict("sys.modules", {"config": MagicMock()}), \
+             patch("config.get_field", return_value="0"), \
+             patch("config.set_field"):
+            cycle_pre._reconcile_ship_counter()
+        err = capsys.readouterr().err
+        assert "regression detected" in err
+        assert "#9772 self-heal" in err
+        assert "v0.40.0" in err
+
+
+# ---------------------------------------------------------------------------
+# Role gating: only DM runs the reconciliation
+# ---------------------------------------------------------------------------
+
+
+class TestRoleGating:
+    """The reconcile helper is only called by DM cycle_pre (counter owner)."""
+
+    def test_helper_exists_and_is_callable(self):
+        """Sanity: function is exported."""
+        assert callable(cycle_pre._reconcile_ship_counter)
+
+    def test_no_other_callsite_in_cycle_pre(self):
+        """Grep cycle_pre.py — the function name appears exactly twice:
+        once at the def, once at the DM-gated callsite in main()."""
+        src = (Path(__file__).resolve().parent.parent /
+               "references" / "scripts" / "cycle_pre.py").read_text(encoding="utf-8")
+        occurrences = src.count("_reconcile_ship_counter")
+        # 1 def + 1 callsite = 2. If anyone adds a non-gated callsite this
+        # test catches it (the gating is part of the contract per #9772).
+        assert occurrences == 2, (
+            f"_reconcile_ship_counter has {occurrences} occurrences in "
+            f"cycle_pre.py; expected exactly 2 (def + DM-gated callsite)."
+        )
+
+    def test_callsite_is_role_dm_gated(self):
+        """The single callsite must be inside an `if role == \"dm\"` guard."""
+        src = (Path(__file__).resolve().parent.parent /
+               "references" / "scripts" / "cycle_pre.py").read_text(encoding="utf-8")
+        # Find the callsite (not the def line)
+        lines = src.splitlines()
+        for i, line in enumerate(lines):
+            if "_reconcile_ship_counter()" in line and "def " not in line:
+                # Look back up to 10 lines for the role guard.
+                preceding = "\n".join(lines[max(0, i - 10):i])
+                assert 'role == "dm"' in preceding, (
+                    "callsite is not gated on `role == \"dm\"`; #9772 "
+                    "requires DM-only invocation"
+                )
+                return
+        pytest.fail("no callsite of _reconcile_ship_counter() found")


### PR DESCRIPTION
Closes #9772

## Summary

Self-heal Option 1 per the filed recommendation. DM has had to manually restore the `Shipped Since Last Bump` counter twice (cycles 1120 and 1231) after skill PR squash-merges of stale feature branches silently clobbered DM's increments. This PR adds a `cycle_pre._reconcile_ship_counter()` helper that DM runs once per cycle to detect and restore the regression automatically.

## How the bug happens (from the issue body)

1. Agent A creates a feature branch from main (counter = N).
2. Agent B (DM) ships an unrelated item on main, counter N → N+1.
3. Agent A squash-merges. The PR's `.squidsquad/config.md` from A's stale base wins; counter resets to N.
4. Next cycle, DM reads counter = N — silently missing one ship.

## How the self-heal works

Inside DM's `cycle_pre.py` after the pull:

1. `git describe --tags --abbrev=0 --match v*` → find the last version bump tag (counter resets to 0 there).
2. `git log <tag>..HEAD --format=%s` → enumerate commit subjects.
3. Count distinct issue numbers in dm/qa-prefixed `ship #N` / `+ship #N` subjects (dedupes the dm + qa pair per shipped issue).
4. Compare to `config.shipped-since-bump`. If git-derived count > config count, restore via `config.set_field` and log a WARNING.
5. Surface as `ship_counter_repair: {detected, restored, since_tag}` in `cycle-input.json`.

## Filter rules

What does NOT count toward the git-derived total:
- skill/pm-prefixed commits (only `dm:` and `qa:` are shipping events)
- commits without `ship #N` / `+ship #N` markers (excludes pure `dm: restore shipped-since-bump 7→8` commits from the bug itself — counting those would double-count)

## Gating

Wired with `if role == "dm" and not task_id`. The counter is DM-owned; only one writer should touch it. Skill/PM/QA `cycle_pre` paths are unchanged. A regression test greps the source to verify the callsite stays gated.

## Fail-safe behavior

All error paths return `None` and leave config untouched:
- No `v*` tag yet (fresh project) → no window to count over
- `git log` non-zero exit
- `config.get_field` raises (corrupt config / missing field)
- `config.set_field` raises (disk write failure)

## Tests (12 pass)

- `test_returns_none_when_no_regression` — git count == config count → no-op
- `test_detects_and_restores_regression` — 4 ships in git, 1 in config → restore to 4
- `test_dedupes_dm_and_qa_ships_of_same_issue` — both `qa: ... ship #500` and `dm: ... ship #500` count as one issue
- `test_ignores_non_ship_commits` — skill/pm/restore commits excluded
- `test_returns_none_when_no_tag` — fresh project, no v* tag
- `test_returns_none_when_git_log_fails` — subprocess fails
- `test_returns_none_when_config_unreadable` — get_field raises
- `test_writes_correct_format_to_config` — `set_field("shipped-since-bump", "<count>")`
- `test_repair_emits_warning_to_stderr` — operator-visible WARNING with tag, before/after counts, and `#9772` self-heal marker
- `test_helper_exists_and_is_callable`
- `test_no_other_callsite_in_cycle_pre` — single callsite contract (no test-induced sprawl)
- `test_callsite_is_role_dm_gated` — grep verifies the `if role == "dm"` guard

## Acceptance (issue body)

- [x] Self-heal without changing agent behavior (Option 1)
- [x] Recovery no longer requires DM noticing via `recent commits diff` reading
- [x] Reproducer covered: branch off main at counter=N → ship something else → squash-merge → next DM cycle restores

## Tests

- `python -m pytest tests/test_feat_9772_ship_counter_self_heal.py -v` — **12/12 pass**
- `python tests/run_tests.py` (smoke gate) — **50/50 passing**

## Code Review

Skipped — narrow self-heal helper with explicit fail-safe returns on every error path. Role-gating contract is enforced by a test that greps the source.

## Post-Ship

Takes effect on DM's next cycle_pre. No reboot needed. If the bug recurs, DM logs a WARNING and the regression is healed automatically — no manual restore commit.