### PR TITLE
skill: #9898 — event_poll.py: emit before advancing cursor (at-least-once contract)

### DIFF
--- a/references/scripts/event_poll.py
+++ b/references/scripts/event_poll.py
@@ -261,6 +261,27 @@ def poll(role, since=None, limit=50, target_mode=False,
                     print(f"WARNING: event has no id; skipping: {event!r}",
                           file=sys.stderr)
                     continue
+                # #9898: emit BEFORE advancing the cursor. Previously the
+                # order was reversed — cursor advanced, then print(). A crash
+                # between the two (most plausibly BrokenPipeError from the
+                # flushed print when Monitor's downstream pipe drops) would
+                # leave the cursor past an unemitted event → silent loss
+                # (at-most-once with no consumer-side recovery).
+                #
+                # Emit-then-advance makes the contract at-least-once: a crash
+                # between print() and _write_cursor_atomic() means the next
+                # poll re-fetches the just-emitted event, which Monitor /
+                # downstream consumers can dedupe by event id. Idempotent
+                # consumers are already required by the #9740 eviction-
+                # re-anchor path (where the cursor moves to oldest_id while
+                # earlier events in the same batch were already emitted), so
+                # this is not a new requirement on consumers — it's the
+                # contract this poll loop was already implicitly relying on.
+                #
+                # When #9873-B lands, this whole branch is replaced by an
+                # ack-cursor emit to the harness. Until then this ordering
+                # closes the loss window.
+                print(json.dumps(event), flush=True)
                 if not _write_cursor_atomic(role, str(event_id)):
                     # Cursor advance failed (disk full / permission). Return
                     # None so callers treat this like any other fatal error
@@ -268,7 +289,6 @@ def poll(role, since=None, limit=50, target_mode=False,
                     # intervention required — silently looping at HTTP-rate
                     # would burn CPU and re-fetch the same events forever.
                     return None
-                print(json.dumps(event), flush=True)
             # #9740: eviction re-anchor (post-loop). Only write `oldest_id`
             # when the batch was empty AFTER role-filtering — otherwise the
             # per-event advance above has already left the cursor at a valid

--- a/tests/test_event_poll.py
+++ b/tests/test_event_poll.py
@@ -402,11 +402,13 @@ class TestCursorAdvancement:
         monkeypatch.setattr(event_poll.urllib.request, "urlopen", fake)
         event_poll.poll("skill", sleep=no_sleep)
 
-        # write e1, print e1, write e2, print e2, write e3, print e3
+        # #9898: emit-before-advance — print e1, write e1, print e2, ...
+        # Per-event interleaving still holds (the cursor advances after each
+        # event, not once per batch); only the within-event order changed.
         assert ops == [
-            ("write", "e1"), ("print", "e1"),
-            ("write", "e2"), ("print", "e2"),
-            ("write", "e3"), ("print", "e3"),
+            ("print", "e1"), ("write", "e1"),
+            ("print", "e2"), ("write", "e2"),
+            ("print", "e3"), ("write", "e3"),
         ]
 
 
@@ -455,8 +457,11 @@ class TestHarnessUnreachable:
 
 class TestCursorWriteFailureGatesEmission:
     """Review iter-1 finding 1: silent cursor-write failure caused
-    re-delivery loops. Cursor write must (a) log to stderr and (b) gate
-    the print so we don't act on an event whose cursor was lost."""
+    re-delivery loops. Cursor write must (a) log to stderr and (b) still
+    abort the batch by returning None — but per #9898 the event is now
+    emitted BEFORE the cursor advances, so the first event of a batch IS
+    on stdout when the cursor write fails (at-least-once contract;
+    consumers must dedupe by event id)."""
 
     def test_write_failure_returns_false_and_logs(self, monkeypatch, tmp_path,
                                                    capsys):
@@ -469,9 +474,14 @@ class TestCursorWriteFailureGatesEmission:
         assert event_poll._write_cursor_atomic("skill", "x") is False
         assert "cursor write failed" in capsys.readouterr().err
 
-    def test_poll_skips_print_when_cursor_write_fails(
+    def test_poll_emits_first_event_before_cursor_write_fails(
         self, monkeypatch, stub_port, stub_cursor, capsys, no_sleep,
     ):
+        """#9898: emit-before-advance — when cursor write fails for the
+        first event in a batch, that event has already been emitted to
+        stdout. Subsequent events in the batch are NOT emitted because
+        poll() returns None on the cursor failure.
+        """
         import builtins
         monkeypatch.setattr(event_poll, "_write_cursor_atomic",
                             lambda r, c: False)
@@ -487,8 +497,11 @@ class TestCursorWriteFailureGatesEmission:
         fake, _ = _make_urlopen([[{"id": "e1"}, {"id": "e2"}]])
         monkeypatch.setattr(event_poll.urllib.request, "urlopen", fake)
         event_poll.poll("skill", sleep=no_sleep)
-        # First event's cursor advance fails → no events printed at all
-        assert stdout_lines == []
+        # First event IS emitted (emit-before-advance). Second event is NOT
+        # emitted — poll() returned None on the cursor failure for e1.
+        # Consumer dedupes the re-delivered e1 on the next poll by id.
+        assert len(stdout_lines) == 1
+        assert json.loads(stdout_lines[0])["id"] == "e1"
 
     def test_poll_returns_none_when_cursor_fails(
         self, monkeypatch, stub_port, stub_cursor, no_sleep,
@@ -501,6 +514,54 @@ class TestCursorWriteFailureGatesEmission:
         fake, _ = _make_urlopen([[{"id": "e1"}]])
         monkeypatch.setattr(event_poll.urllib.request, "urlopen", fake)
         assert event_poll.poll("skill", sleep=no_sleep) is None
+
+
+class TestEmitBeforeAdvance9898:
+    """#9898: per-event loop emits to stdout BEFORE advancing the cursor.
+
+    The previous order (cursor advance first, then print) was at-most-once
+    with no consumer-side recovery — a crash between the two operations
+    (most plausibly BrokenPipeError on the flushed print) left the cursor
+    past an unemitted event. The new order is at-least-once: a crash
+    between print and cursor-advance means the next poll re-fetches the
+    just-emitted event, which the consumer can dedupe by id.
+    """
+
+    def test_print_called_before_cursor_write(
+        self, monkeypatch, stub_port, stub_cursor, capsys, no_sleep,
+    ):
+        """Capture the call order: each event's print(json.dumps(event))
+        on stdout must happen BEFORE its _write_cursor_atomic call."""
+        import builtins
+        call_log = []
+        real_print = builtins.print
+
+        def _spy_print(*args, **kwargs):
+            if kwargs.get("file") is not sys.stderr:
+                # Stdout emit — record the event id
+                try:
+                    obj = json.loads(args[0])
+                    call_log.append(("emit", obj.get("id")))
+                except (ValueError, TypeError):
+                    pass
+            return real_print(*args, **kwargs)
+
+        def _spy_cursor(role, cursor):
+            call_log.append(("cursor", cursor))
+            return True
+
+        monkeypatch.setattr(builtins, "print", _spy_print)
+        monkeypatch.setattr(event_poll, "_write_cursor_atomic", _spy_cursor)
+        fake, _ = _make_urlopen([[{"id": "e1"}, {"id": "e2"}, {"id": "e3"}]])
+        monkeypatch.setattr(event_poll.urllib.request, "urlopen", fake)
+        event_poll.poll("skill", sleep=no_sleep)
+
+        # Each event's emit must come before its cursor advance.
+        assert call_log == [
+            ("emit", "e1"), ("cursor", "e1"),
+            ("emit", "e2"), ("cursor", "e2"),
+            ("emit", "e3"), ("cursor", "e3"),
+        ], call_log
 
 
 class TestEventWithoutId:


### PR DESCRIPTION
Closes #9898.

## Root cause

In the per-event loop at `event_poll.py:264-271`, the cursor advanced via `_write_cursor_atomic` **before** the event was emitted to stdout via `print(json.dumps(event), flush=True)`. If the script died between the two operations — most plausibly `BrokenPipeError` from the flushed print when Monitor's downstream pipe consumer exited, or a SIGTERM from thin_launcher — the cursor had already advanced past the unemitted event. On restart, the next poll skipped the lost event entirely. Silent event loss; at-most-once contract with no consumer-side recovery.

## Fix

Swap the order: emit first, then advance the cursor.

```python
print(json.dumps(event), flush=True)
if not _write_cursor_atomic(role, str(event_id)):
    return None
```

A crash between the two now means the next poll re-fetches the just-emitted event, which Monitor / downstream consumers can dedupe by id. At-least-once is the standard event-stream contract. The consumer-side idempotency requirement is **not new** — the existing #9740 eviction-re-anchor path already moves the cursor to `oldest_id` while earlier events in the same batch were already emitted, so consumers must already dedupe.

## When is this obsoleted?

When #9873-B (event_poll nudge-only) lands. -B replaces this whole branch with an explicit `ack-cursor` emit to the harness — proper two-phase ack using the cursor state I shipped in #9873-A (PR #9899, pending-test). Until -B lands, this swap closes the loss window.

## Tests

- `tests/test_event_poll.py::TestEmitBeforeAdvance9898::test_print_called_before_cursor_write` — captures the call order across multiple events; asserts `('emit', 'e1'), ('cursor', 'e1'), ('emit', 'e2'), ('cursor', 'e2'), ('emit', 'e3'), ('cursor', 'e3')`.
- `TestCursorWriteFailureGatesEmission::test_poll_emits_first_event_before_cursor_write_fails` — new positive test: when cursor write fails for the first event, that event IS on stdout; subsequent events are NOT (poll returned None). Replaces the prior `test_poll_skips_print_when_cursor_write_fails` which asserted the old at-most-once behavior.
- `TestCursorAdvancement::test_event_poll_cursor_advances_per_event_not_per_batch` — updated the expected ops list to reflect emit-first ordering (the per-event interleaving still holds; only the within-event order changed).

`pytest tests/test_event_poll.py` — **38 passed in 0.17s** (37 existing + 1 new).