### PR TITLE
skill: #9724 — fix 4 stale mocks in test_run_comprehension*

### DIFF
--- a/tests/test_run_comprehension.py
+++ b/tests/test_run_comprehension.py
@@ -15,7 +15,13 @@ import run_comprehension_test as rct
 
 class TestFindClaude:
     def test_finds_claude_in_path(self):
-        with patch("shutil.which", return_value="/usr/bin/claude"):
+        # #9724: the Windows branch in _find_claude short-circuits via
+        # `npm_exe.exists()` BEFORE shutil.which is called. Patch Path.exists
+        # to False so the Windows branch falls through to the mocked
+        # shutil.which. No-op on POSIX (the platform check skips the npm
+        # branch entirely there).
+        with patch("pathlib.Path.exists", return_value=False), \
+             patch("shutil.which", return_value="/usr/bin/claude"):
             assert rct._find_claude() == "/usr/bin/claude"
 
     def test_returns_none_when_not_found(self):

--- a/tests/test_run_comprehension_test.py
+++ b/tests/test_run_comprehension_test.py
@@ -122,7 +122,10 @@ class TestFindClaude:
         assert result is None or isinstance(result, str)
 
     def test_finds_claude_on_path(self):
-        with patch.object(rct.shutil, "which", return_value="/usr/bin/claude"):
+        # #9724: see test_run_comprehension.py::TestFindClaude — same
+        # Windows-branch short-circuit, same fix.
+        with patch("pathlib.Path.exists", return_value=False), \
+             patch.object(rct.shutil, "which", return_value="/usr/bin/claude"):
             result = rct._find_claude()
         assert result == "/usr/bin/claude"
 
@@ -195,10 +198,14 @@ class TestEmptyResultsGuard:
         results_file = out_dir / "results.json"
         results_file.write_text("[]", encoding="utf-8")
 
+        # #9724: _run_agent returns (text, proc); using "[]" works for BOTH the
+        # test-agent call (non-empty so the empty-content guard passes) AND the
+        # eval-agent call (parses to an empty JSON list, triggering the
+        # empty-results path under test).
         fake_result = MagicMock(returncode=0, stdout="", stderr="")
         with patch.object(rct, "_check_cache", return_value=False), \
              patch.object(rct, "_find_claude", return_value="/usr/bin/claude"), \
-             patch.object(rct, "_run_agent", return_value=fake_result), \
+             patch.object(rct, "_run_agent", return_value=("[]", fake_result)), \
              patch.object(rct, "REPO_ROOT", tmp_path):
             results, _ = rct.run_test(str(spec), output_dir=str(out_dir))
 
@@ -219,11 +226,14 @@ class TestEmptyResultsGuard:
         (out_dir / "answers.md").write_text("### Q-Q1\nanswer\n", encoding="utf-8")
         (out_dir / "results.json").write_text("[]", encoding="utf-8")
 
+        # #9724: _run_agent returns (text, proc); "[]" works for both calls
+        # (non-empty for the test-agent content guard, empty JSON for the
+        # eval-agent empty-results path).
         cache_dir = tmp_path / ".cache"
         fake_result = MagicMock(returncode=0, stdout="", stderr="")
         with patch.object(rct, "_check_cache", return_value=False), \
              patch.object(rct, "_find_claude", return_value="/usr/bin/claude"), \
-             patch.object(rct, "_run_agent", return_value=fake_result), \
+             patch.object(rct, "_run_agent", return_value=("[]", fake_result)), \
              patch.object(rct, "CACHE_DIR", cache_dir), \
              patch.object(rct, "REPO_ROOT", tmp_path):
             rct.run_test(str(spec), output_dir=str(out_dir))


### PR DESCRIPTION
Closes #9724

## Summary

Pre-existing failures on main, filed by skill-lead during #9588 implementation and left untouched then to keep PR scope tight. Two well-diagnosed root causes:

1. **Windows npm-path short-circuit not mocked** in `_find_claude` tests — the Windows branch checks `npm_exe.exists()` BEFORE calling `shutil.which`. Tests only patched `shutil.which`, so on Windows the real npm-installed `claude.exe` won and the assertion failed.

2. **`_run_agent` return-tuple drift** — production returns `(text, proc)`; tests still mocked with a single MagicMock, causing `ValueError: not enough values to unpack` when `run_test` does `answers_text, test_proc = _run_agent(...)`.

## Fixes

**Tests #1 + #2** (`_find_claude`):
- Added `patch("pathlib.Path.exists", return_value=False)` so the npm-branch `npm_exe.exists()` returns False, the branch falls through, and the mocked `shutil.which` then returns `"/usr/bin/claude"`. No-op on POSIX.

**Tests #3 + #4** (`TestEmptyResultsGuard`):
- Changed `return_value=fake_result` to `return_value=("[]", fake_result)`.
- `"[]"` works for BOTH `_run_agent` calls inside `run_test`:
  - Test agent: `"[]".strip()` is non-empty so the empty-content guard passes
  - Eval agent: `"[]"` parses as an empty JSON list, triggering the empty-results path under test

## Tests

- `python -m pytest tests/test_run_comprehension.py tests/test_run_comprehension_test.py -v` — **32/32 pass**
- `python tests/run_tests.py` (smoke gate) — **50/50 pass** (one flaky integration test on first run — `gh issue edit 9857` rate-limited; clean on retry. Pre-existing flakiness unrelated to this change; diff touches only test files)

## Code Review

Skipped — narrow mock-fix change. Both fixes derive directly from production callsite shapes (verified by reading `run_comprehension_test.py:103-109` and `run_comprehension_test.py:300, 364` before writing patches).

## Post-Ship

No agent reboot needed. Test-only change.