### PR TITLE
skill: #10007 atomic state-file writes via shared_fs.atomic_write_text

### DIFF
--- a/references/scripts/config.py
+++ b/references/scripts/config.py
@@ -404,10 +404,11 @@ def write_event_reactions(reactions_dict, text=None):
         # Append to end of file
         new_text = text.rstrip() + "\n" + new_section
 
-    # Atomic write
-    tmp = CONFIG_PATH.with_suffix(".tmp")
-    tmp.write_text(new_text, encoding="utf-8")
-    tmp.replace(CONFIG_PATH)
+    # #10007 DS review Finding 5: route through shared atomic helper so this
+    # function and set_field stay consistent (both use the same newline
+    # handling and mkstemp/replace pattern; previously this used a bespoke
+    # `with_suffix(".tmp") + write_text + replace` pattern that diverged).
+    atomic_write_text(CONFIG_PATH, new_text)
 
 
 # ---------------------------------------------------------------------------

--- a/references/scripts/config.py
+++ b/references/scripts/config.py
@@ -38,6 +38,9 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent
 CONFIG_PATH = REPO_ROOT / ".squidsquad" / "config.md"
 
+sys.path.insert(0, str(SCRIPT_DIR))
+from shared_fs import atomic_write_text  # #10007
+
 # Known field mappings: short name -> (section_heading, field_name)
 # Section heading is used for disambiguation when field names repeat (e.g. "Enabled")
 FIELD_MAP = {
@@ -282,7 +285,7 @@ def set_field(field, value):
             print(f"ERROR: Field '{field}' not found in config.md", file=sys.stderr)
             sys.exit(1)
 
-    CONFIG_PATH.write_text(new_text, encoding="utf-8")
+    atomic_write_text(CONFIG_PATH, new_text)
     return value
 
 

--- a/references/scripts/cycle.py
+++ b/references/scripts/cycle.py
@@ -35,6 +35,8 @@ except ImportError:
     def _state_path(rel):
         return SQUIDSQUAD_DIR / rel
 
+from shared_fs import atomic_write_text  # #10007
+
 
 def _now():
     """Get current local time."""
@@ -164,7 +166,7 @@ def set_counter(role, value):
         )
     else:
         new_text = text.rstrip("\n") + f"\n- **Quiet Cycle Counter**: {value}\n"
-    ws_path.write_text(new_text, encoding="utf-8")
+    atomic_write_text(ws_path, new_text)
     return value
 
 

--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -46,6 +46,8 @@ except ImportError:
     def _worktree_exists():
         return False
 
+from shared_fs import atomic_write_text  # #10007
+
 # Required top-level fields in cycle-output.json. Mode-gated (#8918): event
 # mode replaces `cycle_number` with `task` — the task IS the cycle in event
 # mode (DECISIONS-4792.md Q7 + CONTEXT.md §5.5 + TEST-PLAN-8701 §3.2 UT-10).
@@ -581,7 +583,7 @@ def _do_version_bump(data, role):
     if skill_md.exists():
         content = skill_md.read_text(encoding="utf-8")
         content = re.sub(r'version:\s*[\d.]+', f'version: {new_version}', content, count=1)
-        skill_md.write_text(content, encoding="utf-8")
+        atomic_write_text(skill_md, content)
 
     # DM always handles CHANGELOG entries (#6261). No PM fallback.
 
@@ -766,7 +768,7 @@ def _do_working_state_update(data, role):
 
     ws_path = _state_path(f"{role}/working-state.md")
     ws_path.parent.mkdir(parents=True, exist_ok=True)
-    ws_path.write_text(update, encoding="utf-8")
+    atomic_write_text(ws_path, update)
 
 
 # ---------------------------------------------------------------------------

--- a/references/scripts/diagnostics.py
+++ b/references/scripts/diagnostics.py
@@ -32,6 +32,8 @@ except ImportError:
     def _read_config():
         return ""
 
+from shared_fs import atomic_write_text  # #10007
+
 try:
     from state_bus import state_path as _state_path
     DIAGNOSTICS_DIR = _state_path("diagnostics")
@@ -94,7 +96,7 @@ def rotate():
         return
 
     # Keep last 500
-    LOG_FILE.write_text("\n".join(lines[-500:]) + "\n", encoding="utf-8")
+    atomic_write_text(LOG_FILE, "\n".join(lines[-500:]) + "\n")
     print(f"Rotated: kept last 500 of {len(lines)} entries")
 
 

--- a/references/scripts/shared_fs.py
+++ b/references/scripts/shared_fs.py
@@ -61,6 +61,44 @@ def init():
     return str(home)
 
 
+def atomic_write_text(path, content, encoding="utf-8"):
+    """Atomically write text to ``path`` (#10007).
+
+    Writes to a sibling ``.tmp`` file in the same directory, then ``os.replace``
+    swaps it into place. Concurrent readers of ``path`` either see the old full
+    file or the new full file — never a partial/torn write.
+
+    Same-directory + ``os.replace`` is required for atomicity (Python docs:
+    atomic on both POSIX and Windows, but only if source and destination are
+    on the same filesystem — which the sibling-tmp pattern guarantees).
+
+    Cleans up the tmp file on any exception during write so a crash mid-write
+    leaves the original file untouched.
+    """
+    path = Path(path)
+    tmp_fd, tmp_path_str = tempfile.mkstemp(
+        prefix=f".{path.name}-", suffix=".tmp", dir=str(path.parent)
+    )
+    tmp_path = Path(tmp_path_str)
+    # Close mkstemp's fd immediately; we re-open by path. This avoids the
+    # fd-leak edge case where ``os.fdopen`` raises (e.g. patched in tests)
+    # and the fd stays open, blocking ``tmp_path.unlink`` on Windows.
+    try:
+        os.close(tmp_fd)
+    except OSError:
+        pass
+    try:
+        with open(tmp_path, "w", encoding=encoding, newline="") as f:
+            f.write(content)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            tmp_path.unlink()
+        except OSError:
+            pass
+        raise
+
+
 def _restrict_permissions(path):
     """Set file permissions to owner-only (chmod 600 / Windows ACL).
 

--- a/references/scripts/shared_fs.py
+++ b/references/scripts/shared_fs.py
@@ -74,6 +74,17 @@ def atomic_write_text(path, content, encoding="utf-8"):
 
     Cleans up the tmp file on any exception during write so a crash mid-write
     leaves the original file untouched.
+
+    Newline handling matches ``Path.write_text``: ``open`` uses the default
+    ``newline=None`` so on Windows ``\\n`` in ``content`` is translated to
+    ``\\r\\n``. This preserves the prior behavior of the 9 call sites this
+    helper replaces, so existing state files don't acquire a phantom git diff
+    from line-ending changes (#10007 DS review Finding 1).
+
+    Note: atomicity is at the write level only. Read-modify-write call sites
+    (e.g. ``cycle.set_counter``, ``vault_remember._upsert_vault_writes``) can
+    still race between the read and the write; that is an application-level
+    concern outside this helper's scope (#10007 DS review Finding 4).
     """
     path = Path(path)
     tmp_fd, tmp_path_str = tempfile.mkstemp(
@@ -88,7 +99,7 @@ def atomic_write_text(path, content, encoding="utf-8"):
     except OSError:
         pass
     try:
-        with open(tmp_path, "w", encoding=encoding, newline="") as f:
+        with open(tmp_path, "w", encoding=encoding) as f:
             f.write(content)
         os.replace(tmp_path, path)
     except Exception:

--- a/references/scripts/shared_fs.py
+++ b/references/scripts/shared_fs.py
@@ -85,6 +85,15 @@ def atomic_write_text(path, content, encoding="utf-8"):
     (e.g. ``cycle.set_counter``, ``vault_remember._upsert_vault_writes``) can
     still race between the read and the write; that is an application-level
     concern outside this helper's scope (#10007 DS review Finding 4).
+
+    Trade-off (#10007 DS round-2 Finding 3): closing the mkstemp fd before
+    re-opening by path leaves a brief window where the empty tmp file is
+    visible on disk with no open handle. For SquidSquad state files in a
+    single-agent directory this is benign — no other process is racing for
+    that specific tmp name. For shared multi-writer files where exclusivity
+    matters between create and first-write, prefer the ``os.fdopen``-on-the
+    mkstemp-fd pattern used by ``write_secret`` (which trades the Windows
+    fd-leak-on-test-patch hazard for the no-window guarantee).
     """
     path = Path(path)
     tmp_fd, tmp_path_str = tempfile.mkstemp(

--- a/references/scripts/soul_adaptation.py
+++ b/references/scripts/soul_adaptation.py
@@ -35,6 +35,9 @@ SQUID_DIR = REPO_ROOT / ".squidsquad"
 VAULT_DIR = SQUID_DIR / "vault"
 ADAPTATIONS_FILE = VAULT_DIR / "areas" / "role-adaptations.md"
 
+sys.path.insert(0, str(SCRIPT_DIR))
+from shared_fs import atomic_write_text  # #10007
+
 ADAPTATION_HEADER = "## Project Adaptation"
 ADAPTATION_FOOTER = "<!-- /project-adaptation -->"
 
@@ -144,7 +147,7 @@ def add_adaptation(role, category, signal, source_task=None):
         else:
             content = content.rstrip() + f"\n{entry}\n"
 
-    ADAPTATIONS_FILE.write_text(content, encoding="utf-8")
+    atomic_write_text(ADAPTATIONS_FILE, content)
     return entry
 
 
@@ -223,7 +226,7 @@ def render_soul(role):
         # Append at end
         content = content.rstrip() + "\n\n" + adaptation_text
 
-    soul_path.write_text(content, encoding="utf-8")
+    atomic_write_text(soul_path, content)
     return True
 
 

--- a/references/scripts/vault_remember.py
+++ b/references/scripts/vault_remember.py
@@ -35,6 +35,8 @@ except ImportError:
     def get_field(field):
         return None
 
+from shared_fs import atomic_write_text  # #10007
+
 
 def _read_working_state(role):
     """Read working-state.md for a role."""
@@ -52,7 +54,7 @@ def _write_working_state_field(role, field_pattern, new_value):
     try:
         text = ws_path.read_text(encoding="utf-8")
         new_text = re.sub(field_pattern, new_value, text)
-        ws_path.write_text(new_text, encoding="utf-8")
+        atomic_write_text(ws_path, new_text)
         return True
     except OSError as e:
         print(f"WARNING: Failed to update {ws_path}: {e}", file=sys.stderr)
@@ -148,7 +150,7 @@ def _upsert_vault_writes(role, new_value):
         if ws_path.exists():
             text = ws_path.read_text(encoding="utf-8")
             text += f"\n- **Vault Writes This Cycle**: {new_value}\n"
-            ws_path.write_text(text, encoding="utf-8")
+            atomic_write_text(ws_path, text)
     return new_value
 
 

--- a/tests/test_shared_fs.py
+++ b/tests/test_shared_fs.py
@@ -367,19 +367,49 @@ class TestAtomicWriteText:
         leftovers = [f for f in tmp_path.iterdir() if f.suffix == ".tmp"]
         assert leftovers == [], f"tmp file leaked: {leftovers}"
 
-    def test_concurrent_reader_never_sees_partial_write(self, tmp_path):
-        """Reader reading the path mid-write either sees old content or new.
-        Validated indirectly via os.replace atomicity: there is no window
-        where the destination exists in a partial state — it's either the
-        pre-existing inode or the new one. The tmp file is in the same
-        directory (same filesystem) so the replace is atomic on all OSes."""
+    def test_large_write_roundtrip(self, tmp_path):
+        """Large content round-trips correctly through the helper.
+
+        The actual concurrent-read safety is a structural guarantee of
+        ``os.replace`` on a same-filesystem path — see
+        ``test_uses_os_replace_for_atomic_swap`` for the source-level lock.
+        This test just locks in that the helper handles non-trivial payload
+        sizes (#10007 DS review Finding 3 — renamed from
+        test_concurrent_reader_never_sees_partial_write because the original
+        name implied a behavioral assertion the test body didn't make)."""
         p = tmp_path / "out.txt"
         shared_fs.atomic_write_text(p, "v1" * 1000)
-        # After successful write, reader sees the complete new content.
-        # (The atomicity guarantee is structural — provided by os.replace
-        # on a same-filesystem path — and is exercised by every other
-        # test in this class. This test serves as documentation.)
         assert p.read_text(encoding="utf-8") == "v1" * 1000
+
+    def test_uses_os_replace_for_atomic_swap(self):
+        """Source-level lock: the helper must call ``os.replace`` (atomic
+        on POSIX and Windows for same-filesystem paths). A future refactor
+        that drops to ``shutil.move`` or similar non-atomic primitive would
+        break the core guarantee (#10007 DS review Finding 3 — companion
+        source-level assertion to the test rename above)."""
+        import inspect
+        source = inspect.getsource(shared_fs.atomic_write_text)
+        assert "os.replace" in source, (
+            "atomic_write_text must use os.replace for the swap step."
+        )
+        assert "mkstemp" in source, (
+            "atomic_write_text must write to a sibling tmp file before swap."
+        )
+
+    def test_preserves_path_write_text_newline_behavior(self, tmp_path):
+        """#10007 DS review Finding 1: the helper must match Path.write_text
+        newline behavior so existing state files don't acquire a phantom
+        git diff from line-ending changes when the helper is first deployed."""
+        p_helper = tmp_path / "helper.txt"
+        p_native = tmp_path / "native.txt"
+        content = "line1\nline2\nline3\n"
+        shared_fs.atomic_write_text(p_helper, content)
+        p_native.write_text(content, encoding="utf-8")
+        # Compare raw bytes — text mode normalizes, defeating the check.
+        assert p_helper.read_bytes() == p_native.read_bytes(), (
+            "atomic_write_text must produce byte-identical output to "
+            "Path.write_text (same newline translation behavior)."
+        )
 
 
 class TestCallSitesUseAtomicWrite:
@@ -397,6 +427,7 @@ class TestCallSitesUseAtomicWrite:
         ("soul_adaptation", "add_adaptation"),
         ("soul_adaptation", "render_soul"),
         ("config", "set_field"),
+        ("config", "write_event_reactions"),  # #10007 DS review Finding 5
         ("diagnostics", "rotate"),
     ])
     def test_call_site_uses_atomic_write_text(self, module_name, function_name):

--- a/tests/test_shared_fs.py
+++ b/tests/test_shared_fs.py
@@ -420,26 +420,37 @@ class TestCallSitesUseAtomicWrite:
     invariants — a future refactor that drops back to direct write_text on
     a concurrently-read state file would regress this issue."""
 
-    @pytest.mark.parametrize("module_name,function_name", [
-        ("vault_remember", "_write_working_state_field"),
-        ("vault_remember", "_upsert_vault_writes"),
-        ("cycle", "set_counter"),
-        ("cycle_post", "_do_working_state_update"),
-        ("cycle_post", "_do_version_bump"),
-        ("soul_adaptation", "add_adaptation"),
-        ("soul_adaptation", "render_soul"),
-        ("config", "set_field"),
-        ("config", "write_event_reactions"),  # #10007 DS review Finding 5
-        ("diagnostics", "rotate"),
+    @pytest.mark.parametrize("module_filename,function_name", [
+        ("vault_remember.py", "_write_working_state_field"),
+        ("vault_remember.py", "_upsert_vault_writes"),
+        ("cycle.py", "set_counter"),
+        ("cycle_post.py", "_do_working_state_update"),
+        ("cycle_post.py", "_do_version_bump"),
+        ("soul_adaptation.py", "add_adaptation"),
+        ("soul_adaptation.py", "render_soul"),
+        ("config.py", "set_field"),
+        ("config.py", "write_event_reactions"),  # #10007 DS review Finding 5
+        ("diagnostics.py", "rotate"),
     ])
-    def test_call_site_uses_atomic_write_text(self, module_name, function_name):
-        import importlib
+    def test_call_site_uses_atomic_write_text(self, module_filename, function_name):
+        """#10007 DS round-3 (Claude fallback) Finding 1: resolve modules by
+        explicit file path under `references/scripts/` instead of bare
+        ``importlib.import_module(name)``. A bare name resolves via sys.path
+        order, so a future PyPI package named e.g. ``config`` could silently
+        shadow our local script and make this regression lock vacuous."""
+        import importlib.util
         import inspect
-        mod = importlib.import_module(module_name)
+
+        script_path = SCRIPTS / module_filename
+        spec = importlib.util.spec_from_file_location(
+            f"_locked_{module_filename[:-3]}", script_path
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
         fn = getattr(mod, function_name)
         source = inspect.getsource(fn)
         assert "atomic_write_text" in source, (
-            f"#10007 regression: {module_name}.{function_name} must call "
+            f"#10007 regression: {module_filename}::{function_name} must call "
             f"atomic_write_text (not Path.write_text) — concurrent readers "
             f"can see torn writes on the state file it manages."
         )

--- a/tests/test_shared_fs.py
+++ b/tests/test_shared_fs.py
@@ -318,27 +318,28 @@ class TestAtomicWriteText:
         assert p.read_text(encoding="utf-8") == content
 
     def test_no_tmp_leftover_after_success(self, tmp_path):
+        """#10007 DS round-2 Finding 1: assert against ANY unexpected file,
+        not just `.tmp` suffix — a future suffix change must not silently
+        skip the leak check."""
         p = tmp_path / "out.txt"
         shared_fs.atomic_write_text(p, "x")
-        leftovers = [f for f in tmp_path.iterdir() if f.suffix == ".tmp"]
-        assert leftovers == []
+        leftovers = [f for f in tmp_path.iterdir() if f != p]
+        assert leftovers == [], f"unexpected files in dir: {leftovers}"
 
     def test_crash_mid_write_leaves_original_intact(self, tmp_path, monkeypatch):
-        """If the inner write raises, the original file must be untouched."""
+        """If the inner write raises, the original file must be untouched.
+
+        #10007 DS round-2 Finding 2: patch ``os.replace`` (the observable
+        swap step) rather than ``builtins.open`` — the latter couples to
+        the internal file-opening mechanism and would silently skip the
+        crash path if the impl ever moves to ``os.fdopen``."""
         p = tmp_path / "out.txt"
         shared_fs.atomic_write_text(p, "original")
 
-        import builtins
-        real_open = builtins.open
-
         def boom(*args, **kwargs):
-            # Only intercept the inner write-to-tmp call (mode 'w');
-            # leave read calls (mode 'r' or no mode) alone.
-            if len(args) >= 2 and args[1] == "w":
-                raise RuntimeError("simulated crash")
-            return real_open(*args, **kwargs)
+            raise RuntimeError("simulated crash at swap step")
 
-        monkeypatch.setattr(builtins, "open", boom)
+        monkeypatch.setattr(shared_fs.os, "replace", boom)
 
         with pytest.raises(RuntimeError):
             shared_fs.atomic_write_text(p, "should not land")
@@ -347,25 +348,26 @@ class TestAtomicWriteText:
         assert p.read_text(encoding="utf-8") == "original"
 
     def test_crash_mid_write_cleans_up_tmp(self, tmp_path, monkeypatch):
-        """If the inner write raises, the tmp sibling must be deleted."""
+        """If the swap step raises, the tmp sibling must be deleted.
+
+        #10007 DS round-2 Findings 1+2: capture pre-call file set, then
+        assert no new files exist after — robust against suffix changes
+        and decoupled from internal open mechanism."""
         p = tmp_path / "out.txt"
         shared_fs.atomic_write_text(p, "original")
-
-        import builtins
-        real_open = builtins.open
+        before = set(tmp_path.iterdir())
 
         def boom(*args, **kwargs):
-            if len(args) >= 2 and args[1] == "w":
-                raise RuntimeError("simulated crash")
-            return real_open(*args, **kwargs)
+            raise RuntimeError("simulated crash at swap step")
 
-        monkeypatch.setattr(builtins, "open", boom)
+        monkeypatch.setattr(shared_fs.os, "replace", boom)
 
         with pytest.raises(RuntimeError):
             shared_fs.atomic_write_text(p, "x")
 
-        leftovers = [f for f in tmp_path.iterdir() if f.suffix == ".tmp"]
-        assert leftovers == [], f"tmp file leaked: {leftovers}"
+        after = set(tmp_path.iterdir())
+        new_files = after - before
+        assert new_files == set(), f"tmp file(s) leaked: {new_files}"
 
     def test_large_write_roundtrip(self, tmp_path):
         """Large content round-trips correctly through the helper.

--- a/tests/test_shared_fs.py
+++ b/tests/test_shared_fs.py
@@ -295,3 +295,118 @@ class TestWriteSecretAtomic9932:
             "#9932 regression: write_secret reverted to direct write_text "
             "(non-atomic — truncates before writing)"
         )
+
+
+class TestAtomicWriteText:
+    """#10007: shared atomic_write_text helper for concurrent-read safety."""
+
+    def test_basic_write(self, tmp_path):
+        p = tmp_path / "out.txt"
+        shared_fs.atomic_write_text(p, "hello world")
+        assert p.read_text(encoding="utf-8") == "hello world"
+
+    def test_overwrites_existing(self, tmp_path):
+        p = tmp_path / "out.txt"
+        p.write_text("old", encoding="utf-8")
+        shared_fs.atomic_write_text(p, "new")
+        assert p.read_text(encoding="utf-8") == "new"
+
+    def test_unicode_roundtrip(self, tmp_path):
+        p = tmp_path / "out.md"
+        content = "Task: #9965 — em-dash and 中文 mix\n"
+        shared_fs.atomic_write_text(p, content)
+        assert p.read_text(encoding="utf-8") == content
+
+    def test_no_tmp_leftover_after_success(self, tmp_path):
+        p = tmp_path / "out.txt"
+        shared_fs.atomic_write_text(p, "x")
+        leftovers = [f for f in tmp_path.iterdir() if f.suffix == ".tmp"]
+        assert leftovers == []
+
+    def test_crash_mid_write_leaves_original_intact(self, tmp_path, monkeypatch):
+        """If the inner write raises, the original file must be untouched."""
+        p = tmp_path / "out.txt"
+        shared_fs.atomic_write_text(p, "original")
+
+        import builtins
+        real_open = builtins.open
+
+        def boom(*args, **kwargs):
+            # Only intercept the inner write-to-tmp call (mode 'w');
+            # leave read calls (mode 'r' or no mode) alone.
+            if len(args) >= 2 and args[1] == "w":
+                raise RuntimeError("simulated crash")
+            return real_open(*args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", boom)
+
+        with pytest.raises(RuntimeError):
+            shared_fs.atomic_write_text(p, "should not land")
+
+        # Critical invariant: the original file is untouched.
+        assert p.read_text(encoding="utf-8") == "original"
+
+    def test_crash_mid_write_cleans_up_tmp(self, tmp_path, monkeypatch):
+        """If the inner write raises, the tmp sibling must be deleted."""
+        p = tmp_path / "out.txt"
+        shared_fs.atomic_write_text(p, "original")
+
+        import builtins
+        real_open = builtins.open
+
+        def boom(*args, **kwargs):
+            if len(args) >= 2 and args[1] == "w":
+                raise RuntimeError("simulated crash")
+            return real_open(*args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", boom)
+
+        with pytest.raises(RuntimeError):
+            shared_fs.atomic_write_text(p, "x")
+
+        leftovers = [f for f in tmp_path.iterdir() if f.suffix == ".tmp"]
+        assert leftovers == [], f"tmp file leaked: {leftovers}"
+
+    def test_concurrent_reader_never_sees_partial_write(self, tmp_path):
+        """Reader reading the path mid-write either sees old content or new.
+        Validated indirectly via os.replace atomicity: there is no window
+        where the destination exists in a partial state — it's either the
+        pre-existing inode or the new one. The tmp file is in the same
+        directory (same filesystem) so the replace is atomic on all OSes."""
+        p = tmp_path / "out.txt"
+        shared_fs.atomic_write_text(p, "v1" * 1000)
+        # After successful write, reader sees the complete new content.
+        # (The atomicity guarantee is structural — provided by os.replace
+        # on a same-filesystem path — and is exercised by every other
+        # test in this class. This test serves as documentation.)
+        assert p.read_text(encoding="utf-8") == "v1" * 1000
+
+
+class TestCallSitesUseAtomicWrite:
+    """#10007 regression locks: every call site listed in the issue body
+    must route through atomic_write_text (not Path.write_text). Source-level
+    invariants — a future refactor that drops back to direct write_text on
+    a concurrently-read state file would regress this issue."""
+
+    @pytest.mark.parametrize("module_name,function_name", [
+        ("vault_remember", "_write_working_state_field"),
+        ("vault_remember", "_upsert_vault_writes"),
+        ("cycle", "set_counter"),
+        ("cycle_post", "_do_working_state_update"),
+        ("cycle_post", "_do_version_bump"),
+        ("soul_adaptation", "add_adaptation"),
+        ("soul_adaptation", "render_soul"),
+        ("config", "set_field"),
+        ("diagnostics", "rotate"),
+    ])
+    def test_call_site_uses_atomic_write_text(self, module_name, function_name):
+        import importlib
+        import inspect
+        mod = importlib.import_module(module_name)
+        fn = getattr(mod, function_name)
+        source = inspect.getsource(fn)
+        assert "atomic_write_text" in source, (
+            f"#10007 regression: {module_name}.{function_name} must call "
+            f"atomic_write_text (not Path.write_text) — concurrent readers "
+            f"can see torn writes on the state file it manages."
+        )


### PR DESCRIPTION
## Summary

Route 10 non-atomic state-file writers through a new `shared_fs.atomic_write_text(path, content, encoding=\"utf-8\")` helper. Concurrent readers (statusline, peer agents, cycle_pre, etc.) can no longer see a torn/partial write.

Closes #10007.

## Helper

```python
def atomic_write_text(path, content, encoding=\"utf-8\"):
    # mkstemp sibling in same directory → close fd → re-open by path → write → os.replace
```

- Same-directory `mkstemp` + `os.replace` for true atomicity on POSIX and Windows.
- Closes mkstemp fd immediately, re-opens by path (avoids Windows fd-leak when `os.fdopen` raises in tests).
- Newline behavior matches `Path.write_text` — no `newline=\"\"` — so existing state files don't acquire a phantom git diff from line-ending changes on Windows.
- Documents the brief TOCTOU window between `os.close(tmp_fd)` and re-open (benign for single-agent state files).
- Documents that read-modify-write races at call sites are app-level concerns outside this helper's scope.

## Routed call sites (10)

| Module | Function | Target file |
|--------|----------|-------------|
| `vault_remember` | `_write_working_state_field` | `.squidsquad/<role>/working-state.md` |
| `vault_remember` | `_upsert_vault_writes` | `.squidsquad/<role>/working-state.md` |
| `cycle` | `set_counter` | `.squidsquad/<role>/working-state.md` |
| `cycle_post` | `_do_working_state_update` | `.squidsquad/<role>/working-state.md` |
| `cycle_post` | `_do_version_bump` | `SKILL.md` (version frontmatter) |
| `soul_adaptation` | `add_adaptation` | `.squidsquad/vault/areas/role-adaptations.md` |
| `soul_adaptation` | `render_soul` | `.squidsquad/<role>/SOUL.md` |
| `config` | `set_field` | `.squidsquad/config.md` |
| `config` | `write_event_reactions` | `.squidsquad/config.md` (added per DS round 1) |
| `diagnostics` | `rotate` | `.squidsquad/diagnostics/diagnostic.jsonl` |

## Tests

`tests/test_shared_fs.py::TestAtomicWriteText` (9 cases):
- basic write, overwrite, unicode round-trip
- no tmp file leftover after success (set-diff against pre-call snapshot)
- crash mid-write leaves original intact (patches `os.replace`, not `builtins.open`)
- crash cleans up tmp (same robust pattern)
- large-write round-trip
- source-level lock on `os.replace` + `mkstemp` usage
- byte-comparison test that newline behavior matches `Path.write_text`

`TestCallSitesUseAtomicWrite` (10 parametrized source-level locks): resolves each module via `importlib.util.spec_from_file_location` against the `SCRIPTS` path constant (decoupled from `sys.path` — a future PyPI package named `config` etc. cannot silently shadow the local script and make these locks vacuous).

**19/19 pass.** Full `tests/run_tests.py`: 50 passed / 1 skipped / 8 unrelated pre-existing ERRORs (`test_deterministic_qa_framework` missing fixture + `test_event_mode_fragments` references non-existent role manifest paths).

## External review iterations

| Round | Reviewer | Findings | Status |
|-------|----------|----------|--------|
| 1 | DeepSeek | 5 (newline regression, write_secret divergence, misleading test name, RMW races, divergent atomic pattern in `write_event_reactions`) | 3 fixed in `2d33f8a6`; 2 justified-ignore |
| 2 | DeepSeek | 3 (vacuous suffix-filter, fragile `builtins.open` patch, undocumented TOCTOU) | All 3 fixed in `b1a1b388` |
| 3 | DeepSeek → Claude fallback | 1 (`importlib.import_module(bare-name)` could be shadowed by PyPI) | Fixed in `74b60f51` |

Justified-ignore from round 1:
- **write_secret keeps its existing `os.fdopen` pattern**. Out of scope: `~/.squidsquad/secrets` is single-writer, not in the #10007 audit table.
- **RMW races in `_upsert_vault_writes` and `set_counter`**. Pre-existing application-level concern; `atomic_write_text` fixes write-atomicity, not RMW atomicity. Documented in the helper docstring. Full RMW redesign would require file-locking; separate effort.

DS round 3 hit the same `model_router` min-length-threshold issue we saw on #10072 — auto-fallback to Claude (sonnet) per established memory rule.

## Test plan

- [ ] CI `python tests/run_tests.py` green (excluding the 8 pre-existing unrelated ERRORs noted above).
- [ ] Verify after merge: agents producing concurrent state writes (statusline tail + peer cycle_pre read) never observe a torn file. Hard to deterministically prove via test; structural guarantee is `os.replace` atomicity.
- [ ] Verify on Windows that no phantom git diff appears on first cycle after deploy (newline behavior preserved).