### PR TITLE
skill: #9890 — anti-wedge defenses on git push (gh credential helper + timeout)

### DIFF
--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -70,6 +70,78 @@ def _run_list(cmd_list, check=True):
     )
 
 
+_GH_AVAILABLE_CACHE = None
+
+
+def _gh_credential_helper_available():
+    """Whether `gh` is on PATH and authenticated, so it can serve as the git
+    credential helper. Cached for the process lifetime.
+
+    #9890: on Windows the default `credential.helper=manager` (Git Credential
+    Manager) can wedge silently in agent sessions waiting on an interactive
+    auth dialog. When `gh` is available, routing credentials through it
+    sidesteps the dialog.
+    """
+    global _GH_AVAILABLE_CACHE
+    if _GH_AVAILABLE_CACHE is not None:
+        return _GH_AVAILABLE_CACHE
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "status"],
+            capture_output=True, text=True, check=False, timeout=10,
+        )
+        _GH_AVAILABLE_CACHE = (result.returncode == 0)
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        _GH_AVAILABLE_CACHE = False
+    return _GH_AVAILABLE_CACHE
+
+
+def _git_push(push_args, timeout=60):
+    """Run `git push <push_args...>` with anti-wedge defenses (#9890).
+
+    Two defenses against the silent-wedge mode observed in cycle 1244:
+
+    1. **Credential helper override**: when `gh` is available and authenticated
+       (cached via `_gh_credential_helper_available()`), prepend
+       `-c credential.helper=` + `-c credential.helper=!gh auth git-credential`
+       so the push routes through the `gh` token rather than the inherited
+       helper (which on Windows defaults to GCM and can wedge on agent sessions).
+    2. **Timeout**: subprocess.run is called with a `timeout` so a wedge fails
+       fast with a synthetic non-zero CompletedProcess (returncode 124, matching
+       GNU `timeout` convention) rather than accumulating zombie git processes.
+
+    Args:
+        push_args: list of args following `git push` (e.g., ["-u", "origin", "br"]).
+                   Pass `[]` for bare `git push`.
+        timeout: seconds before the push is killed. Default 60.
+
+    Returns:
+        subprocess.CompletedProcess. On timeout, returncode is 124 and stderr
+        carries a defense-noted message so existing `if push_result.returncode != 0`
+        callers continue to work without changes.
+    """
+    cmd = ["git"]
+    if _gh_credential_helper_available():
+        cmd.extend([
+            "-c", "credential.helper=",
+            "-c", "credential.helper=!gh auth git-credential",
+        ])
+    cmd.append("push")
+    cmd.extend(push_args)
+    try:
+        return subprocess.run(
+            cmd, capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
+            check=False, cwd=str(REPO_ROOT),
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=124, stdout="",
+            stderr=f"git push timed out after {timeout}s (wedge defense per #9890)",
+        )
+
+
 def _log_diagnostic(severity, message):
     """Log a diagnostic entry (silently fails if diagnostics.py unavailable)."""
     try:
@@ -197,7 +269,7 @@ def commit(role, message):
 
 def push(role=None):
     """Push to remote."""
-    result = _run("git push", check=False)
+    result = _git_push([])
     if result.returncode != 0:
         _log_diagnostic("error", f"push failed: {result.stderr.strip()[:200]}")
         print(f"ERROR: push failed: {result.stderr}", file=sys.stderr)
@@ -253,7 +325,7 @@ def branch_delete(name):
             print(f"ERROR: could not delete local branch {name}: {result.stderr}", file=sys.stderr)
             return False
     # Delete remote tracking
-    _run_list(["git", "push", "origin", "--delete", name], check=False)
+    _git_push(["origin", "--delete", name])
     print(f"Deleted branch: {name}")
     return True
 
@@ -552,7 +624,7 @@ def commit_code(role, branch, message):
         return False
 
     # Push branch — failure is fatal for branch workflow (#5444)
-    push_result = _run_list(["git", "push", "-u", "origin", branch], check=False)
+    push_result = _git_push(["-u", "origin", branch])
     if push_result.returncode != 0:
         _log_diagnostic("error", f"branch push failed: {push_result.stderr.strip()[:200]}")
         print(f"ERROR: branch push failed: {push_result.stderr}", file=sys.stderr)
@@ -745,7 +817,7 @@ def commit_state(role, message):
                          "files_changed": len(state_files), "commit_type": "state"})
 
     # Push main — failure logged but state is committed locally (#5444)
-    push_result = _run("git push", check=False)
+    push_result = _git_push([])
     if push_result.returncode != 0:
         _log_diagnostic("error", f"state push failed: {push_result.stderr.strip()[:200]}")
         print(f"WARNING: state push failed: {push_result.stderr}", file=sys.stderr)

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -128,13 +128,16 @@ class TestCommit:
 
 class TestPush:
     @patch("git_ops._run")
-    def test_successful_push(self, mock_run):
-        mock_run.return_value = _mock_result()
+    @patch("git_ops._git_push")
+    def test_successful_push(self, mock_git_push, mock_run):
+        mock_git_push.return_value = _mock_result()
+        mock_run.return_value = _mock_result(stdout="main\n")  # branch --show-current
         assert git_ops.push() is True
 
     @patch("git_ops._run")
-    def test_push_failure(self, mock_run):
-        mock_run.return_value = _mock_result(stderr="rejected", returncode=1)
+    @patch("git_ops._git_push")
+    def test_push_failure(self, mock_git_push, mock_run):
+        mock_git_push.return_value = _mock_result(stderr="rejected", returncode=1)
         assert git_ops.push() is False
 
 
@@ -167,9 +170,11 @@ class TestPullEmitsRole:
 class TestPushEmitsRole:
     @patch("git_ops._emit")
     @patch("git_ops._run")
-    def test_push_emits_role(self, mock_run, mock_emit):
+    @patch("git_ops._git_push")
+    def test_push_emits_role(self, mock_git_push, mock_run, mock_emit):
         """push(role='skill') passes role to _emit()."""
-        mock_run.return_value = _mock_result()
+        mock_git_push.return_value = _mock_result()
+        mock_run.return_value = _mock_result(stdout="main\n")
         git_ops.push(role="skill")
         mock_emit.assert_called()
         _, kwargs = mock_emit.call_args
@@ -177,9 +182,11 @@ class TestPushEmitsRole:
 
     @patch("git_ops._emit")
     @patch("git_ops._run")
-    def test_push_without_role_backward_compat(self, mock_run, mock_emit):
+    @patch("git_ops._git_push")
+    def test_push_without_role_backward_compat(self, mock_git_push, mock_run, mock_emit):
         """push() without role still works (role=None passed to _emit)."""
-        mock_run.return_value = _mock_result()
+        mock_git_push.return_value = _mock_result()
+        mock_run.return_value = _mock_result(stdout="main\n")
         git_ops.push()
         mock_emit.assert_called()
         _, kwargs = mock_emit.call_args
@@ -498,10 +505,11 @@ class TestIsStateFile:
 # ---------------------------------------------------------------------------
 
 class TestCommitCode:
+    @patch("git_ops._git_push")
     @patch("git_ops._run_list")
     @patch("git_ops._run")
     @patch("subprocess.run")
-    def test_splits_code_from_state(self, mock_subproc, mock_run, mock_run_list):
+    def test_splits_code_from_state(self, mock_subproc, mock_run, mock_run_list, mock_git_push):
         """commit_code only stages non-.squidsquad/ files."""
         # git status --porcelain: XY<space>path (3 chars prefix)
         mock_run.side_effect = [
@@ -515,9 +523,10 @@ class TestCommitCode:
             _mock_result(),  # git checkout branch
             _mock_result(),  # git add (code file)
             _mock_result(),  # git checkout config.md revert (#7491)
-            _mock_result(),  # git push -u
             _mock_result(),  # git checkout main
         ]
+        # push now routes through _git_push (#9890)
+        mock_git_push.return_value = _mock_result()
         # git commit
         mock_subproc.return_value = _mock_result(stdout="1 file changed")
 
@@ -529,10 +538,11 @@ class TestCommitCode:
         assert len(add_calls) == 1
         assert add_calls[0][0][0][2] == "references/scripts/git_ops.py"
 
+    @patch("git_ops._git_push")
     @patch("git_ops._run_list")
     @patch("git_ops._run")
     @patch("subprocess.run")
-    def test_reverts_config_md_before_commit(self, mock_subproc, mock_run, mock_run_list):
+    def test_reverts_config_md_before_commit(self, mock_subproc, mock_run, mock_run_list, mock_git_push):
         """#7491: commit_code reverts config.md to working branch version."""
         mock_run.side_effect = [
             _mock_result(stdout=" M references/scripts/harness.py\n"),
@@ -544,9 +554,9 @@ class TestCommitCode:
             _mock_result(),  # git checkout branch
             _mock_result(),  # git add (code file)
             _mock_result(),  # git checkout config.md revert
-            _mock_result(),  # git push -u
             _mock_result(),  # git checkout main
         ]
+        mock_git_push.return_value = _mock_result()
         mock_subproc.return_value = _mock_result(stdout="1 file changed")
 
         git_ops.commit_code("skill", "squidsquad/task/7491", "test fix")
@@ -585,17 +595,18 @@ class TestCommitCode:
 # ---------------------------------------------------------------------------
 
 class TestCommitState:
+    @patch("git_ops._git_push")
     @patch("git_ops._run")
     @patch("git_ops._run_list")
     @patch("subprocess.run")
-    def test_only_stages_squidsquad_files(self, mock_subproc, mock_run_list, mock_run):
+    def test_only_stages_squidsquad_files(self, mock_subproc, mock_run_list, mock_run, mock_git_push):
         """commit_state only stages .squidsquad/ files on main."""
         mock_run.side_effect = [
             _mock_result(stdout=" M references/scripts/git_ops.py\n M .squidsquad/skill/working-state.md\n"),
             _mock_result(stdout="main\n"),  # current branch
-            _mock_result(),  # push
         ]
         mock_run_list.return_value = _mock_result()  # git add
+        mock_git_push.return_value = _mock_result()  # state push (#9890)
         mock_subproc.return_value = _mock_result(stdout="1 file changed")
 
         result = git_ops.commit_state("skill", "state update")
@@ -926,12 +937,13 @@ class TestCommitCodePushFailure:
     @patch("git_ops._get_alias", return_value="skill")
     @patch("git_ops._get_working_branch", return_value="main")
     @patch("git_ops._safe_checkout", return_value=True)
+    @patch("git_ops._git_push")
     @patch("git_ops._run_list")
     @patch("git_ops._run")
     @patch("subprocess.run")
     def test_returns_false_on_push_failure(
-        self, mock_subproc, mock_run, mock_run_list, mock_safe_checkout,
-        mock_gwb, mock_alias
+        self, mock_subproc, mock_run, mock_run_list, mock_git_push,
+        mock_safe_checkout, mock_gwb, mock_alias
     ):
         # git status shows code file changed
         mock_run.side_effect = [
@@ -942,20 +954,22 @@ class TestCommitCodePushFailure:
         mock_run_list.side_effect = [
             _mock_result(),  # git add
             _mock_result(),  # git checkout config.md revert (#7491)
-            _mock_result(returncode=1, stderr="push rejected"),  # push FAILS
         ]
+        # push now routed through _git_push (#9890) and FAILS here
+        mock_git_push.return_value = _mock_result(returncode=1, stderr="push rejected")
         result = git_ops.commit_code("skill", "squidsquad/task/100", "test")
         assert result is False
 
     @patch("git_ops._get_alias", return_value="skill")
     @patch("git_ops._get_working_branch", return_value="main")
     @patch("git_ops._safe_checkout", return_value=True)
+    @patch("git_ops._git_push")
     @patch("git_ops._run_list")
     @patch("git_ops._run")
     @patch("subprocess.run")
     def test_returns_true_on_push_success(
-        self, mock_subproc, mock_run, mock_run_list, mock_safe_checkout,
-        mock_gwb, mock_alias
+        self, mock_subproc, mock_run, mock_run_list, mock_git_push,
+        mock_safe_checkout, mock_gwb, mock_alias
     ):
         mock_run.side_effect = [
             _mock_result(stdout=" M src/app.py\n"),  # status
@@ -965,8 +979,8 @@ class TestCommitCodePushFailure:
         mock_run_list.side_effect = [
             _mock_result(),  # git add
             _mock_result(),  # git checkout config.md revert (#7491)
-            _mock_result(),  # push succeeds
         ]
+        mock_git_push.return_value = _mock_result()  # push succeeds (#9890)
         result = git_ops.commit_code("skill", "squidsquad/task/100", "test")
         assert result is True
 
@@ -978,11 +992,13 @@ class TestCommitCodePushFailure:
 class TestCommitCodeUsesWorkingBranch:
     @patch("git_ops._get_working_branch", return_value="develop")
     @patch("git_ops._safe_checkout", return_value=True)
+    @patch("git_ops._git_push")
     @patch("git_ops._run_list")
     @patch("git_ops._run")
     @patch("subprocess.run")
     def test_commit_code_switches_back_to_working_branch(
-        self, mock_subproc, mock_run, mock_run_list, mock_safe_checkout, mock_gwb
+        self, mock_subproc, mock_run, mock_run_list, mock_git_push,
+        mock_safe_checkout, mock_gwb
     ):
         """commit_code returns to _get_working_branch(), not hardcoded 'main'."""
         mock_run.side_effect = [
@@ -994,8 +1010,8 @@ class TestCommitCodeUsesWorkingBranch:
             _mock_result(),  # git checkout
             _mock_result(),  # git add
             _mock_result(),  # git checkout config.md revert (#7491)
-            _mock_result(),  # git push -u
         ]
+        mock_git_push.return_value = _mock_result()  # push (#9890)
         mock_subproc.return_value = _mock_result(stdout="1 file changed")
 
         result = git_ops.commit_code("skill", "squidsquad/skill/3341", "test fix")
@@ -1031,19 +1047,20 @@ class TestCommitStateUsesWorkingBranch:
         assert result is False
 
     @patch("git_ops._get_working_branch", return_value="develop")
+    @patch("git_ops._git_push")
     @patch("git_ops._run")
     @patch("git_ops._run_list")
     @patch("subprocess.run")
     def test_commit_state_succeeds_on_working_branch(
-        self, mock_subproc, mock_run_list, mock_run, mock_gwb
+        self, mock_subproc, mock_run_list, mock_run, mock_git_push, mock_gwb
     ):
         """commit_state succeeds when on the configured working branch."""
         mock_run.side_effect = [
             _mock_result(stdout=" M .squidsquad/skill/working-state.md\n"),
             _mock_result(stdout="develop\n"),  # on working branch
-            _mock_result(),  # push
         ]
         mock_run_list.return_value = _mock_result()  # git add
+        mock_git_push.return_value = _mock_result()  # state push (#9890)
         mock_subproc.return_value = _mock_result(stdout="1 file changed")
 
         result = git_ops.commit_state("skill", "state update")
@@ -1475,3 +1492,104 @@ class TestGetBranchName:
         with patch.dict("sys.modules", {"config": fake_config}):
             result = git_ops.get_branch_name("skill", "77")
         assert result == "squidsquad/task/77"
+
+
+# ---------------------------------------------------------------------------
+# _gh_credential_helper_available() and _git_push() (#9890)
+# ---------------------------------------------------------------------------
+
+class TestGhCredentialHelperAvailable:
+    def setup_method(self):
+        # Reset cache before each test (module-level cache leaks across tests).
+        git_ops._GH_AVAILABLE_CACHE = None
+
+    @patch("git_ops.subprocess.run")
+    def test_returns_true_when_gh_authenticated(self, mock_run):
+        mock_run.return_value = _mock_result(returncode=0)
+        assert git_ops._gh_credential_helper_available() is True
+        call_args = mock_run.call_args[0][0]
+        assert call_args[:3] == ["gh", "auth", "status"]
+
+    @patch("git_ops.subprocess.run")
+    def test_returns_false_when_gh_unauthenticated(self, mock_run):
+        mock_run.return_value = _mock_result(returncode=1, stderr="not logged in")
+        assert git_ops._gh_credential_helper_available() is False
+
+    @patch("git_ops.subprocess.run", side_effect=FileNotFoundError("gh"))
+    def test_returns_false_when_gh_missing(self, mock_run):
+        assert git_ops._gh_credential_helper_available() is False
+
+    @patch("git_ops.subprocess.run", side_effect=subprocess.TimeoutExpired("gh", 10))
+    def test_returns_false_when_gh_hangs(self, mock_run):
+        """A wedged `gh auth status` should not propagate the timeout."""
+        assert git_ops._gh_credential_helper_available() is False
+
+    @patch("git_ops.subprocess.run")
+    def test_caches_result(self, mock_run):
+        """Second call should not re-invoke subprocess."""
+        mock_run.return_value = _mock_result(returncode=0)
+        git_ops._gh_credential_helper_available()
+        git_ops._gh_credential_helper_available()
+        git_ops._gh_credential_helper_available()
+        assert mock_run.call_count == 1
+
+
+class TestGitPush:
+    def setup_method(self):
+        git_ops._GH_AVAILABLE_CACHE = None
+
+    @patch("git_ops._gh_credential_helper_available", return_value=True)
+    @patch("git_ops.subprocess.run")
+    def test_prepends_credential_override_when_gh_available(self, mock_run, _mock_gh):
+        mock_run.return_value = _mock_result()
+        git_ops._git_push(["-u", "origin", "squidsquad/task/9890"])
+        cmd = mock_run.call_args[0][0]
+        # Must inject -c flags BEFORE "push" subcommand.
+        assert cmd[0] == "git"
+        push_idx = cmd.index("push")
+        injected = cmd[1:push_idx]
+        assert "-c" in injected
+        assert "credential.helper=" in injected
+        assert "credential.helper=!gh auth git-credential" in injected
+        # User args preserved after "push".
+        assert cmd[push_idx + 1:] == ["-u", "origin", "squidsquad/task/9890"]
+
+    @patch("git_ops._gh_credential_helper_available", return_value=False)
+    @patch("git_ops.subprocess.run")
+    def test_uses_plain_push_when_gh_unavailable(self, mock_run, _mock_gh):
+        mock_run.return_value = _mock_result()
+        git_ops._git_push(["origin", "--delete", "branch-x"])
+        cmd = mock_run.call_args[0][0]
+        # No -c override flags when gh isn't available.
+        assert cmd == ["git", "push", "origin", "--delete", "branch-x"]
+
+    @patch("git_ops._gh_credential_helper_available", return_value=False)
+    @patch("git_ops.subprocess.run")
+    def test_passes_timeout_to_subprocess(self, mock_run, _mock_gh):
+        mock_run.return_value = _mock_result()
+        git_ops._git_push([], timeout=42)
+        assert mock_run.call_args.kwargs.get("timeout") == 42
+
+    @patch("git_ops._gh_credential_helper_available", return_value=False)
+    @patch("git_ops.subprocess.run")
+    def test_default_timeout_is_60(self, mock_run, _mock_gh):
+        mock_run.return_value = _mock_result()
+        git_ops._git_push([])
+        assert mock_run.call_args.kwargs.get("timeout") == 60
+
+    @patch("git_ops._gh_credential_helper_available", return_value=False)
+    @patch("git_ops.subprocess.run",
+           side_effect=subprocess.TimeoutExpired("git push", 60))
+    def test_timeout_returns_synthetic_failure(self, _mock_run, _mock_gh):
+        result = git_ops._git_push([], timeout=60)
+        assert result.returncode == 124
+        assert "timed out" in result.stderr
+        assert "9890" in result.stderr  # references the issue in the message
+
+    @patch("git_ops._gh_credential_helper_available", return_value=False)
+    @patch("git_ops.subprocess.run")
+    def test_empty_args_produces_bare_push(self, mock_run, _mock_gh):
+        mock_run.return_value = _mock_result()
+        git_ops._git_push([])
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["git", "push"]


### PR DESCRIPTION
Closes #9890

## Root cause

On Windows the default `credential.helper=manager` (Git Credential Manager) can wedge silently in agent sessions waiting on an interactive auth dialog that cannot surface. Combined with `_run`/`_run_list` (L55-70) calling `subprocess.run` without a `timeout=`, a wedged push hangs indefinitely — accumulating zombie git processes for hours. Observed in cycles 1244-1245.

## Fix

Two defenses on every `git push` in `git_ops.py`:

1. **Credential helper override**: new `_gh_credential_helper_available()` probes `gh auth status` once (cached) and, when `gh` is available, `_git_push()` prepends `-c credential.helper= -c credential.helper=!gh auth git-credential` so credentials route through `gh` rather than the inherited GCM helper. Falls back to a plain `git push` when `gh` isn't installed.
2. **Timeout**: `_git_push()` calls `subprocess.run` with `timeout=60` and synthesizes a `CompletedProcess` with `returncode=124` on `TimeoutExpired` (GNU `timeout` convention) — preserves the existing `if push_result.returncode != 0` contract at every call site.

Routed all 4 push call sites through `_git_push()`:
- L272 `push()` (was `_run("git push")`)
- L328 `delete_branch()` remote delete (was `_run_list(["git", "push", "origin", "--delete", name])`)
- L627 `task_end()` feature branch push (was `_run_list(["git", "push", "-u", "origin", branch])`) — this was the cycle-1244 wedge
- L820 `commit_state()` state push (was `_run("git push")`)

## Tests

`tests/test_git_ops.py`: 120 pass.
`tests/test_cycle_post.py`: 94 pass.

New test classes:
- `TestGhCredentialHelperAvailable` — 5 tests covering authenticated / unauthenticated / missing-binary / hang / cache.
- `TestGitPush` — 6 tests covering credential override injection, plain-push fallback, timeout pass-through, default timeout, synthetic-failure on `TimeoutExpired`, and bare `git push` for empty args.

Updated existing tests that previously patched `_run`/`_run_list` for push: `TestPush`, `TestPushEmitsRole`, `TestCommitCode` (2 tests), `TestCommitState` (1 test), `TestCommitCodePushFailure` (2 tests), `TestCommitCodeUsesWorkingBranch` (1 test), `TestCommitStateUsesWorkingBranch` (1 test) — each now patches `_git_push` for the push step and shortens the `_run_list`/`_run` side-effect sequences accordingly.

## Self-test

This PR was pushed using its own helper — `commit-code` invoked `_git_push(["-u", "origin", "squidsquad/task/9890"])` and it landed cleanly. No wedge.

## Out of scope

`cycle_post.py` (L480, L605, L606) and `state_bus.py` (L115, L257) still call `subprocess.run(["git", "push", ...])` directly. Will file a follow-up to migrate them to the new helper. The 7 pre-existing failures in `test_feat_3645_auto_merge.py` and `test_feat_3663_pr_conflict_check.py` (stale assertions from the #9478 cleanup) are unaffected by this PR and reproduce on `main`.