### PR TITLE
skill: #10156 — sweep tests for hardcoded {dev, qa} role-name residuals post-#6274.2

### DIFF
--- a/tests/test_agent_boundaries.py
+++ b/tests/test_agent_boundaries.py
@@ -85,17 +85,17 @@ def test_ac4_roster_has_exactly_active_roles():
     ("feedback_auto_approve_bugs", "references/sub-skills/roles/pm/responsibility.md"),
     ("feedback_dm_optional", "references/sub-skills/roles/pm/responsibility.md"),
     # QA L2 absorptions
-    ("feedback_no_ship_failed_tc", "references/sub-skills/roles/qa/responsibility.md"),
-    ("feedback_no_ship_with_gaps", "references/sub-skills/roles/qa/responsibility.md"),
+    ("feedback_no_ship_failed_tc", "references/sub-skills/roles/verifier/responsibility.md"),
+    ("feedback_no_ship_with_gaps", "references/sub-skills/roles/verifier/responsibility.md"),
     # DM L2 absorptions
     ("feedback_dm_optional", "references/sub-skills/roles/dm/responsibility.md"),
     ("feedback_no_ship_failed_tc", "references/sub-skills/roles/dm/responsibility.md"),
     ("feedback_no_ship_with_gaps", "references/sub-skills/roles/dm/responsibility.md"),
     # Cross-role test_workflow_separation
     ("feedback_test_workflow_separation", "references/sub-skills/roles/pm/responsibility.md"),
-    ("feedback_test_workflow_separation", "references/sub-skills/roles/qa/responsibility.md"),
+    ("feedback_test_workflow_separation", "references/sub-skills/roles/verifier/responsibility.md"),
     ("feedback_test_workflow_separation", "references/sub-skills/roles/dm/responsibility.md"),
-    ("feedback_test_workflow_separation", "references/sub-skills/roles/dev/responsibility.md"),
+    ("feedback_test_workflow_separation", "references/sub-skills/roles/worker/responsibility.md"),
 ])
 def test_ac6_memory_absorption_lineage_tag(source, filename):
     """AC6: each memory entry from D5 is absorbed into the indicated L2
@@ -114,7 +114,8 @@ def test_ac6_memory_absorption_lineage_tag(source, filename):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("role", ["dev", "dm", "pm", "qa"])
+# #10156: post-#6274.2 rename — dev→worker, qa→verifier.
+@pytest.mark.parametrize("role", ["worker", "dm", "pm", "verifier"])
 @pytest.mark.parametrize("variant", ["android", "fullstack", "ios", "skill", "web"])
 def test_ac7_l3_stub_exists_and_matches_template(role, variant):
     """AC7: all 20 L3 stub files exist and match the D6a template
@@ -134,7 +135,8 @@ def test_ac7_l3_stub_exists_and_matches_template(role, variant):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("prefix", ["pm", "qa", "dm", "dev", "shared"])
+# #10156: post-#6274.2 rename — dev→worker, qa→verifier prefix.
+@pytest.mark.parametrize("prefix", ["pm", "verifier", "dm", "worker", "shared"])
 def test_ac8_l4_seed_stub_exists(prefix):
     """AC8 (seed half): seed templates at references/sub-skills/project/."""
     seed = REPO / "references" / "sub-skills" / "project" / f"{prefix}-responsibility.md"
@@ -143,7 +145,8 @@ def test_ac8_l4_seed_stub_exists(prefix):
     assert "Install-specific responsibility additions" in content
 
 
-@pytest.mark.parametrize("prefix", ["pm", "qa", "dm", "dev", "shared"])
+# #10156: post-#6274.2 rename — dev→worker, qa→verifier prefix.
+@pytest.mark.parametrize("prefix", ["pm", "verifier", "dm", "worker", "shared"])
 def test_ac8_l4_live_stub_exists(prefix):
     """AC8 (live half): live stubs at .squidsquad/project/."""
     live = REPO / ".squidsquad" / "project" / f"{prefix}-responsibility.md"

--- a/tests/test_agent_boundaries.py
+++ b/tests/test_agent_boundaries.py
@@ -26,11 +26,14 @@ import compose  # noqa: E402
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("role", ["pm", "qa", "dm", "skill"])
+# #10156: post-#6274.2 rename — qa→verifier, dev→worker. "skill" remains
+# as the variant name (config.md's `Workers: skill`); the role behind it
+# is now `worker` after composition.
+@pytest.mark.parametrize("role", ["pm", "verifier", "dm", "skill"])
 def test_ac4_composed_contains_l1_awareness_and_l2(role):
-    """For each of pm/qa/dm/dev (skill is the dev variant), the composed
-    output must contain the L1 awareness instruction, the roster header,
-    and the role's own L2 'What this role does' header (#9925 AC4).
+    """For each of pm/verifier/dm/worker (skill is the worker variant), the
+    composed output must contain the L1 awareness instruction, the roster
+    header, and the role's own L2 'What this role does' header (#9925 AC4).
     """
     composed = compose.compose_role(role)
     assert "Know each other's responsibilities" in composed, (
@@ -48,11 +51,10 @@ def test_ac4_composed_contains_l1_awareness_and_l2(role):
 
 
 def test_ac4_roster_has_exactly_active_roles():
-    """AC4: for the current install (`Dev Agents: skill` + mandatory
-    PM/QA/DM), the roster MUST contain exactly 4 entries — one per
-    pm/qa/dm/dev. Roles whose manifest exists but are NOT active in
-    config.md must NOT appear (F4 lock).
-    """
+    """AC4: for the current install (`Workers: skill` + mandatory
+    PM/Verifier/DM), the roster MUST contain exactly 4 entries — one per
+    pm/verifier/dm/worker. Roles whose manifest exists but are NOT active
+    in config.md must NOT appear (F4 lock). #10156: post-#6274.2 rename."""
     composed = compose.compose_role("pm")
     # Each rendered entry uses a `### <DisplayName>` header inside the
     # 'Your Teammates' Responsibilities' block. Slice the roster section
@@ -68,7 +70,7 @@ def test_ac4_roster_has_exactly_active_roles():
     roster_block = composed[start:end]
     h3_count = roster_block.count("\n### ")
     assert h3_count == 4, (
-        f"AC4: expected exactly 4 roster entries (one per pm/qa/dm/dev), "
+        f"AC4: expected exactly 4 roster entries (one per pm/verifier/dm/worker), "
         f"saw {h3_count}. Roster block:\n{roster_block}"
     )
 
@@ -84,7 +86,7 @@ def test_ac4_roster_has_exactly_active_roles():
     ("feedback_bugs_behavior_only", "references/sub-skills/roles/pm/responsibility.md"),
     ("feedback_auto_approve_bugs", "references/sub-skills/roles/pm/responsibility.md"),
     ("feedback_dm_optional", "references/sub-skills/roles/pm/responsibility.md"),
-    # QA L2 absorptions
+    # Verifier L2 absorptions (#10156: was "QA" pre-#6274.2)
     ("feedback_no_ship_failed_tc", "references/sub-skills/roles/verifier/responsibility.md"),
     ("feedback_no_ship_with_gaps", "references/sub-skills/roles/verifier/responsibility.md"),
     # DM L2 absorptions

--- a/tests/test_deterministic_qa_framework.py
+++ b/tests/test_deterministic_qa_framework.py
@@ -49,7 +49,8 @@ class TestVerificationSubSkill:
 
     @pytest.fixture
     def verification(self):
-        return (REPO / "references/sub-skills/roles/qa/verification.md").read_text(encoding="utf-8")
+        # #10156: post-#6274.2 rename — qa→verifier directory.
+        return (REPO / "references/sub-skills/roles/verifier/verification.md").read_text(encoding="utf-8")
 
     def test_deferred_not_valid(self, verification):
         assert '"Deferred"' in verification and "NOT valid" in verification

--- a/tests/test_event_mode_fragments.py
+++ b/tests/test_event_mode_fragments.py
@@ -178,7 +178,9 @@ class TestAc6M62ManifestWiring:
         "common-events/idle-cooldown-loop",
         "common-events/comment-handling",
     ]
-    ROLES = ["dev", "pm", "qa", "dm"]
+    # #10156: post-#6274.2 rename — dev→worker, qa→verifier. Directories
+    # on disk are references/roles/{worker,pm,verifier,dm}/.
+    ROLES = ["worker", "pm", "verifier", "dm"]
 
     @pytest.fixture(scope="class")
     def includes_by_role(self):

--- a/tests/test_feat_1328_blocked_skip.py
+++ b/tests/test_feat_1328_blocked_skip.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 REPO = Path(__file__).parent.parent
 PM_VERIFICATION = REPO / "references/sub-skills/roles/pm/testing-and-verification.md"
-QA_VERIFICATION = REPO / "references/sub-skills/roles/qa/verification.md"
+QA_VERIFICATION = REPO / "references/sub-skills/roles/verifier/verification.md"  # #10156
 
 
 class TestPMVerificationBlockedCheck:
@@ -19,8 +19,9 @@ class TestPMVerificationBlockedCheck:
         return PM_VERIFICATION.read_text(encoding="utf-8")
 
     def test_pm_does_not_verify_directly(self, content):
-        """PM template explicitly states QA handles verification."""
-        assert "QA handles all testing and verification" in content
+        """PM template explicitly states the verifier handles verification.
+        #10156: terminology — post-#6274.2 the role is `verifier`, not `qa`."""
+        assert "Verifier handles all testing and verification" in content
 
     def test_pm_has_no_verification_steps(self, content):
         """PM should not contain Step 5/6 verification sections."""

--- a/tests/test_feat_1328_blocked_skip.py
+++ b/tests/test_feat_1328_blocked_skip.py
@@ -1,8 +1,11 @@
 """Tests for #1328 — verification skips blocked:human-action items.
 
-Structural assertions that both PM and QA verification sub-skills
-include the blocked:human-action check before attempting verification.
-"""
+Structural assertions that both PM and verifier sub-skills include the
+blocked:human-action check before attempting verification.
+
+#10156: post-#6274.2 rename (qa→verifier). Test method and class names
+that contain `qa` are intentionally NOT renamed to avoid breaking
+`pytest -k` filters and CI configs; only docstrings + assertions updated."""
 import pytest
 from pathlib import Path
 
@@ -12,7 +15,7 @@ QA_VERIFICATION = REPO / "references/sub-skills/roles/verifier/verification.md" 
 
 
 class TestPMVerificationBlockedCheck:
-    """PM delegates verification to QA — no direct verification steps."""
+    """PM delegates verification to the verifier — no direct verification steps."""
 
     @pytest.fixture
     def content(self):
@@ -30,21 +33,23 @@ class TestPMVerificationBlockedCheck:
 
 
 class TestShipCounterOwnership:
-    """Regression test for #7793 — only QA increments the ship counter."""
+    """Regression test for #7793 — only the verifier increments the ship counter."""
 
     def test_qa_owns_ship_counter(self):
-        """QA verification.md is the authoritative owner of ship counter increment."""
+        """Verifier verification.md is the authoritative owner of ship counter increment.
+        Method name retained for pytest -k compatibility (#10156)."""
         content = QA_VERIFICATION.read_text(encoding="utf-8")
         assert "Shipped Since Last Bump" in content
 
     def test_pm_does_not_own_ship_counter(self):
-        """PM must never increment the ship counter (QA owns it)."""
+        """PM must never increment the ship counter (verifier owns it)."""
         content = PM_VERIFICATION.read_text(encoding="utf-8")
         assert "Shipped Since Last Bump" not in content
 
 
 class TestQAVerificationBlockedCheck:
-    """QA verification (Steps 4-5) skips blocked:human-action items."""
+    """Verifier verification (Steps 4-5) skips blocked:human-action items.
+    Class name retained for pytest -k compatibility (#10156)."""
 
     @pytest.fixture
     def content(self):

--- a/tests/test_feat_3645_auto_merge.py
+++ b/tests/test_feat_3645_auto_merge.py
@@ -8,7 +8,7 @@ import pytest
 from pathlib import Path
 
 REPO = Path(__file__).parent.parent
-QA_VERIFICATION = REPO / "references/sub-skills/roles/qa/verification.md"
+QA_VERIFICATION = REPO / "references/sub-skills/roles/verifier/verification.md"  # #10156
 PM_VERIFICATION = REPO / "references/sub-skills/roles/pm/testing-and-verification.md"
 SCRIPTS = REPO / "references" / "scripts"
 sys.path.insert(0, str(SCRIPTS))


### PR DESCRIPTION
## Summary

Fixes #10156. Sweeps the `tests/` directory for hardcoded legacy role names (`dev`, `qa`) and paths (`references/(sub-skills/)?roles/(dev|qa)/...`) that survived the #6274.2 rename (dev→worker, qa→verifier).

## Files touched

- `tests/test_event_mode_fragments.py:181` — `ROLES = [dev,pm,qa,dm]` → `[worker,pm,verifier,dm]`
- `tests/test_deterministic_qa_framework.py:52` — `roles/qa/verification.md` → `roles/verifier/verification.md`
- `tests/test_agent_boundaries.py` — `roles/{qa,dev}/responsibility.md` → `roles/{verifier,worker}/responsibility.md`; AC7/AC8 parametrize lists renamed; AC4 parametrize + stale docstrings/comments fixed (DS review round 1)
- `tests/test_feat_1328_blocked_skip.py:11,23` — verifier path + `'QA handles'` → `'Verifier handles'` assertion string; test class/method names deferred (renaming pytest -k targets risks breaking CI configs)
- `tests/test_feat_3645_auto_merge.py:11` — verifier path (QA-side only)

## Test impact

Before: 14 ERROR + 18+ FAILED across these files (missing paths, wrong role names).
After: 152/155 in-scope tests pass on this branch. The 3 remaining failures in `tests/test_feat_3645_auto_merge.py::TestPMVerificationAutoMerge` are out of scope here — content relocation, not rename — and are tracked separately under #10213.

`python tests/run_tests.py` (configured suite): 50 pass / 1 skipped / 0 errors.

## Test plan

- [x] Targeted reruns of the 5 affected files green (modulo 3 documented out-of-scope failures)
- [x] `python tests/run_tests.py` green
- [x] DS review round 1 findings addressed (commit 48559bf1)
- [x] Follow-up #10213 filed for the out-of-scope PM-side failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)