### PR TITLE
fix #9927 — model_router.py setup_provider: platform.system() -> sys.platform (close #9903 sweep gap)

### DIFF
--- a/references/scripts/model_router.py
+++ b/references/scripts/model_router.py
@@ -903,11 +903,13 @@ def setup_provider(provider_name):
     print(f"\nManifest file: {manifest_path}")
     print("Opening manifest in editor...")
     try:
-        import platform as plat
-        system = plat.system().lower()
-        if system == "windows":
+        # #9927: use sys.platform (compile-time constant) instead of
+        # platform.system() — the latter triggers a WMI query on Windows
+        # that can hang indefinitely (#9903 root cause, swept across 6
+        # other files in e7a47737 but this call site was missed).
+        if sys.platform == "win32":
             os.startfile(str(manifest_path))
-        elif system == "darwin":
+        elif sys.platform == "darwin":
             subprocess.Popen(["open", str(manifest_path)])
         else:
             subprocess.Popen(["xdg-open", str(manifest_path)])

--- a/tests/test_model_router.py
+++ b/tests/test_model_router.py
@@ -735,3 +735,78 @@ class TestEnsureYaml:
         # Should only appear inside _ensure_yaml (2 times: try + after install)
         assert len(import_lines) <= 2, \
             f"Found {len(import_lines)} bare 'import yaml' lines — should be ≤2 (inside _ensure_yaml only)"
+
+
+# ---------------------------------------------------------------------------
+# #9927 / #9903 Windows-WMI wedge surface — no platform.system() calls
+# ---------------------------------------------------------------------------
+
+
+class TestNoPlatformSystem9927:
+    """#9927: model_router.py must not call ``platform.system()`` — that
+    API triggers a WMI query on Windows that can hang indefinitely
+    (#9903 root cause). Commit ``e7a47737`` swept the pattern across six
+    other files but missed ``setup_provider`` in this module. This test
+    locks that regression closed.
+    """
+
+    def test_no_platform_system_calls(self):
+        """No executable ``platform.system()`` call (direct or aliased)
+        anywhere in the module. AST-based check ignores comments and
+        docstrings (which legitimately mention the API when documenting
+        why it's been removed).
+        """
+        import ast
+        source_path = model_router.SCRIPT_DIR / "model_router.py"
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+
+        # Collect every `import platform [as <alias>]` to know what name
+        # to flag in subsequent attribute access.
+        platform_aliases = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for n in node.names:
+                    if n.name == "platform":
+                        platform_aliases.add(n.asname or n.name)
+
+        # No platform import at all is the strongest invariant.
+        assert not platform_aliases, (
+            f"`import platform` detected in model_router.py "
+            f"(aliases: {platform_aliases}) — the module must not depend "
+            f"on the `platform` stdlib (#9927). Use sys.platform for OS "
+            f"branching to avoid the Windows-WMI wedge (#9903)."
+        )
+
+        # Defense in depth: even if a future change re-adds `import platform`
+        # in a way this test misses, also reject `.system(` calls on any
+        # name that walks like a platform module attribute.
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                if node.func.attr == "system" and isinstance(node.func.value, ast.Name):
+                    name = node.func.value.id
+                    # os.system is also unwelcome here (no shell execution
+                    # in this module), but the specific WMI wedge target
+                    # is platform.system(). Flag both for safety.
+                    assert name not in ("platform",) and name not in platform_aliases, (
+                        f"Call to {name}.system() at line {node.lineno} — "
+                        f"this is the #9903 WMI wedge surface. Use sys.platform."
+                    )
+
+    def test_setup_provider_uses_sys_platform(self):
+        """The specific call site (``setup_provider``) — the one that
+        was missed by ``e7a47737`` — must branch on ``sys.platform``."""
+        import inspect
+        source = inspect.getsource(model_router.setup_provider)
+        assert "sys.platform" in source, (
+            "setup_provider must branch on sys.platform for cross-platform "
+            "editor opening — using platform.system() instead would re-open "
+            "the #9903 WMI wedge surface."
+        )
+        # And specifically check the win32 branch is present (the Windows
+        # branch is the one whose absence would be most painful — startfile
+        # is the only way to open a file in the default editor on Windows).
+        assert 'sys.platform == "win32"' in source or \
+               "sys.platform == 'win32'" in source, (
+            "setup_provider must specifically check sys.platform == 'win32' "
+            "for the os.startfile() branch (Windows editor open)."
+        )


### PR DESCRIPTION
Closes-via-tracker: #9927

Drive-by cleanup of the one call site that `e7a47737` missed when sweeping `platform.system()` across the codebase for #9903. `setup_provider` in `model_router.py` is gated behind a user-invoked CLI subcommand, so it's not a routine-path blocker — but the wedge vulnerability is identical to #9903 and worth closing for hygiene + to avoid a future repeat report.

## Fix

`references/scripts/model_router.py:902-916` — removed `import platform as plat` + `plat.system().lower()` branching, replaced with direct `sys.platform == "win32" / "darwin"` checks. `sys` was already imported at module top; the local `platform` import is gone entirely. Behavior is unchanged (`os.startfile` on Windows, `open` on macOS, `xdg-open` elsewhere) — only the WMI syscall surface goes away.

## Tests

New class `TestNoPlatformSystem9927` (2 cases, both passing):

1. `test_no_platform_system_calls` — AST-based scan: asserts (a) zero `import platform [as <alias>]` statements anywhere in the module, and (b) zero `.system()` calls on any platform alias. AST-based so it ignores docstring/comment mentions (a substring scan false-positives on the new explanatory comment that names the removed API). Future drive-by adds of `import platform` will trip this test.
2. `test_setup_provider_uses_sys_platform` — `inspect.getsource(setup_provider)` + assert `sys.platform == "win32"` branch is present. Locks the specific call site that was missed by `e7a47737`.

## Regression

- `pytest tests/test_model_router.py` → **85 passed in 0.31s** (was 83 pre-fix, +2 new tests).

No scope expansion. The other findings noted in cycle 1254's scan-history (e.g., `_grep_python` not excluding heavy dirs) were classified as performance-only, not filed as defects, and are not addressed here.