### PR TITLE
skill: #9967 — event_bus_reader.query() honors harness eviction signal

### DIFF
--- a/references/scripts/event_bus_reader.py
+++ b/references/scripts/event_bus_reader.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 import json
+import sys
 import urllib.request
 import urllib.error
 from pathlib import Path
@@ -70,6 +71,23 @@ def query(since=None, role=None, event_type=None, limit=100):
         req = urllib.request.Request(url, method="GET")
         resp = urllib.request.urlopen(req, timeout=_TIMEOUT)
         data = json.loads(resp.read().decode("utf-8"))
+        # #9967: When the harness signals eviction (cursor predates the
+        # retained window), the `events` field contains the OLDEST events
+        # in the buffer — not events after the cursor. Returning them
+        # would make the caller re-process stale events on every cycle
+        # (PM observed 51 stale events from 25h before the cursor). Per
+        # PM's recommendation in the bug report, surface as no-events.
+        # A one-line stderr breadcrumb preserves the forensic signal.
+        if data.get("evicted"):
+            oldest_id = data.get("oldest_id")
+            evicted_hint = data.get("evicted_count_hint")
+            print(
+                f"event_bus_reader: cursor evicted from harness window "
+                f"(oldest_id={oldest_id}, evicted_count_hint={evicted_hint}); "
+                f"returning [] instead of buffer-start (#9967)",
+                file=sys.stderr,
+            )
+            return []
         return data.get("events", [])
     except Exception:
         # Silent empty-list — same contract as emit's fire-and-forget

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -330,14 +330,27 @@ class TestAckStop:
 
 
 class TestNoUnusedImports:
-    """#8193 regression: event bus modules must not have unused imports."""
+    """#8193 regression: event bus modules must not have unused imports.
+
+    Updated #9967: the assertion is "if `import sys` is present it must be
+    used", not "import is forbidden". event_bus_reader now uses sys.stderr
+    to surface the eviction breadcrumb per the #9967 fix.
+    """
+
+    def _assert_no_unused_sys(self, module):
+        import inspect
+        source = inspect.getsource(module)
+        if "import sys" in source:
+            # Strip the import line itself before checking for usage so
+            # the import never trivially satisfies its own usage check.
+            without_import = source.replace("import sys\n", "", 1)
+            assert "sys." in without_import, (
+                f"{module.__name__}: `import sys` present but `sys.` not "
+                f"referenced anywhere — unused import (#8193 regression)."
+            )
 
     def test_event_bus_no_unused_sys(self):
-        import inspect
-        source = inspect.getsource(event_bus)
-        assert "import sys" not in source
+        self._assert_no_unused_sys(event_bus)
 
     def test_event_bus_reader_no_unused_sys(self):
-        import inspect
-        source = inspect.getsource(event_bus_reader)
-        assert "import sys" not in source
+        self._assert_no_unused_sys(event_bus_reader)

--- a/tests/test_event_bus_reader.py
+++ b/tests/test_event_bus_reader.py
@@ -115,6 +115,96 @@ class TestQuery:
 
 
 # ---------------------------------------------------------------------------
+# #9967 — eviction signal handling
+# ---------------------------------------------------------------------------
+
+class TestQueryEvictionHandling:
+    """#9967: when harness signals `evicted: true`, drop the stale events
+    list (buffer-start) and return [] so callers don't re-process events
+    older than their cursor on every cycle.
+    """
+
+    def test_evicted_response_returns_empty_list(self):
+        """Harness returns `evicted: true` + oldest-events fallback → query() returns []."""
+        stale_events = [
+            {"id": "old1", "event_type": "git-pull", "timestamp": "2026-05-22T01:45:31"},
+            {"id": "old2", "event_type": "cycle-start", "timestamp": "2026-05-22T08:45:21"},
+        ]
+        resp = MagicMock()
+        resp.read.return_value = json.dumps({
+            "events": stale_events,
+            "total": 1000,
+            "evicted": True,
+            "oldest_id": "old1",
+            "evicted_count_hint": 250,
+        }).encode("utf-8")
+
+        with patch.object(event_bus_reader, "_discover_port", return_value=7373), \
+             patch("urllib.request.urlopen", return_value=resp):
+            result = event_bus_reader.query(since="evicted_cursor")
+
+        assert result == [], (
+            "evicted response must return [] (not the buffer-start events) "
+            "so callers don't re-process events older than the cursor"
+        )
+
+    def test_evicted_response_emits_stderr_breadcrumb(self, capsys):
+        """Eviction case prints a one-line forensic signal to stderr."""
+        resp = MagicMock()
+        resp.read.return_value = json.dumps({
+            "events": [{"id": "old1", "event_type": "x"}],
+            "evicted": True,
+            "oldest_id": "old1",
+            "evicted_count_hint": 250,
+        }).encode("utf-8")
+
+        with patch.object(event_bus_reader, "_discover_port", return_value=7373), \
+             patch("urllib.request.urlopen", return_value=resp):
+            event_bus_reader.query(since="evicted_cursor")
+
+        captured = capsys.readouterr()
+        assert "cursor evicted" in captured.err
+        assert "oldest_id=old1" in captured.err
+        assert "evicted_count_hint=250" in captured.err
+        assert "#9967" in captured.err
+
+    def test_non_evicted_response_returns_events(self):
+        """Normal (non-evicted) response still returns the events list."""
+        fresh_events = [
+            {"id": "new1", "event_type": "cycle-start"},
+            {"id": "new2", "event_type": "git-pull"},
+        ]
+        resp = MagicMock()
+        resp.read.return_value = json.dumps({
+            "events": fresh_events,
+            "total": 50,
+            # No `evicted` key — normal path.
+        }).encode("utf-8")
+
+        with patch.object(event_bus_reader, "_discover_port", return_value=7373), \
+             patch("urllib.request.urlopen", return_value=resp):
+            result = event_bus_reader.query(since="fresh_cursor")
+
+        assert len(result) == 2
+        assert result[0]["id"] == "new1"
+
+    def test_evicted_false_explicit_returns_events(self):
+        """`evicted: false` explicitly (not missing) still returns events."""
+        events = [{"id": "x"}]
+        resp = MagicMock()
+        resp.read.return_value = json.dumps({
+            "events": events,
+            "evicted": False,
+        }).encode("utf-8")
+
+        with patch.object(event_bus_reader, "_discover_port", return_value=7373), \
+             patch("urllib.request.urlopen", return_value=resp):
+            result = event_bus_reader.query(since="cursor")
+
+        assert result == events
+
+
+# ---------------------------------------------------------------------------
 # Harness GET /events endpoint filtering (EventStream.get_since)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes ​#9967

### Summary

The event bus reader (`references/scripts/event_bus_reader.py`) silently dropped the harness eviction signal (`evicted: true`, `oldest_id`, `evicted_count_hint`) from `/events` responses. When the caller's cursor predated the retained window, the harness correctly returned the buffer-start events with the eviction marker — but the reader's bare `return data.get("events", [])` surfaced those stale events as if they were new.

Symptom PM observed in the issue: 51 stale events from 2026-05-22 re-processed every PM cycle since cycle 1596; cursor `df9f33751a6a` stuck because the agent kept writing it back as `Last Processed Event ID`.

Fix: when `data.get("evicted")` is truthy, emit a one-line stderr breadcrumb with `oldest_id` + `evicted_count_hint` + `#9967`, and return `[]`. Non-evicted path is unchanged. This matches PM's recommended behavior in the bug Notes ("buffer-start rather than 400/no-events" → no-events).

The event-driven path (`event_poll.py:220-247`) already handled eviction correctly (logs + re-anchors to `oldest_id`); this brings polling-mode parity for the failure mode without changing the `cycle_pre` / working-state cursor-management contract (out of scope for #9967; can be a follow-up if PM wants polling-mode auto-re-anchor).

### Acceptance Criteria

- [ ] `query()` returns `[]` when the harness response includes `evicted: true`.
- [ ] A one-line `event_bus_reader: cursor evicted …` breadcrumb is emitted to stderr in that case (with `oldest_id` and `evicted_count_hint` for forensics).
- [ ] Non-evicted responses are unchanged.
- [ ] `#8193` no-unused-sys invariant still enforced (now via the real check, not the absence-of-import proxy).

### Changes

- **Files**:
  - `references/scripts/event_bus_reader.py` — eviction handling + stderr breadcrumb; `import sys` added (now used).
  - `tests/test_event_bus_reader.py` — `TestQueryEvictionHandling` (4 cases).
  - `tests/test_event_bus.py` — `TestNoUnusedImports` helper updated to assert the actual invariant.
- **What**: 4 tests added; 2 tests refactored; 1 source function gains an early-return path; the no-unused-sys regression contract is preserved through a more honest check.
- **Why**: PM observed the broken cursor advancement blocking event-driven mode activation. Fix matches PM's recommended behavior in the bug body.

### QA Status

- [ ] Unit tests passing (44/44 in the touched modules).
- [ ] Smoke tests passing (`python tests/run_tests.py static` → 0 failed).
- [ ] Acceptance criteria met.
