### PR TITLE
fix #9939 — migrate_state_branch captures commit_and_push failure (exit 1 + NOT-durable diagnostic)

### DIFF
--- a/references/scripts/migrate_state_branch.py
+++ b/references/scripts/migrate_state_branch.py
@@ -127,12 +127,36 @@ def migrate(dry_run=False):
         except (OSError, UnicodeDecodeError) as e:
             print(f"  WARNING: Failed to migrate {rel}: {e}", file=sys.stderr)
 
-    # Commit the migration
+    # Commit the migration. #9939: capture the return — commit_and_push
+    # returns False on commit failure OR push failure (e.g., the #9930
+    # credential-helper wedge), and the original code discarded that
+    # signal, reporting "Migrated X/Y" with exit 0 even when the state
+    # never actually reached origin. A failed-but-reported-success
+    # migration during the 3-branch cutover can silently lose state on
+    # the next `git fetch + reset --hard` (e.g., from the #9934 manual
+    # recovery one-liner).
     if migrated > 0:
-        state_bus.commit_and_push(
+        pushed = state_bus.commit_and_push(
             f"migrate: {migrated} state files from working branch",
             role="migration",
         )
+        if not pushed:
+            print(
+                f"\nMigrated {migrated}/{len(state_files)} files LOCALLY, "
+                "but commit_and_push failed — migration is NOT durable.",
+                file=sys.stderr,
+            )
+            print(
+                "  Files exist in .squidsquad-state/ on this machine but "
+                "have NOT reached origin/<state-branch>.",
+                file=sys.stderr,
+            )
+            print(
+                "  Investigate BEFORE deleting originals from the working "
+                "branch. Common cause: #9930 credential-helper wedge.",
+                file=sys.stderr,
+            )
+            return 1
 
     print(f"\nMigrated {migrated}/{len(state_files)} files to state branch.")
     if migrated == 0 and len(state_files) > 0:

--- a/tests/test_migrate_state_branch.py
+++ b/tests/test_migrate_state_branch.py
@@ -179,3 +179,81 @@ class TestMain:
              patch.object(migrate_state_branch, "migrate", side_effect=RuntimeError("boom")):
             result = migrate_state_branch.main()
         assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# #9939 — migrate() captures commit_and_push return value
+# ---------------------------------------------------------------------------
+
+
+class TestMigratePushFailure9939:
+    """#9939: migrate() must NOT report success when state_bus.commit_and_push
+    fails (returns False). The original code discarded the return value and
+    printed 'Migrated X/Y files' with exit 0 even when the push silently
+    failed — a footgun on machines hit by #9930's credential-helper wedge,
+    because the next git fetch + reset --hard wipes the locally-copied
+    state files that never reached origin.
+    """
+
+    def test_returns_one_when_push_fails(self, tmp_path, capsys):
+        """commit_and_push -> False must produce exit 1, not exit 0."""
+        src = tmp_path / "skill" / "working-state.md"
+        src.parent.mkdir(parents=True)
+        src.write_text("- **Task**: none\n", encoding="utf-8")
+        fake_state_bus = MagicMock()
+        fake_state_bus.write_file.return_value = True
+        fake_state_bus.commit_and_push.return_value = False  # PUSH FAILED
+        with patch.object(migrate_state_branch, "find_state_files",
+                          return_value=[Path("skill/working-state.md")]), \
+             patch.object(migrate_state_branch, "SQUIDSQUAD_DIR", tmp_path), \
+             patch.dict(sys.modules, {"state_bus": fake_state_bus}):
+            result = migrate_state_branch.migrate(dry_run=False)
+        assert result == 1, (
+            "#9939: migrate() must return 1 when commit_and_push returns False"
+        )
+        # The user-facing diagnostic must mention 'NOT durable' so an
+        # operator scanning stderr doesn't miss the failure mode.
+        err = capsys.readouterr().err
+        assert "NOT durable" in err, (
+            "expected explicit 'NOT durable' diagnostic on push failure; "
+            f"saw: {err!r}"
+        )
+
+    def test_returns_zero_when_push_succeeds(self, tmp_path):
+        """Happy path: commit_and_push -> True still returns 0."""
+        src = tmp_path / "skill" / "working-state.md"
+        src.parent.mkdir(parents=True)
+        src.write_text("- **Task**: none\n", encoding="utf-8")
+        fake_state_bus = MagicMock()
+        fake_state_bus.write_file.return_value = True
+        fake_state_bus.commit_and_push.return_value = True
+        with patch.object(migrate_state_branch, "find_state_files",
+                          return_value=[Path("skill/working-state.md")]), \
+             patch.object(migrate_state_branch, "SQUIDSQUAD_DIR", tmp_path), \
+             patch.dict(sys.modules, {"state_bus": fake_state_bus}):
+            result = migrate_state_branch.migrate(dry_run=False)
+        assert result == 0, (
+            "happy path regression: commit_and_push True should still exit 0"
+        )
+
+    def test_diagnostic_warns_against_deleting_originals(self, tmp_path, capsys):
+        """The push-failure diagnostic must explicitly warn the operator
+        NOT to delete originals from the working branch — that's how the
+        silent failure becomes catastrophic (originals removed, state-branch
+        copy never durable, all state lost on next reset)."""
+        src = tmp_path / "skill" / "working-state.md"
+        src.parent.mkdir(parents=True)
+        src.write_text("x", encoding="utf-8")
+        fake_state_bus = MagicMock()
+        fake_state_bus.write_file.return_value = True
+        fake_state_bus.commit_and_push.return_value = False
+        with patch.object(migrate_state_branch, "find_state_files",
+                          return_value=[Path("skill/working-state.md")]), \
+             patch.object(migrate_state_branch, "SQUIDSQUAD_DIR", tmp_path), \
+             patch.dict(sys.modules, {"state_bus": fake_state_bus}):
+            migrate_state_branch.migrate(dry_run=False)
+        err = capsys.readouterr().err
+        assert "deleting originals" in err.lower() or "delete originals" in err.lower(), (
+            "diagnostic must warn against deleting working-branch originals; "
+            f"saw: {err!r}"
+        )


### PR DESCRIPTION
Closes-via-tracker: #9939

Closing the silent-success gap in the one-shot migration tool. Before this PR, `migrate_state_branch.migrate()` discarded `state_bus.commit_and_push()`'s return value and printed `Migrated X/Y files to state branch` + exit 0 even when the push silently failed (the exact failure mode #9930 fixed in `state_bus`, but observable on machines that ran the migration before #9930 shipped or before its merge to main).

## Failure mode closed

1. Operator runs migration during the 3-branch cutover.
2. State files copy LOCALLY into `.squidsquad-state/`.
3. `commit_and_push` returns False (credential wedge, network blip, branch conflict — see #9930 for the credential.helper=manager case observed in this session).
4. Pre-fix: stdout shows `Migrated 47/47 files` + exit 0. Operator concludes durable.
5. Operator deletes originals from working branch (common follow-up step).
6. Next `git fetch origin <state-branch> && git reset --hard` (e.g., from the #9934 manual-recovery one-liner) wipes the local-only copies.
7. Everything is gone — no copy on origin, no original on working branch.

## Fix

Capture the return value as `pushed`. On False:

- Stderr: `Migrated X/Y files LOCALLY, but commit_and_push failed — migration is NOT durable.`
- Stderr (follow-up): files exist on this machine only, have NOT reached origin, **investigate before deleting originals**, point at #9930 as the common cause.
- Return code: 1.

On True: behavior unchanged.

## Tests

New class `TestMigratePushFailure9939` (3 cases, all passing):

1. `test_returns_one_when_push_fails` — mock `state_bus.commit_and_push` → False; assert exit 1 AND `NOT durable` appears in stderr.
2. `test_returns_zero_when_push_succeeds` — happy-path regression: True → exit 0.
3. `test_diagnostic_warns_against_deleting_originals` — asserts the explicit operator-facing warning is present (the bridge from silent failure to catastrophic data loss is the operator deleting originals; the warning has to be visible).

## Regression

- `pytest tests/test_migrate_state_branch.py` → **30 passed in 0.15s** (was 27, +3 new — all original state-pattern, find-state-files, and main-flag tests still pass).

No DeepSeek pre-push review for this one — diff is ~15 lines on a one-shot tool with a single behavioral change (capture-and-act-on-return). The integration tests exercise the new path directly.