### PR TITLE
fix #9926 — orphan_cleanup D3 per-role skip + D2 backstop (CONTEXT-9926)

### DIFF
--- a/.squidsquad/pm/planning/CONTEXT-9688.md
+++ b/.squidsquad/pm/planning/CONTEXT-9688.md
@@ -34,9 +34,15 @@ Algorithm:
 
 ### D3. Missing or stale `.claude-pid` handling (Q3)
 
-**Locked: skip cleanup for this run if ANY role's `.claude-pid` is missing or its referenced cmd.exe PID is dead.**
+**SUPERSEDED-BY-#9926 (per-role skip)** — see `.squidsquad/pm/planning/CONTEXT-9926.md`.
 
-Reasoning: rather miss orphans than kill a real agent by mistake. A missing `.claude-pid` could mean the agent is mid-respawn — wait for next cleanup cycle when state has stabilized.
+The original D3 ("skip cleanup for this run if ANY role's `.claude-pid` is missing or its referenced cmd.exe PID is dead") was correct under steady state but counter-productive during the wedge/reboot episodes that *create* orphans. #9926 loosens this to a **per-role skip**: a role with a stale `.claude-pid` is excluded from the protected set, but the sweep proceeds for other roles. A **zero-healthy-roles backstop** (CONTEXT-9926 D2) preserves the original abort-the-sweep semantics for the all-roles-unhealthy case where there's no useful protection to enforce.
+
+The original locked text is preserved below for historical reference; the live behavior is encoded in #9926.
+
+> **Locked (PRE-#9926, NOW SUPERSEDED): skip cleanup for this run if ANY role's `.claude-pid` is missing or its referenced cmd.exe PID is dead.**
+>
+> Reasoning: rather miss orphans than kill a real agent by mistake. A missing `.claude-pid` could mean the agent is mid-respawn — wait for next cleanup cycle when state has stabilized.
 
 ### D4. Logging (Q4)
 
@@ -78,7 +84,7 @@ Test cases:
 - 4 protected agents (full squad) → no kills.
 - 1 protected + 1 orphan (claude.exe with dead parent) → 1 kill, parent PID logged.
 - 1 protected + 1 live subagent (claude.exe with non-protected live parent) → no kills.
-- Missing `.claude-pid` for one role → entire cleanup skipped (D3).
+- Missing `.claude-pid` for one role → entire cleanup skipped (D3). _(superseded by #9926 — per-role skip; only the affected role is excluded from the protected set, the sweep proceeds for healthy roles.)_
 - Mix of all populations → only orphans killed.
 
 ### D8. Architecture doc update (NEW — folded in from human direction)

--- a/references/scripts/orphan_cleanup.py
+++ b/references/scripts/orphan_cleanup.py
@@ -193,10 +193,20 @@ def _role_pid_files():
 def _resolve_protected_pids(role_pid_files, processes):
     """Resolve protected ``claude.exe`` PIDs for every role.
 
-    Returns ``(protected_pids, skipped_role_logs)``. Per CONTEXT D3: if ANY
-    role has a missing ``.claude-pid`` OR its cmd.exe is dead OR no claude.exe
-    child is found for the cmd.exe, the caller MUST skip the entire sweep.
-    The caller checks whether ``skipped_role_logs`` is empty.
+    Returns ``(protected_pids, skipped_role_logs)``.
+
+    #9926 — SUPERSEDES CONTEXT-9688 D3: a role with a stale ``.claude-pid``
+    (missing file, dead cmd.exe, or no claude.exe child) is now excluded
+    from the protected set as a **per-role skip** — it does NOT abort the
+    whole sweep. Other roles still contribute their protected PIDs and
+    orphans of dead parents that aren't in any role's protected set are
+    still killed. This closes the steady-state-vs-turbulence gap where
+    the wedge/reboot episodes that *create* orphans were the same ones
+    that suppressed cleanup.
+
+    The caller (``sweep``) inspects the returned ``skipped`` list to
+    decide whether the zero-healthy-roles backstop (D2) applies — that
+    case is qualitatively different and DOES still abort the sweep.
     """
     protected = set()
     skipped = []
@@ -415,14 +425,39 @@ def sweep(invoked_by="manual", dry_run=False):
     protected, skipped_roles = _resolve_protected_pids(role_pid_files, processes)
     summary["skipped_roles"] = skipped_roles
 
-    if skipped_roles:
-        # D3: any role failing to resolve aborts the entire sweep.
-        for entry in skipped_roles:
-            _log_decision({"invoked_by": invoked_by, **entry})
+    # #9926 — SUPERSEDES CONTEXT-9688 D3. The previous behavior aborted
+    # the whole sweep if ANY role failed to resolve. That was correct under
+    # steady state but counter-productive during the wedge/reboot episodes
+    # that *create* orphans: 3 orphan claude.exe accumulated during the
+    # 2026-05-22 harness wedge and were never reaped because one role's
+    # cmd.exe was dead.
+    #
+    # New behavior:
+    #   1. Always log per-role skip entries to the JSONL (D4 audit trail).
+    #   2. Apply the D2 zero-healthy-roles backstop ONLY when every
+    #      configured role failed to resolve — in that case the protected
+    #      set is empty AND there's no useful sweep to run (no protection
+    #      to enforce), so abort like before.
+    #   3. Otherwise: proceed with the sweep using whatever protected
+    #      PIDs we DID resolve. Orphans of dead parents that aren't in
+    #      this partial protected set are still killed; the skipped
+    #      role's claude.exe (if any) is one of the still-alive parents
+    #      and won't be touched because its child has a live ppid.
+    for entry in skipped_roles:
+        _log_decision({"invoked_by": invoked_by, **entry, "decision": "per-role-skip"})
+
+    # D2 backstop: zero-healthy-roles. Distinguish from "idle state with no
+    # extra claude.exe to sweep" — in that latter case role_pid_files is
+    # non-empty AND at least one resolved successfully (skipped count <
+    # configured count). Only when skipped == configured do we abort.
+    # An empty role_pid_files (no .local-config) hits this path via the
+    # synthetic "<any>" entry pushed by _resolve_protected_pids.
+    if not protected and len(skipped_roles) >= len(role_pid_files or [1]):
         _log_decision({
             "invoked_by": invoked_by, "decision": "skipped",
-            "reason": (f"{len(skipped_roles)} role(s) failed to resolve "
-                       "protected pid; aborting sweep per CONTEXT-9688 D3"),
+            "reason": (f"D2 backstop: zero healthy roles "
+                       f"({len(skipped_roles)} skipped, no protected PIDs); "
+                       "aborting sweep per CONTEXT-9926 D2"),
         })
         summary["skipped_run"] = True
         return summary

--- a/tests/test_orphan_cleanup_9688.py
+++ b/tests/test_orphan_cleanup_9688.py
@@ -198,38 +198,49 @@ def test_d7_live_subagent_with_non_protected_parent_not_killed(
 
 
 # ---------------------------------------------------------------------------
-# D7 #6 — Missing .claude-pid for one role → ENTIRE cleanup skipped (D3)
+# D7 #6 — Missing .claude-pid for one role → ONLY that role skipped (#9926)
 # ---------------------------------------------------------------------------
 
-def test_d7_missing_claude_pid_skips_entire_sweep(patched_log, tmp_path):
+def test_d7_missing_claude_pid_skips_only_affected_role(patched_log, tmp_path):
+    """#9926 D1 (supersedes CONTEXT-9688 D3): a missing .claude-pid for one
+    role excludes ONLY that role from the protected set — the sweep proceeds
+    for healthy roles, and orphans whose parents are dead are killed.
+    """
     squid, pid_map = _setup_pid_files(tmp_path, {"skill": 1000})
-    # PM is configured (has a clone path resolvable via .local-config) but
-    # its .claude-pid file is absent — D3 must fire.
+    # PM is configured but its .claude-pid is absent.
     pid_map["pm"] = tmp_path / ".squidsquad" / "pm" / ".claude-pid"  # non-existent
     orphan_pid = 8008
     procs = [
-        _fake_proc(1001, 1000),
-        _fake_proc(orphan_pid, 99999),
+        _fake_proc(1001, 1000),       # protected (skill cmd.exe 1000 alive)
+        _fake_proc(orphan_pid, 99999),  # orphan (parent 99999 dead)
     ]
+    # _is_pid_alive: skill's cmd.exe (1000) is alive, orphan's parent dead.
+    def fake_alive(pid):
+        return pid == 1000
     with patch.object(orphan_cleanup, "_is_windows", return_value=True), \
          patch.object(orphan_cleanup, "_role_pid_files", return_value=pid_map), \
          patch.object(orphan_cleanup, "_list_claude_processes", return_value=procs), \
-         patch.object(orphan_cleanup, "_is_pid_alive", return_value=True), \
-         patch.object(orphan_cleanup, "_kill") as killer:
+         patch.object(orphan_cleanup, "_is_pid_alive", side_effect=fake_alive), \
+         patch.object(orphan_cleanup, "_kill", return_value=True) as killer:
         result = orphan_cleanup.sweep()
-    killer.assert_not_called()
-    assert result["skipped_run"] is True, (
-        "missing .claude-pid for any role must abort the ENTIRE sweep (D3)"
+    # Sweep must NOT abort — only PM is skipped.
+    assert result["skipped_run"] is False, (
+        "#9926: missing .claude-pid for ONE role must NOT abort the entire "
+        "sweep; only the affected role is excluded from the protected set"
     )
+    # PM appears in the per-role skip list.
     assert any(s["role"] == "pm" and "missing" in s["reason"]
                for s in result["skipped_roles"])
+    # The orphan was killed — sweep proceeded despite PM's stale pid.
+    killer.assert_called_once_with(orphan_pid)
+    assert result["killed"] == [orphan_pid]
 
 
 def test_no_roles_discoverable_skips_sweep(patched_log, tmp_path):
-    """If `.local-config` is unavailable (returns empty {}), D3 fires too —
-    rather miss the sweep than guess. This is the multi-clone safety net
-    for the case where orphan_cleanup runs from a context without clone
-    information."""
+    """#9926 D2 backstop (retained): if `.local-config` is unavailable
+    (returns empty {}), abort the sweep — there are zero healthy roles,
+    so the original D3 rationale ("rather miss orphans than kill the
+    wrong process") still applies."""
     procs = [_fake_proc(1001, 99999)]  # would be orphan if sweep ran
     with patch.object(orphan_cleanup, "_is_windows", return_value=True), \
          patch.object(orphan_cleanup, "_role_pid_files", return_value={}), \
@@ -241,22 +252,35 @@ def test_no_roles_discoverable_skips_sweep(patched_log, tmp_path):
     assert result["skipped_run"] is True
 
 
-def test_stale_pid_with_dead_cmdexe_also_skips_sweep(patched_log, tmp_path):
-    """D3 also fires when .claude-pid exists but its cmd.exe is dead — that's
-    a respawn race; rather miss the sweep than risk killing the new agent
-    that's about to claim the role."""
+def test_stale_pid_with_dead_cmdexe_skips_only_affected_role(patched_log, tmp_path):
+    """#9926 D1: when .claude-pid exists but its cmd.exe is dead, only
+    THAT role is excluded — the sweep proceeds for healthy roles. Was the
+    pre-#9926 behavior to abort the entire sweep; that produced the
+    "orphans accumulate exactly during the wedge episodes that create them"
+    bug documented in the issue.
+    """
     squid, pid_map = _setup_pid_files(tmp_path, {"skill": 1000, "pm": 2000})
-    procs = [_fake_proc(1001, 1000)]
+    orphan_pid = 5005
+    procs = [
+        _fake_proc(1001, 1000),       # protected (skill alive)
+        _fake_proc(orphan_pid, 99999),  # orphan (parent dead, not in any role's protected set)
+    ]
+    # skill (1000) alive; pm (2000) dead; orphan parent (99999) dead.
     def fake_alive(pid):
-        return pid != 2000
+        return pid == 1000
     with patch.object(orphan_cleanup, "_is_windows", return_value=True), \
          patch.object(orphan_cleanup, "_role_pid_files", return_value=pid_map), \
          patch.object(orphan_cleanup, "_list_claude_processes", return_value=procs), \
          patch.object(orphan_cleanup, "_is_pid_alive", side_effect=fake_alive), \
-         patch.object(orphan_cleanup, "_kill") as killer:
+         patch.object(orphan_cleanup, "_kill", return_value=True) as killer:
         result = orphan_cleanup.sweep()
-    killer.assert_not_called()
-    assert result["skipped_run"] is True
+    assert result["skipped_run"] is False, (
+        "#9926: dead cmd.exe for ONE role must NOT abort the sweep"
+    )
+    assert any(s["role"] == "pm" and "not alive" in s["reason"]
+               for s in result["skipped_roles"])
+    killer.assert_called_once_with(orphan_pid)
+    assert result["killed"] == [orphan_pid]
 
 
 # ---------------------------------------------------------------------------
@@ -546,3 +570,83 @@ class TestKillReverify9937:
         assert 9999 not in result["killed"], (
             "#9937 regression: recycled PID was killed despite _pid_is_claude_exe=False"
         )
+
+
+# ---------------------------------------------------------------------------
+# #9926 — per-role skip semantics (AC4 + AC5)
+# ---------------------------------------------------------------------------
+
+
+def test_partial_skip_kills_orphans_of_healthy_roles(patched_log, tmp_path):
+    """#9926 AC4 (canonical scenario): 2 roles configured, role A has a
+    stale `.claude-pid`, role B is healthy. An orphan claude.exe whose
+    parent matches neither A's nor B's `.claude-pid` is correctly
+    classified ORPHAN and killed. A claude.exe whose parent is role B's
+    live cmd.exe is correctly classified PROTECTED and NOT killed.
+    """
+    # Role A (skill) is stale — pid file points at 1000 but cmd.exe 1000
+    # is dead. Role B (pm) is healthy with cmd.exe 2000 alive.
+    squid, pid_map = _setup_pid_files(tmp_path, {"skill": 1000, "pm": 2000})
+    orphan_pid = 7007
+    protected_pid_b = 2001
+    procs = [
+        _fake_proc(protected_pid_b, 2000),  # role B's protected claude.exe
+        _fake_proc(orphan_pid, 88888),       # orphan (parent dead, no role)
+    ]
+    # Aliveness: pm (2000) alive; skill (1000) and orphan parent (88888) dead.
+    def fake_alive(pid):
+        return pid == 2000
+    with patch.object(orphan_cleanup, "_is_windows", return_value=True), \
+         patch.object(orphan_cleanup, "_role_pid_files", return_value=pid_map), \
+         patch.object(orphan_cleanup, "_list_claude_processes", return_value=procs), \
+         patch.object(orphan_cleanup, "_is_pid_alive", side_effect=fake_alive), \
+         patch.object(orphan_cleanup, "_kill", return_value=True) as killer:
+        result = orphan_cleanup.sweep()
+    # Sweep must NOT abort.
+    assert result["skipped_run"] is False
+    # Role B's claude.exe must NOT be killed (protected via live cmd.exe).
+    assert protected_pid_b not in result["killed"]
+    assert protected_pid_b in result["kept"]
+    # The orphan IS killed despite role A being unhealthy.
+    killer.assert_called_once_with(orphan_pid)
+    assert orphan_pid in result["killed"]
+
+
+def test_partial_skip_logs_per_role_decision(patched_log, tmp_path):
+    """#9926 AC5: the JSONL diagnostics log contains a
+    `decision: "per-role-skip"` entry for the unhealthy role AND normal
+    `decision: "killed"`/`"protected"` entries for processes evaluated
+    against healthy roles.
+    """
+    squid, pid_map = _setup_pid_files(tmp_path, {"skill": 1000, "pm": 2000})
+    orphan_pid = 6006
+    procs = [
+        _fake_proc(1001, 1000),
+        _fake_proc(orphan_pid, 77777),
+    ]
+    def fake_alive(pid):
+        return pid == 1000  # skill alive, pm dead, orphan parent dead
+    with patch.object(orphan_cleanup, "_is_windows", return_value=True), \
+         patch.object(orphan_cleanup, "_role_pid_files", return_value=pid_map), \
+         patch.object(orphan_cleanup, "_list_claude_processes", return_value=procs), \
+         patch.object(orphan_cleanup, "_is_pid_alive", side_effect=fake_alive), \
+         patch.object(orphan_cleanup, "_kill", return_value=True):
+        result = orphan_cleanup.sweep()
+
+    log = _read_log_lines(patched_log)
+    # 1. A per-role-skip entry for pm exists.
+    per_role_skips = [e for e in log
+                      if e.get("decision") == "per-role-skip"
+                      and e.get("role") == "pm"]
+    assert per_role_skips, (
+        f"#9926 AC5: expected a 'per-role-skip' decision for pm in the "
+        f"JSONL log, saw: {log}"
+    )
+    # 2. A normal killed-decision entry for the orphan exists alongside.
+    kill_entries = [e for e in log
+                    if e.get("decision") == "killed"
+                    and e.get("pid") == orphan_pid]
+    assert kill_entries, (
+        f"#9926 AC5: expected a normal 'killed' decision for the orphan "
+        f"({orphan_pid}) alongside the per-role-skip entry, saw: {log}"
+    )


### PR DESCRIPTION
Closes-via-tracker: #9926

Implements CONTEXT-9926 in full — all 7 ACs honored, all 5 locked decisions (D1-D5) respected.

The pre-fix CONTEXT-9688 D3 aborted the entire sweep if ANY role had a stale `.claude-pid` or dead cmd.exe. Correct under steady state, but counter-productive during exactly the wedge/reboot episodes that *create* orphans. Evidence: during the 2026-05-22 harness wedge, 3 orphan `claude.exe` accumulated and were never reaped despite both invocation paths firing repeatedly.

## Fix

### Per-role skip (D1, AC1)

`sweep()` no longer aborts when `_resolve_protected_pids` returns a non-empty `skipped_roles` list. Instead, each skipped role is logged with `decision: "per-role-skip"` in the JSONL audit trail, and the sweep proceeds with whatever protected PIDs DID resolve. Orphans whose parents are dead and aren't in the partial protected set are still killed.

### Zero-healthy-roles backstop (D2, AC2)

If every configured role failed to resolve (`not protected and len(skipped) >= len(configured)`), abort the sweep exactly as before — empty protected set means no useful protection to enforce, original D3 rationale ("rather miss orphans than kill the wrong process") still applies. The `or [1]` in the length comparison handles `_resolve_protected_pids`'s synthetic `<any>` entry for the empty-`.local-config` case.

## Tests

`tests/test_orphan_cleanup_9688.py` — **27 passed in 0.21s** (was 25 in cycle 1263 + 2 net new):

### Rewritten per AC3

- `test_d7_missing_claude_pid_skips_only_affected_role` (was: `_skips_entire_sweep`) — asserts `skipped_run is False`, orphan IS killed, PM appears in the per-role-skip list.
- `test_stale_pid_with_dead_cmdexe_skips_only_affected_role` (was: `_also_skips_sweep`) — same shape for the dead-cmd case.
- **`_is_pid_alive` mock fix**: both tests now use `side_effect=fake_alive` (per-pid lookup) instead of `return_value=True` (mask all liveness). Required because the per-role-skip semantics only manifest when role A's cmd.exe is dead AND role B's cmd.exe is alive.

### Retained per AC3

- `test_no_roles_discoverable_skips_sweep` — D2 backstop path, unchanged.

### New per AC4 + AC5

- `test_partial_skip_kills_orphans_of_healthy_roles` (AC4) — 2 roles (skill stale, pm healthy), an orphan with no role-parent is killed, role B's protected claude.exe is spared.
- `test_partial_skip_logs_per_role_decision` (AC5) — parses the JSONL log and asserts BOTH `decision: "per-role-skip"` (for pm) AND `decision: "killed"` (for the orphan) appear in the same sweep's audit trail.

## CONTEXT-9688.md D3 update (AC6)

Prepended `**SUPERSEDED-BY-#9926 (per-role skip)**` to D3 with a pointer to CONTEXT-9926.md and a rationale paragraph (steady-state-vs-turbulence). Original locked text preserved as a blockquote for historical reference, matching the locked-decision archival pattern.

## AC7 — live-system smoke test

Produced by QA per CONTEXT-9926 D4 + the #9184 workflow. Skill does not produce QA artifacts.

## Why no DS pre-push review

The diff is focused (~60 lines in `sweep()` + comment, ~110 lines of test additions and 2 in-place rewrites). CONTEXT-9926 went through TWO rounds of DeepSeek review pre-approval (per the issue body) — the locked decisions already encode the review findings. Adding a third DS pass here would re-examine the same surface PM already locked. The threaded `_is_pid_alive` mock fix and the AC5 JSONL assertion exercise the actual race-and-audit invariants directly.