### PR TITLE
skill: #9901 — harden cycle.py status_bar + consolidate 3 drifted copies

### DIFF
--- a/references/scripts/cycle.py
+++ b/references/scripts/cycle.py
@@ -64,14 +64,47 @@ def step_marker(message):
 
 
 def status_bar(role, phase, description=""):
-    """Write current-state atomically for status bar display."""
+    """Write current-state atomically for status bar display.
+
+    #9901: silent on failure — the status bar is cosmetic, so its write
+    must NEVER break a cycle. Defensive practices:
+
+    1. ``state_dir.mkdir(parents=True, exist_ok=True)`` so a first-ever
+       write for a role works even before cycle_pre has materialized the
+       directory (e.g., from tests or a fresh repo).
+    2. ``try / except OSError`` around the write+replace so transient I/O
+       failures (disk full, EBUSY on Windows, permission flap) don't
+       propagate. The function still returns the intended content so
+       callers and tests observe the contract; only the disk side-effect
+       is best-effort.
+
+    Replaces the two drifted private copies in ``cycle_pre.py`` and
+    ``cycle_post.py`` — those modules now import this function.
+    """
     state_dir = SQUIDSQUAD_DIR / role
     tmp_path = state_dir / "current-state.tmp"
     final_path = state_dir / "current-state"
 
     content = f"{phase}|{description}" if description else f"{phase}|"
-    tmp_path.write_text(content, encoding="utf-8")
-    tmp_path.replace(final_path)
+    try:
+        state_dir.mkdir(parents=True, exist_ok=True)
+        tmp_path.write_text(content, encoding="utf-8")
+        tmp_path.replace(final_path)
+    except OSError as e:
+        # Cosmetic write — failures must not break the cycle, but log to
+        # stderr so persistent issues don't go unnoticed. Best-effort cleanup
+        # of the `.tmp` file: if write_text succeeded but replace failed,
+        # the tmp would otherwise leak until the next successful write
+        # overwrites it (Windows file-lock on current-state is the realistic
+        # failure mode for the replace step).
+        print(
+            f"WARNING: status_bar write failed for {role}/{phase}: {e}",
+            file=sys.stderr,
+        )
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
     return content
 
 

--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -117,15 +117,17 @@ def _timestamp_short():
 
 
 def _write_status_bar(role, phase, description):
-    """Write status bar state atomically."""
-    state_file = SQUID_DIR / role / "current-state"
-    tmp_file = state_file.with_suffix(".tmp")
-    content = f"{phase}|{description}"
-    try:
-        tmp_file.write_text(content, encoding="utf-8")
-        tmp_file.replace(state_file)
-    except OSError:
-        pass
+    """Write status bar state atomically.
+
+    #9901: delegates to ``cycle.status_bar``, the single source of truth.
+    Previously this was a drifted private copy that lacked the mkdir
+    defensive practice; now there is one implementation and three
+    callers route through it.
+    """
+    if str(SCRIPT_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPT_DIR))
+    from cycle import status_bar
+    status_bar(role, phase, description)
 
 
 # ---------------------------------------------------------------------------

--- a/references/scripts/cycle_pre.py
+++ b/references/scripts/cycle_pre.py
@@ -93,15 +93,17 @@ def _config_get_int(field, default=0):
 
 
 def _write_status_bar(role, phase, description):
-    """Write status bar state atomically."""
-    state_file = SQUID_DIR / role / "current-state"
-    tmp_file = state_file.with_suffix(".tmp")
-    content = f"{phase}|{description}"
-    try:
-        tmp_file.write_text(content, encoding="utf-8")
-        tmp_file.replace(state_file)
-    except OSError:
-        pass
+    """Write status bar state atomically.
+
+    #9901: delegates to ``cycle.status_bar``, the single source of truth.
+    Previously this was a drifted private copy that lacked the mkdir
+    defensive practice; now there is one implementation and three
+    callers route through it.
+    """
+    if str(SCRIPT_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPT_DIR))
+    from cycle import status_bar
+    status_bar(role, phase, description)
 
 
 def _timestamp():

--- a/tests/test_cycle.py
+++ b/tests/test_cycle.py
@@ -56,6 +56,101 @@ class TestStatusBar:
             result = cycle.status_bar("skill", "idle")
         assert result == "idle|"
 
+    def test_missing_role_dir_does_not_raise_9901(self, tmp_path):
+        """#9901: status_bar must mkdir the role dir if absent. Previously
+        the missing-dir case crashed the agent on its first cosmetic write."""
+        # No role_dir created; SQUIDSQUAD_DIR exists but skill/ does not
+        with patch.object(cycle, "SQUIDSQUAD_DIR", tmp_path):
+            result = cycle.status_bar("skill", "implementing", "#1 fresh...")
+        assert result == "implementing|#1 fresh..."
+        state = (tmp_path / "skill" / "current-state").read_text(encoding="utf-8")
+        assert state == "implementing|#1 fresh..."
+
+    def test_disk_failure_does_not_raise_9901(self, tmp_path, monkeypatch, capsys):
+        """#9901: any OSError on the write+replace path is swallowed.
+        Function still returns the intended content so callers and tests
+        observe the contract; only the disk side-effect is best-effort.
+
+        Also asserts the failure is logged to stderr (DS finding 2) so
+        persistent issues don't go unnoticed — silent on the exception
+        path but NOT silent on the diagnostic.
+        """
+        (tmp_path / "skill").mkdir()
+
+        def _boom(self, *args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(Path, "write_text", _boom)
+        with patch.object(cycle, "SQUIDSQUAD_DIR", tmp_path):
+            # Must not raise — caller must keep cycling on cosmetic-write failure.
+            result = cycle.status_bar("skill", "implementing", "#9 fail-soft")
+        assert result == "implementing|#9 fail-soft"
+        # DS finding 2: write failure must log to stderr (observability).
+        err = capsys.readouterr().err
+        assert "status_bar write failed" in err
+        assert "skill" in err and "implementing" in err
+
+    def test_mkdir_failure_does_not_raise_9901(self, tmp_path, monkeypatch, capsys):
+        """#9901 (DS finding 4): an OSError from mkdir must be swallowed and
+        logged. Previously only the write_text failure path was tested."""
+
+        def _boom_mkdir(self, *args, **kwargs):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "mkdir", _boom_mkdir)
+        with patch.object(cycle, "SQUIDSQUAD_DIR", tmp_path):
+            result = cycle.status_bar("skill", "implementing", "mkdir-boom")
+        assert result == "implementing|mkdir-boom"
+        assert "status_bar write failed" in capsys.readouterr().err
+
+    def test_replace_failure_does_not_raise_9901(self, tmp_path, monkeypatch, capsys):
+        """#9901 (DS finding 3+4): an OSError from Path.replace (e.g. Windows
+        file-lock on current-state) must be swallowed, logged, AND the orphan
+        `.tmp` file cleaned up — otherwise a persistent replace-failure would
+        accumulate garbage."""
+        role_dir = tmp_path / "skill"
+        role_dir.mkdir()
+
+        def _boom_replace(self, *args, **kwargs):
+            raise OSError("file locked")
+
+        monkeypatch.setattr(Path, "replace", _boom_replace)
+        with patch.object(cycle, "SQUIDSQUAD_DIR", tmp_path):
+            result = cycle.status_bar("skill", "implementing", "replace-boom")
+        assert result == "implementing|replace-boom"
+        assert "status_bar write failed" in capsys.readouterr().err
+        # DS finding 3: orphan .tmp must be cleaned up after replace failure.
+        # The cleanup unlink() in status_bar's except block does not use
+        # replace, so it runs successfully even with replace patched.
+        tmp_file = role_dir / "current-state.tmp"
+        assert not tmp_file.exists(), (
+            f"Orphan .tmp file leaked after replace failure: {tmp_file}"
+        )
+
+    def test_consolidation_cycle_pre_delegates_9901(self, tmp_path):
+        """#9901: cycle_pre._write_status_bar is a thin shim that delegates
+        to cycle.status_bar — no separate logic to drift."""
+        sys.path.insert(0, str(SCRIPTS))
+        import cycle_pre
+        (tmp_path / "skill").mkdir()
+        with patch.object(cycle, "SQUIDSQUAD_DIR", tmp_path):
+            cycle_pre._write_status_bar("skill", "pulling", "via shim")
+        assert (tmp_path / "skill" / "current-state").read_text(
+            encoding="utf-8"
+        ) == "pulling|via shim"
+
+    def test_consolidation_cycle_post_delegates_9901(self, tmp_path):
+        """#9901: cycle_post._write_status_bar is a thin shim that delegates
+        to cycle.status_bar — single source of truth for the write logic."""
+        sys.path.insert(0, str(SCRIPTS))
+        import cycle_post
+        (tmp_path / "skill").mkdir()
+        with patch.object(cycle, "SQUIDSQUAD_DIR", tmp_path):
+            cycle_post._write_status_bar("skill", "committing", "via shim")
+        assert (tmp_path / "skill" / "current-state").read_text(
+            encoding="utf-8"
+        ) == "committing|via shim"
+
 
 class TestStatusBarSelf:
     """#9747: status-bar-self derives role from SQUIDSQUAD_ROLE env."""

--- a/tests/test_cycle_post.py
+++ b/tests/test_cycle_post.py
@@ -11,6 +11,10 @@ SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 import cycle_post
+# #9901: cycle_post._write_status_bar now delegates to cycle.status_bar, which
+# uses cycle.SQUIDSQUAD_DIR — patching only cycle_post.SQUID_DIR would let
+# writes escape to the real repo. Import cycle here so patch_dirs can patch it.
+import cycle
 
 
 # ---------------------------------------------------------------------------
@@ -29,9 +33,18 @@ def squid_dir(tmp_path):
 
 @pytest.fixture
 def patch_dirs(squid_dir, tmp_path, monkeypatch):
-    """Patch REPO_ROOT and SQUID_DIR to use tmp_path."""
+    """Patch REPO_ROOT and SQUID_DIR to use tmp_path.
+
+    #9901: also patch ``cycle.SQUIDSQUAD_DIR`` because
+    ``cycle_post._write_status_bar`` now delegates to ``cycle.status_bar``,
+    which reads from ``cycle.SQUIDSQUAD_DIR``. Without this patch, tests
+    that exercise status-bar writes pollute the real repo's
+    ``.squidsquad/<role>/current-state`` files (DeepSeek finding 1+5).
+    """
     monkeypatch.setattr(cycle_post, "REPO_ROOT", tmp_path)
     monkeypatch.setattr(cycle_post, "SQUID_DIR", squid_dir)
+    monkeypatch.setattr(cycle, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(cycle, "SQUIDSQUAD_DIR", squid_dir)
     return tmp_path
 
 


### PR DESCRIPTION
Closes #9901

### Summary

cycle.status_bar had three drifted copies of the same write logic in cycle.py, cycle_pre.py, and cycle_post.py. On first-spawn or disk error, the missing role-dir + unhandled OSError crashed the agent. This PR consolidates the writers into a single hardened implementation in cycle.py, and cycle_pre._write_status_bar / cycle_post._write_status_bar become thin shims.

### Acceptance Criteria

- [x] Single canonical writer in cycle.status_bar — cycle_pre and cycle_post delegate
- [x] mkdir(parents=True, exist_ok=True) ensures role-dir exists on first spawn
- [x] All OSError paths swallowed and logged to stderr (role + phase + exception)
- [x] Orphan .tmp file cleanup after replace failure (with guarded unlink)
- [x] Unit tests cover write/mkdir/replace failure paths

### Changes

- **Files**: references/scripts/cycle.py, cycle_post.py, cycle_pre.py, tests/test_cycle.py, tests/test_cycle_post.py
- **What**: 3 drifted writers consolidated into one; mkdir guard; stderr diagnostic; orphan .tmp cleanup; 5 new failure-path tests; test fixture now patches cycle.SQUIDSQUAD_DIR + cycle.REPO_ROOT to prevent live-state pollution
- **Why**: prevent agent crash on first spawn / transient disk error; eliminate write-logic drift

### QA Status

- [x] Unit tests passing (50/50 in python tests/run_tests.py)
- [x] DS pass-1 review applied (5 findings: 1 error + 4 warns — all fixed)
- [x] DS pass-2 fallback via Claude subagent: all pass-1 fixes verified, 1 cosmetic WARN fixed (N1 vestigial code), 1 INFO justified-ignored (N2 harmless always-true guard)
- [ ] QA acceptance criteria verification