### PR TITLE
fix #9934 — divergence diagnostic after state_bus retry exhaustion (QA #9930 follow-up)

### DIFF
--- a/references/scripts/state_bus.py
+++ b/references/scripts/state_bus.py
@@ -298,6 +298,7 @@ def commit_and_push(message, role="unknown"):
     # history linear instead of accumulating merge commits — a previous
     # default-merge pull was creating `Merge branch 'squid-squad'` commits
     # on every concurrent-write cycle.
+    last_pull_result = None
     for attempt in range(3):
         result = _run(
             ["git"] + _GH_CREDENTIAL_OVERRIDE +
@@ -315,6 +316,7 @@ def commit_and_push(message, role="unknown"):
             ["pull", "--rebase", "origin", state_branch],
             cwd=cwd, check=False, timeout=DEFAULT_GIT_TIMEOUT,
         )
+        last_pull_result = pull_result
         if pull_result.returncode != 0:
             _run(["git", "rebase", "--abort"], cwd=cwd, check=False)
             # #9930 DS review F1: if the pull timed out (returncode=124),
@@ -330,8 +332,80 @@ def commit_and_push(message, role="unknown"):
                     cwd=cwd, check=False, timeout=DEFAULT_GIT_TIMEOUT,
                 )
 
-    print(f"WARNING: State push failed after 3 attempts", file=sys.stderr)
+    # #9934: All 3 attempts exhausted. The retry loop fixes credential /
+    # timeout / merge-pollution issues from #9930, but it CANNOT recover
+    # from a real content conflict — pull --rebase keeps failing in the
+    # same way, and the next push attempt is back to square one. When
+    # this happens, give the operator a structured diagnostic with the
+    # actual divergence and a manual recovery command (per QA's
+    # recommendation #3 in the issue — the lower-risk paths). Don't
+    # auto-recover; that's outside this fix's risk budget.
+    print("WARNING: State push failed after 3 attempts", file=sys.stderr)
+    _print_divergence_diagnostic(cwd, state_branch, last_pull_result)
     return False
+
+
+def _print_divergence_diagnostic(cwd, state_branch, last_pull_result):
+    """#9934: emit a structured diagnostic after retry exhaustion.
+
+    Reports the local-vs-origin commit divergence (so the operator knows
+    whether this is a small concurrent-write race or a long-disconnected
+    worktree), surfaces the last pull stderr (which usually contains the
+    actual ``CONFLICT (content)`` lines), and prints the manual recovery
+    one-liner. Best-effort — any sub-call failure is swallowed because
+    we're already on the error path.
+    """
+    try:
+        # Local commits not on origin, and origin commits not on local.
+        # `git rev-list --count A..B` is None-on-error tolerant via _run.
+        local_ahead = _run(
+            ["git", "rev-list", "--count",
+             f"origin/{state_branch}..HEAD"],
+            cwd=cwd, check=False, timeout=DEFAULT_GIT_TIMEOUT,
+        )
+        local_behind = _run(
+            ["git", "rev-list", "--count",
+             f"HEAD..origin/{state_branch}"],
+            cwd=cwd, check=False, timeout=DEFAULT_GIT_TIMEOUT,
+        )
+        ahead = local_ahead.stdout.strip() if local_ahead.returncode == 0 else "?"
+        behind = local_behind.stdout.strip() if local_behind.returncode == 0 else "?"
+
+        # Surface the conflict signal if pull stderr mentions it.
+        pull_stderr = (last_pull_result.stderr or "") if last_pull_result else ""
+        had_conflict = (
+            "CONFLICT" in pull_stderr
+            or "cannot pull" in pull_stderr.lower()
+            or "fix conflicts" in pull_stderr.lower()
+        )
+
+        msg = [
+            "  state-branch divergence: "
+            f"local is {ahead} ahead, origin is {behind} ahead "
+            f"of '{state_branch}'.",
+        ]
+        if had_conflict:
+            msg.append(
+                "  Last pull --rebase reported a real content conflict — "
+                "retries cannot resolve this automatically."
+            )
+        msg.append(
+            "  Manual recovery (loses local state-branch commits — "
+            "iteration logs / scan history are reconstructable from "
+            "git history on main):"
+        )
+        msg.append(
+            f"    cd .squidsquad-state && "
+            f"git fetch origin {state_branch} && "
+            f"git reset --hard origin/{state_branch}"
+        )
+        msg.append("  See #9934 for context.")
+        for line in msg:
+            print(line, file=sys.stderr)
+    except Exception:
+        # Diagnostic is best-effort. If git rev-list itself wedges or
+        # cwd is gone, swallow — the primary warning has already printed.
+        pass
 
 
 def status():

--- a/tests/test_state_bus.py
+++ b/tests/test_state_bus.py
@@ -567,3 +567,127 @@ class TestPushHardening9930:
             f"Expected `git rebase --abort` after failed pull --rebase, "
             f"saw: {[c.args[0] for c in mock_run.call_args_list]}"
         )
+
+
+# ---------------------------------------------------------------------------
+# #9934 — divergence diagnostic after retry exhaustion
+# ---------------------------------------------------------------------------
+
+
+class TestDivergenceDiagnostic9934:
+    """#9934 (follow-up to #9930): when the retry loop exhausts all 3
+    attempts because of a real content conflict (push fails, pull --rebase
+    keeps failing in the same way), emit a structured diagnostic so the
+    operator can manually recover — don't just print the generic
+    'failed after 3 attempts' warning and disappear.
+    """
+
+    @patch("state_bus._worktree_exists", return_value=True)
+    @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
+    @patch("state_bus._run")
+    def test_exhausted_loop_prints_divergence_counts(self, mock_run, mock_config, mock_wt, capsys):
+        """After 3 attempts fail, the diagnostic must include both
+        local-ahead and origin-ahead commit counts so the operator can
+        tell a 1-commit race from a 1000-commit drift."""
+        # 3 attempts, each: push fail + pull fail + abort.
+        # Then 2 rev-list calls for the divergence summary.
+        per_attempt = [
+            MagicMock(stdout="", returncode=1),     # push FAILS
+            MagicMock(stdout="", stderr="CONFLICT (content) ...", returncode=1),  # pull --rebase FAILS
+            MagicMock(stdout="", returncode=0),     # rebase --abort
+        ]
+        mock_run.side_effect = [
+            MagicMock(stdout="", returncode=0),                 # add -A
+            MagicMock(stdout=" M file.md\n", returncode=0),     # status
+            MagicMock(stdout="", stderr="", returncode=0),      # commit
+        ] + per_attempt * 3 + [
+            MagicMock(stdout="2\n", returncode=0),              # rev-list local ahead
+            MagicMock(stdout="1110\n", returncode=0),           # rev-list origin ahead
+        ]
+        result = state_bus.commit_and_push("msg", role="skill")
+        assert result is False
+        captured = capsys.readouterr()
+        stderr = captured.err
+        assert "WARNING: State push failed after 3 attempts" in stderr
+        # Divergence counts must appear so operator knows the scale.
+        assert "local is 2 ahead" in stderr
+        assert "origin is 1110 ahead" in stderr
+        # And the manual recovery command must be visible.
+        assert "git fetch origin squid-squad" in stderr
+        assert "git reset --hard origin/squid-squad" in stderr
+
+    @patch("state_bus._worktree_exists", return_value=True)
+    @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
+    @patch("state_bus._run")
+    def test_diagnostic_flags_content_conflict(self, mock_run, mock_config, mock_wt, capsys):
+        """If the last pull stderr mentioned CONFLICT, the diagnostic
+        must say so explicitly — operators reading scrollback shouldn't
+        have to dig for the actual failure mode."""
+        per_attempt = [
+            MagicMock(stdout="", returncode=1),
+            MagicMock(stdout="",
+                      stderr="CONFLICT (content): Merge conflict in qa/working-state.md",
+                      returncode=1),
+            MagicMock(stdout="", returncode=0),
+        ]
+        mock_run.side_effect = [
+            MagicMock(stdout="", returncode=0),
+            MagicMock(stdout=" M file.md\n", returncode=0),
+            MagicMock(stdout="", stderr="", returncode=0),
+        ] + per_attempt * 3 + [
+            MagicMock(stdout="0\n", returncode=0),
+            MagicMock(stdout="1\n", returncode=0),
+        ]
+        state_bus.commit_and_push("msg", role="skill")
+        stderr = capsys.readouterr().err
+        assert "real content conflict" in stderr.lower()
+
+    @patch("state_bus._worktree_exists", return_value=True)
+    @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
+    @patch("state_bus._run")
+    def test_diagnostic_skipped_on_success(self, mock_run, mock_config, mock_wt, capsys):
+        """The divergence diagnostic must NOT print when the push
+        eventually succeeds — only after the loop truly exhausts."""
+        mock_run.side_effect = [
+            MagicMock(stdout="", returncode=0),                 # add -A
+            MagicMock(stdout=" M file.md\n", returncode=0),     # status
+            MagicMock(stdout="", stderr="", returncode=0),      # commit
+            MagicMock(stdout="", returncode=0),                 # push SUCCEEDS first try
+        ]
+        result = state_bus.commit_and_push("msg", role="skill")
+        assert result is True
+        stderr = capsys.readouterr().err
+        assert "divergence" not in stderr.lower()
+        assert "manual recovery" not in stderr.lower()
+
+    @patch("state_bus._worktree_exists", return_value=True)
+    @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
+    @patch("state_bus._run")
+    def test_diagnostic_tolerates_rev_list_failure(self, mock_run, mock_config, mock_wt, capsys):
+        """The diagnostic is best-effort: if the rev-list calls
+        themselves fail (e.g., origin ref missing), the function must
+        not raise — the primary 'failed after 3 attempts' warning is
+        already on stderr, and the loss of divergence counts is
+        recoverable noise, not a crash worth propagating.
+        """
+        per_attempt = [
+            MagicMock(stdout="", returncode=1),
+            MagicMock(stdout="", stderr="", returncode=1),
+            MagicMock(stdout="", returncode=0),
+        ]
+        mock_run.side_effect = [
+            MagicMock(stdout="", returncode=0),
+            MagicMock(stdout=" M file.md\n", returncode=0),
+            MagicMock(stdout="", stderr="", returncode=0),
+        ] + per_attempt * 3 + [
+            MagicMock(stdout="", stderr="fatal: bad revision", returncode=128),
+            MagicMock(stdout="", stderr="fatal: bad revision", returncode=128),
+        ]
+        # Must not raise.
+        result = state_bus.commit_and_push("msg", role="skill")
+        assert result is False
+        stderr = capsys.readouterr().err
+        # Primary warning still printed; divergence line uses '?' for
+        # the missing counts.
+        assert "WARNING: State push failed after 3 attempts" in stderr
+        assert "local is ? ahead" in stderr or "origin is ? ahead" in stderr


### PR DESCRIPTION
Closes-via-tracker: #9934

Follow-up to #9930 surfaced by QA's predictive E2E (cycle 733). #9930 fixed the credential / timeout / pull-strategy issues, but the retry loop still couldn't recover from a real content conflict — `pull --rebase` kept failing identically across all 3 attempts, and the generic 'failed after 3 attempts' warning gave operators no hint about WHY or what to do.

## QA's observed state

```
local:  qa: cycle 145 state    (1 commit ahead of origin)
origin: dm: cycle 1266 state   (1110 commits ahead of local)
```

Real `CONFLICT (content)` in append-only diagnostic files.

## Fix — recommendation #3 (lowest risk)

After the retry loop exhausts, a new `_print_divergence_diagnostic` helper emits a structured stderr block:

1. **Divergence summary**: `git rev-list --count` in both directions (`origin/<branch>..HEAD` and `HEAD..origin/<branch>`). Operator sees `local is N ahead, origin is M ahead` and can immediately classify the situation as 'benign concurrent-write race' vs 'long-disconnected worktree.'
2. **Conflict flag**: if the last pull stderr contained `CONFLICT`, `cannot pull`, or `fix conflicts`, an explicit line says retries cannot resolve this automatically. Saves the operator from re-reading scrollback.
3. **Manual recovery one-liner** verbatim from QA's reproduction, with a note about what's lost (state-branch commits are reconstructable from main's git history).
4. **Pointer to #9934** for future context.

## Intentionally NOT implemented

- **Auto-stash + cherry-pick** (QA's recommendation #2) — QA explicitly flagged this as risky; the deeper auto-recovery needs its own design discussion.
- **Detect-and-stop-retrying-early** (QA's recommendation #1) — partially implicit (we still print after 3 attempts; the diagnostic makes the no-recovery state visible without changing control flow). A stricter early-stop is a separate change.

## Best-effort guarantee

The diagnostic is wrapped in `try/except` — `rev-list` failures (e.g., missing origin ref) fall back to `'?'` counts so the diagnostic can never crash on the error path. The primary `WARNING: State push failed after 3 attempts` always fires first regardless.

## Tests

New class `TestDivergenceDiagnostic9934` (4 cases, all passing):

1. `test_exhausted_loop_prints_divergence_counts` — counts (`2 ahead`, `1110 ahead`) and recovery command both appear in stderr.
2. `test_diagnostic_flags_content_conflict` — pull stderr containing `CONFLICT` triggers the explicit 'real content conflict' line.
3. `test_diagnostic_skipped_on_success` — quiet path: successful push must NOT print divergence noise (don't be chatty on the happy path).
4. `test_diagnostic_tolerates_rev_list_failure` — rev-list returning rc=128 (bad revision) yields `?` counts, no crash.

## Regression

- `pytest tests/test_state_bus.py` → **50 passed in 0.20s** (was 46, +4 new — full #9930 13-case suite still passes alongside).