### PR TITLE
skill: #10265 — stop e2e test from clobbering live .harness-port

### DIFF
--- a/references/scripts/event_bus_reader.py
+++ b/references/scripts/event_bus_reader.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 import json
+import os
 import sys
 import urllib.request
 import urllib.error
@@ -25,7 +26,6 @@ def _resolve_squid_dir() -> Path:
     can be discovered by event_bus_reader without the live
     .harness-port file getting in the way. Matches the pattern in
     harness._resolve_squidsquad_dir and event_bus._resolve_squid_dir."""
-    import os
     raw = (os.environ.get("SQUIDSQUAD_DIR") or "").strip()
     if not raw:
         return REPO_ROOT / ".squidsquad"

--- a/references/scripts/event_bus_reader.py
+++ b/references/scripts/event_bus_reader.py
@@ -18,7 +18,21 @@ from urllib.parse import urlencode
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent
-SQUID_DIR = REPO_ROOT / ".squidsquad"
+
+
+def _resolve_squid_dir() -> Path:
+    """#10265: honor SQUIDSQUAD_DIR env var so isolated test harnesses
+    can be discovered by event_bus_reader without the live
+    .harness-port file getting in the way. Matches the pattern in
+    harness._resolve_squidsquad_dir and event_bus._resolve_squid_dir."""
+    import os
+    raw = (os.environ.get("SQUIDSQUAD_DIR") or "").strip()
+    if not raw:
+        return REPO_ROOT / ".squidsquad"
+    return Path(raw).expanduser()
+
+
+SQUID_DIR = _resolve_squid_dir()
 
 # Timeout: 500ms — never blocks agent cycle
 _TIMEOUT = 0.5

--- a/references/scripts/event_poll.py
+++ b/references/scripts/event_poll.py
@@ -28,6 +28,7 @@ Exit codes: 0 = events found / loop exit, 1 = no events, 2 = invocation error.
 import argparse
 import http.client
 import json
+import os
 import sys
 import time
 import urllib.error
@@ -47,7 +48,6 @@ def _resolve_squid_dir() -> Path:
     `.squidsquad/.harness-port` (which other SquidSquad processes
     then route to). Matches harness._resolve_squidsquad_dir and
     event_bus._resolve_squid_dir."""
-    import os
     raw = (os.environ.get("SQUIDSQUAD_DIR") or "").strip()
     if not raw:
         return REPO_ROOT / ".squidsquad"

--- a/references/scripts/event_poll.py
+++ b/references/scripts/event_poll.py
@@ -37,7 +37,24 @@ from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent
-SQUID_DIR = REPO_ROOT / ".squidsquad"
+
+
+def _resolve_squid_dir() -> Path:
+    """#10265: honor SQUIDSQUAD_DIR env var so isolated test harnesses
+    can be discovered by event_poll subprocesses without the live
+    .harness-port file getting in the way. Without this, e2e tests
+    that spawn event_poll.py have to write their port to the LIVE
+    `.squidsquad/.harness-port` (which other SquidSquad processes
+    then route to). Matches harness._resolve_squidsquad_dir and
+    event_bus._resolve_squid_dir."""
+    import os
+    raw = (os.environ.get("SQUIDSQUAD_DIR") or "").strip()
+    if not raw:
+        return REPO_ROOT / ".squidsquad"
+    return Path(raw).expanduser()
+
+
+SQUID_DIR = _resolve_squid_dir()
 
 _DEFAULT_HTTP_TIMEOUT = 2.0
 _BACKOFF_CAP = 300

--- a/tests/integration/test_event_mode_e2e.py
+++ b/tests/integration/test_event_mode_e2e.py
@@ -238,12 +238,19 @@ class EventModeE2ETestBase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls._port_file = SQUID_DIR / ".harness-port"
-        cls._port_backup = (
-            cls._port_file.read_bytes() if cls._port_file.exists() else None
-        )
+        # #10265: route this test's port file and per-role state to an
+        # isolated SQUIDSQUAD_DIR so a tearDown crash, KeyboardInterrupt,
+        # or restored-backup race can never leave the LIVE
+        # `.squidsquad/.harness-port` pointing at a test-only random
+        # port. event_poll.py (the subprocess under test) was updated
+        # in lockstep to honor SQUIDSQUAD_DIR.
+        import tempfile
+        cls._squid_tmpdir = tempfile.mkdtemp(prefix="sq-e2e-")
+        cls._squid_dir = Path(cls._squid_tmpdir)
+        cls._squid_dir.mkdir(parents=True, exist_ok=True)
+        cls._port_file = cls._squid_dir / ".harness-port"
 
-        cls._test_role_dir = SQUID_DIR / TEST_ROLE
+        cls._test_role_dir = cls._squid_dir / TEST_ROLE
         cls._test_role_dir.mkdir(parents=True, exist_ok=True)
 
         cls._stream = EventStream(maxlen=1000)
@@ -257,7 +264,6 @@ class EventModeE2ETestBase(unittest.TestCase):
         cls._thread.start()
 
         # event_poll.py discovers the server via this file.
-        cls._port_file.parent.mkdir(parents=True, exist_ok=True)
         cls._port_file.write_text(str(cls._port), encoding="utf-8")
 
     @classmethod
@@ -266,15 +272,10 @@ class EventModeE2ETestBase(unittest.TestCase):
         cls._server.server_close()
         cls._thread.join(timeout=5)
 
-        if cls._port_backup is not None:
-            cls._port_file.write_bytes(cls._port_backup)
-        else:
-            try:
-                cls._port_file.unlink()
-            except FileNotFoundError:
-                pass
-
-        shutil.rmtree(cls._test_role_dir, ignore_errors=True)
+        # #10265: rmtree the isolated SQUIDSQUAD_DIR — no live file to
+        # restore, no backup race window where a crashed test leaves
+        # a stale port in the live discovery file.
+        shutil.rmtree(cls._squid_tmpdir, ignore_errors=True)
 
     def setUp(self):
         with self._stream._lock:
@@ -308,9 +309,15 @@ class EventModeE2ETestBase(unittest.TestCase):
             cmd += ["--since", since]
         if limit is not None:
             cmd += ["--limit", str(limit)]
+        # #10265: route the subprocess to the isolated test SQUIDSQUAD_DIR so
+        # event_poll.py reads our port file (not the live one) and writes its
+        # working-state under our test role dir.
+        import os
+        env = os.environ.copy()
+        env["SQUIDSQUAD_DIR"] = str(self._squid_dir)
         return subprocess.run(
             cmd, capture_output=True, text=True,
-            cwd=str(REPO_ROOT), timeout=20,
+            cwd=str(REPO_ROOT), timeout=20, env=env,
         )
 
     def _read_cursor(self) -> str:
@@ -321,6 +328,64 @@ class EventModeE2ETestBase(unittest.TestCase):
             if line.startswith("- **Last Processed Event ID**:"):
                 return line.split(":", 1)[1].strip()
         return ""
+
+
+class TestLiveHarnessPortNotTouched(EventModeE2ETestBase):
+    """#10265: this test class must NOT modify the live
+    `.squidsquad/.harness-port` file. Prior to #10265 the e2e test
+    base wrote its random server port directly to the live file,
+    relying on a tearDownClass restore — a teardown crash or
+    KeyboardInterrupt would leak the test port into the live
+    discovery surface and other SquidSquad processes (DM cycles,
+    statusline, event poll from agents) would mis-route. Now the
+    test uses an isolated SQUIDSQUAD_DIR + event_poll.py honors
+    that env var, so the live file is untouched."""
+
+    def test_live_squidsquad_harness_port_untouched(self):
+        live_port = REPO_ROOT / ".squidsquad" / ".harness-port"
+        if not live_port.exists():
+            self.skipTest("no live .harness-port to guard against")
+        # The fixture has already set up by the time this test runs
+        # (setUpClass on EventModeE2ETestBase fires before the first
+        # test method). The fact that setUpClass touched it should
+        # be invisible to the live file — assert that.
+        live_content = live_port.read_text(encoding="utf-8").strip()
+        try:
+            live_port_value = int(live_content)
+        except ValueError:
+            self.fail(
+                f"live .harness-port content is not a valid int: "
+                f"{live_content!r}"
+            )
+        # The test's server port (self._port) was bound from
+        # _find_free_port() — a random ephemeral port. If the
+        # isolation broke, the live file would contain this exact
+        # value.
+        self.assertNotEqual(
+            live_port_value, self._port,
+            msg=(
+                "Live .squidsquad/.harness-port has been clobbered with "
+                f"the e2e fixture's random test port ({self._port}). "
+                "This means SQUIDSQUAD_DIR isolation is broken and any "
+                "concurrent SquidSquad process reading the live port "
+                "file will route to a dead test server. Root cause "
+                "#10265."
+            ),
+        )
+
+    def test_test_port_file_is_in_isolated_tmpdir(self):
+        """The test's own port file must live under the isolated
+        SQUIDSQUAD_DIR, NOT under the live `.squidsquad/`."""
+        self.assertEqual(
+            self._port_file.parent.resolve(),
+            self._squid_dir.resolve(),
+            msg="test port file must be inside the isolated SQUIDSQUAD_DIR",
+        )
+        live_squid = (REPO_ROOT / ".squidsquad").resolve()
+        self.assertNotEqual(
+            self._port_file.parent.resolve(), live_squid,
+            msg="test port file must NOT be under the live .squidsquad/",
+        )
 
 
 class TestCursorLongLag(EventModeE2ETestBase):

--- a/tests/integration/test_event_mode_e2e.py
+++ b/tests/integration/test_event_mode_e2e.py
@@ -227,9 +227,10 @@ class EventModeE2ETestBase(unittest.TestCase):
     _server: ThreadingHTTPServer
     _thread: threading.Thread
     _stream: "EventStream"
-    _port_backup: bytes | None
     _test_role_dir: Path
     _port_file: Path
+    _squid_tmpdir: str
+    _squid_dir: Path
 
     # Reacts-to fixture for the role-targeted /events/for/{role} endpoint.
     # Subclasses exercising role filtering override this to lock in a
@@ -244,27 +245,43 @@ class EventModeE2ETestBase(unittest.TestCase):
         # `.squidsquad/.harness-port` pointing at a test-only random
         # port. event_poll.py (the subprocess under test) was updated
         # in lockstep to honor SQUIDSQUAD_DIR.
+        #
+        # Snapshot the live file's mtime BEFORE any test setup so the
+        # isolation-guard test can assert the live file was never
+        # touched, without relying on the test's random port being
+        # different from the live port (a coincidence-prone check).
         import tempfile
-        cls._squid_tmpdir = tempfile.mkdtemp(prefix="sq-e2e-")
-        cls._squid_dir = Path(cls._squid_tmpdir)
-        cls._squid_dir.mkdir(parents=True, exist_ok=True)
-        cls._port_file = cls._squid_dir / ".harness-port"
-
-        cls._test_role_dir = cls._squid_dir / TEST_ROLE
-        cls._test_role_dir.mkdir(parents=True, exist_ok=True)
-
-        cls._stream = EventStream(maxlen=1000)
-        cls._port = _find_free_port()
-        handler_cls = _make_handler(cls._stream, reacts_to=cls.REACTS_TO)
-        cls._server = ThreadingHTTPServer(("127.0.0.1", cls._port), handler_cls)
-        cls._thread = threading.Thread(
-            target=cls._server.serve_forever, daemon=True,
-            name="test-event-stream-http",
+        live_port_file = REPO_ROOT / ".squidsquad" / ".harness-port"
+        cls._live_port_mtime_before_setup = (
+            live_port_file.stat().st_mtime_ns if live_port_file.exists()
+            else None
         )
-        cls._thread.start()
 
-        # event_poll.py discovers the server via this file.
-        cls._port_file.write_text(str(cls._port), encoding="utf-8")
+        cls._squid_tmpdir = tempfile.mkdtemp(prefix="sq-e2e-")
+        # If any step below raises, unittest does NOT call tearDownClass —
+        # wrap the rest of setup so a failed mid-setup still cleans up.
+        try:
+            cls._squid_dir = Path(cls._squid_tmpdir)
+            cls._port_file = cls._squid_dir / ".harness-port"
+
+            cls._test_role_dir = cls._squid_dir / TEST_ROLE
+            cls._test_role_dir.mkdir(parents=True, exist_ok=True)
+
+            cls._stream = EventStream(maxlen=1000)
+            cls._port = _find_free_port()
+            handler_cls = _make_handler(cls._stream, reacts_to=cls.REACTS_TO)
+            cls._server = ThreadingHTTPServer(("127.0.0.1", cls._port), handler_cls)
+            cls._thread = threading.Thread(
+                target=cls._server.serve_forever, daemon=True,
+                name="test-event-stream-http",
+            )
+            cls._thread.start()
+
+            # event_poll.py discovers the server via this file.
+            cls._port_file.write_text(str(cls._port), encoding="utf-8")
+        except BaseException:
+            shutil.rmtree(cls._squid_tmpdir, ignore_errors=True)
+            raise
 
     @classmethod
     def tearDownClass(cls):
@@ -343,33 +360,28 @@ class TestLiveHarnessPortNotTouched(EventModeE2ETestBase):
 
     def test_live_squidsquad_harness_port_untouched(self):
         live_port = REPO_ROOT / ".squidsquad" / ".harness-port"
-        if not live_port.exists():
+        if self._live_port_mtime_before_setup is None:
             self.skipTest("no live .harness-port to guard against")
-        # The fixture has already set up by the time this test runs
-        # (setUpClass on EventModeE2ETestBase fires before the first
-        # test method). The fact that setUpClass touched it should
-        # be invisible to the live file — assert that.
-        live_content = live_port.read_text(encoding="utf-8").strip()
-        try:
-            live_port_value = int(live_content)
-        except ValueError:
+        # Assert the live file's mtime is unchanged since before
+        # setUpClass. This catches the clobber without false-positives
+        # on the rare port collision between _find_free_port() and the
+        # live harness's bound port (which the value-based check would
+        # have flagged as "isolation broken").
+        if not live_port.exists():
             self.fail(
-                f"live .harness-port content is not a valid int: "
-                f"{live_content!r}"
+                "Live .squidsquad/.harness-port existed before setUpClass "
+                "but is gone now — the test deleted it (a stronger "
+                "clobber than the value-mismatch case). Root cause #10265."
             )
-        # The test's server port (self._port) was bound from
-        # _find_free_port() — a random ephemeral port. If the
-        # isolation broke, the live file would contain this exact
-        # value.
-        self.assertNotEqual(
-            live_port_value, self._port,
+        live_mtime_now = live_port.stat().st_mtime_ns
+        self.assertEqual(
+            self._live_port_mtime_before_setup, live_mtime_now,
             msg=(
-                "Live .squidsquad/.harness-port has been clobbered with "
-                f"the e2e fixture's random test port ({self._port}). "
-                "This means SQUIDSQUAD_DIR isolation is broken and any "
-                "concurrent SquidSquad process reading the live port "
-                "file will route to a dead test server. Root cause "
-                "#10265."
+                "Live .squidsquad/.harness-port mtime changed during the "
+                "e2e fixture lifetime. This means SQUIDSQUAD_DIR isolation "
+                "is broken: setUpClass touched the live discovery file "
+                "and any concurrent SquidSquad process reading it will "
+                "route to a dead test server. Root cause #10265."
             ),
         )
 


### PR DESCRIPTION
## Summary

Fixes #10265. Root cause of the cycle-to-cycle drift DM observed (61506, 38798 appearing in `.squidsquad/.harness-port` while the live harness stayed steady on 7373 with unchanged `boot_time`): `tests/integration/test_event_mode_e2e.py` setUpClass wrote its random test-server port (from `_find_free_port()`) directly to the **live** `.squidsquad/.harness-port`, then restored from a backup in tearDownClass. A teardown crash, KeyboardInterrupt, or hard kill (or a re-entrant test invocation racing the restore) leaked the test port into the live discovery surface — every other SquidSquad process subsequently routed to a dead test server, exactly the "61506/38798 then nothing listens" shape the issue describes.

The test couldn't trivially be moved to an isolated `SQUIDSQUAD_DIR` because `event_poll.py` (the subprocess under test) read `SQUID_DIR = REPO_ROOT / ".squidsquad"` as a module-level constant — no env-var hook. `event_bus_reader.py` had the same gap. So this PR fixes the test **and** both scripts in lockstep.

## Approach

**Production:**
- `references/scripts/event_poll.py` — add `_resolve_squid_dir()` that honors `SQUIDSQUAD_DIR` (whitespace-stripped, `~` expanded, empty falls back to default). Matches the pattern already in `harness._resolve_squidsquad_dir` and `event_bus._resolve_squid_dir`.
- `references/scripts/event_bus_reader.py` — same change.

**Test:**
- `tests/integration/test_event_mode_e2e.py` — replace the setUpClass live-file write + backup/restore with a `tempfile.mkdtemp(prefix="sq-e2e-")`. `_port_file` lives in the tmpdir; the subprocess gets `env["SQUIDSQUAD_DIR"]` pointing at it. tearDownClass just `rmtree`s the tmpdir. No live-file write window, no backup race.
- Wrap post-`mkdtemp` body in `try/except BaseException` so a failed mid-setup rmtrees the tmpdir (unittest skips `tearDownClass` if `setUpClass` fails).
- New `TestLiveHarnessPortNotTouched` class (2 tests) as a guard:
  - `test_live_squidsquad_harness_port_untouched` — mtime snapshot of the live file taken BEFORE setUpClass; assert unchanged after. Mtime check is coincidence-immune (no false positive if `_find_free_port()` happens to pick the live harness's bound port).
  - `test_test_port_file_is_in_isolated_tmpdir` — assert `_port_file.parent` is the isolated tmp dir, NOT the live `.squidsquad/`.

## DS review (round 1)

4 warnings, all addressed in `5fd61d4b`:

| # | Finding | Disposition |
|---|---------|-------------|
| 1 | Stale `_port_backup: bytes \| None` class annotation from the deleted backup/restore path | Removed; added annotations for the new `_squid_tmpdir` / `_squid_dir` attributes |
| 2 | Live-port test compared values — false-positive on coincidental `_find_free_port()` ↔ live-harness port match | Switched to mtime-snapshot-before-vs-after — coincidence-immune |
| 3 | `tempfile.mkdtemp` could leak if a later setUpClass step raised (unittest skips tearDownClass) | Wrapped post-mkdtemp body in `try/except BaseException` — rmtree on failure, re-raise |
| 4 | `import os` was inside `_resolve_squid_dir()` — drifted from `harness.py` / `event_bus.py` which import at module level | Moved to module-level imports in both files |

## Test impact

- `tests/integration/test_event_mode_e2e.py`: 12 pass / 1 skipped (was 11 pass; +2 new under `TestLiveHarnessPortNotTouched`). The skip is the live-file mtime guard when no live `.harness-port` exists (clean-checkout case — `harness_status: unreachable` in cycle-input.json confirms this is the current local state).
- `python tests/run_tests.py`: 50/52 pass, 2 skipped (was 50/50 + 1; +2 new). No regressions.

## Verification path

After this lands and the next compose runs, run any pair of consecutive DM cycles with the e2e suite executing between them. `.squidsquad/.harness-port` content should remain equal to the actual bound port (7373 by default) across cycles, and `cycle_pre.py` should report `harness_status: reachable` whenever the harness is up. The guard tests (`TestLiveHarnessPortNotTouched`) will FAIL the build if a future change re-introduces a live-file write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)