### PR TITLE
skill: #10005 — redact diagnostic entries in generate_report (close #8235 sibling bypass)

### DIFF
--- a/references/scripts/diagnostics.py
+++ b/references/scripts/diagnostics.py
@@ -27,9 +27,14 @@ MAX_LOG_BYTES = 1_000_000  # 1MB cap
 # (operates on config.md key:value lines) and _redact_entry (#10005, walks
 # diagnostic-entry context dicts). Keep this list in one place so the
 # redaction surface stays uniform across the two flows.
+#
+# "raw" is included because log_entry wraps non-JSON context as {"raw": text}
+# (line 59). That wrapper opts the caller out of structured redaction, so
+# treat it as sensitive by default — bug reports default to safety; callers
+# wanting visible content should pass structured JSON.
 _SENSITIVE_KEYWORDS = (
     "repo", "path", "email", "token", "secret", "key",
-    "url", "clone", "webhook", "password",
+    "url", "clone", "webhook", "password", "raw",
 )
 
 

--- a/references/scripts/diagnostics.py
+++ b/references/scripts/diagnostics.py
@@ -22,6 +22,44 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent
 MAX_LOG_BYTES = 1_000_000  # 1MB cap
 
+# Substring keywords that mark a key as sensitive; values under matching keys
+# are redacted from the bug-report output. Shared between _sanitize_config
+# (operates on config.md key:value lines) and _redact_entry (#10005, walks
+# diagnostic-entry context dicts). Keep this list in one place so the
+# redaction surface stays uniform across the two flows.
+_SENSITIVE_KEYWORDS = (
+    "repo", "path", "email", "token", "secret", "key",
+    "url", "clone", "webhook", "password",
+)
+
+
+def _is_sensitive_key(name):
+    """True if any sensitive keyword is a substring of ``name`` (case-insensitive)."""
+    if not isinstance(name, str):
+        return False
+    lower = name.lower()
+    return any(k in lower for k in _SENSITIVE_KEYWORDS)
+
+
+def _redact_entry(obj):
+    """Return a deep-redacted copy of ``obj`` suitable for inclusion in a
+    bug report. Walks dicts recursively; any value whose key matches the
+    sensitive-keyword list is replaced with ``"[REDACTED]"``. List values
+    are recursed into element-by-element (lists have no keys of their own).
+    Scalars and non-matching keys pass through unchanged. The input is not
+    mutated."""
+    if isinstance(obj, dict):
+        out = {}
+        for k, v in obj.items():
+            if _is_sensitive_key(k):
+                out[k] = "[REDACTED]"
+            else:
+                out[k] = _redact_entry(v)
+        return out
+    if isinstance(obj, list):
+        return [_redact_entry(v) for v in obj]
+    return obj
+
 # Import config reader and state_bus path resolution (#3664)
 sys.path.insert(0, str(SCRIPT_DIR))
 try:
@@ -111,12 +149,10 @@ def _sanitize_config():
     # and a colon is treated as a key-value pair and redacted (#7518).
     lines = []
     for line in text.splitlines():
-        lower = line.lower()
-        if any(k in lower for k in ["repo", "path", "email", "token", "secret", "key", "url", "clone", "webhook", "password"]):
-            if ":" in line:
-                field = line.split(":", 1)[0]
-                lines.append(f"{field}: [REDACTED]")
-                continue
+        if _is_sensitive_key(line) and ":" in line:
+            field = line.split(":", 1)[0]
+            lines.append(f"{field}: [REDACTED]")
+            continue
         lines.append(line)
     return "\n".join(lines)
 
@@ -162,7 +198,7 @@ def generate_report():
     if entries:
         diag_text = "\n### Recent Diagnostics\n\n```json\n"
         for e in entries:
-            diag_text += json.dumps(e) + "\n"
+            diag_text += json.dumps(_redact_entry(e)) + "\n"
         diag_text += "```\n"
 
     report = f"""## Issue Report — SquidSquad

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -280,6 +280,62 @@ class TestGenerateReport:
         assert "not json" not in report
 
 
+class TestRedactEntry:
+    """#10005: diagnostic entries must be redacted before inclusion in the
+    bug-report output. The keyword list mirrors `_sanitize_config`'s — values
+    under matching keys are replaced with `[REDACTED]`."""
+
+    def test_redacts_sensitive_context_key(self):
+        entry = {"severity": "error", "context": {"token": "abc123", "ok": "safe"}}
+        result = diagnostics._redact_entry(entry)
+        assert result["context"]["token"] == "[REDACTED]"
+        assert result["context"]["ok"] == "safe"
+
+    def test_redacts_nested_dict(self):
+        entry = {"context": {"outer": {"clone_url": "https://x.y/repo.git", "name": "ok"}}}
+        result = diagnostics._redact_entry(entry)
+        assert result["context"]["outer"]["clone_url"] == "[REDACTED]"
+        assert result["context"]["outer"]["name"] == "ok"
+
+    def test_recurses_through_lists(self):
+        entry = {"context": {"items": [{"password": "p1"}, {"name": "ok"}]}}
+        result = diagnostics._redact_entry(entry)
+        assert result["context"]["items"][0]["password"] == "[REDACTED]"
+        assert result["context"]["items"][1]["name"] == "ok"
+
+    def test_non_matching_top_level_keys_pass_through(self):
+        entry = {"severity": "info", "source": "boot", "message": "ok"}
+        result = diagnostics._redact_entry(entry)
+        assert result == entry
+
+    def test_does_not_mutate_input(self):
+        entry = {"context": {"token": "abc"}}
+        diagnostics._redact_entry(entry)
+        assert entry["context"]["token"] == "abc"
+
+    def test_generate_report_redacts_diagnostic_context(self, tmp_path):
+        """End-to-end: a token logged into context must not appear in the
+        rendered report. This is the public-tracker leak path from the
+        original finding."""
+        log_file = tmp_path / "diagnostic.jsonl"
+        log_file.write_text(
+            json.dumps({
+                "severity": "error",
+                "source": "boot",
+                "message": "fail",
+                "context": {"token": "abc-secret-123", "ok": "visible"},
+            }) + "\n",
+            encoding="utf-8",
+        )
+        with patch.object(diagnostics, "get_field", return_value="1.0.0"), \
+             patch.object(diagnostics, "_sanitize_config", return_value="cfg"), \
+             patch.object(diagnostics, "LOG_FILE", log_file):
+            report = diagnostics.generate_report()
+        assert "abc-secret-123" not in report
+        assert "[REDACTED]" in report
+        assert "visible" in report
+
+
 class TestLastFlagValidation:
     """#7519: --last flag must reject non-integer arguments."""
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -313,6 +313,35 @@ class TestRedactEntry:
         diagnostics._redact_entry(entry)
         assert entry["context"]["token"] == "abc"
 
+    def test_redacts_non_json_raw_fallback(self):
+        """log_entry wraps non-JSON context as {'raw': text}. That wrapper
+        is a default-deny path — secrets pasted as free-form context strings
+        must be redacted, since the caller opted out of structured JSON."""
+        entry = {"context": {"raw": "plain text with secret-token-xyz"}}
+        result = diagnostics._redact_entry(entry)
+        assert result["context"]["raw"] == "[REDACTED]"
+
+    def test_generate_report_redacts_non_json_context_end_to_end(self, tmp_path):
+        """End-to-end: a non-JSON context (which log_entry wraps in {'raw': ...})
+        must not leak into the rendered report. Closes the bypass path called
+        out in the #10005 DS review."""
+        log_file = tmp_path / "diagnostic.jsonl"
+        log_file.write_text(
+            json.dumps({
+                "severity": "error",
+                "source": "git",
+                "message": "clone failed",
+                "context": {"raw": "https://user:abc-secret-token@github.com/x.git"},
+            }) + "\n",
+            encoding="utf-8",
+        )
+        with patch.object(diagnostics, "get_field", return_value="1.0.0"), \
+             patch.object(diagnostics, "_sanitize_config", return_value="cfg"), \
+             patch.object(diagnostics, "LOG_FILE", log_file):
+            report = diagnostics.generate_report()
+        assert "abc-secret-token" not in report
+        assert "[REDACTED]" in report
+
     def test_generate_report_redacts_diagnostic_context(self, tmp_path):
         """End-to-end: a token logged into context must not appear in the
         rendered report. This is the public-tracker leak path from the


### PR DESCRIPTION
## Summary

Fixes #10005. `_sanitize_config` already redacts sensitive keys in the config snapshot (per #8235), but the `Recent Diagnostics` block in `generate_report` was dumping each entry verbatim via `json.dumps(e)`. Callers across the codebase log paths, tokens, URLs, and tracebacks into `context` — any of those shipped out unredacted when a user pasted the report into a public tracker. Same defect-family as #8235.

## Approach

- Extract `_SENSITIVE_KEYWORDS` and `_is_sensitive_key` so the redaction surface lives in one place (was duplicated as a literal list inside `_sanitize_config`).
- Add `_redact_entry`: walks dicts recursively, replaces values under sensitive keys with `[REDACTED]`. Lists recurse element-by-element; scalars pass through. Non-mutating.
- `generate_report` applies `_redact_entry` to each entry before dumping.
- `_sanitize_config` now uses the shared matcher (no behavior change; same keyword set).

DS review round 1 caught one bypass path: `log_entry`'s non-JSON context fallback wraps the input as `{"raw": text}`. The key `"raw"` did not match the sensitive list, so the wrapper bypassed `_redact_entry`. Closed by adding `"raw"` to `_SENSITIVE_KEYWORDS` — the wrapper is a caller opt-out of structured redaction, so default it to safety. Callers wanting visible content should pass structured JSON with non-sensitive keys.

## Test impact

- `tests/test_diagnostics.py`: 37/37 pass (was 29). 8 new tests under `TestRedactEntry` exercise: key-based redaction, nested dicts, list recursion, non-mutation, top-level pass-through, end-to-end public-tracker leak case, the `{"raw": ...}` bypass, and the non-JSON end-to-end leak.
- `python tests/run_tests.py`: 50/50 pass / 1 skipped (unchanged from main).

## Commits

1. `3f63fae8` — extract sensitive-keyword machinery, add `_redact_entry`, apply in `generate_report`, regression tests.
2. `959c7dec` — DS round 1 finding 1 fix: add `"raw"` to keywords + targeted tests.

## Test plan

- [x] `python -m pytest tests/test_diagnostics.py -v` — 37/37 pass
- [x] `python tests/run_tests.py` — 50/50 pass
- [x] DS review round 1: 1 warning addressed in `959c7dec`

🤖 Generated with [Claude Code](https://claude.com/claude-code)