### PR TITLE
skill: #10133 — test_cycle_pre TestGetVerifiableRoles qa → verifier

### DIFF
--- a/tests/test_cycle_pre.py
+++ b/tests/test_cycle_pre.py
@@ -951,28 +951,29 @@ class TestGetVerifiableRoles:
         assert "qa" in roles
 
     def test_always_includes_mandatory_roles(self, monkeypatch):
-        """pm, qa, dm are always included regardless of config (#9318).
+        """pm, verifier, dm are always included regardless of config (#9318, #6274.2).
 
-        Post-#6055 these are mandatory roles. qa was previously sourced
-        from dev-agents — when config.md stopped listing it there
-        (#9318), the test below catches the regression where qa would
-        silently drop out of PM's verifiable-role queries.
+        Post-#6055 these are mandatory roles. verifier (renamed from qa
+        in #6274.2) was previously sourced from dev-agents — when
+        config.md stopped listing it there (#9318), the test below
+        catches the regression where verifier would silently drop out
+        of PM's verifiable-role queries.
         """
         monkeypatch.setattr(cycle_pre, "_config_get", lambda f: "skill" if f == "dev-agents" else "")
         roles = cycle_pre._get_verifiable_roles()
         assert "dm" in roles
         assert "pm" in roles
-        assert "qa" in roles
+        assert "verifier" in roles
 
     def test_fallback_when_config_empty(self, monkeypatch):
         """If config returns empty, at least skill is present."""
         monkeypatch.setattr(cycle_pre, "_config_get", lambda f: "")
         roles = cycle_pre._get_verifiable_roles()
         assert "skill" in roles
-        # mandatory roles always added (pm, qa, dm — #9318)
+        # mandatory roles always added (pm, verifier, dm — #9318 / #6274.2)
         assert "dm" in roles
         assert "pm" in roles
-        assert "qa" in roles
+        assert "verifier" in roles
 
     def test_deduplicates(self, monkeypatch):
         """Roles are not duplicated even if they appear in config and hardcoded."""


### PR DESCRIPTION
Closes #10133

## Summary

QA-caught residual qa-role assertions in tests/test_cycle_pre.py::TestGetVerifiableRoles. Two assertions at L965 and L975 still asserted `'qa' in roles` after #9965 (6274.2) renamed the role identity to verifier. Same defect class as the test_manifest_registry.py gap caught in #9965 cycle 1376 QA reject.

## Changes

- `tests/test_cycle_pre.py:965` — `assert 'qa' in roles` → `assert 'verifier' in roles`
- `tests/test_cycle_pre.py:975` — same
- Docstrings on both tests updated to reflect verifier-as-mandatory-role and cite #6274.2

## Peer assertions audited (intentionally NOT changed)

- `tests/test_cycle_pre.py:951` — passes on main; tests config-preservation behavior through the dual-aware shim (different code path).
- `tests/test_boot_remote.py:386, :395` — same dual-aware preservation; all passing.
- `tests/test_config_functions.py:326` — file is excluded from STATIC_TEST_MODULES per existing comment.

## QA Notes

- `python -m pytest tests/test_cycle_pre.py::TestGetVerifiableRoles` → 5/5 pass.
- `python tests/run_tests.py` → integration suite green.

Refs #6274 AC2.6 (residual sweep)