### PR TITLE
skill: #10002 — surface version-bump push/commit/tag failures; gate counter reset on success

### DIFF
--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -599,17 +599,51 @@ def _do_version_bump(data, role):
         print(f"  Version bump v{new_version}: no staged changes — skipping commit/tag/push")
         return
 
-    _run(["git", "commit", "-m", f"chore: bump version to v{new_version}"])
+    commit_result = _run(["git", "commit", "-m", f"chore: bump version to v{new_version}"])
+    if commit_result.returncode != 0:
+        print(
+            f"  ERROR: version bump commit failed (rc={commit_result.returncode}): "
+            f"{commit_result.stderr.strip() or '(no stderr)'} — "
+            f"shipped-since-bump NOT reset; v{new_version} NOT pushed",
+            file=sys.stderr,
+        )
+        return
 
     # Check if tag exists
     tag_check = _run(["git", "tag", "-l", f"v{new_version}"])
     if not tag_check.stdout.strip():
-        _run(["git", "tag", f"v{new_version}"])
+        tag_result = _run(["git", "tag", f"v{new_version}"])
+        if tag_result.returncode != 0:
+            print(
+                f"  ERROR: git tag v{new_version} failed (rc={tag_result.returncode}): "
+                f"{tag_result.stderr.strip() or '(no stderr)'} — "
+                f"shipped-since-bump NOT reset; tag/push NOT completed",
+                file=sys.stderr,
+            )
+            return
 
-    _run(["git", "push"])
-    _run(["git", "push", "--tags"])
+    push_result = _run(["git", "push"])
+    if push_result.returncode != 0:
+        print(
+            f"  ERROR: git push failed (rc={push_result.returncode}): "
+            f"{push_result.stderr.strip() or '(no stderr)'} — "
+            f"local commit + tag v{new_version} exist but did NOT reach origin; "
+            f"shipped-since-bump NOT reset",
+            file=sys.stderr,
+        )
+        return
 
-    # Reset counter
+    push_tags_result = _run(["git", "push", "--tags"])
+    if push_tags_result.returncode != 0:
+        print(
+            f"  ERROR: git push --tags failed (rc={push_tags_result.returncode}): "
+            f"{push_tags_result.stderr.strip() or '(no stderr)'} — "
+            f"commit pushed but tag v{new_version} did NOT reach origin; "
+            f"shipped-since-bump NOT reset",
+            file=sys.stderr,
+        )
+        return
+
     _run_script("config.py", "set", "shipped-since-bump", "0")
 
     print(f"  Version v{new_version} tagged and pushed")

--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -611,6 +611,14 @@ def _do_version_bump(data, role):
 
     # Check if tag exists
     tag_check = _run(["git", "tag", "-l", f"v{new_version}"])
+    if tag_check.returncode != 0:
+        print(
+            f"  ERROR: git tag -l failed (rc={tag_check.returncode}): "
+            f"{tag_check.stderr.strip() or '(no stderr)'} — "
+            f"cannot determine if tag v{new_version} exists; aborting bump",
+            file=sys.stderr,
+        )
+        return
     if not tag_check.stdout.strip():
         tag_result = _run(["git", "tag", f"v{new_version}"])
         if tag_result.returncode != 0:

--- a/tests/test_cycle_post.py
+++ b/tests/test_cycle_post.py
@@ -970,6 +970,170 @@ class TestVersionBumpHappyPath:
 
 
 # ---------------------------------------------------------------------------
+# #10002: _do_version_bump must surface push/commit/tag failures and refuse
+# to reset shipped-since-bump or print the success line when any step fails.
+# ---------------------------------------------------------------------------
+
+class TestVersionBumpPushFailure:
+    """#10002: any non-zero result from commit / tag-create / push / push --tags
+    must (a) emit a clear ERROR to stderr, (b) skip the shipped-since-bump
+    reset, and (c) skip the success print. Otherwise DM-side state claims the
+    bump shipped while no v<NEW> tag exists on origin."""
+
+    def _fake_run_factory(self, failing_cmd_prefix, run_calls):
+        """Returns a fake _run that fails (rc=1, stderr filled) when the
+        supplied command prefix matches; success otherwise. The diff guard
+        always returns rc=1 (staged changes present) so the commit path runs."""
+        def fake_run(cmd, **kwargs):
+            run_calls.append(cmd)
+            r = MagicMock()
+            r.stdout = ""
+            r.stderr = ""
+            if cmd == ["git", "diff", "--cached", "--quiet"]:
+                r.returncode = 1
+            elif "tag" in cmd and "-l" in cmd:
+                r.stdout = ""  # tag doesn't exist yet
+                r.returncode = 0
+            elif failing_cmd_prefix is not None and cmd[:len(failing_cmd_prefix)] == failing_cmd_prefix:
+                r.returncode = 1
+                r.stderr = "fatal: simulated failure"
+            else:
+                r.returncode = 0
+            return r
+        return fake_run
+
+    def test_push_failure_skips_counter_reset(self, monkeypatch, capsys):
+        """`git push` fails -> shipped-since-bump NOT reset."""
+        script_calls = []
+        run_calls = []
+
+        def fake_run_script(script, *args, **kwargs):
+            script_calls.append((script, args))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(cycle_post, "_run_script", fake_run_script)
+        monkeypatch.setattr(cycle_post, "_run",
+                            self._fake_run_factory(["git", "push"], run_calls))
+        monkeypatch.setattr(cycle_post, "REPO_ROOT", Path("/fake"))
+
+        data = {"version_bump": {"new_version": "5.0.0"}}
+        cycle_post._do_version_bump(data, "dm")
+
+        reset_calls = [c for c in script_calls
+                       if c[0] == "config.py" and "shipped-since-bump" in c[1]]
+        assert reset_calls == [], (
+            "shipped-since-bump must NOT be reset when git push fails"
+        )
+
+        captured = capsys.readouterr()
+        assert "ERROR" in captured.err
+        assert "push" in captured.err.lower()
+        assert "v5.0.0" in captured.err
+        assert "tagged and pushed" not in captured.out
+
+    def test_push_tags_failure_skips_counter_reset(self, monkeypatch, capsys):
+        """`git push --tags` fails -> shipped-since-bump NOT reset."""
+        script_calls = []
+        run_calls = []
+
+        def fake_run_script(script, *args, **kwargs):
+            script_calls.append((script, args))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(cycle_post, "_run_script", fake_run_script)
+        monkeypatch.setattr(cycle_post, "_run",
+                            self._fake_run_factory(["git", "push", "--tags"], run_calls))
+        monkeypatch.setattr(cycle_post, "REPO_ROOT", Path("/fake"))
+
+        data = {"version_bump": {"new_version": "5.1.0"}}
+        cycle_post._do_version_bump(data, "dm")
+
+        reset_calls = [c for c in script_calls
+                       if c[0] == "config.py" and "shipped-since-bump" in c[1]]
+        assert reset_calls == [], (
+            "shipped-since-bump must NOT be reset when git push --tags fails"
+        )
+
+        captured = capsys.readouterr()
+        assert "ERROR" in captured.err
+        assert "tags" in captured.err.lower()
+        assert "tagged and pushed" not in captured.out
+
+    def test_commit_failure_skips_everything_downstream(self, monkeypatch, capsys):
+        """`git commit` fails -> no tag, no push, no counter reset."""
+        script_calls = []
+        run_calls = []
+
+        def fake_run_script(script, *args, **kwargs):
+            script_calls.append((script, args))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(cycle_post, "_run_script", fake_run_script)
+        monkeypatch.setattr(cycle_post, "_run",
+                            self._fake_run_factory(["git", "commit"], run_calls))
+        monkeypatch.setattr(cycle_post, "REPO_ROOT", Path("/fake"))
+
+        data = {"version_bump": {"new_version": "5.2.0"}}
+        cycle_post._do_version_bump(data, "dm")
+
+        # No tag-create, no push, no push --tags after commit failure
+        assert ["git", "tag", "v5.2.0"] not in run_calls
+        assert ["git", "push"] not in run_calls
+        assert ["git", "push", "--tags"] not in run_calls
+        reset_calls = [c for c in script_calls
+                       if c[0] == "config.py" and "shipped-since-bump" in c[1]]
+        assert reset_calls == []
+
+        captured = capsys.readouterr()
+        assert "ERROR" in captured.err
+        assert "commit" in captured.err.lower()
+
+    def test_tag_create_failure_skips_push_and_counter(self, monkeypatch, capsys):
+        """`git tag v<NEW>` fails -> push not attempted, counter not reset."""
+        script_calls = []
+        run_calls = []
+
+        def fake_run_script(script, *args, **kwargs):
+            script_calls.append((script, args))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        # Custom: tag-create fails (not the tag-check -l variant)
+        def fake_run(cmd, **kwargs):
+            run_calls.append(cmd)
+            r = MagicMock()
+            r.stdout = ""
+            r.stderr = ""
+            if cmd == ["git", "diff", "--cached", "--quiet"]:
+                r.returncode = 1
+            elif cmd == ["git", "tag", "-l", "v5.3.0"]:
+                r.stdout = ""
+                r.returncode = 0
+            elif cmd == ["git", "tag", "v5.3.0"]:
+                r.returncode = 1
+                r.stderr = "fatal: simulated tag failure"
+            else:
+                r.returncode = 0
+            return r
+
+        monkeypatch.setattr(cycle_post, "_run_script", fake_run_script)
+        monkeypatch.setattr(cycle_post, "_run", fake_run)
+        monkeypatch.setattr(cycle_post, "REPO_ROOT", Path("/fake"))
+
+        data = {"version_bump": {"new_version": "5.3.0"}}
+        cycle_post._do_version_bump(data, "dm")
+
+        assert ["git", "push"] not in run_calls
+        assert ["git", "push", "--tags"] not in run_calls
+        reset_calls = [c for c in script_calls
+                       if c[0] == "config.py" and "shipped-since-bump" in c[1]]
+        assert reset_calls == []
+
+        captured = capsys.readouterr()
+        assert "ERROR" in captured.err
+        assert "tag" in captured.err.lower()
+
+
+# ---------------------------------------------------------------------------
 # Branch push fallback — regression #4837
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cycle_post.py
+++ b/tests/test_cycle_post.py
@@ -922,6 +922,7 @@ class TestVersionBumpHappyPath:
                 r.returncode = 1
             elif "tag" in cmd and "-l" in cmd:
                 r.stdout = ""
+                r.returncode = 0
             else:
                 r.returncode = 0
             return r
@@ -980,10 +981,12 @@ class TestVersionBumpPushFailure:
     reset, and (c) skip the success print. Otherwise DM-side state claims the
     bump shipped while no v<NEW> tag exists on origin."""
 
-    def _fake_run_factory(self, failing_cmd_prefix, run_calls):
+    def _fake_run_factory(self, failing_cmd, run_calls):
         """Returns a fake _run that fails (rc=1, stderr filled) when the
-        supplied command prefix matches; success otherwise. The diff guard
-        always returns rc=1 (staged changes present) so the commit path runs."""
+        supplied command matches exactly; success otherwise. Exact-match
+        (not prefix-match) avoids false-positives where ['git', 'push']
+        would also match ['git', 'push', '--tags']. The diff guard always
+        returns rc=1 (staged changes present) so the commit path runs."""
         def fake_run(cmd, **kwargs):
             run_calls.append(cmd)
             r = MagicMock()
@@ -994,7 +997,7 @@ class TestVersionBumpPushFailure:
             elif "tag" in cmd and "-l" in cmd:
                 r.stdout = ""  # tag doesn't exist yet
                 r.returncode = 0
-            elif failing_cmd_prefix is not None and cmd[:len(failing_cmd_prefix)] == failing_cmd_prefix:
+            elif failing_cmd is not None and cmd == failing_cmd:
                 r.returncode = 1
                 r.stderr = "fatal: simulated failure"
             else:
@@ -1070,7 +1073,9 @@ class TestVersionBumpPushFailure:
 
         monkeypatch.setattr(cycle_post, "_run_script", fake_run_script)
         monkeypatch.setattr(cycle_post, "_run",
-                            self._fake_run_factory(["git", "commit"], run_calls))
+                            self._fake_run_factory(
+                                ["git", "commit", "-m", "chore: bump version to v5.2.0"],
+                                run_calls))
         monkeypatch.setattr(cycle_post, "REPO_ROOT", Path("/fake"))
 
         data = {"version_bump": {"new_version": "5.2.0"}}
@@ -1087,6 +1092,50 @@ class TestVersionBumpPushFailure:
         captured = capsys.readouterr()
         assert "ERROR" in captured.err
         assert "commit" in captured.err.lower()
+
+    def test_tag_list_failure_aborts_bump(self, monkeypatch, capsys):
+        """`git tag -l` itself fails (rc != 0) -> abort before tag-create
+        or push; counter NOT reset. Pairs with the returncode check added
+        to the `git tag -l` call so a listing failure cannot mask an
+        already-existing tag and produce a misleading downstream error."""
+        script_calls = []
+        run_calls = []
+
+        def fake_run_script(script, *args, **kwargs):
+            script_calls.append((script, args))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        def fake_run(cmd, **kwargs):
+            run_calls.append(cmd)
+            r = MagicMock()
+            r.stdout = ""
+            r.stderr = ""
+            if cmd == ["git", "diff", "--cached", "--quiet"]:
+                r.returncode = 1
+            elif cmd == ["git", "tag", "-l", "v5.4.0"]:
+                r.returncode = 1
+                r.stderr = "fatal: simulated tag-list failure"
+            else:
+                r.returncode = 0
+            return r
+
+        monkeypatch.setattr(cycle_post, "_run_script", fake_run_script)
+        monkeypatch.setattr(cycle_post, "_run", fake_run)
+        monkeypatch.setattr(cycle_post, "REPO_ROOT", Path("/fake"))
+
+        data = {"version_bump": {"new_version": "5.4.0"}}
+        cycle_post._do_version_bump(data, "dm")
+
+        assert ["git", "tag", "v5.4.0"] not in run_calls
+        assert ["git", "push"] not in run_calls
+        assert ["git", "push", "--tags"] not in run_calls
+        reset_calls = [c for c in script_calls
+                       if c[0] == "config.py" and "shipped-since-bump" in c[1]]
+        assert reset_calls == []
+
+        captured = capsys.readouterr()
+        assert "ERROR" in captured.err
+        assert "tag -l" in captured.err
 
     def test_tag_create_failure_skips_push_and_counter(self, monkeypatch, capsys):
         """`git tag v<NEW>` fails -> push not attempted, counter not reset."""


### PR DESCRIPTION
## Summary

Fixes #10002. `_do_version_bump` was firing `git commit` / `tag` / `push` / `push --tags` via `_run` without inspecting `returncode`, then unconditionally resetting `shipped-since-bump=0` and printing `"Version v{new} tagged and pushed"`. On a credential-helper wedge (#9890) or network blip, the local clone had the bump commit + tag while `origin` did not — DM-side state claimed the bump shipped but no `v{new}` tag existed on origin. Same defect-family as #9890, #9930, #9939.

## Approach

- Capture returncode for `commit`, `tag -l`, `tag-create`, `push`, `push --tags`.
- On any non-zero result: emit a clear `ERROR` to stderr that names the failing step, the rc, the stderr, the affected version, and what was NOT done (counter reset, push). Return early.
- `shipped-since-bump` reset + success print gated on **all** steps succeeding.
- Did NOT add the `gh auth git-credential` workaround. The issue calls it out as a "consider", not a blocker — operator workaround for the underlying wedge lives in `feedback_git_push_credential_wedge`. Surfacing the failure is enough; pre-emptively rewriting the auth path is scope creep.

## DS review (round 1)

4 warnings — 3 addressed in commit `93f8ebf7`, 1 deferred to **#10241**:

| # | Finding | Disposition |
|---|---------|-------------|
| 1 | `git tag -l` returncode never checked | Fixed: added the check with the same abort-and-error pattern |
| 2 | Test factory used prefix matching (would also match supersets) | Fixed: switched to exact-match |
| 3 | No test exercised the tag-list-failure path | Fixed: added `test_tag_list_failure_aborts_bump` |
| 4 | Orphaned-tag recovery: half-completed bump unrecoverable across cycles (diff guard short-circuits the retry) | Deferred to #10241 — separate intent (self-healing) on top of failure-surfacing |

## Test impact

- `tests/test_cycle_post.py`: 99/99 pass (was 94 on main). 5 new tests: `test_push_failure_skips_counter_reset`, `test_push_tags_failure_skips_counter_reset`, `test_commit_failure_skips_everything_downstream`, `test_tag_create_failure_skips_push_and_counter`, `test_tag_list_failure_aborts_bump`. Each asserts: counter NOT reset, downstream steps NOT attempted (where applicable), `ERROR` on stderr, no success print.
- `python tests/run_tests.py`: 50/50 pass / 1 skipped (unchanged).

## Commits

1. `cd2849ae` — capture rc for commit/tag-create/push/push --tags; gate counter reset; 4 regression tests.
2. `93f8ebf7` — DS round 1 findings 1-3: add `tag -l` rc check, exact-match factory, tag-list test.

## Test plan

- [x] `python -m pytest tests/test_cycle_post.py -v` — 99/99 pass
- [x] `python tests/run_tests.py` — 50/50 pass
- [x] DS review round 1: 3/4 findings addressed; 1 filed as #10241

🤖 Generated with [Claude Code](https://claude.com/claude-code)