### PR TITLE
skill: #10287 — DM stacked-PR base check at Step 2c.0b

### DIFF
--- a/references/sub-skills/roles/dm/delivery-packaging.md
+++ b/references/sub-skills/roles/dm/delivery-packaging.md
@@ -41,21 +41,22 @@ For each Pending Ship task that is NOT skipped:
    ```bash
    gh pr list --search "squidsquad/" --state open --json number,headRefName,baseRefName,body --limit 20
    ```
-   Find the PR matching this issue number. If found, **first** check the PR's base branch (#10287 stacked-PR auto-close trap):
+   Find the PR matching this issue number. Extract its `baseRefName` from the **same** list payload (no second `gh pr view` round trip). Compare against the configured working branch (#10287 stacked-PR auto-close trap):
 
    ```bash
    WORKING_BRANCH=$(python references/scripts/config.py get working-branch 2>/dev/null || echo "main")
-   PR_BASE=$(gh pr view [PR_NUMBER] --json baseRefName -q .baseRefName)
+   # PR_BASE comes from the gh pr list payload above — the matching PR's baseRefName field.
    ```
 
-   - **If `$PR_BASE` != `$WORKING_BRANCH`**: the PR is stacked on another feature branch. Merging the parent would squash-delete its source and auto-close this PR (`state=CLOSED, mergeable=CONFLICTING`); the PR cannot be re-targeted in place once that happens. Do **not** request a harness merge. Route back to in-progress so the worker agent rebases onto `$WORKING_BRANCH`:
+   - **If `$PR_BASE` is empty** (PR not found in list, or `gh pr list` returned a degraded payload): skip the base check defensively and fall through to the citation gate. Do not infer a stacked-PR state from missing data — a false-positive route-back here would block ship for transient `gh` failures.
+   - **If `$PR_BASE` is non-empty AND `$PR_BASE` != `$WORKING_BRANCH`**: the PR is stacked on another feature branch. Merging the parent would squash-delete its source and auto-close this PR (`state=CLOSED, mergeable=CONFLICTING`); the PR cannot be re-targeted in place once that happens. Do **not** request a harness merge. Route back to in-progress so the worker agent rebases onto `$WORKING_BRANCH` **and** retargets the PR base on GitHub (a git rebase alone does NOT change the GitHub PR's `baseRefName` — without `gh pr edit --base`, DM will detect the same stacked state next cycle and the route-back loops):
      ```bash
      python references/scripts/tracker.py transition [NUMBER] pending-ship in-progress --role dm-lead
-     python references/scripts/tracker.py comment [NUMBER] --role dm-lead --message "PR #[PR_NUMBER] is stacked on \`$PR_BASE\` instead of \`$WORKING_BRANCH\`. Stacked PRs auto-close when their parent merges (squash-delete) and cannot be re-targeted in place. Rebase onto \`$WORKING_BRANCH\` (or wait for the parent to merge first) and re-route to pending-ship."
+     python references/scripts/tracker.py comment [NUMBER] --role dm-lead --message "PR #[PR_NUMBER] is stacked on \`$PR_BASE\` instead of \`$WORKING_BRANCH\`. Stacked PRs auto-close when their parent merges (squash-delete) and cannot be re-targeted in place. Worker agent: rebase the branch onto \`$WORKING_BRANCH\`, then retarget the PR base with \`gh pr edit [PR_NUMBER] --base $WORKING_BRANCH\` (the git rebase alone does not change the PR's baseRefName on GitHub), then re-route to pending-ship. Alternatively wait for the parent PR to merge before re-routing."
      ```
      Skip this item and move to the next.
 
-   If the base check passes, apply the contract-citation soft gate (#8950 Gate #4):
+   If the base check passes (PR_BASE matches WORKING_BRANCH, or PR_BASE was empty and skipped), apply the contract-citation soft gate (#8950 Gate #4):
 
    ```bash
    ARTIFACTS=$(ls .squidsquad/pm/planning/*[NUMBER]* .squidsquad/qa/planning/*[NUMBER]* 2>/dev/null)

--- a/references/sub-skills/roles/dm/delivery-packaging.md
+++ b/references/sub-skills/roles/dm/delivery-packaging.md
@@ -39,9 +39,23 @@ For each Pending Ship task that is NOT skipped:
 
 0b. **PR merge gate** (#9478: branch+PR is the only mode): check for an associated PR:
    ```bash
-   gh pr list --search "squidsquad/" --state open --json number,headRefName,body --limit 20
+   gh pr list --search "squidsquad/" --state open --json number,headRefName,baseRefName,body --limit 20
    ```
-   Find the PR matching this issue number. If found, **first** apply the contract-citation soft gate (#8950 Gate #4):
+   Find the PR matching this issue number. If found, **first** check the PR's base branch (#10287 stacked-PR auto-close trap):
+
+   ```bash
+   WORKING_BRANCH=$(python references/scripts/config.py get working-branch 2>/dev/null || echo "main")
+   PR_BASE=$(gh pr view [PR_NUMBER] --json baseRefName -q .baseRefName)
+   ```
+
+   - **If `$PR_BASE` != `$WORKING_BRANCH`**: the PR is stacked on another feature branch. Merging the parent would squash-delete its source and auto-close this PR (`state=CLOSED, mergeable=CONFLICTING`); the PR cannot be re-targeted in place once that happens. Do **not** request a harness merge. Route back to in-progress so the worker agent rebases onto `$WORKING_BRANCH`:
+     ```bash
+     python references/scripts/tracker.py transition [NUMBER] pending-ship in-progress --role dm-lead
+     python references/scripts/tracker.py comment [NUMBER] --role dm-lead --message "PR #[PR_NUMBER] is stacked on \`$PR_BASE\` instead of \`$WORKING_BRANCH\`. Stacked PRs auto-close when their parent merges (squash-delete) and cannot be re-targeted in place. Rebase onto \`$WORKING_BRANCH\` (or wait for the parent to merge first) and re-route to pending-ship."
+     ```
+     Skip this item and move to the next.
+
+   If the base check passes, apply the contract-citation soft gate (#8950 Gate #4):
 
    ```bash
    ARTIFACTS=$(ls .squidsquad/pm/planning/*[NUMBER]* .squidsquad/qa/planning/*[NUMBER]* 2>/dev/null)

--- a/tests/test_feat_6126_harness_merge.py
+++ b/tests/test_feat_6126_harness_merge.py
@@ -330,6 +330,51 @@ class TestTemplateUpdates:
         content = path.read_text(encoding="utf-8")
         assert "POST" in content and "/merge" in content
 
+    def test_dm_delivery_has_stacked_pr_base_check(self):
+        """#10287: DM Step 2c.0b must check baseRefName before requesting
+        harness merge — stacked PRs auto-close when their parent squash-merges
+        and cannot be re-targeted in place. Without this gate the trap recurs
+        on every multi-issue ship sequence with one PR stacked on another."""
+        path = REPO_ROOT / "references" / "sub-skills" / "roles" / "dm" / "delivery-packaging.md"
+        content = path.read_text(encoding="utf-8")
+        assert "baseRefName" in content, (
+            "delivery-packaging.md must read the PR's baseRefName before "
+            "requesting merge (#10287 stacked-PR auto-close trap)"
+        )
+        assert "PR_BASE" in content, (
+            "delivery-packaging.md must compare PR_BASE against the configured "
+            "working-branch (#10287)"
+        )
+        assert "10287" in content, (
+            "the stacked-PR check should cite #10287 so future readers can "
+            "find the incident context"
+        )
+
+    def test_dm_delivery_routes_back_on_stacked_pr(self):
+        """#10287: when base != working-branch, DM must route the issue back to
+        in-progress rather than requesting the harness merge. The route-back
+        comment must explain rebase-onto-main as the remediation so the
+        worker agent knows exactly what to do."""
+        path = REPO_ROOT / "references" / "sub-skills" / "roles" / "dm" / "delivery-packaging.md"
+        content = path.read_text(encoding="utf-8")
+        # The route-back transition must appear in the base-check block, before
+        # the citation gate or merge POST.
+        base_check_idx = content.find("baseRefName")
+        citation_idx = content.find("Gate #4")
+        assert base_check_idx >= 0 and citation_idx >= 0
+        assert base_check_idx < citation_idx, (
+            "the baseRefName check must come BEFORE the citation gate — if a "
+            "PR is stacked, no other gate matters because the merge will trap"
+        )
+        # Route-back transition is the in-block remediation
+        block = content[base_check_idx:citation_idx]
+        assert "pending-ship in-progress" in block, (
+            "stacked-PR detection must route the issue back to in-progress"
+        )
+        assert "rebase" in block.lower(), (
+            "the route-back comment must mention rebase as the remediation"
+        )
+
     def test_pm_post_merge_recompose_deleted(self):
         """PM post-merge-recompose.md should be deleted (#6126 AC-6)."""
         path = REPO_ROOT / "references" / "sub-skills" / "roles" / "pm" / "post-merge-recompose.md"

--- a/tests/test_feat_6126_harness_merge.py
+++ b/tests/test_feat_6126_harness_merge.py
@@ -353,8 +353,10 @@ class TestTemplateUpdates:
     def test_dm_delivery_routes_back_on_stacked_pr(self):
         """#10287: when base != working-branch, DM must route the issue back to
         in-progress rather than requesting the harness merge. The route-back
-        comment must explain rebase-onto-main as the remediation so the
-        worker agent knows exactly what to do."""
+        comment must explain BOTH rebase AND the PR-retarget step — git
+        rebase alone does NOT change a GitHub PR's baseRefName, so without
+        the explicit retarget step DM detects the same stacked state next
+        cycle and loops indefinitely."""
         path = REPO_ROOT / "references" / "sub-skills" / "roles" / "dm" / "delivery-packaging.md"
         content = path.read_text(encoding="utf-8")
         # The route-back transition must appear in the base-check block, before
@@ -366,13 +368,76 @@ class TestTemplateUpdates:
             "the baseRefName check must come BEFORE the citation gate — if a "
             "PR is stacked, no other gate matters because the merge will trap"
         )
-        # Route-back transition is the in-block remediation
         block = content[base_check_idx:citation_idx]
         assert "pending-ship in-progress" in block, (
             "stacked-PR detection must route the issue back to in-progress"
         )
         assert "rebase" in block.lower(), (
-            "the route-back comment must mention rebase as the remediation"
+            "the route-back comment must mention rebase as the local-history "
+            "remediation"
+        )
+        assert "gh pr edit" in block and "--base" in block, (
+            "the route-back comment must also instruct the worker to retarget "
+            "the PR on GitHub — git rebase alone does not change baseRefName"
+        )
+        assert "Skip this item" in block or "move to the next" in block, (
+            "the stacked-PR route-back must include a skip instruction so DM "
+            "does not fall through to the citation gate on the same item"
+        )
+
+    def test_dm_delivery_compares_base_against_working_branch(self):
+        """#10287 Finding 4: the comparison must be an inequality between
+        PR_BASE and WORKING_BRANCH. Static presence tests can pass even if
+        someone inverts the operator (== instead of !=) and breaks the
+        gate semantically; assert the inequality is in the block."""
+        path = REPO_ROOT / "references" / "sub-skills" / "roles" / "dm" / "delivery-packaging.md"
+        content = path.read_text(encoding="utf-8")
+        base_check_idx = content.find("baseRefName")
+        citation_idx = content.find("Gate #4")
+        block = content[base_check_idx:citation_idx]
+        assert "$PR_BASE" in block and "$WORKING_BRANCH" in block, (
+            "the base check must use the named shell variables PR_BASE and "
+            "WORKING_BRANCH, not literal strings"
+        )
+        # The route-back fires on inequality (`!=`); the pass case on equality.
+        # Either bash form is acceptable (POSIX `-ne` is for ints — strings use !=).
+        assert "!=" in block, (
+            "the base check must use string inequality (!=); an inverted "
+            "operator would route back on the happy path and merge stacks"
+        )
+
+    def test_dm_delivery_base_check_has_distinct_pass_branch(self):
+        """#10287 Finding 5: the protocol must mark the happy path as a
+        distinct branch ('If the base check passes...') AFTER the route-back
+        block. Without a labeled pass branch, the protocol could be edited
+        to always route back and the other structural tests would still pass."""
+        path = REPO_ROOT / "references" / "sub-skills" / "roles" / "dm" / "delivery-packaging.md"
+        content = path.read_text(encoding="utf-8")
+        pass_idx = content.find("If the base check passes")
+        route_back_idx = content.find("pending-ship in-progress")
+        assert pass_idx > 0, (
+            "the protocol must explicitly label the happy path as 'If the "
+            "base check passes' so future readers see the branch structure"
+        )
+        assert pass_idx > route_back_idx, (
+            "the pass branch must appear AFTER the route-back so it reads as "
+            "the alternative path, not unconditional fall-through"
+        )
+
+    def test_dm_delivery_handles_empty_pr_base_defensively(self):
+        """#10287 Finding 1: the protocol must handle an empty PR_BASE
+        without false-positive route-back. A transient gh failure should not
+        block ship — treat empty PR_BASE as 'skip the check, fall through to
+        citation gate'."""
+        path = REPO_ROOT / "references" / "sub-skills" / "roles" / "dm" / "delivery-packaging.md"
+        content = path.read_text(encoding="utf-8")
+        base_check_idx = content.find("baseRefName")
+        citation_idx = content.find("Gate #4")
+        block = content[base_check_idx:citation_idx]
+        assert "empty" in block.lower(), (
+            "the protocol must explicitly describe the empty PR_BASE case "
+            "(transient gh failure or degraded payload); without this guard "
+            "the inequality fires on '' != 'main' and traps ship on gh blips"
         )
 
     def test_pm_post_merge_recompose_deleted(self):


### PR DESCRIPTION
## Summary

Fixes #10287. Without this gate, when one pending-ship PR is stacked on another (B's base = A's task branch, not `main`), DM merges A first, the harness squash-deletes A's source, and GitHub auto-closes B (`state=CLOSED, mergeable=CONFLICTING`). B cannot be re-targeted in place — `gh pr edit --base main` fails on a classic-projects GraphQL error and `gh pr reopen` fails because the base is gone. Recovery costs a full skill+QA cycle to reconstruct.

Cycle 1445 hit this concretely with PR #10271 stacked on PR #10247 — recovery via #10293 + this issue. See [feedback_stacked_pr_auto_close](https://github.com/WallyDoodlez/SquidSquad/blob/main/memory/feedback_stacked_pr_auto_close.md) for worker-side guidance.

## Approach

Edit `references/sub-skills/roles/dm/delivery-packaging.md` Step 2c.0b:

- Add `baseRefName` to the `gh pr list` payload — single round trip, no second `gh pr view` call.
- Extract `PR_BASE` from the matching PR's list entry; compare against `WORKING_BRANCH` (configurable via `config.py get working-branch`, default `main`).
- **Empty `$PR_BASE`** (transient `gh` failure, degraded payload) → skip the check, fall through to citation gate. False-positive route-back on a transient blip is worse than missing the trap once.
- **`$PR_BASE` non-empty AND `$PR_BASE != $WORKING_BRANCH`** → route back to `in-progress` with a comment that names BOTH remediations: `git rebase` for local history AND `gh pr edit --base $WORKING_BRANCH` for the GitHub-side metadata. Without the explicit retarget step, the worker rebases, re-routes to pending-ship, and DM detects the same stacked state next cycle (infinite loop). Then `Skip this item and move to the next` so DM doesn't fall through to the citation gate or merge POST.
- Otherwise, fall through to the existing `### 8950 Gate #4` citation soft-gate.

Did NOT add the auto-retarget alternative (`gh pr edit --base main` from DM-side before merging) — the issue body notes that path has its own classic-projects GraphQL failure mode that needs separate debugging. Routing back to the worker is the conservative, well-tested path.

## DS review (round 1)

6 warnings, all addressed in `771fad42`:

| # | Finding | Disposition |
|---|---------|-------------|
| 1 | Empty `$PR_BASE` would false-positive route-back on transient `gh` failures | Added explicit empty-guard that falls through to citation gate |
| 2 | "Rebase onto main" remediation alone won't unstick the trap — git rebase does not change a GitHub PR's `baseRefName` | Updated route-back comment to include `gh pr edit --base $WORKING_BRANCH` retarget step |
| 3 | Test didn't assert "Skip this item" is in the route-back block | Added the assertion |
| 4 | Tests were string-presence only; an inverted `==` operator would still pass | Added test that asserts `!=` is in the comparison block |
| 5 | No test for the happy-path branch label | Added test that asserts "If the base check passes" appears AFTER the route-back |
| 6 | Dead `baseRefName` data — added to `gh pr list` payload but re-fetched via `gh pr view` | Removed the redundant `gh pr view` call; PR_BASE comes from the list payload |

## Test impact

- `tests/test_feat_6126_harness_merge.py::TestTemplateUpdates`: 5 new structural tests under `TestTemplateUpdates`:
  - `test_dm_delivery_has_stacked_pr_base_check` — `baseRefName`, `PR_BASE`, `#10287` lineage present
  - `test_dm_delivery_routes_back_on_stacked_pr` — route-back block contains transition, rebase, `gh pr edit --base`, and skip instruction; appears BEFORE citation gate
  - `test_dm_delivery_compares_base_against_working_branch` — inequality `!=` between `$PR_BASE` and `$WORKING_BRANCH` (Finding 4)
  - `test_dm_delivery_base_check_has_distinct_pass_branch` — "If the base check passes" labeled and after route-back (Finding 5)
  - `test_dm_delivery_handles_empty_pr_base_defensively` — empty-`PR_BASE` case described (Finding 1)
- Module total: 45/45 pass (was 40 on main).
- `python tests/run_tests.py`: 50/50 pass / 1 skipped.

## Verification path

QA can verify by simulating a stacked-PR ship: create two PRs A (base=main) + B (base=A's task branch), mark both pending-ship, run the DM cycle. DM should route B back to in-progress with the rebase + retarget comment and NOT POST `/merge` for B. After QA's manual rebase + `gh pr edit --base main` of B, the next DM cycle should pass the gate and proceed to citation + merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)