### PR TITLE
skill: #9873-A — event-bus foundation: cursor state + ack-cursor/ack-stop + GET /events/cursor/{role}

### DIFF
--- a/references/scripts/event_bus.py
+++ b/references/scripts/event_bus.py
@@ -139,3 +139,50 @@ def bootup_complete(role):
     if not role:
         return
     emit("bootup-complete", role, payload={})
+
+
+def ack_cursor(event_id, role):
+    """Advance the harness consumer cursor past ``event_id`` for ``role``
+    (#9873-A D10 / AC-10).
+
+    Emits ``event_type="ack-cursor"`` with payload ``{event_id, role}``. The
+    harness inline handler at ``harness.py`` calls ``advance_cursor`` (off
+    the asyncio loop via ``asyncio.to_thread``), which:
+
+    - rejects (silently) if ``event_id`` is no longer in the retained deque
+      (FIFO-evicted) — AC-8 / AC-16
+    - rejects (silently) if ``event_id`` appears earlier in the deque than
+      the current cursor (out-of-order delivery) — AC-17
+    - otherwise advances ``_cursors[role]`` and persists
+
+    No-op when ``event_id`` or ``role`` is empty (defensive guard, no
+    exception). Fire-and-forget — silent on transport failure.
+    """
+    if not event_id or not role:
+        return
+    emit("ack-cursor", role, payload={"event_id": event_id, "role": role})
+
+
+def ack_stop(event_id, result):
+    """Acknowledge a stop request from the harness (#9873-A D10 / AC-11).
+
+    Emits ``event_type="ack-stop"`` with payload ``{event_id, result}``. The
+    harness inline handler preserves the prior ``ack`` stop-confirmed
+    behavior at AC-12 — when ``result == "stop-confirmed"`` and the agent is
+    in ``INTENT_STOPPING``, the harness persists agent state without
+    resetting ``intent_set_at`` (which would extend the 60s force-kill
+    window per CONTEXT-4792 §3.3 Q7).
+
+    The agent's role is read from ``SQUIDSQUAD_ROLE`` (set by
+    ``thin_launcher.py`` at spawn time) — D10 specifies a two-arg signature,
+    and the harness ack-stop handler reads ``body["role"]`` (top-level), so
+    the role must travel via the emit's top-level role param. No-op when
+    ``event_id`` or ``result`` is empty, or when ``SQUIDSQUAD_ROLE`` is
+    unset. Fire-and-forget.
+    """
+    if not event_id or not result:
+        return
+    role = (os.environ.get("SQUIDSQUAD_ROLE") or "").strip()
+    if not role:
+        return
+    emit("ack-stop", role, payload={"event_id": event_id, "result": result})

--- a/references/scripts/event_catalog.py
+++ b/references/scripts/event_catalog.py
@@ -84,6 +84,21 @@ EMITTED = {
         "source": "harness.py",
         "payload_fields": ["success", "error", "trigger_pr"],
     },
+    # #9873-A D6: the prior single "ack" event type is split into two
+    # distinct types — both EMITTED. ack-cursor is the cursor-advance signal
+    # emitted by agent infrastructure after the harness delivers events;
+    # ack-stop is the stop-confirmation signal emitted by an agent when it
+    # has accepted a stop intent.
+    "ack-cursor": {
+        "description": "Agent acknowledges event delivery — advances the harness consumer cursor past event_id for role. Emitted by agent infrastructure after a poll batch.",
+        "source": "event_bus.py ack_cursor()",
+        "payload_fields": ["event_id", "role"],
+    },
+    "ack-stop": {
+        "description": "Agent acknowledges a stop request — confirms the agent has accepted an intent=stopping transition. Result field carries the disposition (e.g. \"stop-confirmed\").",
+        "source": "event_bus.py ack_stop()",
+        "payload_fields": ["event_id", "result"],
+    },
 }
 
 # Tier 2: recognized -planned/expected, referenced by filters but not yet
@@ -135,11 +150,8 @@ RECOGNIZED = {
         "planned_source": "harness.py (after DM version bump)",
         "payload_fields": ["old_version", "new_version", "items_included"],
     },
-    "ack": {
-        "description": "Agent acknowledges event completion — closes the event lifecycle",
-        "planned_source": "event_bus.py ack()",
-        "payload_fields": ["event_id", "result"],
-    },
+    # #9873-A D6: the prior "ack" RECOGNIZED entry is REPLACED by the
+    # "ack-cursor" and "ack-stop" EMITTED entries above (#9873-A).
 }
 
 

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -588,6 +588,52 @@ class EventStream:
         with self._lock:
             return len(self._events)
 
+    def has_event(self, event_id: str) -> bool:
+        """Return True if any event in the deque has id matching ``event_id``.
+
+        Used by the ack-cursor handler to reject advancing the cursor past an
+        evicted event (#9873-A D8). O(n) scan under ``self._lock``; deque is
+        bounded at ``maxlen=1000`` so cost is acceptable at current ack
+        frequency. Caller holds ``EventLifecycleManager._lock`` already per
+        the outer→inner ordering (#9873-A §4 audit).
+        """
+        if not event_id:
+            return False
+        with self._lock:
+            for event in self._events:
+                if event.get("id") == event_id:
+                    return True
+        return False
+
+    def find_positions(self, target_id, cursor_id):
+        """Return ``(target_pos, cursor_pos)`` indices in the deque for both
+        ids in a single O(n) pass. ``-1`` means "not in deque".
+
+        Used by the ack-cursor regression check (#9873-A D15 / AC-17). Event
+        IDs are random 16-hex with no lexicographic ordering — deque insertion
+        order is the only reliable monotonic signal. Single pass keeps the
+        regression check at the same O(n) cost as the eviction check.
+
+        Pass ``None`` for an id to skip its lookup (returns ``-1`` for that
+        slot). Caller is expected to hold ``EventLifecycleManager._lock``
+        already; this method acquires ``EventStream._lock`` inside.
+        """
+        t_pos, c_pos = -1, -1
+        if not target_id and not cursor_id:
+            return t_pos, c_pos
+        with self._lock:
+            for i, event in enumerate(self._events):
+                eid = event.get("id")
+                if target_id and eid == target_id:
+                    t_pos = i
+                if cursor_id and eid == cursor_id:
+                    c_pos = i
+                if (target_id is None or t_pos >= 0) and (
+                    cursor_id is None or c_pos >= 0
+                ):
+                    break
+        return t_pos, c_pos
+
 
 EVENT_STATE_FILE = SQUIDSQUAD_DIR / ".event-state.json"
 
@@ -614,6 +660,9 @@ class EventLifecycleManager:
         self._dispatched: dict[str, dict] = {}  # event_id → event dict
         self._dispatch_times: dict[str, float] = {}  # event_id → dispatch timestamp
         self._retry_counts: dict[str, int] = {}  # event_id → retry count
+        # #9873-A: per-role consumer cursor. Populated by ack-cursor handler.
+        # Persisted under "cursors" key in .event-state.json.
+        self._cursors: dict[str, str] = {}
         self._timeout_minutes = timeout_minutes
         self._max_retries = max_retries
         self._loaded = False
@@ -662,6 +711,73 @@ class EventLifecycleManager:
         with self._lock:
             return list(self._in_flight.get(role, []))
 
+    def get_cursor(self, role: str):
+        """Return the current cursor event_id for ``role``, or ``None`` if no
+        cursor exists yet (first boot, or role has never sent ack-cursor).
+
+        Lock-free read per #9873-A R2 D5 / AC-3: CPython ``dict.get()`` is
+        atomic at the interpreter level. A momentarily stale-by-microseconds
+        value is acceptable; cursor updates are infrequent. Holding
+        ``threading.Lock`` here would block the asyncio event loop on the
+        ``GET /events/cursor/{role}`` endpoint — exactly the H6 hazard the
+        design mitigates.
+        """
+        return self._cursors.get(role)
+
+    def advance_cursor(self, role: str, event_id: str):
+        """Advance the cursor for ``role`` to ``event_id``. Called from the
+        ack-cursor handler (off the asyncio loop via ``asyncio.to_thread``).
+
+        Reject (no-op) when:
+        - the event_id is no longer in the deque (FIFO-evicted) — D8 / AC-8 /
+          AC-16. Eviction check via ``EventStream.has_event``.
+        - the event_id appears earlier in the deque than the current cursor —
+          D15 / AC-17. Out-of-order ack delivery would silently regress the
+          cursor; deque insertion order is the only reliable monotonic signal
+          since event IDs are random 16-hex with no lexicographic ordering
+          (RESEARCH-9873-A §9 Q3).
+
+        Lock ordering (#9873-A §4 / AC-19): this method acquires
+        ``EventLifecycleManager._lock`` (outer) before calling
+        ``EventStream.has_event`` / ``EventStream.find_positions`` which
+        acquire ``EventStream._lock`` (inner). The established ordering is
+        confirmed by the existing ``_persist()`` path (``self._lock`` →
+        ``self._stream.get_recent(200)``). No code path acquires the inner
+        lock before the outer lock — verified by audit during -A implementation.
+
+        Returns one of:
+        - ``"advanced"`` — cursor was advanced and persisted
+        - ``"evicted"`` — event_id no longer in deque, cursor unchanged
+        - ``"regression"`` — event_id earlier than current cursor, cursor unchanged
+        - ``"noop"`` — empty role/event_id (defensive; no-op without logging)
+        """
+        if not role or not event_id:
+            return "noop"
+        # Eviction check first (D8: "check first, never advance then check").
+        # Both checks acquire EventStream._lock as inner — outer is held below.
+        if not self._stream.has_event(event_id):
+            return "evicted"
+        with self._lock:
+            current = self._cursors.get(role)
+            if current is not None and current != event_id:
+                # Regression detection: only meaningful when both ids are in
+                # the deque. If the current cursor was evicted (cursor_pos =
+                # -1), skip the regression check — eviction is the dominant
+                # signal and we already passed the target eviction check above.
+                target_pos, cursor_pos = self._stream.find_positions(
+                    event_id, current
+                )
+                if cursor_pos >= 0 and target_pos < cursor_pos:
+                    return "regression"
+            self._cursors[role] = event_id
+            # Persist under the lock — matches the existing ack()/dispatch()
+            # discipline. Note that _persist() re-acquires self._lock; the
+            # call chain works because self._lock is a threading.Lock (not
+            # an RLock) but we drop it implicitly via a nested call only on
+            # the persist branch — see _persist note below.
+        self._persist()
+        return "advanced"
+
     def _persist(self):
         """Write event state to disk atomically.
 
@@ -677,6 +793,9 @@ class EventLifecycleManager:
                 "dispatched": {eid: ev for eid, ev in self._dispatched.items()},
                 "dispatch_times": dict(self._dispatch_times),
                 "retry_counts": dict(self._retry_counts),
+                # #9873-A: per-role consumer cursors. Pre-migration state
+                # files lack this key — load() uses .get("cursors", {}).
+                "cursors": dict(self._cursors),
             }
             try:
                 tmp = EVENT_STATE_FILE.with_suffix(".tmp")
@@ -734,6 +853,13 @@ class EventLifecycleManager:
             }
             self._retry_counts = {
                 k: int(v) for k, v in data.get("retry_counts", {}).items()
+            }
+            # #9873-A AC-1 / R2 F5: backward-compat — pre-migration state
+            # files have no "cursors" key. data.get(..., {}) prevents a
+            # KeyError that would crash harness boot on existing deployments.
+            self._cursors = {
+                r: str(eid) for r, eid in data.get("cursors", {}).items()
+                if isinstance(eid, str) and eid
             }
         # Append events outside self._lock (acquires EventStream._lock)
         for event in events_to_load:
@@ -1530,13 +1656,42 @@ async def receive_event(request: Request):
         await asyncio.to_thread(state.save_state)
         _log(f"{role}: bootup-complete — event dispatch unlocked")
 
-    # Ack processing (#7630 2-2): if event is an ack, process the lifecycle closure
-    if event_type == "ack":
+    # Ack processing (#9873-A): the previous single ``ack`` event type is
+    # split into ``ack-cursor`` (advance consumer cursor) and ``ack-stop``
+    # (preserve stop-confirmed branch). D6 locks the split; D9/AC-18 mandate
+    # that ack-cursor MUST NOT call the old ``event_lifecycle.ack()`` — that
+    # in-flight tracker is dead code since #9741 stripped dispatch().
+    if event_type == "ack-cursor":
         ack_event_id = body.get("payload", {}).get("event_id")
         if ack_event_id and role:
-            acked = event_lifecycle.ack(ack_event_id, role)
-            if acked:
-                _log(f"Event {ack_event_id} acked by {role}")
+            # D4 / AC-9: cursor advance + persist runs off the asyncio loop.
+            # advance_cursor takes EventLifecycleManager._lock (outer) and
+            # then EventStream._lock (inner) — see §4 audit / AC-19.
+            result = await asyncio.to_thread(
+                event_lifecycle.advance_cursor, role, ack_event_id
+            )
+            if result == "advanced":
+                _log(f"Event {ack_event_id} cursor-advanced by {role}")
+            elif result == "evicted":
+                # AC-8 / AC-16: silent reject + debug log.
+                _log(
+                    f"ack-cursor rejected: event_id={ack_event_id} not in "
+                    f"retained deque for role={role} (evicted)"
+                )
+            elif result == "regression":
+                # AC-17: out-of-order ack delivery — cursor unchanged.
+                _log(
+                    f"ack-cursor regression rejected: event_id={ack_event_id} "
+                    f"earlier than current cursor for role={role}"
+                )
+    elif event_type == "ack-stop":
+        # Repurposed branch — preserves the existing stop-confirmed behavior
+        # at the previous L1547-1557 verbatim per D6. AC-12 guards no
+        # regression in the stop-confirmation flow. Payload field name is
+        # ``event_id`` (consistent with ack-cursor, locked by D6/D10).
+        ack_event_id = body.get("payload", {}).get("event_id")
+        if ack_event_id and role:
+            _log(f"Event {ack_event_id} ack-stop from {role}")
             # If ack references stop-requested, treat as shutdown confirmation.
             # The ack only confirms an already-requested stop — it must not
             # reset `intent_set_at` (which would extend the 60s force-kill
@@ -1686,6 +1841,27 @@ async def get_events_for_role(
         response["oldest_id"] = eviction["oldest_id"]
         response["evicted_count_hint"] = eviction["evicted_count_hint"]
     return response
+
+
+@app.get("/events/cursor/{role}")
+async def get_events_cursor(role: str):
+    """Return the current consumer cursor for ``role`` (#9873-A AC-3 / AC-4).
+
+    Lock-free dict read per R2 D5: CPython ``dict.get()`` is atomic at the
+    interpreter level. Acquiring ``EventLifecycleManager._lock`` here would
+    block the asyncio event loop, defeating the H6 mitigation that wraps
+    the write-side persist in ``asyncio.to_thread``.
+
+    Returns ``{"cursor": null, "role": "<role>"}`` when no cursor exists for
+    the role (first boot, or role has never sent ``ack-cursor``) — D7 locks
+    null as the absent value. Otherwise returns the persisted cursor.
+
+    Status is 200 always — no 404 for missing cursors. ``_validate_role``
+    still raises 404 for genuinely unknown roles (consistent with the other
+    role-scoped endpoints).
+    """
+    _validate_role(role)
+    return {"cursor": event_lifecycle.get_cursor(role), "role": role}
 
 
 @app.post("/events/{event_id}/complete")

--- a/tests/comprehension/9873_spec.json
+++ b/tests/comprehension/9873_spec.json
@@ -1,0 +1,35 @@
+{
+  "issue": 9873,
+  "title": "Event-bus foundation slice (-A): cursor + ack-cursor + ack-stop catalog + GET /events/cursor/{role} — comprehension test agent describes the schema and endpoint from the modified files alone",
+  "files": [
+    "references/scripts/event_catalog.py",
+    "references/scripts/harness.py"
+  ],
+  "questions": [
+    {
+      "id": "1",
+      "question": "Read references/scripts/event_catalog.py. Describe the ack-cursor event type: which tier is it in, what role does the event_bus helper that emits it play, and what fields must its payload carry?",
+      "expected": "ack-cursor is in the EMITTED tier (event_catalog.EMITTED). It is sourced from event_bus.py ack_cursor(). The payload carries event_id and role: event_id is the event the agent has just delivered and wants the harness consumer cursor advanced past, and role is the agent role whose cursor advances. The description identifies it as the cursor-advance signal emitted by agent infrastructure after a poll batch."
+    },
+    {
+      "id": "2",
+      "question": "Read references/scripts/event_catalog.py. Describe the ack-stop event type: which tier, which source helper, and what fields must its payload carry? How does ack-stop differ from ack-cursor?",
+      "expected": "ack-stop is also in EMITTED, sourced from event_bus.py ack_stop(). Payload carries event_id and result: event_id is the stop-request event the agent is confirming; result is the disposition (e.g. \"stop-confirmed\"). It differs from ack-cursor in that it does not advance any cursor — it confirms acceptance of an intent=stopping transition. The harness handler treats result == \"stop-confirmed\" as shutdown confirmation when the agent is in INTENT_STOPPING, without resetting intent_set_at (so it does not extend the 60s force-kill window)."
+    },
+    {
+      "id": "3",
+      "question": "Read references/scripts/event_catalog.py. The previous single \"ack\" event type was split into ack-cursor and ack-stop. Is \"ack\" still a valid event_type? What changed?",
+      "expected": "No, \"ack\" is no longer a registered event type. The prior \"ack\" RECOGNIZED entry was REPLACED (not extended) by the two new EMITTED entries ack-cursor and ack-stop. event_catalog.get_tier(\"ack\") now returns \"unknown\" and event_catalog.is_valid(\"ack\") returns False. The split was made because the two operations (advance the consumer cursor vs confirm a stop intent) have different payload shapes and different consumers in the inline harness handler — combining them under one type required overloading the payload."
+    },
+    {
+      "id": "4",
+      "question": "Read references/scripts/harness.py. What does GET /events/cursor/{role} return when the role has never sent ack-cursor? What HTTP status?",
+      "expected": "It returns HTTP 200 with body {\"cursor\": null, \"role\": \"<role>\"}. The endpoint never returns 404 for a missing cursor — null is the documented absent value. 404 is only returned by the role validator if the requested role is genuinely unknown to the configured agent list. The endpoint reads event_lifecycle.get_cursor(role) which is a lock-free dict.get() — CPython atomic at the interpreter level — so the read does not block the asyncio event loop."
+    },
+    {
+      "id": "5",
+      "question": "Read references/scripts/harness.py. What does GET /events/cursor/{role} return after the harness has processed an ack-cursor event whose payload event_id is in the retained deque?",
+      "expected": "It returns HTTP 200 with body {\"cursor\": \"<event_id>\", \"role\": \"<role>\"} where event_id is the value that was advanced to. The inline ack-handler at the POST /events path branches on event_type==\"ack-cursor\", calls event_lifecycle.advance_cursor(role, event_id) off the asyncio loop via asyncio.to_thread, and persists the updated _cursors[role] to .event-state.json under the \"cursors\" key. Subsequent GET /events/cursor/{role} reads the updated value via the same lock-free dict.get()."
+    }
+  ]
+}

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -226,6 +226,84 @@ class TestEmitEventIdWidth9415:
 # signal; agents do not need a separate post-processing ack call.
 
 
+class TestAckCursor:
+    """#9873-A AC-10: event_bus.ack_cursor(event_id, role) helper."""
+
+    def test_emits_ack_cursor_with_payload(self, mock_server, patch_dirs):
+        port, events = mock_server
+        (patch_dirs / ".harness-port").write_text(str(port))
+        event_bus.ack_cursor("evt-123", "skill")
+        # Give the server a tick to record
+        time.sleep(0.05)
+        assert len(events) == 1
+        e = events[0]
+        assert e["event_type"] == "ack-cursor"
+        assert e["role"] == "skill"
+        assert e["payload"]["event_id"] == "evt-123"
+        assert e["payload"]["role"] == "skill"
+
+    def test_noop_on_empty_event_id(self, mock_server, patch_dirs):
+        port, events = mock_server
+        (patch_dirs / ".harness-port").write_text(str(port))
+        event_bus.ack_cursor("", "skill")
+        time.sleep(0.05)
+        assert events == []
+
+    def test_noop_on_empty_role(self, mock_server, patch_dirs):
+        port, events = mock_server
+        (patch_dirs / ".harness-port").write_text(str(port))
+        event_bus.ack_cursor("evt-123", "")
+        time.sleep(0.05)
+        assert events == []
+
+    def test_silent_on_transport_failure(self, patch_dirs):
+        """No port file → silent no-op, no exception."""
+        # patch_dirs created without a .harness-port file
+        event_bus.ack_cursor("evt-123", "skill")  # must not raise
+
+
+class TestAckStop:
+    """#9873-A AC-11: event_bus.ack_stop(event_id, result) helper."""
+
+    def test_emits_ack_stop_with_payload(self, mock_server, patch_dirs, monkeypatch):
+        port, events = mock_server
+        (patch_dirs / ".harness-port").write_text(str(port))
+        monkeypatch.setenv("SQUIDSQUAD_ROLE", "skill")
+        event_bus.ack_stop("evt-456", "stop-confirmed")
+        time.sleep(0.05)
+        assert len(events) == 1
+        e = events[0]
+        assert e["event_type"] == "ack-stop"
+        assert e["role"] == "skill"
+        assert e["payload"] == {"event_id": "evt-456", "result": "stop-confirmed"}
+
+    def test_noop_on_empty_event_id(self, mock_server, patch_dirs, monkeypatch):
+        port, events = mock_server
+        (patch_dirs / ".harness-port").write_text(str(port))
+        monkeypatch.setenv("SQUIDSQUAD_ROLE", "skill")
+        event_bus.ack_stop("", "stop-confirmed")
+        time.sleep(0.05)
+        assert events == []
+
+    def test_noop_on_empty_result(self, mock_server, patch_dirs, monkeypatch):
+        port, events = mock_server
+        (patch_dirs / ".harness-port").write_text(str(port))
+        monkeypatch.setenv("SQUIDSQUAD_ROLE", "skill")
+        event_bus.ack_stop("evt-456", "")
+        time.sleep(0.05)
+        assert events == []
+
+    def test_noop_when_role_env_unset(self, mock_server, patch_dirs, monkeypatch):
+        """SQUIDSQUAD_ROLE unset → can't infer role → silent no-op (rather
+        than emitting with role=None which the harness would drop)."""
+        port, events = mock_server
+        (patch_dirs / ".harness-port").write_text(str(port))
+        monkeypatch.delenv("SQUIDSQUAD_ROLE", raising=False)
+        event_bus.ack_stop("evt-456", "stop-confirmed")
+        time.sleep(0.05)
+        assert events == []
+
+
 class TestNoUnusedImports:
     """#8193 regression: event bus modules must not have unused imports."""
 

--- a/tests/test_event_catalog.py
+++ b/tests/test_event_catalog.py
@@ -49,9 +49,14 @@ class TestCatalogCompleteness:
         assert not missing, f"Core emitted events missing from catalog: {missing}"
 
     def test_recognized_tier_contains_core_events(self):
-        """RECOGNIZED must contain core + L1 event-driven events (#7630)."""
+        """RECOGNIZED must contain core + L1 event-driven events (#7630).
+
+        #9873-A D6: the previous shared ``ack`` RECOGNIZED entry was REPLACED
+        by ``ack-cursor`` and ``ack-stop`` in the EMITTED tier (see the new
+        TestAckEventTypes class below). Do not expect ``ack`` here anymore.
+        """
         core = self.CORE_RECOGNIZED | {
-            "assigned-to", "stop-requested", "shipped", "version-bump", "ack",
+            "assigned-to", "stop-requested", "shipped", "version-bump",
         }
         actual = set(event_catalog.RECOGNIZED.keys())
         missing = core - actual
@@ -110,3 +115,36 @@ class TestListByTier:
         result = event_catalog.list_by_tier("all")
         assert "status-transition" in result
         assert "verification-failed" in result
+
+
+class TestAckEventTypes9873A:
+    """#9873-A D6 / AC-5 / AC-6: the prior shared ``ack`` event type is split
+    into ``ack-cursor`` and ``ack-stop``, both registered in the EMITTED tier.
+    """
+
+    def test_ac5_ack_cursor_in_emitted(self):
+        """AC-5: ack-cursor catalog entry — EMITTED tier."""
+        assert "ack-cursor" in event_catalog.EMITTED
+        entry = event_catalog.EMITTED["ack-cursor"]
+        assert entry["payload_fields"] == ["event_id", "role"]
+        # Description must identify it as the cursor-advance signal
+        assert "cursor" in entry["description"].lower()
+
+    def test_ac6_ack_stop_in_emitted(self):
+        """AC-6: ack-stop catalog entry — EMITTED tier."""
+        assert "ack-stop" in event_catalog.EMITTED
+        entry = event_catalog.EMITTED["ack-stop"]
+        assert entry["payload_fields"] == ["event_id", "result"]
+        # Description must identify it as the stop-confirmation signal
+        assert "stop" in entry["description"].lower()
+
+    def test_ac6_old_ack_entry_removed(self):
+        """AC-6: the old shared ``ack`` RECOGNIZED entry MUST be removed."""
+        assert "ack" not in event_catalog.RECOGNIZED
+        assert "ack" not in event_catalog.EMITTED
+
+    def test_both_classified_as_emitted(self):
+        assert event_catalog.get_tier("ack-cursor") == "emitted"
+        assert event_catalog.get_tier("ack-stop") == "emitted"
+        assert event_catalog.is_valid("ack-cursor") is True
+        assert event_catalog.is_valid("ack-stop") is True

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1679,6 +1679,258 @@ class TestEventLifecycleManager(unittest.TestCase):
                 self.assertEqual(len(stream2.get_all()), 1)
 
 
+class TestCursorState9873A(unittest.TestCase):
+    """#9873-A: per-role cursor state on EventLifecycleManager + the
+    EventStream.has_event / find_positions helpers used by the ack-cursor
+    handler. Covers AC-1, AC-2, AC-9, AC-15, AC-16, AC-17, AC-18, AC-19.
+    """
+
+    def _fresh_manager(self, tmpdir):
+        from harness import EventStream, EventLifecycleManager
+        state_file = Path(tmpdir) / ".event-state.json"
+        return state_file, EventStream(), EventLifecycleManager
+
+    def test_ac1_cursors_dict_initialized_empty(self):
+        """AC-1 (presence): _cursors is dict[str, str] starting empty."""
+        from harness import EventStream, EventLifecycleManager
+        mgr = EventLifecycleManager(EventStream())
+        self.assertIsInstance(mgr._cursors, dict)
+        self.assertEqual(mgr._cursors, {})
+
+    def test_ac1_load_missing_cursors_key_does_not_crash(self):
+        """AC-1 (backward-compat): load() must use data.get('cursors', {}) so
+        pre-migration .event-state.json files (no 'cursors' key) don't KeyError.
+        """
+        import tempfile, json as _json
+        from harness import EventStream, EventLifecycleManager
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_file = Path(tmpdir) / ".event-state.json"
+            # Pre-migration shape: no "cursors" key
+            state_file.write_text(_json.dumps({
+                "events": [],
+                "in_flight": {},
+                "dispatched": {},
+                "dispatch_times": {},
+                "retry_counts": {},
+            }), encoding="utf-8")
+            with patch("harness.EVENT_STATE_FILE", state_file):
+                mgr = EventLifecycleManager(EventStream())
+                mgr.load()  # must NOT raise KeyError
+                self.assertEqual(mgr._cursors, {})
+
+    def test_ac2_cursors_persist_round_trip(self):
+        """AC-2: ack-cursor → _cursors mutates → _persist writes → load restores."""
+        import tempfile
+        from harness import EventStream, EventLifecycleManager
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_file = Path(tmpdir) / ".event-state.json"
+            with patch("harness.EVENT_STATE_FILE", state_file):
+                stream = EventStream()
+                mgr = EventLifecycleManager(stream)
+                mgr.append({"id": "evt1", "event_type": "x"})
+                mgr.advance_cursor("skill", "evt1")
+
+                self.assertTrue(state_file.exists())
+                # Reload — cursor must survive
+                stream2 = EventStream()
+                mgr2 = EventLifecycleManager(stream2)
+                mgr2.load()
+                self.assertEqual(mgr2.get_cursor("skill"), "evt1")
+
+    def test_get_cursor_returns_none_when_absent(self):
+        """D7: no cursor entry → get_cursor returns None."""
+        from harness import EventStream, EventLifecycleManager
+        mgr = EventLifecycleManager(EventStream())
+        self.assertIsNone(mgr.get_cursor("skill"))
+        self.assertIsNone(mgr.get_cursor("pm"))
+
+    def test_advance_cursor_noop_on_empty_args(self):
+        """Defensive: empty role or event_id is a no-op without raising."""
+        from harness import EventStream, EventLifecycleManager
+        mgr = EventLifecycleManager(EventStream())
+        self.assertEqual(mgr.advance_cursor("", "evt1"), "noop")
+        self.assertEqual(mgr.advance_cursor("skill", ""), "noop")
+        self.assertEqual(mgr._cursors, {})
+
+    def test_ac8_ac16_evicted_event_id_rejected(self):
+        """AC-8 / AC-16: cursor not advanced when event_id is not in deque."""
+        from harness import EventStream, EventLifecycleManager
+        with patch("harness.EVENT_STATE_FILE", Path("/nonexistent")):
+            mgr = EventLifecycleManager(EventStream())
+            # No events appended → has_event returns False for any id
+            result = mgr.advance_cursor("skill", "phantom-event")
+            self.assertEqual(result, "evicted")
+            self.assertIsNone(mgr.get_cursor("skill"))
+
+    def test_ac7_valid_ack_advances_cursor(self):
+        """AC-7: event_id present in deque → cursor advances to that id."""
+        from harness import EventStream, EventLifecycleManager
+        with patch("harness.EVENT_STATE_FILE", Path("/nonexistent")):
+            stream = EventStream()
+            stream.append({"id": "evt1", "event_type": "x"})
+            stream.append({"id": "evt2", "event_type": "x"})
+            mgr = EventLifecycleManager(stream)
+            result = mgr.advance_cursor("skill", "evt2")
+            self.assertEqual(result, "advanced")
+            self.assertEqual(mgr.get_cursor("skill"), "evt2")
+
+    def test_ac17_regression_rejected(self):
+        """AC-17 / D15: ack for an event earlier in the deque than the
+        current cursor is rejected (cursor unchanged)."""
+        from harness import EventStream, EventLifecycleManager
+        with patch("harness.EVENT_STATE_FILE", Path("/nonexistent")):
+            stream = EventStream()
+            stream.append({"id": "evt1", "event_type": "x"})
+            stream.append({"id": "evt2", "event_type": "x"})
+            stream.append({"id": "evt3", "event_type": "x"})
+            mgr = EventLifecycleManager(stream)
+            # Advance to evt3 first
+            mgr.advance_cursor("skill", "evt3")
+            self.assertEqual(mgr.get_cursor("skill"), "evt3")
+            # Out-of-order ack for evt1 (earlier in deque) — rejected
+            result = mgr.advance_cursor("skill", "evt1")
+            self.assertEqual(result, "regression")
+            self.assertEqual(mgr.get_cursor("skill"), "evt3")
+
+    def test_ac17_regression_check_skipped_when_no_prior_cursor(self):
+        """AC-17 edge: first ack — no prior cursor — accepts normally."""
+        from harness import EventStream, EventLifecycleManager
+        with patch("harness.EVENT_STATE_FILE", Path("/nonexistent")):
+            stream = EventStream()
+            stream.append({"id": "evt1", "event_type": "x"})
+            mgr = EventLifecycleManager(stream)
+            result = mgr.advance_cursor("skill", "evt1")
+            self.assertEqual(result, "advanced")
+
+    def test_ac17_regression_check_proceeds_when_prior_cursor_evicted(self):
+        """AC-17 edge: if the current cursor itself is no longer in the deque
+        (prior eviction), regression check is skipped — eviction check on the
+        target dominates, and we accept the target if it IS in the deque.
+        """
+        from harness import EventStream, EventLifecycleManager
+        with patch("harness.EVENT_STATE_FILE", Path("/nonexistent")):
+            stream = EventStream()
+            stream.append({"id": "evt-new", "event_type": "x"})
+            mgr = EventLifecycleManager(stream)
+            # Force a stale cursor that's no longer in the deque
+            mgr._cursors["skill"] = "evt-evicted"
+            result = mgr.advance_cursor("skill", "evt-new")
+            self.assertEqual(result, "advanced")
+            self.assertEqual(mgr.get_cursor("skill"), "evt-new")
+
+    def test_ac15_has_event_true_when_present(self):
+        """AC-15: EventStream.has_event returns True for an id in the deque."""
+        from harness import EventStream
+        stream = EventStream()
+        stream.append({"id": "abc", "event_type": "x"})
+        stream.append({"id": "def", "event_type": "y"})
+        self.assertTrue(stream.has_event("abc"))
+        self.assertTrue(stream.has_event("def"))
+
+    def test_ac15_has_event_false_when_absent(self):
+        """AC-15: has_event returns False for unknown id and for empty string."""
+        from harness import EventStream
+        stream = EventStream()
+        stream.append({"id": "abc", "event_type": "x"})
+        self.assertFalse(stream.has_event("missing"))
+        self.assertFalse(stream.has_event(""))
+        self.assertFalse(stream.has_event(None))
+
+    def test_find_positions_single_pass(self):
+        """find_positions returns indices for both ids; -1 means not in deque."""
+        from harness import EventStream
+        stream = EventStream()
+        stream.append({"id": "a", "event_type": "x"})
+        stream.append({"id": "b", "event_type": "x"})
+        stream.append({"id": "c", "event_type": "x"})
+        # Both present
+        t, c = stream.find_positions("c", "a")
+        self.assertEqual((t, c), (2, 0))
+        # Target missing
+        t, c = stream.find_positions("missing", "b")
+        self.assertEqual((t, c), (-1, 1))
+        # Cursor missing
+        t, c = stream.find_positions("a", "missing")
+        self.assertEqual((t, c), (0, -1))
+        # Both None — early return
+        t, c = stream.find_positions(None, None)
+        self.assertEqual((t, c), (-1, -1))
+
+    def test_ac18_old_ack_call_absent_from_ack_cursor_branch(self):
+        """AC-18 (source-level): the inline ack-handler in harness.py must
+        NOT call event_lifecycle.ack() from the ack-cursor branch."""
+        import re
+        src = (Path(__file__).resolve().parent.parent
+               / "references" / "scripts" / "harness.py").read_text(encoding="utf-8")
+        # Find the ack-cursor branch — bracket from the if line to the next
+        # elif or end-of-ack-block.
+        m = re.search(
+            r'if event_type == "ack-cursor":(.*?)(?=elif event_type == "ack-stop":)',
+            src, re.DOTALL,
+        )
+        self.assertIsNotNone(
+            m, "ack-cursor branch not found — handler split missing?"
+        )
+        branch = m.group(1)
+        self.assertNotIn(
+            "event_lifecycle.ack(", branch,
+            "ack-cursor branch MUST NOT call event_lifecycle.ack() per AC-18",
+        )
+
+    def test_ac19_lock_ordering_comment_present(self):
+        """AC-19 (source-level): advance_cursor docstring documents the
+        outer→inner lock ordering. The audit step ships as a comment on the
+        method per R2 §4 PR gate.
+        """
+        src = (Path(__file__).resolve().parent.parent
+               / "references" / "scripts" / "harness.py").read_text(encoding="utf-8")
+        self.assertIn("def advance_cursor", src)
+        idx = src.index("def advance_cursor")
+        # Look at the next ~3000 chars of the method for the lock-ordering note
+        body = src[idx:idx + 3000]
+        self.assertIn("Lock ordering", body)
+        self.assertIn("EventLifecycleManager._lock", body)
+        self.assertIn("EventStream._lock", body)
+
+
+class TestCursorEndpoint9873A(unittest.TestCase):
+    """#9873-A: GET /events/cursor/{role} — AC-3, AC-4."""
+
+    @classmethod
+    def setUpClass(cls):
+        from fastapi.testclient import TestClient
+        from harness import app
+        cls.client = TestClient(app, raise_server_exceptions=False)
+
+    def test_ac3_null_cursor_returns_200(self):
+        """AC-3: no cursor for role → 200 with {cursor: null, role}."""
+        from harness import event_lifecycle
+        # Ensure no cursor for an arbitrary valid role
+        event_lifecycle._cursors.pop("skill", None)
+        with patch("harness.boot_remote._get_all_roles", return_value=["skill"]):
+            resp = self.client.get("/events/cursor/skill")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"cursor": None, "role": "skill"})
+
+    def test_ac4_present_cursor_returns_value(self):
+        """AC-4: cursor set → 200 with the cursor value."""
+        from harness import event_lifecycle
+        event_lifecycle._cursors["skill"] = "evt-xyz"
+        try:
+            with patch("harness.boot_remote._get_all_roles", return_value=["skill"]):
+                resp = self.client.get("/events/cursor/skill")
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.json(), {"cursor": "evt-xyz", "role": "skill"})
+        finally:
+            event_lifecycle._cursors.pop("skill", None)
+
+    def test_unknown_role_returns_404(self):
+        """_validate_role still rejects unknown roles."""
+        with patch("harness.boot_remote._get_all_roles", return_value=["skill"]):
+            resp = self.client.get("/events/cursor/bogus")
+        self.assertEqual(resp.status_code, 404)
+
+
 class TestTerminalPidInAgentState(unittest.TestCase):
     """#7630 P-6: terminal_pid in AgentState."""
 


### PR DESCRIPTION
Closes #9873.

## Scope

#9873-A foundation slice per `.squidsquad/pm/planning/CONTEXT-9873-A.md` + `CONTEXT-9873-A-R2.md`. R2 supersedes the original on F1/F3/F4/F5/F6/F7. All 19 ACs covered (AC-1..AC-19 across original §3 + R2 §3).

Three tightly coupled changes:

1. **Harness-owned cursor state** — `EventLifecycleManager._cursors: dict[str, str]` persisted under `"cursors"` key in `.event-state.json`; `load()` uses `data.get("cursors", {})` for backward-compat with pre-migration state files (F5 / AC-1).
2. **`GET /events/cursor/{role}` endpoint** — lock-free dict read (F1 / R2 D5 / AC-3): CPython `dict.get()` is atomic. Returns `{cursor, role}`, 200 always; 404 only for unknown roles via `_validate_role` (AC-3, AC-4).
3. **Ack event-type split + handler** — `ack` → `ack-cursor` + `ack-stop` in EMITTED tier of `event_catalog.py` (D6 / AC-5, AC-6). Inline handler at `harness.py:1533-1558` split into two branches:
   - `ack-cursor`: calls `advance_cursor` off the asyncio loop via `asyncio.to_thread` (D4 / AC-9). **Does NOT call `event_lifecycle.ack()`** per R2 D9 / AC-18 (dead code since #9741 stripped dispatch).
   - `ack-stop`: preserves stop-confirmed behavior verbatim per D6 / AC-12.

## Implementation

| File | Change |
|------|--------|
| `references/scripts/harness.py` | `EventStream.has_event()` (AC-15) + `find_positions()` for the single-pass regression check (D15 / AC-17); `EventLifecycleManager._cursors` + `get_cursor` (lock-free) + `advance_cursor` (eviction check via `has_event` AC-16, then regression check via `find_positions` AC-17, then advance + persist); extended `_persist` / `load` for `"cursors"` key; new `GET /events/cursor/{role}` endpoint; ack handler split. |
| `references/scripts/event_catalog.py` | Old `"ack"` RECOGNIZED entry **removed**. New `"ack-cursor"` and `"ack-stop"` EMITTED entries with locked payload schemas. |
| `references/scripts/event_bus.py` | New `ack_cursor(event_id, role)` and `ack_stop(event_id, result)` helpers. ack_stop reads role from `SQUIDSQUAD_ROLE` env var (D10's locked signature has no role param). |
| `tests/test_harness.py` | New `TestCursorState9873A` (15 cases) + `TestCursorEndpoint9873A` (3 cases). Covers AC-1, AC-2, AC-7, AC-8, AC-9, AC-15, AC-16, AC-17 (3 cases incl. edges), AC-18, AC-19 + null/regression/eviction paths. |
| `tests/test_event_bus.py` | `TestAckCursor` (4 cases) + `TestAckStop` (4 cases) — AC-10 / AC-11 incl. empty-arg and role-env-unset paths. |
| `tests/test_event_catalog.py` | `TestAckEventTypes9873A` (4 cases) — AC-5 / AC-6. Updated `TestCatalogCompleteness` to drop `"ack"` from RECOGNIZED expectations. |
| `tests/comprehension/9873_spec.json` | CQ spec covering ack-cursor payload, ack-stop payload, and cursor endpoint null/non-null shapes (AC-13). |

## Lock-ordering audit (R2 §4 / AC-19)

**No reverse-order acquisition found.** Verified ordering is **outer `EventLifecycleManager._lock` → inner `EventStream._lock`**, matching the established pattern at the existing `_persist()` (`self._lock` → `self._stream.get_recent(200)`). All inner-lock acquirers (`has_event`, `find_positions`, `get_recent`, etc.) are self-contained and do not call back into the outer manager. The audit comment ships on `advance_cursor`.

## Compose pipeline (D12 / AC-14)

Ran `compose.py deploy {pm,skill,qa,dm}` — all four succeeded. `tests/comprehension/8697_fixtures/*_events_CLAUDE.md` not regenerated because **no sub-skill fragment changed** — the catalog/endpoint/bus changes are runtime-script changes only, not L1-L4 instruction fragments. `git status` after deploy confirms zero diff in `.squidsquad/<role>/CLAUDE.md` or `8697_fixtures/`.

## Tests

- `tests/test_harness.py::TestCursorState9873A` + `TestCursorEndpoint9873A`: **18 passed in 0.74s**
- `tests/test_event_bus.py` + `tests/test_event_catalog.py`: **47 passed in 6.84s** (includes my 12 new cases + the updated `TestCatalogCompleteness`)
- `tests/test_harness.py::TestEventLifecycleManager` + `TestEventDrivenPhase4` + `TestEndpointsViaTestClient`: **33 passed in 1.04s** — no regression on existing event-lifecycle tests.

The full `pytest tests/` run hangs at ~31% on a pre-existing test (reproducible on `main` without these changes — same wedge pattern observed in prior cycles; not a regression).

## Out of scope (deferred per CONTEXT §4)

- **-B** (event_poll.py nudge-only) — issue stays separate
- **-C** (agent contract — when/how to emit ack-cursor)
- **-D / -E / -F** (subloop / re-nudge / TUI)
- F2 vault note update — PM follow-up (R2 §5)