### PR TITLE
fix #9930 — state_bus.commit_and_push: credential override + timeout + rebase pull (close push-wedge loop)

### DIFF
--- a/.deepseek-9930.diff
+++ b/.deepseek-9930.diff
@@ -1,0 +1,277 @@
+diff --git a/references/scripts/state_bus.py b/references/scripts/state_bus.py
+index d8c05fbf..c1f0b761 100644
+--- a/references/scripts/state_bus.py
++++ b/references/scripts/state_bus.py
+@@ -32,13 +32,45 @@ STATE_WORKTREE = REPO_ROOT / ".squidsquad-state"
+ DEFAULT_WORKING_BRANCH = "stag"
+ DEFAULT_STATE_BRANCH = "squid-squad"
+ 
+-
+-def _run(cmd, check=True, cwd=None):
+-    """Run a git command. Returns CompletedProcess."""
+-    return subprocess.run(
+-        cmd, capture_output=True, text=True, check=check,
+-        cwd=cwd or str(REPO_ROOT),
+-    )
++# #9930: bound git operations so a wedged credential helper or network
++# blip can't hang commit_and_push forever. 120s is generous for normal
++# state-branch push/pull (typically <5s) but tight enough that the
++# 3-attempt retry loop can't burn more than ~6 minutes total.
++DEFAULT_GIT_TIMEOUT = 120
++
++# #9930: bypass credential.helper=manager (which hangs silently on
++# Windows — see memory note `feedback_git_push_credential_wedge`) by
++# delegating to `gh auth git-credential` for state-branch network ops.
++# The `!` prefix tells git to run the value as a shell command. We
++# apply this per-command via `git -c credential.helper=...` rather than
++# mutating the worktree's git config, so the workaround is scoped to
++# state_bus operations and other tools see whatever the user configured.
++_GH_CREDENTIAL_OVERRIDE = ["-c", "credential.helper=!gh auth git-credential"]
++
++
++def _run(cmd, check=True, cwd=None, timeout=None):
++    """Run a git command. Returns CompletedProcess.
++
++    #9930: ``timeout`` (seconds) bounds the call. On expiry, returns a
++    fake ``CompletedProcess`` with ``returncode=124`` (POSIX `timeout`
++    convention) instead of raising — every existing call site already
++    treats ``returncode != 0`` as failure, so a wedged ``git push`` now
++    converts a hang into a recoverable retry. Pass ``timeout=None``
++    (the default — preserves prior behavior) to opt out.
++    """
++    try:
++        return subprocess.run(
++            cmd, capture_output=True, text=True, check=check,
++            cwd=cwd or str(REPO_ROOT),
++            timeout=timeout,
++        )
++    except subprocess.TimeoutExpired as e:
++        msg = f"TIMEOUT after {timeout}s: {' '.join(str(c) for c in cmd)}"
++        print(f"  WARNING: {msg}", file=sys.stderr)
++        return subprocess.CompletedProcess(
++            args=cmd, returncode=124, stdout="",
++            stderr=(e.stderr.decode("utf-8", "replace") if isinstance(e.stderr, bytes) else (e.stderr or "")) + msg,
++        )
+ 
+ 
+ def _read_branch_config():
+@@ -251,17 +283,32 @@ def commit_and_push(message, role="unknown"):
+               file=sys.stderr)
+         return False
+ 
+-    # Push with retry (up to 3 attempts for concurrent conflicts)
++    # Push with retry (up to 3 attempts for concurrent conflicts).
++    # #9930: each git op is bounded by DEFAULT_GIT_TIMEOUT and uses the
++    # gh-credential override so credential.helper=manager can't wedge it.
++    # The pull is `--rebase` (not the default merge) so divergence keeps
++    # history linear instead of accumulating merge commits — a previous
++    # default-merge pull was creating `Merge branch 'squid-squad'` commits
++    # on every concurrent-write cycle.
+     for attempt in range(3):
+         result = _run(
+-            ["git", "push", "origin", state_branch],
+-            cwd=cwd, check=False,
++            ["git"] + _GH_CREDENTIAL_OVERRIDE +
++            ["push", "origin", state_branch],
++            cwd=cwd, check=False, timeout=DEFAULT_GIT_TIMEOUT,
+         )
+         if result.returncode == 0:
+             return True
+-        # Pull and retry
+-        _run(["git", "pull", "origin", state_branch],
+-             cwd=cwd, check=False)
++        # Pull --rebase and retry. If the rebase itself fails (true
++        # conflict), abort it so the next iteration starts from a clean
++        # worktree — leaving a half-rebased state would make `git push`
++        # fail in a worse way on the next attempt.
++        pull_result = _run(
++            ["git"] + _GH_CREDENTIAL_OVERRIDE +
++            ["pull", "--rebase", "origin", state_branch],
++            cwd=cwd, check=False, timeout=DEFAULT_GIT_TIMEOUT,
++        )
++        if pull_result.returncode != 0:
++            _run(["git", "rebase", "--abort"], cwd=cwd, check=False)
+ 
+     print(f"WARNING: State push failed after 3 attempts", file=sys.stderr)
+     return False
+diff --git a/tests/test_state_bus.py b/tests/test_state_bus.py
+index fb5214cd..1afb8c3f 100644
+--- a/tests/test_state_bus.py
++++ b/tests/test_state_bus.py
+@@ -303,3 +303,176 @@ class TestCommitAndPushFailedCommit:
+         ]
+         result = state_bus.commit_and_push("test msg", role="skill")
+         assert result is True
++
++
++# ---------------------------------------------------------------------------
++# #9930 — credential helper override + timeout + --rebase pull
++# ---------------------------------------------------------------------------
++
++
++class TestPushHardening9930:
++    """#9930: commit_and_push must (a) bypass credential.helper=manager
++    via `gh auth git-credential`, (b) bound every git op with a timeout
++    so a wedged helper can't hang the cycle, and (c) use `pull --rebase`
++    instead of default-merge so retry divergence keeps history linear.
++    """
++
++    def test_default_git_timeout_is_bounded(self):
++        """The default must be a positive finite value — not None."""
++        assert isinstance(state_bus.DEFAULT_GIT_TIMEOUT, (int, float))
++        assert 0 < state_bus.DEFAULT_GIT_TIMEOUT <= 600
++
++    def test_run_returns_124_on_timeout(self):
++        """`_run` must catch TimeoutExpired and return CompletedProcess
++        with returncode=124 — never raise — so existing
++        `if result.returncode != 0` paths degrade gracefully.
++        """
++        import subprocess
++        with patch.object(state_bus.subprocess, "run") as mock_sp:
++            mock_sp.side_effect = subprocess.TimeoutExpired(
++                cmd=["git", "push"], timeout=1
++            )
++            result = state_bus._run(["git", "push"], check=False, timeout=1)
++        assert result.returncode == 124
++        assert "TIMEOUT" in result.stderr
++
++    def test_run_passes_timeout_to_subprocess(self):
++        """`_run` forwards `timeout` to subprocess.run when set."""
++        import subprocess
++        captured = {}
++
++        def fake_sp(cmd, **kwargs):
++            captured.update(kwargs)
++            return subprocess.CompletedProcess(cmd, 0, "", "")
++
++        with patch.object(state_bus.subprocess, "run", side_effect=fake_sp):
++            state_bus._run(["git", "status"], check=False, timeout=42)
++        assert captured.get("timeout") == 42
++
++    def test_run_default_timeout_is_none_for_backcompat(self):
++        """`_run` without explicit timeout passes ``None`` — the
++        constructor signature change must NOT alter the behavior of
++        existing call sites that didn't ask for a bound."""
++        import subprocess
++        captured = {}
++
++        def fake_sp(cmd, **kwargs):
++            captured.update(kwargs)
++            return subprocess.CompletedProcess(cmd, 0, "", "")
++
++        with patch.object(state_bus.subprocess, "run", side_effect=fake_sp):
++            state_bus._run(["git", "status"], check=False)
++        assert captured.get("timeout") is None
++
++    @patch("state_bus._worktree_exists", return_value=True)
++    @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
++    @patch("state_bus._run")
++    def test_push_uses_gh_credential_override(self, mock_run, mock_config, mock_wt):
++        """The push command must include `-c credential.helper=!gh auth
++        git-credential` so credential.helper=manager (which hangs
++        silently on Windows) is bypassed for this network op.
++        """
++        mock_run.side_effect = [
++            MagicMock(stdout="", returncode=0),                 # add -A
++            MagicMock(stdout=" M file.md\n", returncode=0),     # status
++            MagicMock(stdout="", stderr="", returncode=0),      # commit
++            MagicMock(stdout="", returncode=0),                 # push (success)
++        ]
++        state_bus.commit_and_push("msg", role="skill")
++        # The 4th call is the push — inspect its command list.
++        push_call = mock_run.call_args_list[3]
++        cmd = push_call.args[0]
++        assert "credential.helper=!gh auth git-credential" in cmd, (
++            f"push command missing credential override: {cmd}"
++        )
++        assert "push" in cmd and "origin" in cmd
++
++    @patch("state_bus._worktree_exists", return_value=True)
++    @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
++    @patch("state_bus._run")
++    def test_push_bounded_by_default_timeout(self, mock_run, mock_config, mock_wt):
++        """Push call must pass `timeout=DEFAULT_GIT_TIMEOUT` so a
++        wedged credential helper can't hang indefinitely (the original
++        #9930 symptom)."""
++        mock_run.side_effect = [
++            MagicMock(stdout="", returncode=0),                 # add -A
++            MagicMock(stdout=" M file.md\n", returncode=0),     # status
++            MagicMock(stdout="", stderr="", returncode=0),      # commit
++            MagicMock(stdout="", returncode=0),                 # push
++        ]
++        state_bus.commit_and_push("msg", role="skill")
++        push_call = mock_run.call_args_list[3]
++        assert push_call.kwargs.get("timeout") == state_bus.DEFAULT_GIT_TIMEOUT
++
++    @patch("state_bus._worktree_exists", return_value=True)
++    @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
++    @patch("state_bus._run")
++    def test_retry_pull_uses_rebase(self, mock_run, mock_config, mock_wt):
++        """On push failure, the retry pull must use `--rebase` (not the
++        default merge) so divergent state-branch history stays linear
++        instead of accumulating `Merge branch 'squid-squad'` commits.
++        """
++        mock_run.side_effect = [
++            MagicMock(stdout="", returncode=0),                 # add -A
++            MagicMock(stdout=" M file.md\n", returncode=0),     # status
++            MagicMock(stdout="", stderr="", returncode=0),      # commit
++            MagicMock(stdout="", returncode=1),                 # push FAILS
++            MagicMock(stdout="", returncode=0),                 # pull --rebase
++            MagicMock(stdout="", returncode=0),                 # push retry SUCCEEDS
++        ]
++        state_bus.commit_and_push("msg", role="skill")
++        # 5th call should be the pull --rebase.
++        pull_call = mock_run.call_args_list[4]
++        cmd = pull_call.args[0]
++        assert "pull" in cmd
++        assert "--rebase" in cmd, f"retry pull missing --rebase: {cmd}"
++
++    @patch("state_bus._worktree_exists", return_value=True)
++    @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
++    @patch("state_bus._run")
++    def test_retry_pull_uses_credential_override(self, mock_run, mock_config, mock_wt):
++        """The retry pull is also a network op — it must use the same
++        credential override or it'd wedge on the same helper as push."""
++        mock_run.side_effect = [
++            MagicMock(stdout="", returncode=0),                 # add -A
++            MagicMock(stdout=" M file.md\n", returncode=0),     # status
++            MagicMock(stdout="", stderr="", returncode=0),      # commit
++            MagicMock(stdout="", returncode=1),                 # push FAILS
++            MagicMock(stdout="", returncode=0),                 # pull --rebase
++            MagicMock(stdout="", returncode=0),                 # push retry
++        ]
++        state_bus.commit_and_push("msg", role="skill")
++        pull_call = mock_run.call_args_list[4]
++        cmd = pull_call.args[0]
++        assert "credential.helper=!gh auth git-credential" in cmd
++
++    @patch("state_bus._worktree_exists", return_value=True)
++    @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
++    @patch("state_bus._run")
++    def test_rebase_abort_on_pull_failure(self, mock_run, mock_config, mock_wt):
++        """If the retry `pull --rebase` itself fails (e.g., real
++        conflict), the loop must `git rebase --abort` so the worktree
++        is left clean for the next attempt — leaving a half-rebased
++        state was part of the #9930 'leaked state across attempts' bug.
++        """
++        mock_run.side_effect = [
++            MagicMock(stdout="", returncode=0),                 # add -A
++            MagicMock(stdout=" M file.md\n", returncode=0),     # status
++            MagicMock(stdout="", stderr="", returncode=0),      # commit
++            MagicMock(stdout="", returncode=1),                 # push FAILS (1)
++            MagicMock(stdout="", returncode=1),                 # pull --rebase FAILS
++            MagicMock(stdout="", returncode=0),                 # rebase --abort
++            MagicMock(stdout="", returncode=0),                 # push retry SUCCEEDS (2)
++        ]
++        state_bus.commit_and_push("msg", role="skill")
++        # Check that one of the calls is `git rebase --abort`.
++        abort_seen = any(
++            (lambda cmd: "--abort" in cmd and "rebase" in cmd)(
++                c.args[0] if c.args else []
++            )
++            for c in mock_run.call_args_list
++        )
++        assert abort_seen, (
++            f"Expected `git rebase --abort` after failed pull --rebase, "
++            f"saw: {[c.args[0] for c in mock_run.call_args_list]}"
++        )

--- a/.deepseek-9930.out
+++ b/.deepseek-9930.out
@@ -1,0 +1,3 @@
+# STATUS: generating...
+# Task: 9930
+# Model: deepseek-v4-pro

--- a/references/scripts/state_bus.py
+++ b/references/scripts/state_bus.py
@@ -32,13 +32,45 @@ STATE_WORKTREE = REPO_ROOT / ".squidsquad-state"
 DEFAULT_WORKING_BRANCH = "stag"
 DEFAULT_STATE_BRANCH = "squid-squad"
 
+# #9930: bound git operations so a wedged credential helper or network
+# blip can't hang commit_and_push forever. 120s is generous for normal
+# state-branch push/pull (typically <5s) but tight enough that the
+# 3-attempt retry loop can't burn more than ~6 minutes total.
+DEFAULT_GIT_TIMEOUT = 120
 
-def _run(cmd, check=True, cwd=None):
-    """Run a git command. Returns CompletedProcess."""
-    return subprocess.run(
-        cmd, capture_output=True, text=True, check=check,
-        cwd=cwd or str(REPO_ROOT),
-    )
+# #9930: bypass credential.helper=manager (which hangs silently on
+# Windows — see memory note `feedback_git_push_credential_wedge`) by
+# delegating to `gh auth git-credential` for state-branch network ops.
+# The `!` prefix tells git to run the value as a shell command. We
+# apply this per-command via `git -c credential.helper=...` rather than
+# mutating the worktree's git config, so the workaround is scoped to
+# state_bus operations and other tools see whatever the user configured.
+_GH_CREDENTIAL_OVERRIDE = ["-c", "credential.helper=!gh auth git-credential"]
+
+
+def _run(cmd, check=True, cwd=None, timeout=None):
+    """Run a git command. Returns CompletedProcess.
+
+    #9930: ``timeout`` (seconds) bounds the call. On expiry, returns a
+    fake ``CompletedProcess`` with ``returncode=124`` (POSIX `timeout`
+    convention) instead of raising — every existing call site already
+    treats ``returncode != 0`` as failure, so a wedged ``git push`` now
+    converts a hang into a recoverable retry. Pass ``timeout=None``
+    (the default — preserves prior behavior) to opt out.
+    """
+    try:
+        return subprocess.run(
+            cmd, capture_output=True, text=True, check=check,
+            cwd=cwd or str(REPO_ROOT),
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as e:
+        msg = f"TIMEOUT after {timeout}s: {' '.join(str(c) for c in cmd)}"
+        print(f"  WARNING: {msg}", file=sys.stderr)
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=124, stdout="",
+            stderr=(e.stderr.decode("utf-8", "replace") if isinstance(e.stderr, bytes) else (e.stderr or "")) + msg,
+        )
 
 
 def _read_branch_config():
@@ -251,17 +283,32 @@ def commit_and_push(message, role="unknown"):
               file=sys.stderr)
         return False
 
-    # Push with retry (up to 3 attempts for concurrent conflicts)
+    # Push with retry (up to 3 attempts for concurrent conflicts).
+    # #9930: each git op is bounded by DEFAULT_GIT_TIMEOUT and uses the
+    # gh-credential override so credential.helper=manager can't wedge it.
+    # The pull is `--rebase` (not the default merge) so divergence keeps
+    # history linear instead of accumulating merge commits — a previous
+    # default-merge pull was creating `Merge branch 'squid-squad'` commits
+    # on every concurrent-write cycle.
     for attempt in range(3):
         result = _run(
-            ["git", "push", "origin", state_branch],
-            cwd=cwd, check=False,
+            ["git"] + _GH_CREDENTIAL_OVERRIDE +
+            ["push", "origin", state_branch],
+            cwd=cwd, check=False, timeout=DEFAULT_GIT_TIMEOUT,
         )
         if result.returncode == 0:
             return True
-        # Pull and retry
-        _run(["git", "pull", "origin", state_branch],
-             cwd=cwd, check=False)
+        # Pull --rebase and retry. If the rebase itself fails (true
+        # conflict), abort it so the next iteration starts from a clean
+        # worktree — leaving a half-rebased state would make `git push`
+        # fail in a worse way on the next attempt.
+        pull_result = _run(
+            ["git"] + _GH_CREDENTIAL_OVERRIDE +
+            ["pull", "--rebase", "origin", state_branch],
+            cwd=cwd, check=False, timeout=DEFAULT_GIT_TIMEOUT,
+        )
+        if pull_result.returncode != 0:
+            _run(["git", "rebase", "--abort"], cwd=cwd, check=False)
 
     print(f"WARNING: State push failed after 3 attempts", file=sys.stderr)
     return False

--- a/references/scripts/state_bus.py
+++ b/references/scripts/state_bus.py
@@ -35,7 +35,10 @@ DEFAULT_STATE_BRANCH = "squid-squad"
 # #9930: bound git operations so a wedged credential helper or network
 # blip can't hang commit_and_push forever. 120s is generous for normal
 # state-branch push/pull (typically <5s) but tight enough that the
-# 3-attempt retry loop can't burn more than ~6 minutes total.
+# 3-attempt retry loop bounds at ~12 minutes worst case (3 × 2 × 120s
+# for push + pull each, all timing out) — far better than the previous
+# unbounded hang. Corrected from the original ~6m comment after #9930
+# DS review F2.
 DEFAULT_GIT_TIMEOUT = 120
 
 # #9930: bypass credential.helper=manager (which hangs silently on
@@ -65,11 +68,16 @@ def _run(cmd, check=True, cwd=None, timeout=None):
             timeout=timeout,
         )
     except subprocess.TimeoutExpired as e:
+        # #9930 DS review F3+F4: preserve partial stdout (a pre-push hook
+        # may have printed diagnostics before the hang), and drop the
+        # dead `isinstance(e.stderr, bytes)` branch — with text=True
+        # above, e.stdout / e.stderr are always str | None.
         msg = f"TIMEOUT after {timeout}s: {' '.join(str(c) for c in cmd)}"
         print(f"  WARNING: {msg}", file=sys.stderr)
         return subprocess.CompletedProcess(
-            args=cmd, returncode=124, stdout="",
-            stderr=(e.stderr.decode("utf-8", "replace") if isinstance(e.stderr, bytes) else (e.stderr or "")) + msg,
+            args=cmd, returncode=124,
+            stdout=(e.stdout or ""),
+            stderr=(e.stderr or "") + msg,
         )
 
 
@@ -299,9 +307,9 @@ def commit_and_push(message, role="unknown"):
         if result.returncode == 0:
             return True
         # Pull --rebase and retry. If the rebase itself fails (true
-        # conflict), abort it so the next iteration starts from a clean
-        # worktree — leaving a half-rebased state would make `git push`
-        # fail in a worse way on the next attempt.
+        # conflict OR pull timeout), abort it so the next iteration
+        # starts from a clean worktree — leaving a half-rebased state
+        # would make `git push` fail in a worse way on the next attempt.
         pull_result = _run(
             ["git"] + _GH_CREDENTIAL_OVERRIDE +
             ["pull", "--rebase", "origin", state_branch],
@@ -309,6 +317,18 @@ def commit_and_push(message, role="unknown"):
         )
         if pull_result.returncode != 0:
             _run(["git", "rebase", "--abort"], cwd=cwd, check=False)
+            # #9930 DS review F1: if the pull timed out (returncode=124),
+            # the child `git fetch` may have left tmp packfiles or a
+            # FETCH_HEAD.lock behind — `rebase --abort` only cleans up
+            # rebase state. Prune remote-tracking refs so the next
+            # fetch starts from a clean slate. Bounded by the same
+            # timeout — defense in depth.
+            if pull_result.returncode == 124:
+                _run(
+                    ["git"] + _GH_CREDENTIAL_OVERRIDE +
+                    ["remote", "prune", "origin"],
+                    cwd=cwd, check=False, timeout=DEFAULT_GIT_TIMEOUT,
+                )
 
     print(f"WARNING: State push failed after 3 attempts", file=sys.stderr)
     return False

--- a/tests/test_state_bus.py
+++ b/tests/test_state_bus.py
@@ -303,3 +303,176 @@ class TestCommitAndPushFailedCommit:
         ]
         result = state_bus.commit_and_push("test msg", role="skill")
         assert result is True
+
+
+# ---------------------------------------------------------------------------
+# #9930 — credential helper override + timeout + --rebase pull
+# ---------------------------------------------------------------------------
+
+
+class TestPushHardening9930:
+    """#9930: commit_and_push must (a) bypass credential.helper=manager
+    via `gh auth git-credential`, (b) bound every git op with a timeout
+    so a wedged helper can't hang the cycle, and (c) use `pull --rebase`
+    instead of default-merge so retry divergence keeps history linear.
+    """
+
+    def test_default_git_timeout_is_bounded(self):
+        """The default must be a positive finite value — not None."""
+        assert isinstance(state_bus.DEFAULT_GIT_TIMEOUT, (int, float))
+        assert 0 < state_bus.DEFAULT_GIT_TIMEOUT <= 600
+
+    def test_run_returns_124_on_timeout(self):
+        """`_run` must catch TimeoutExpired and return CompletedProcess
+        with returncode=124 — never raise — so existing
+        `if result.returncode != 0` paths degrade gracefully.
+        """
+        import subprocess
+        with patch.object(state_bus.subprocess, "run") as mock_sp:
+            mock_sp.side_effect = subprocess.TimeoutExpired(
+                cmd=["git", "push"], timeout=1
+            )
+            result = state_bus._run(["git", "push"], check=False, timeout=1)
+        assert result.returncode == 124
+        assert "TIMEOUT" in result.stderr
+
+    def test_run_passes_timeout_to_subprocess(self):
+        """`_run` forwards `timeout` to subprocess.run when set."""
+        import subprocess
+        captured = {}
+
+        def fake_sp(cmd, **kwargs):
+            captured.update(kwargs)
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        with patch.object(state_bus.subprocess, "run", side_effect=fake_sp):
+            state_bus._run(["git", "status"], check=False, timeout=42)
+        assert captured.get("timeout") == 42
+
+    def test_run_default_timeout_is_none_for_backcompat(self):
+        """`_run` without explicit timeout passes ``None`` — the
+        constructor signature change must NOT alter the behavior of
+        existing call sites that didn't ask for a bound."""
+        import subprocess
+        captured = {}
+
+        def fake_sp(cmd, **kwargs):
+            captured.update(kwargs)
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        with patch.object(state_bus.subprocess, "run", side_effect=fake_sp):
+            state_bus._run(["git", "status"], check=False)
+        assert captured.get("timeout") is None
+
+    @patch("state_bus._worktree_exists", return_value=True)
+    @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
+    @patch("state_bus._run")
+    def test_push_uses_gh_credential_override(self, mock_run, mock_config, mock_wt):
+        """The push command must include `-c credential.helper=!gh auth
+        git-credential` so credential.helper=manager (which hangs
+        silently on Windows) is bypassed for this network op.
+        """
+        mock_run.side_effect = [
+            MagicMock(stdout="", returncode=0),                 # add -A
+            MagicMock(stdout=" M file.md\n", returncode=0),     # status
+            MagicMock(stdout="", stderr="", returncode=0),      # commit
+            MagicMock(stdout="", returncode=0),                 # push (success)
+        ]
+        state_bus.commit_and_push("msg", role="skill")
+        # The 4th call is the push — inspect its command list.
+        push_call = mock_run.call_args_list[3]
+        cmd = push_call.args[0]
+        assert "credential.helper=!gh auth git-credential" in cmd, (
+            f"push command missing credential override: {cmd}"
+        )
+        assert "push" in cmd and "origin" in cmd
+
+    @patch("state_bus._worktree_exists", return_value=True)
+    @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
+    @patch("state_bus._run")
+    def test_push_bounded_by_default_timeout(self, mock_run, mock_config, mock_wt):
+        """Push call must pass `timeout=DEFAULT_GIT_TIMEOUT` so a
+        wedged credential helper can't hang indefinitely (the original
+        #9930 symptom)."""
+        mock_run.side_effect = [
+            MagicMock(stdout="", returncode=0),                 # add -A
+            MagicMock(stdout=" M file.md\n", returncode=0),     # status
+            MagicMock(stdout="", stderr="", returncode=0),      # commit
+            MagicMock(stdout="", returncode=0),                 # push
+        ]
+        state_bus.commit_and_push("msg", role="skill")
+        push_call = mock_run.call_args_list[3]
+        assert push_call.kwargs.get("timeout") == state_bus.DEFAULT_GIT_TIMEOUT
+
+    @patch("state_bus._worktree_exists", return_value=True)
+    @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
+    @patch("state_bus._run")
+    def test_retry_pull_uses_rebase(self, mock_run, mock_config, mock_wt):
+        """On push failure, the retry pull must use `--rebase` (not the
+        default merge) so divergent state-branch history stays linear
+        instead of accumulating `Merge branch 'squid-squad'` commits.
+        """
+        mock_run.side_effect = [
+            MagicMock(stdout="", returncode=0),                 # add -A
+            MagicMock(stdout=" M file.md\n", returncode=0),     # status
+            MagicMock(stdout="", stderr="", returncode=0),      # commit
+            MagicMock(stdout="", returncode=1),                 # push FAILS
+            MagicMock(stdout="", returncode=0),                 # pull --rebase
+            MagicMock(stdout="", returncode=0),                 # push retry SUCCEEDS
+        ]
+        state_bus.commit_and_push("msg", role="skill")
+        # 5th call should be the pull --rebase.
+        pull_call = mock_run.call_args_list[4]
+        cmd = pull_call.args[0]
+        assert "pull" in cmd
+        assert "--rebase" in cmd, f"retry pull missing --rebase: {cmd}"
+
+    @patch("state_bus._worktree_exists", return_value=True)
+    @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
+    @patch("state_bus._run")
+    def test_retry_pull_uses_credential_override(self, mock_run, mock_config, mock_wt):
+        """The retry pull is also a network op — it must use the same
+        credential override or it'd wedge on the same helper as push."""
+        mock_run.side_effect = [
+            MagicMock(stdout="", returncode=0),                 # add -A
+            MagicMock(stdout=" M file.md\n", returncode=0),     # status
+            MagicMock(stdout="", stderr="", returncode=0),      # commit
+            MagicMock(stdout="", returncode=1),                 # push FAILS
+            MagicMock(stdout="", returncode=0),                 # pull --rebase
+            MagicMock(stdout="", returncode=0),                 # push retry
+        ]
+        state_bus.commit_and_push("msg", role="skill")
+        pull_call = mock_run.call_args_list[4]
+        cmd = pull_call.args[0]
+        assert "credential.helper=!gh auth git-credential" in cmd
+
+    @patch("state_bus._worktree_exists", return_value=True)
+    @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
+    @patch("state_bus._run")
+    def test_rebase_abort_on_pull_failure(self, mock_run, mock_config, mock_wt):
+        """If the retry `pull --rebase` itself fails (e.g., real
+        conflict), the loop must `git rebase --abort` so the worktree
+        is left clean for the next attempt — leaving a half-rebased
+        state was part of the #9930 'leaked state across attempts' bug.
+        """
+        mock_run.side_effect = [
+            MagicMock(stdout="", returncode=0),                 # add -A
+            MagicMock(stdout=" M file.md\n", returncode=0),     # status
+            MagicMock(stdout="", stderr="", returncode=0),      # commit
+            MagicMock(stdout="", returncode=1),                 # push FAILS (1)
+            MagicMock(stdout="", returncode=1),                 # pull --rebase FAILS
+            MagicMock(stdout="", returncode=0),                 # rebase --abort
+            MagicMock(stdout="", returncode=0),                 # push retry SUCCEEDS (2)
+        ]
+        state_bus.commit_and_push("msg", role="skill")
+        # Check that one of the calls is `git rebase --abort`.
+        abort_seen = any(
+            (lambda cmd: "--abort" in cmd and "rebase" in cmd)(
+                c.args[0] if c.args else []
+            )
+            for c in mock_run.call_args_list
+        )
+        assert abort_seen, (
+            f"Expected `git rebase --abort` after failed pull --rebase, "
+            f"saw: {[c.args[0] for c in mock_run.call_args_list]}"
+        )

--- a/tests/test_state_bus.py
+++ b/tests/test_state_bus.py
@@ -446,6 +446,97 @@ class TestPushHardening9930:
         cmd = pull_call.args[0]
         assert "credential.helper=!gh auth git-credential" in cmd
 
+    def test_run_preserves_stdout_on_timeout(self):
+        """#9930 DS review F3: TimeoutExpired handler must preserve
+        partial stdout (a pre-push hook may print diagnostics before
+        the hang). Earlier the handler dropped it unconditionally."""
+        import subprocess
+        with patch.object(state_bus.subprocess, "run") as mock_sp:
+            mock_sp.side_effect = subprocess.TimeoutExpired(
+                cmd=["git", "push"],
+                timeout=1,
+                output="some stdout from a pre-push hook",
+                stderr="partial stderr",
+            )
+            result = state_bus._run(["git", "push"], check=False, timeout=1)
+        assert result.stdout == "some stdout from a pre-push hook", (
+            "TimeoutExpired stdout was dropped — should be preserved"
+        )
+        assert "partial stderr" in result.stderr
+        assert "TIMEOUT" in result.stderr
+
+    def test_run_handles_none_streams_on_timeout(self):
+        """#9930 DS review F4: with text=True, e.stdout / e.stderr are
+        str | None, never bytes. The handler must accept None for either
+        stream without crashing (e.g., child killed before any output).
+        """
+        import subprocess
+        with patch.object(state_bus.subprocess, "run") as mock_sp:
+            mock_sp.side_effect = subprocess.TimeoutExpired(
+                cmd=["git", "push"], timeout=1, output=None, stderr=None,
+            )
+            result = state_bus._run(["git", "push"], check=False, timeout=1)
+        assert result.returncode == 124
+        assert result.stdout == ""
+        assert "TIMEOUT" in result.stderr
+
+    @patch("state_bus._worktree_exists", return_value=True)
+    @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
+    @patch("state_bus._run")
+    def test_pull_timeout_triggers_remote_prune(self, mock_run, mock_config, mock_wt):
+        """#9930 DS review F1: if `pull --rebase` times out (rc=124),
+        the child `git fetch` may have left tmp packfiles / a
+        FETCH_HEAD.lock. `rebase --abort` only cleans rebase state; we
+        also need `git remote prune origin` to clear stale fetch state
+        before the next push attempt."""
+        mock_run.side_effect = [
+            MagicMock(stdout="", returncode=0),                 # add -A
+            MagicMock(stdout=" M file.md\n", returncode=0),     # status
+            MagicMock(stdout="", stderr="", returncode=0),      # commit
+            MagicMock(stdout="", returncode=1),                 # push FAILS
+            MagicMock(stdout="", returncode=124),               # pull TIMEOUT
+            MagicMock(stdout="", returncode=0),                 # rebase --abort
+            MagicMock(stdout="", returncode=0),                 # remote prune origin
+            MagicMock(stdout="", returncode=0),                 # push retry SUCCEEDS
+        ]
+        state_bus.commit_and_push("msg", role="skill")
+        prune_seen = any(
+            "prune" in (c.args[0] if c.args else [])
+            and "origin" in (c.args[0] if c.args else [])
+            for c in mock_run.call_args_list
+        )
+        assert prune_seen, (
+            f"Expected `git remote prune origin` after pull timeout (rc=124), "
+            f"saw: {[c.args[0] for c in mock_run.call_args_list]}"
+        )
+
+    @patch("state_bus._worktree_exists", return_value=True)
+    @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
+    @patch("state_bus._run")
+    def test_pull_non_timeout_failure_does_not_prune(self, mock_run, mock_config, mock_wt):
+        """The prune is specifically for timeout cleanup. A normal
+        rebase conflict (rc=1, not 124) should NOT trigger a prune —
+        that would waste a 120s budget on every conflict retry."""
+        mock_run.side_effect = [
+            MagicMock(stdout="", returncode=0),                 # add -A
+            MagicMock(stdout=" M file.md\n", returncode=0),     # status
+            MagicMock(stdout="", stderr="", returncode=0),      # commit
+            MagicMock(stdout="", returncode=1),                 # push FAILS
+            MagicMock(stdout="", returncode=1),                 # pull rc=1 (NOT 124)
+            MagicMock(stdout="", returncode=0),                 # rebase --abort
+            MagicMock(stdout="", returncode=0),                 # push retry
+        ]
+        state_bus.commit_and_push("msg", role="skill")
+        prune_seen = any(
+            "prune" in (c.args[0] if c.args else [])
+            for c in mock_run.call_args_list
+        )
+        assert not prune_seen, (
+            f"`git remote prune` should ONLY fire on pull timeout (rc=124), "
+            f"not on normal conflict failures. Saw: "
+            f"{[c.args[0] for c in mock_run.call_args_list]}"
+        )
+
     @patch("state_bus._worktree_exists", return_value=True)
     @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
     @patch("state_bus._run")


### PR DESCRIPTION
Closes-via-tracker: #9930

Fixes the recurring `WARNING: State push failed after 3 attempts` that fired on every cycle this session (1250-1257). Three compounding issues, three layers:

## Root cause

1. **`credential.helper=manager`** (Windows) hangs silently waiting for an interactive prompt. Memory note `feedback_git_push_credential_wedge` documented the workaround (`gh auth git-credential`) but `state_bus.py` wasn't applying it.
2. **No timeout** on `subprocess.run`, so the hang was unbounded.
3. **Default-merge `git pull`** in the retry loop polluted state-branch history with `Merge branch 'squid-squad'` commits AND left half-merged state in the worktree across attempts.

## Fix (3 layers)

### Layer 1 — credential override

```python
_GH_CREDENTIAL_OVERRIDE = [
    "-c", "credential.helper=!gh auth git-credential",
]
```

Prefixed to every state-branch network command (push + retry pull). The `!` syntax tells git to run the value as a shell command. Per-command scope — the worktree's git config is untouched, so other tools see whatever the user configured.

### Layer 2 — per-call timeout

- `_run(cmd, check=True, cwd=None, timeout=None)` — new kwarg, default `None` for back-compat with `init()`'s many unconditional callers.
- `commit_and_push` passes `DEFAULT_GIT_TIMEOUT = 120` (seconds) to both push and pull.
- On `subprocess.TimeoutExpired`, `_run` catches and returns `CompletedProcess(returncode=124, stdout="", stderr="TIMEOUT after Ns: <cmd>")` (POSIX `timeout` exit-code convention) — never raises.
- Mirror of #9904's `cycle_pre.py` guard. Every existing `if result.returncode != 0` path degrades gracefully.
- Worst-case retry loop latency: ~6 min (3 attempts × ~2 min each) instead of infinity.

### Layer 3 — `pull --rebase` + abort on conflict

`git pull` → `git pull --rebase`. Linear history. If the rebase itself fails (real conflict), `git rebase --abort` runs so the worktree is clean for the next retry — closing the 'leaked state across attempts' part of the original bug, where mid-cycle inspections were finding `D iter-1246.md` / `M working-state.md` residue.

## Tests

New class `TestPushHardening9930` (9 cases, all passing):

1. `test_default_git_timeout_is_bounded` — 0 < value ≤ 600.
2. `test_run_returns_124_on_timeout` — `TimeoutExpired` caught, `returncode=124`, `TIMEOUT` in stderr, no exception.
3. `test_run_passes_timeout_to_subprocess` — kwarg forwarded.
4. `test_run_default_timeout_is_none_for_backcompat` — `None` default preserves existing callers.
5. `test_push_uses_gh_credential_override` — push command contains `credential.helper=!gh auth git-credential`.
6. `test_push_bounded_by_default_timeout` — push passes `timeout=DEFAULT_GIT_TIMEOUT`.
7. `test_retry_pull_uses_rebase` — retry pull has `--rebase` flag.
8. `test_retry_pull_uses_credential_override` — retry pull also gets the creds override.
9. `test_rebase_abort_on_pull_failure` — `git rebase --abort` fires when pull-rebase fails before the next push attempt.

## Regression

- `pytest tests/test_state_bus.py` → **42 passed in 0.19s** (was 33 pre-fix, +9 new).

DeepSeek pre-push review running in parallel; any findings will land as follow-up commits on this PR before merge.