### PR TITLE
skill: #10072 cycle_pre._enforce_branch regex extraction

### DIFF
--- a/references/scripts/cycle_pre.py
+++ b/references/scripts/cycle_pre.py
@@ -210,7 +210,7 @@ def _enforce_branch(role, working_state):
         # bare ("#9965", "9965"), verbose ("#9965 — description"), and
         # whitespace-tolerant ("# 9965") forms. Trailing anchor rejects
         # glued suffixes like "9965-fix" that old `.isdigit()` also rejected.
-        m = re.match(r"#?\s*(\d+)(?:\s|—|$)", task.lstrip())
+        m = re.match(r"#*\s*(\d+)(?:\s|—|$)", task.lstrip())
         if m:
             number = m.group(1)
             result = _run_script("git_ops.py", "task-begin", role, number)

--- a/references/scripts/cycle_pre.py
+++ b/references/scripts/cycle_pre.py
@@ -20,6 +20,7 @@ Exit codes:
 """
 
 import json
+import re
 import shlex
 import subprocess
 import sys
@@ -205,9 +206,13 @@ def _enforce_branch(role, working_state):
     status = working_state.get("status", "none")
 
     if task != "none" and status == "in-progress":
-        # Extract issue number from task field (e.g. "#4942" -> "4942")
-        number = task.lstrip("#").strip()
-        if number.isdigit():
+        # Extract issue number from task field (#10072). Anchored to match
+        # bare ("#9965", "9965"), verbose ("#9965 — description"), and
+        # whitespace-tolerant ("# 9965") forms. Trailing anchor rejects
+        # glued suffixes like "9965-fix" that old `.isdigit()` also rejected.
+        m = re.match(r"#?\s*(\d+)(?:\s|—|$)", task.lstrip())
+        if m:
+            number = m.group(1)
             result = _run_script("git_ops.py", "task-begin", role, number)
             if result.returncode != 0:
                 # Non-fatal — log and continue on current branch

--- a/tests/test_cycle_pre.py
+++ b/tests/test_cycle_pre.py
@@ -1221,6 +1221,70 @@ class TestEnforceBranch:
         assert len(task_begin_calls) == 1
         assert "4942" in task_begin_calls[0]
 
+    @pytest.mark.parametrize("task_field,expected_number", [
+        ("#9965", "9965"),
+        ("9965", "9965"),
+        ("#9965 — 6274.2 AC2.8 catch-up (PM option-3 path) [PAUSED]", "9965"),
+        ("#10072 — verbose description with em-dash", "10072"),
+        ("9965 — bare-number verbose form", "9965"),
+        # Whitespace tolerance (DS review Finding 1 — was a regression vs old code)
+        ("# 9965", "9965"),
+        ("  #9965", "9965"),
+        ("#\t9965", "9965"),
+        ("#9965 - ASCII dash separator", "9965"),
+    ])
+    def test_extracts_number_from_verbose_task_field(
+        self, monkeypatch, task_field, expected_number
+    ):
+        """#10072: regex extraction handles both bare and verbose task forms."""
+        calls = []
+
+        def fake_run_script(*args, **kwargs):
+            calls.append(args)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(cycle_pre, "_config_get",
+                            lambda f: "yes" if f == "branch-workflow" else "main")
+        monkeypatch.setattr(cycle_pre, "_run_script", fake_run_script)
+        monkeypatch.setattr(cycle_pre, "_run",
+                            lambda cmd, **kw: MagicMock(returncode=0, stdout="main\n", stderr=""))
+
+        ws = {"task": task_field, "status": "in-progress"}
+        cycle_pre._enforce_branch("skill", ws)
+
+        task_begin_calls = [c for c in calls if "task-begin" in c]
+        assert len(task_begin_calls) == 1, f"task-begin not called for {task_field!r}"
+        assert expected_number in task_begin_calls[0], \
+            f"expected {expected_number} in {task_begin_calls[0]} for {task_field!r}"
+
+    @pytest.mark.parametrize("task_field", [
+        "no-number-here",
+        "#",                # DS review Finding 2: hash with no digits
+        "#abc",             # hash followed by non-digits
+        "9965-fix",         # DS review Finding 3: glued suffix — old code rejected
+        "9965abc",          # digits glued to letters
+    ])
+    def test_skips_task_begin_for_non_numeric_task(self, monkeypatch, task_field):
+        """#10072: malformed task fields skip task-begin without crashing."""
+        calls = []
+
+        def fake_run_script(*args, **kwargs):
+            calls.append(args)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(cycle_pre, "_config_get",
+                            lambda f: "yes" if f == "branch-workflow" else "main")
+        monkeypatch.setattr(cycle_pre, "_run_script", fake_run_script)
+        monkeypatch.setattr(cycle_pre, "_run",
+                            lambda cmd, **kw: MagicMock(returncode=0, stdout="main\n", stderr=""))
+
+        ws = {"task": task_field, "status": "in-progress"}
+        cycle_pre._enforce_branch("skill", ws)
+
+        task_begin_calls = [c for c in calls if "task-begin" in c]
+        assert len(task_begin_calls) == 0, \
+            f"task-begin unexpectedly called for {task_field!r}: {task_begin_calls}"
+
     def test_switches_to_working_branch_when_no_task(self, monkeypatch):
         """When no active task, switches to working branch."""
         checkout_targets = []

--- a/tests/test_cycle_pre.py
+++ b/tests/test_cycle_pre.py
@@ -1232,6 +1232,9 @@ class TestEnforceBranch:
         ("  #9965", "9965"),
         ("#\t9965", "9965"),
         ("#9965 - ASCII dash separator", "9965"),
+        # Backward compat with old task.lstrip("#") behavior (DS round 2 Finding 1)
+        ("##4942", "4942"),
+        ("###9965 — triple-hash typo", "9965"),
     ])
     def test_extracts_number_from_verbose_task_field(
         self, monkeypatch, task_field, expected_number


### PR DESCRIPTION
## Summary

Fix `cycle_pre._enforce_branch` parsing of the working-state `task` field so it correctly extracts the issue number from the verbose `#NNNN — description` convention (not just bare `#NNNN`).

Old code: `task.lstrip(\"#\").strip()` + `.isdigit()` — works for `#9965` and `9965` but silently no-ops for `#9965 — desc`, leaving the agent on the wrong branch.

New code: `re.match(r\"#*\s*(\d+)(?:\s|—|\$)\", task.lstrip())` with anchored capture.

Closes #10072.

## Behavior

| Input | Old | New |
|-------|-----|-----|
| `#9965` | accept → 9965 | accept → 9965 |
| `9965` | accept → 9965 | accept → 9965 |
| `#9965 — desc` | **reject** (regression) | accept → 9965 |
| `# 9965` | accept → 9965 | accept → 9965 |
| `##4942` | accept → 4942 | accept → 4942 |
| `9965-fix` | reject | reject |
| `#abc` | reject | reject |

## Tests

`tests/test_cycle_pre.py::TestEnforceBranch` — 19 tests, all passing:
- 11 positive parametrized cases (bare, hash, verbose em-dash, whitespace variants, multi-hash typos, ASCII-dash separator)
- 5 negative parametrized cases (`no-number-here`, `#`, `#abc`, `9965-fix`, `9965abc`)
- 3 pre-existing tests (calls task-begin, switches working branch, stays on working branch)

## External review iterations

| Round | Reviewer | Findings | Status |
|-------|----------|----------|--------|
| 1 | DeepSeek | 3 warnings (whitespace regression, missing whitespace tests, relaxed-match) | All fixed in `5851b7f1` |
| 2 | DeepSeek | 1 warning (`#?` rejected `##NNNN` typos) | Fixed in `427b4e20` |
| 3 | Claude (DS output too short, auto-fallback) | NO_FINDINGS | Converged |

## Test plan

- [ ] CI runs `python tests/run_tests.py` — should be green (4 unrelated pre-existing ERRORs in `test_deterministic_qa_framework::TestVerificationSubSkill` due to missing fixture `references/sub-skills/roles/qa/verification.md` — not in scope of this change).
- [ ] Verify the fix resolves the production symptom: after merge, a feature task with verbose working-state form should trigger `git_ops.py task-begin` automatically (no manual checkout needed; the bug memory rule `feedback_always_checkout_feature_branch` can be retired).