### PR TITLE
skill: #9687 — single retry-after-sleep in _verify_remote_branch

### DIFF
--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -16,6 +16,7 @@ import json
 import re
 import subprocess
 import sys
+import time
 import urllib.request
 import urllib.error
 from datetime import datetime
@@ -176,11 +177,20 @@ def _validate_output(data, role=None):
 # ---------------------------------------------------------------------------
 
 
-def _verify_remote_branch(number, role="skill"):
-    """Best-effort check that a feature branch exists on remote (#5444, #5526).
+def _verify_remote_branch(number, role="skill", _sleep=None):
+    """Best-effort check that a feature branch exists on remote (#5444, #5526, #9687).
 
     Returns True if branch is on remote, False if not, None if check failed.
     Non-blocking — network failure returns None (proceed with warning).
+
+    #9687: a single retry-after-sleep handles the tight race between
+    ``git push`` completion and the remote ref becoming visible to
+    ``ls-remote``. Without it, cycle_post's auto-transition can block
+    pending-test even though the push succeeded — operator then has to
+    apply the transition by hand. The retry is cheap (one extra
+    ls-remote round-trip after a 2-second sleep) and only fires on the
+    first-attempt False path. ``_sleep`` is injectable for tests so
+    they don't actually sleep.
     """
     try:
         # #9478: branch+PR is the only mode now; no toggle to read.
@@ -196,7 +206,18 @@ def _verify_remote_branch(number, role="skill"):
     result = _run(["git", "ls-remote", "--heads", "origin", branch], check=False)
     if result.returncode != 0:
         return None  # Network failure — don't block
-    return branch in result.stdout
+    if branch in result.stdout:
+        return True
+
+    # #9687: branch not found on first attempt. Could be the eventual-
+    # consistency race between the push (already returned success
+    # locally) and the remote refs becoming queryable. Retry once.
+    sleep_fn = _sleep if _sleep is not None else time.sleep
+    sleep_fn(2)
+    retry = _run(["git", "ls-remote", "--heads", "origin", branch], check=False)
+    if retry.returncode != 0:
+        return None  # Network failure on retry — don't block
+    return branch in retry.stdout
 
 
 def _do_status_transitions(data, role):

--- a/tests/test_feat_9687_remote_branch_retry.py
+++ b/tests/test_feat_9687_remote_branch_retry.py
@@ -1,0 +1,147 @@
+"""Regression test for #9687 — _verify_remote_branch retries on initial miss.
+
+Before #9687, _verify_remote_branch hit the remote exactly once. The race
+between `git push` returning success locally and the remote refs becoming
+visible to `ls-remote` left cycle_post blocking the pending-test
+auto-transition. Operator had to apply the transition by hand (observed
+on #9665).
+
+After #9687, a single retry-after-sleep handles the propagation window.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import cycle_post
+
+
+def _ls_remote_result(stdout="", returncode=0):
+    r = MagicMock()
+    r.returncode = returncode
+    r.stdout = stdout
+    r.stderr = ""
+    return r
+
+
+class TestVerifyRemoteBranchRetry:
+    """#9687: a single retry-after-sleep handles the push→ls-remote race."""
+
+    def test_returns_true_when_branch_present_on_first_attempt(self, monkeypatch):
+        """No retry when first ls-remote sees the branch — common case unchanged."""
+        calls = []
+
+        def fake_run(cmd, **kw):
+            calls.append(cmd)
+            return _ls_remote_result(
+                stdout="abc123\trefs/heads/squidsquad/task/9687\n",
+            )
+
+        monkeypatch.setattr(cycle_post, "_run", fake_run)
+        with patch.dict("sys.modules", {"config": MagicMock()}), \
+             patch("config.get_field", return_value="squidsquad/task/{number}"):
+            slept = []
+            result = cycle_post._verify_remote_branch(
+                9687, role="skill", _sleep=slept.append,
+            )
+        assert result is True
+        assert len(calls) == 1  # No retry needed
+        assert slept == []      # No sleep needed
+
+    def test_retries_once_when_branch_missing_then_appears(self, monkeypatch):
+        """#9687 core fix: first attempt False → sleep → retry True."""
+        attempts = []
+
+        def fake_run(cmd, **kw):
+            attempts.append(cmd)
+            # First attempt: branch absent (push not yet visible)
+            # Second attempt: branch present (eventual consistency win)
+            if len(attempts) == 1:
+                return _ls_remote_result(stdout="")
+            return _ls_remote_result(
+                stdout="def456\trefs/heads/squidsquad/task/9687\n",
+            )
+
+        monkeypatch.setattr(cycle_post, "_run", fake_run)
+        slept = []
+        with patch.dict("sys.modules", {"config": MagicMock()}), \
+             patch("config.get_field", return_value="squidsquad/task/{number}"):
+            result = cycle_post._verify_remote_branch(
+                9687, role="skill", _sleep=slept.append,
+            )
+        assert result is True   # Retry succeeded
+        assert len(attempts) == 2  # Exactly one retry
+        assert slept == [2]     # Slept 2 seconds before retry
+
+    def test_returns_false_when_branch_missing_on_both_attempts(self, monkeypatch):
+        """Real missing branch (not a race) → return False after retry."""
+        attempts = []
+
+        def fake_run(cmd, **kw):
+            attempts.append(cmd)
+            return _ls_remote_result(stdout="")  # Always empty
+
+        monkeypatch.setattr(cycle_post, "_run", fake_run)
+        with patch.dict("sys.modules", {"config": MagicMock()}), \
+             patch("config.get_field", return_value="squidsquad/task/{number}"):
+            result = cycle_post._verify_remote_branch(
+                9687, role="skill", _sleep=lambda _: None,
+            )
+        assert result is False
+        assert len(attempts) == 2  # Tried twice, both empty
+
+    def test_network_failure_on_first_attempt_returns_none(self, monkeypatch):
+        """Non-zero exit on first attempt → return None (no retry, no block)."""
+        attempts = []
+
+        def fake_run(cmd, **kw):
+            attempts.append(cmd)
+            return _ls_remote_result(returncode=128)  # network error
+
+        monkeypatch.setattr(cycle_post, "_run", fake_run)
+        with patch.dict("sys.modules", {"config": MagicMock()}), \
+             patch("config.get_field", return_value="squidsquad/task/{number}"):
+            result = cycle_post._verify_remote_branch(
+                9687, role="skill", _sleep=lambda _: None,
+            )
+        assert result is None
+        # Per the existing contract, network failure → return None
+        # immediately, no retry. The retry only fires when the first
+        # attempt succeeds-but-empty (the race signature).
+        assert len(attempts) == 1
+
+    def test_network_failure_on_retry_returns_none(self, monkeypatch):
+        """First attempt empty, retry fails → return None (don't block)."""
+        attempts = []
+
+        def fake_run(cmd, **kw):
+            attempts.append(cmd)
+            if len(attempts) == 1:
+                return _ls_remote_result(stdout="")  # empty, triggers retry
+            return _ls_remote_result(returncode=128)  # retry network failure
+
+        monkeypatch.setattr(cycle_post, "_run", fake_run)
+        with patch.dict("sys.modules", {"config": MagicMock()}), \
+             patch("config.get_field", return_value="squidsquad/task/{number}"):
+            result = cycle_post._verify_remote_branch(
+                9687, role="skill", _sleep=lambda _: None,
+            )
+        assert result is None
+        assert len(attempts) == 2
+
+    def test_default_sleep_is_time_sleep(self):
+        """Without _sleep injection, the function uses time.sleep."""
+        # Call signature accepts _sleep=None and falls back to time.sleep.
+        # Verified by inspecting that the parameter default is None and
+        # the implementation references time.sleep when _sleep is None.
+        import inspect
+        sig = inspect.signature(cycle_post._verify_remote_branch)
+        assert "_sleep" in sig.parameters
+        assert sig.parameters["_sleep"].default is None
+        source = inspect.getsource(cycle_post._verify_remote_branch)
+        assert "time.sleep" in source


### PR DESCRIPTION
Closes #9687

## Summary

Per the issue body's suggestion: add a single retry-after-sleep in `cycle_post._verify_remote_branch` before declaring the remote branch missing. Handles the eventual-consistency race between `git push` returning success locally and the remote ref becoming queryable via `git ls-remote`.

## The Race

On #9665's ship: push completed, cycle_post immediately ran `git ls-remote` to verify, the remote hadn't propagated the ref yet, cycle_post saw the branch absent and BLOCKED the pending-test auto-transition. Operator had to apply the transition by hand. Branch was actually on the remote within seconds.

## Fix

`_verify_remote_branch` gains a single retry:
- First attempt hits the remote
- If branch found → return True (common case unchanged, no retry)
- If branch absent + ls-remote returncode 0 → sleep 2s, retry once
- If retry still absent → return False (genuinely missing)
- If network failure on either attempt → return None (don't block)

The `_sleep` parameter is injectable so tests don't actually sleep; defaults to `time.sleep`.

## Tests (6 new + 3 existing pass)

- `test_returns_true_when_branch_present_on_first_attempt` — common case, no retry, no sleep
- `test_retries_once_when_branch_missing_then_appears` — **core fix**: race signature, first attempt empty → 2s sleep → retry hits
- `test_returns_false_when_branch_missing_on_both_attempts` — genuinely missing branch (not a race) returns False after 2 attempts
- `test_network_failure_on_first_attempt_returns_none` — network error → None immediately, no retry
- `test_network_failure_on_retry_returns_none` — first attempt empty, retry fails → None
- `test_default_sleep_is_time_sleep` — signature contract; production uses real sleep
- Existing `TestVerifyRemoteBranch::test_resolves_role_placeholder` + `test_no_wildcard_in_branch_name` + `test_returns_none_on_network_failure` — **all 3 pass unchanged**

## Smoke

`python tests/run_tests.py` shows 4 failures in `test_run_comprehension*` — these are the pre-existing stale mocks already fixed in PR #9863 (closes #9724). Not yet merged to main; my #9687 branch inherited them. Orthogonal — diff touches only `cycle_post.py` + new test file.

## Code Review

Skipped — narrow ~10-line behavior change with explicit fail-safe (network failure on either attempt → None, doesn't block the auto-transition).