### PR TITLE
skill: #10213 — replace obsolete PM auto-merge assertions with delegation contract

### DIFF
--- a/tests/test_feat_3645_auto_merge.py
+++ b/tests/test_feat_3645_auto_merge.py
@@ -1,7 +1,14 @@
 """Tests for #3645 — Auto Merge config wired into PR Flow verification.
 
-Structural assertions that QA and PM verification sub-skills check Auto Merge
-config and review:human-required label before deciding merge vs human review.
+Structural assertions that verifier checks Auto Merge config and
+review:human-required label before deciding merge vs human review.
+
+#10213: PM-side coverage (TestPMVerificationAutoMerge) was removed
+when #6274.2 rewrote PM's testing-and-verification.md to delegate
+all verification to verifier — the auto-merge gate no longer lives
+in the PM file by design. The TestQAVerificationAutoMerge class
+below covers the assertions against the verifier file (the new
+home of the gate logic).
 """
 import sys
 import pytest
@@ -9,7 +16,6 @@ from pathlib import Path
 
 REPO = Path(__file__).parent.parent
 QA_VERIFICATION = REPO / "references/sub-skills/roles/verifier/verification.md"  # #10156
-PM_VERIFICATION = REPO / "references/sub-skills/roles/pm/testing-and-verification.md"
 SCRIPTS = REPO / "references" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
@@ -45,22 +51,44 @@ class TestQAVerificationAutoMerge:
         assert abs(idx_auto - idx_review) < 2000
 
 
-class TestPMVerificationAutoMerge:
-    """PM verification (QA fallback) checks Auto Merge."""
+class TestPMDelegatesToVerifier:
+    """#10213: After #6274.2, PM's testing-and-verification.md was rewritten
+    to delegate all verification to verifier — including the auto-merge gate.
+    The old TestPMVerificationAutoMerge class asserted PM-side `auto-merge`,
+    `review:human-required`, and `PR Flow gate` substrings; those were
+    moved to the verifier file (`PR Flow gate` was retired entirely). This
+    class replaces those obsolete assertions with the inverse contract:
+    the PM file delegates and does NOT carry the gate itself."""
+
+    PM_VERIFICATION = REPO / "references/sub-skills/roles/pm/testing-and-verification.md"
 
     @pytest.fixture
     def content(self):
-        return PM_VERIFICATION.read_text(encoding="utf-8")
+        return self.PM_VERIFICATION.read_text(encoding="utf-8")
 
-    def test_checks_auto_merge_config(self, content):
-        assert "auto-merge" in content
+    def test_pm_does_not_carry_auto_merge_gate(self, content):
+        """PM no longer evaluates Auto Merge — that lives in verifier per
+        #6274.2's delegation rewrite. If a future edit re-introduces it
+        in PM, the gate decision will be in two places and drift."""
+        assert "auto-merge" not in content.lower(), (
+            "PM testing-and-verification.md must not carry the auto-merge "
+            "gate — verifier owns it post-#6274.2"
+        )
 
-    def test_checks_human_required_label(self, content):
-        assert "review:human-required" in content
+    def test_pm_does_not_check_human_required_label(self, content):
+        """Same deal for the per-ticket override label."""
+        assert "review:human-required" not in content, (
+            "PM testing-and-verification.md must not check "
+            "review:human-required — verifier owns the routing decision"
+        )
 
-    def test_pr_flow_gate_exists(self, content):
-        """PM Step 6 has a PR Flow gate for Auto Merge."""
-        assert "PR Flow gate" in content
+    def test_pm_delegates_to_verifier(self, content):
+        """The delegation statement must remain — it's the contract that
+        prevents the gate from drifting back into PM."""
+        assert "erifier" in content, (
+            "PM testing-and-verification.md must contain a delegation "
+            "statement that names verifier"
+        )
 
 
 class TestTrackerLabelTaxonomy:

--- a/tests/test_feat_3645_auto_merge.py
+++ b/tests/test_feat_3645_auto_merge.py
@@ -76,18 +76,24 @@ class TestPMDelegatesToVerifier:
         )
 
     def test_pm_does_not_check_human_required_label(self, content):
-        """Same deal for the per-ticket override label."""
-        assert "review:human-required" not in content, (
+        """Same deal for the per-ticket override label. Case-normalized
+        so any uppercase drift (e.g. `Review:Human-Required`) is also
+        caught — matches the lowercase check in the auto-merge test."""
+        assert "review:human-required" not in content.lower(), (
             "PM testing-and-verification.md must not check "
             "review:human-required — verifier owns the routing decision"
         )
 
     def test_pm_delegates_to_verifier(self, content):
         """The delegation statement must remain — it's the contract that
-        prevents the gate from drifting back into PM."""
-        assert "erifier" in content, (
+        prevents the gate from drifting back into PM. Bare `"erifier" in
+        content` would pass for any verifier mention (e.g. 'the verifier
+        is not involved'); require the active delegation verb so the
+        contract isn't gameable by an unrelated reference."""
+        assert "erifier handles" in content.lower(), (
             "PM testing-and-verification.md must contain a delegation "
-            "statement that names verifier"
+            "statement of the form 'Verifier handles ...' — verifier "
+            "owns verification post-#6274.2"
         )
 
 


### PR DESCRIPTION
## Summary

Fixes #10213. After #6274.2 rewrote PM's `testing-and-verification.md` to delegate all verification to verifier, the existing `TestPMVerificationAutoMerge` class became conceptually obsolete: PM no longer carries the auto-merge gate, so structural assertions that PM "checks Auto Merge" were testing for substrings that intentionally don't live in the PM file anymore. The 3 failing assertions:

| Assertion | Status |
|-----------|--------|
| `'auto-merge' in content` | Moved to verifier file — already covered by `TestQAVerificationAutoMerge::test_checks_auto_merge_config` |
| `'review:human-required' in content` | Moved to verifier file — already covered by `TestQAVerificationAutoMerge::test_checks_human_required_label` |
| `'PR Flow gate' in content` | Retired entirely — string doesn't exist anywhere in `references/sub-skills/` |

## Approach

Chose **replace with inverse contract** over **delete** because the rewrite contract is load-bearing: nothing else stops a future edit from accidentally adding the auto-merge gate back into PM, creating a two-places-of-truth bug. The new `TestPMDelegatesToVerifier` class enforces the absence:

- `test_pm_does_not_carry_auto_merge_gate` — `auto-merge` MUST NOT appear in PM file (case-normalized).
- `test_pm_does_not_check_human_required_label` — same shape for the per-ticket override label (case-normalized).
- `test_pm_delegates_to_verifier` — the delegation statement must contain the active phrase `"verifier handles"` (case-insensitive). Bare `"verifier"` match would pass for non-delegation mentions; requiring the verb closes that loophole.

Removed the now-unused module-level `PM_VERIFICATION` constant.

## DS review (round 1)

2 warnings, both addressed in `589b4741`:

| # | Finding | Disposition |
|---|---------|-------------|
| 1 (error) | `test_pm_does_not_check_human_required_label` missed `.lower()` — uppercase drift in PM file would evade the negative assertion | Normalized case to match the sibling auto-merge check |
| 2 (warning) | `test_pm_delegates_to_verifier` used `"erifier" in content` — too weak; would pass for any verifier mention even in non-delegation contexts | Tightened to `"erifier handles"` (case-insensitive) — active delegation verb required |

## Test impact

- `tests/test_feat_3645_auto_merge.py`: 9/9 pass (was 6/9 — 3 PM-side were failing on main).
- `python tests/run_tests.py`: 50/50 pass / 2 skipped (unchanged from main).

## Commits

1. `d611a928` — replace `TestPMVerificationAutoMerge` with `TestPMDelegatesToVerifier`; remove unused `PM_VERIFICATION` constant.
2. `589b4741` — DS round 1: case-normalize the human-required negative check; strengthen the delegation assertion to require the active verb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)