### PR TITLE
skill: #9882 — config.py docstring: add alias/sync-agents/list-agents to Usage

### DIFF
--- a/references/scripts/config.py
+++ b/references/scripts/config.py
@@ -10,6 +10,9 @@ Usage:
     python scripts/config.py dump                  # Dump all fields as JSON
     python scripts/config.py agents                # List agents as JSON
     python scripts/config.py schema-version        # Print 1 or 2
+    python scripts/config.py alias <role>          # Get role alias (falls back to role name)
+    python scripts/config.py sync-agents           # Sync Agents section from .squidsquad/*/CLAUDE.md
+    python scripts/config.py list-agents           # Tab-separated agents for shell consumers
     python scripts/config.py --help                # Show usage
 
 Schema versions:


### PR DESCRIPTION
Closes #9882

3-line addition to the module docstring's Usage block so `python config.py --help` matches the actual dispatcher (`main()` handles `alias`, `sync-agents`, and `list-agents` but they were undocumented).

Pure docstring change — no behavior change.