### PR TITLE
skill: #10241 — orphaned-tag self-healing recovery (stacks on #10247)

### DIFF
--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -564,6 +564,52 @@ def _do_commit_push(data, role):
         _state_commit(state_msg, role)
 
 
+def _recover_orphaned_tag(new_version):
+    """Self-heal a half-completed prior bump (#10241).
+
+    When the diff guard fires (config.md is already at ``new_version``,
+    nothing fresh to stage), check whether a local tag ``v{new_version}``
+    exists while origin's refs/tags/ does not. If so, push the tag and
+    return True so the caller can reset shipped-since-bump and exit. Any
+    other configuration (no local tag, both have it, or push fails)
+    returns False so the caller falls through to its normal skip message.
+
+    Designed to be cheap on the happy path: two read-only git calls
+    (``tag -l``, ``ls-remote``) and only when those agree on the
+    asymmetric state does it run ``git push origin v{new_version}``.
+    Failure modes (any non-zero rc, any unexpected stderr shape) leave
+    state untouched — recovery is opportunistic, never destructive."""
+    local_check = _run(["git", "tag", "-l", f"v{new_version}"])
+    if local_check.returncode != 0:
+        return False
+    if not local_check.stdout.strip():
+        return False  # no local tag → nothing to recover
+
+    remote_check = _run(
+        ["git", "ls-remote", "--tags", "origin", f"refs/tags/v{new_version}"]
+    )
+    if remote_check.returncode != 0:
+        return False  # network/auth failure — leave state untouched
+    if remote_check.stdout.strip():
+        return False  # remote already has the tag → not orphaned
+
+    push_result = _run(["git", "push", "origin", f"v{new_version}"])
+    if push_result.returncode != 0:
+        print(
+            f"  ERROR: orphaned-tag recovery push failed (rc={push_result.returncode}): "
+            f"{push_result.stderr.strip() or '(no stderr)'} — "
+            f"local tag v{new_version} still not on origin; shipped-since-bump NOT reset",
+            file=sys.stderr,
+        )
+        return False
+
+    print(
+        f"  Recovered orphaned tag v{new_version}: pushed to origin "
+        f"(prior bump cycle landed locally but did not reach origin)"
+    )
+    return True
+
+
 def _do_version_bump(data, role):
     """Execute version bump sequence (DM only)."""
     bump = data.get("version_bump")
@@ -593,9 +639,15 @@ def _do_version_bump(data, role):
         bump_files.append("SKILL.md")
     _run(["git", "add", "--"] + bump_files)
 
-    # Guard: skip commit/tag/push if nothing was staged (#5126)
+    # Guard: skip commit/tag/push if nothing was staged (#5126). Before
+    # returning, attempt orphaned-tag recovery (#10241): if config.md is
+    # already at the target version but the local tag exists while origin
+    # does not, push the tag so a prior half-completed bump self-heals.
     diff_check = _run(["git", "diff", "--cached", "--quiet"])
     if diff_check.returncode == 0:
+        if _recover_orphaned_tag(new_version):
+            _run_script("config.py", "set", "shipped-since-bump", "0")
+            return
         print(f"  Version bump v{new_version}: no staged changes — skipping commit/tag/push")
         return
 

--- a/tests/test_cycle_post.py
+++ b/tests/test_cycle_post.py
@@ -823,12 +823,15 @@ class TestVersionBumpHappyPath:
         data = {"version_bump": {"new_version": "2.0.0"}}
         cycle_post._do_version_bump(data, "dm")
 
-        # Should NOT have commit, tag, or push calls
+        # Should NOT have commit, tag-CREATE, or push calls.
+        # Read-only probes (tag -l, ls-remote) are allowed — they fuel the
+        # orphaned-tag recovery check (#10241) which is a no-op here because
+        # this fake_run never reports a local tag.
         commit_calls = [c for c in run_calls if "commit" in c and "-m" in c]
-        tag_calls = [c for c in run_calls if "tag" in c and "v2.0.0" in c]
+        tag_create_calls = [c for c in run_calls if c == ["git", "tag", "v2.0.0"]]
         push_calls = [c for c in run_calls if c == ["git", "push"]]
         assert len(commit_calls) == 0
-        assert len(tag_calls) == 0
+        assert len(tag_create_calls) == 0
         assert len(push_calls) == 0
 
         captured = capsys.readouterr()
@@ -1180,6 +1183,191 @@ class TestVersionBumpPushFailure:
         captured = capsys.readouterr()
         assert "ERROR" in captured.err
         assert "tag" in captured.err.lower()
+
+
+# ---------------------------------------------------------------------------
+# #10241: orphaned-tag self-healing recovery — when the diff guard would
+# otherwise short-circuit, check whether a prior bump landed locally but
+# never reached origin, and push the tag if so.
+# ---------------------------------------------------------------------------
+
+class TestOrphanedTagRecovery:
+    """#10241: _do_version_bump must self-heal a half-completed prior bump.
+
+    Setup pattern for these tests: ``git diff --cached --quiet`` returns 0
+    (no staged changes — config.md already at target version, the post-#10002
+    blocker scenario). The recovery helper then probes local + remote for the
+    tag and pushes if asymmetric."""
+
+    def _build_fake_run(self, run_calls, local_has_tag, remote_has_tag,
+                       push_succeeds=True, ls_remote_succeeds=True,
+                       tag_l_succeeds=True):
+        """Returns a fake _run that simulates the post-#10002 stall state.
+
+        diff --cached --quiet returns 0 (no staged changes). tag -l returns
+        the tag name iff local_has_tag. ls-remote returns a ref line iff
+        remote_has_tag. push origin <tag> succeeds iff push_succeeds."""
+        def fake_run(cmd, **kwargs):
+            run_calls.append(cmd)
+            r = MagicMock()
+            r.stdout = ""
+            r.stderr = ""
+            r.returncode = 0
+            if cmd == ["git", "diff", "--cached", "--quiet"]:
+                r.returncode = 0  # nothing staged
+            elif "tag" in cmd and "-l" in cmd:
+                if not tag_l_succeeds:
+                    r.returncode = 1
+                    r.stderr = "fatal: simulated tag -l failure"
+                elif local_has_tag:
+                    r.stdout = cmd[-1] + "\n"
+            elif cmd[:3] == ["git", "ls-remote", "--tags"]:
+                if not ls_remote_succeeds:
+                    r.returncode = 1
+                    r.stderr = "fatal: simulated ls-remote failure"
+                elif remote_has_tag:
+                    r.stdout = f"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\t{cmd[-1]}\n"
+            elif cmd[:3] == ["git", "push", "origin"]:
+                if not push_succeeds:
+                    r.returncode = 1
+                    r.stderr = "fatal: simulated recovery push failure"
+            return r
+        return fake_run
+
+    def _build_run_script(self, script_calls):
+        def fake_run_script(script, *args, **kwargs):
+            script_calls.append((script, args))
+            return MagicMock(returncode=0, stdout="", stderr="")
+        return fake_run_script
+
+    def test_recovers_when_local_has_tag_remote_does_not(self, monkeypatch, capsys):
+        """Local v6.0.0 exists, origin does not → push it, reset counter."""
+        script_calls = []
+        run_calls = []
+        monkeypatch.setattr(cycle_post, "_run_script",
+                            self._build_run_script(script_calls))
+        monkeypatch.setattr(cycle_post, "_run",
+                            self._build_fake_run(run_calls,
+                                                  local_has_tag=True,
+                                                  remote_has_tag=False))
+        monkeypatch.setattr(cycle_post, "REPO_ROOT", Path("/fake"))
+
+        cycle_post._do_version_bump(
+            {"version_bump": {"new_version": "6.0.0"}}, "dm",
+        )
+
+        # Recovery push attempted with the tag-specific form (not push --tags)
+        assert ["git", "push", "origin", "v6.0.0"] in run_calls
+        # Counter was reset (bump is now fully complete)
+        reset_calls = [c for c in script_calls
+                       if c[0] == "config.py" and "shipped-since-bump" in c[1]]
+        assert len(reset_calls) == 1
+
+        captured = capsys.readouterr()
+        assert "Recovered orphaned tag v6.0.0" in captured.out
+        assert "skipping commit/tag/push" not in captured.out
+
+    def test_no_recovery_when_local_tag_missing(self, monkeypatch, capsys):
+        """No local tag → nothing to recover; fall through to skip message."""
+        script_calls = []
+        run_calls = []
+        monkeypatch.setattr(cycle_post, "_run_script",
+                            self._build_run_script(script_calls))
+        monkeypatch.setattr(cycle_post, "_run",
+                            self._build_fake_run(run_calls,
+                                                  local_has_tag=False,
+                                                  remote_has_tag=False))
+        monkeypatch.setattr(cycle_post, "REPO_ROOT", Path("/fake"))
+
+        cycle_post._do_version_bump(
+            {"version_bump": {"new_version": "6.1.0"}}, "dm",
+        )
+
+        # No push attempted
+        assert not any(c[:3] == ["git", "push", "origin"] for c in run_calls)
+        # No counter reset
+        reset_calls = [c for c in script_calls
+                       if c[0] == "config.py" and "shipped-since-bump" in c[1]]
+        assert reset_calls == []
+
+        captured = capsys.readouterr()
+        assert "skipping commit/tag/push" in captured.out
+
+    def test_no_recovery_when_remote_already_has_tag(self, monkeypatch, capsys):
+        """Both have the tag → bump is fully done; fall through to skip."""
+        script_calls = []
+        run_calls = []
+        monkeypatch.setattr(cycle_post, "_run_script",
+                            self._build_run_script(script_calls))
+        monkeypatch.setattr(cycle_post, "_run",
+                            self._build_fake_run(run_calls,
+                                                  local_has_tag=True,
+                                                  remote_has_tag=True))
+        monkeypatch.setattr(cycle_post, "REPO_ROOT", Path("/fake"))
+
+        cycle_post._do_version_bump(
+            {"version_bump": {"new_version": "6.2.0"}}, "dm",
+        )
+
+        assert not any(c[:3] == ["git", "push", "origin"] for c in run_calls)
+        reset_calls = [c for c in script_calls
+                       if c[0] == "config.py" and "shipped-since-bump" in c[1]]
+        assert reset_calls == []
+
+        captured = capsys.readouterr()
+        assert "skipping commit/tag/push" in captured.out
+
+    def test_recovery_push_failure_skips_counter_reset(self, monkeypatch, capsys):
+        """Local-yes / origin-no but `git push origin v<NEW>` fails →
+        recovery attempted, ERROR surfaced, counter NOT reset (next
+        cycle will retry)."""
+        script_calls = []
+        run_calls = []
+        monkeypatch.setattr(cycle_post, "_run_script",
+                            self._build_run_script(script_calls))
+        monkeypatch.setattr(cycle_post, "_run",
+                            self._build_fake_run(run_calls,
+                                                  local_has_tag=True,
+                                                  remote_has_tag=False,
+                                                  push_succeeds=False))
+        monkeypatch.setattr(cycle_post, "REPO_ROOT", Path("/fake"))
+
+        cycle_post._do_version_bump(
+            {"version_bump": {"new_version": "6.3.0"}}, "dm",
+        )
+
+        assert ["git", "push", "origin", "v6.3.0"] in run_calls
+        reset_calls = [c for c in script_calls
+                       if c[0] == "config.py" and "shipped-since-bump" in c[1]]
+        assert reset_calls == []
+
+        captured = capsys.readouterr()
+        assert "ERROR" in captured.err
+        assert "recovery push failed" in captured.err
+        assert "v6.3.0" in captured.err
+
+    def test_ls_remote_failure_aborts_recovery_safely(self, monkeypatch, capsys):
+        """ls-remote network/auth failure → leave state untouched (no
+        push attempted, no counter reset, fall through to skip message)."""
+        script_calls = []
+        run_calls = []
+        monkeypatch.setattr(cycle_post, "_run_script",
+                            self._build_run_script(script_calls))
+        monkeypatch.setattr(cycle_post, "_run",
+                            self._build_fake_run(run_calls,
+                                                  local_has_tag=True,
+                                                  remote_has_tag=False,
+                                                  ls_remote_succeeds=False))
+        monkeypatch.setattr(cycle_post, "REPO_ROOT", Path("/fake"))
+
+        cycle_post._do_version_bump(
+            {"version_bump": {"new_version": "6.4.0"}}, "dm",
+        )
+
+        assert not any(c[:3] == ["git", "push", "origin"] for c in run_calls)
+        reset_calls = [c for c in script_calls
+                       if c[0] == "config.py" and "shipped-since-bump" in c[1]]
+        assert reset_calls == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cycle_post.py
+++ b/tests/test_cycle_post.py
@@ -1345,6 +1345,7 @@ class TestOrphanedTagRecovery:
         assert "ERROR" in captured.err
         assert "recovery push failed" in captured.err
         assert "v6.3.0" in captured.err
+        assert "skipping commit/tag/push" in captured.out
 
     def test_ls_remote_failure_aborts_recovery_safely(self, monkeypatch, capsys):
         """ls-remote network/auth failure → leave state untouched (no
@@ -1368,6 +1369,37 @@ class TestOrphanedTagRecovery:
         reset_calls = [c for c in script_calls
                        if c[0] == "config.py" and "shipped-since-bump" in c[1]]
         assert reset_calls == []
+
+        captured = capsys.readouterr()
+        assert "skipping commit/tag/push" in captured.out
+
+    def test_tag_l_failure_aborts_recovery_safely(self, monkeypatch, capsys):
+        """`git tag -l` itself failing inside the recovery probe → no
+        ls-remote attempted, no push attempted, no counter reset, fall
+        through to skip message. Closes the dead-parameter coverage gap."""
+        script_calls = []
+        run_calls = []
+        monkeypatch.setattr(cycle_post, "_run_script",
+                            self._build_run_script(script_calls))
+        monkeypatch.setattr(cycle_post, "_run",
+                            self._build_fake_run(run_calls,
+                                                  local_has_tag=True,
+                                                  remote_has_tag=False,
+                                                  tag_l_succeeds=False))
+        monkeypatch.setattr(cycle_post, "REPO_ROOT", Path("/fake"))
+
+        cycle_post._do_version_bump(
+            {"version_bump": {"new_version": "6.5.0"}}, "dm",
+        )
+
+        assert not any(c[:3] == ["git", "ls-remote", "--tags"] for c in run_calls)
+        assert not any(c[:3] == ["git", "push", "origin"] for c in run_calls)
+        reset_calls = [c for c in script_calls
+                       if c[0] == "config.py" and "shipped-since-bump" in c[1]]
+        assert reset_calls == []
+
+        captured = capsys.readouterr()
+        assert "skipping commit/tag/push" in captured.out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #10241. Builds on **PR #10247 (#10002)** — this PR's base is `squidsquad/task/10002`, not `main`. After #10002 closed the silent-success path, a `push --tags` failure correctly leaves `shipped-since-bump` high. But the next cycle's diff guard at `cycle_post.py:597` short-circuits the retry because `config.md` already records the bumped version — the local tag exists, origin does not, and the bump never re-pushes. Manual `git push --tags` was the only recovery.

> ⚠️ Merge order: land #10247 (#10002) first, then this PR. The base will need re-targeting to `main` after the parent merges.

## Approach

Adds an opportunistic recovery check at the diff-guard early-return path. `_recover_orphaned_tag(new_version)`:

- Runs `git tag -l v{new}` (local) and `git ls-remote --tags origin refs/tags/v{new}` (remote). Both are read-only probes.
- Returns `False` (caller falls through to existing skip message) when: `tag -l` fails, `ls-remote` fails, no local tag, remote already has the tag.
- On local-yes / origin-no: runs `git push origin v{new}` — the **tag-specific** form, not `push --tags`. Narrower blast radius.
- On push success: prints a `Recovered` line; returns `True` so the caller resets `shipped-since-bump` (bump now complete).
- On push failure: emits `ERROR` to stderr, returns `False`, counter stays high so the next cycle retries.

Cheap on the happy path — steady state is either "no local tag" or "both have it" (two read-only git calls, no push). Push only fires on the asymmetric state.

## DS review (round 1)

3 warnings, all test-coverage gaps — production code clean:

| # | Finding | Disposition |
|---|---------|-------------|
| 1 | `tag_l_succeeds=False` test parameter dead — `tag -l` failure branch never exercised | Fixed: added `test_tag_l_failure_aborts_recovery_safely` |
| 2 | `test_ls_remote_failure_aborts_recovery_safely` docstring promised fall-through skip message but didn't assert it | Fixed: added the stdout assertion |
| 3 | `test_recovery_push_failure_skips_counter_reset` checked stderr but not the fall-through skip message | Fixed: added the stdout assertion |

## Test impact

- `tests/test_cycle_post.py`: 105/105 pass (was 99 on the #10002 base; +6 new). New `TestOrphanedTagRecovery` class covers: happy-path recovery, no-recovery cases (no local tag, both have it), failure paths (recovery push fails, ls-remote fails, tag-l fails). Adjusted pre-existing `test_staged_diff_guard_skips_empty_commit` to allow read-only `tag -l` + `ls-remote` probes (asserts absence of tag-CREATE specifically, not all "tag" calls).
- `python tests/run_tests.py`: 47 pass / 3 errors in `tests/integration/test_status_flow.py` — confirmed flaky (12/12 pass on rerun, gh-CLI race against the test-issue cleanup, untouched by this change).

## Commits

1. `c506001b` — `_recover_orphaned_tag` helper, wired into the diff-guard path, 5 regression tests.
2. `7eb6c879` — DS round 1: added the `tag -l` failure test (closing the dead-parameter gap) + skip-message assertions on two existing tests.

## Test plan

- [x] `python -m pytest tests/test_cycle_post.py -v` — 105/105 pass
- [x] `python -m pytest tests/test_cycle_post.py::TestOrphanedTagRecovery -v` — 6/6 pass
- [x] `python tests/run_tests.py` — 50/50 pass on the targeted modules; 3 flakes in integration/test_status_flow confirmed unrelated
- [x] DS review round 1: all 3 findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)