### PR TITLE
skill: #10006 — cmd_stop returns 0 when no agents to stop (matches cmd_status)

### DIFF
--- a/references/scripts/squidsquad_cli.py
+++ b/references/scripts/squidsquad_cli.py
@@ -209,11 +209,17 @@ def cmd_stop(role: str | None = None):
     except HarnessAPIError:
         return 1
     results = result.get("results", [])
+    if not results:
+        # #10006: nothing to stop is a no-op success, matching cmd_status's
+        # treatment of the empty-agents case. Without this, defensive
+        # teardown scripts (`squidsquad stop && next-step`) saw exit 1
+        # when the squad was already idle.
+        print("No agents to stop.")
+        return 0
     for r in results:
         status = "OK" if r.get("success") else "FAIL"
         print(f"  [{r.get('role', '?')}] {status}")
-    all_ok = bool(results) and all(r.get("success", False) for r in results)
-    return 0 if all_ok else 1
+    return 0 if all(r.get("success", False) for r in results) else 1
 
 
 def cmd_restart(role: str):

--- a/references/scripts/squidsquad_cli.py
+++ b/references/scripts/squidsquad_cli.py
@@ -211,10 +211,12 @@ def cmd_stop(role: str | None = None):
     results = result.get("results", [])
     if not results:
         # #10006: nothing to stop is a no-op success, matching cmd_status's
-        # treatment of the empty-agents case. Without this, defensive
-        # teardown scripts (`squidsquad stop && next-step`) saw exit 1
-        # when the squad was already idle.
-        print("No agents to stop.")
+        # treatment of the empty-agents case. Same wording as cmd_status
+        # so operators grepping logs / writing shell predicates see one
+        # string for "no agents are registered with the harness." Without
+        # this, defensive teardown scripts (`squidsquad stop && next-step`)
+        # saw exit 1 when the squad was already idle.
+        print("No agents detected.")
         return 0
     for r in results:
         status = "OK" if r.get("success") else "FAIL"

--- a/tests/test_squidsquad_cli.py
+++ b/tests/test_squidsquad_cli.py
@@ -233,6 +233,24 @@ class TestCommandsWithHarness:
         assert result == 0
         mock_api.assert_called_once_with(8080, "POST", "/agents/all/stop")
 
+    def test_stop_all_empty_results_returns_0(self, capsys):
+        """#10006: cmd_stop with an empty results list (no agents to stop)
+        must return 0, not 1 — matches cmd_status's treatment of the
+        no-agents case. Defensive teardown scripts (`squidsquad stop &&
+        next-step`) previously saw exit 1 when the squad was already
+        idle."""
+        with patch.object(squidsquad_cli, "_discover_harness", return_value=8080), \
+             patch.object(squidsquad_cli, "_api_call",
+                          return_value={"results": []}):
+            result = squidsquad_cli.cmd_stop()
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "No agents to stop" in out, (
+            "empty-results case must print an informational message "
+            "so the user knows the no-op was a real no-op, not a "
+            "silent success that hid a bug"
+        )
+
     def test_restart_success(self, capsys):
         with patch.object(squidsquad_cli, "_discover_harness", return_value=8080), \
              patch.object(squidsquad_cli, "_api_call", return_value={

--- a/tests/test_squidsquad_cli.py
+++ b/tests/test_squidsquad_cli.py
@@ -245,11 +245,25 @@ class TestCommandsWithHarness:
             result = squidsquad_cli.cmd_stop()
         assert result == 0
         out = capsys.readouterr().out
-        assert "No agents to stop" in out, (
+        assert "No agents detected" in out, (
             "empty-results case must print an informational message "
-            "so the user knows the no-op was a real no-op, not a "
-            "silent success that hid a bug"
+            "(matches cmd_status wording) so the user knows the no-op "
+            "was a real no-op, not a silent success that hid a bug"
         )
+
+    def test_stop_all_missing_results_key_returns_0(self, capsys):
+        """#10006: cmd_stop must handle the case where the harness
+        response omits the 'results' key entirely (early-return code
+        path or older API version). result.get('results', []) makes
+        the production path robust, but without this test a future
+        refactor to `result['results']` would silently regress to
+        KeyError + exit 1."""
+        with patch.object(squidsquad_cli, "_discover_harness", return_value=8080), \
+             patch.object(squidsquad_cli, "_api_call",
+                          return_value={}):
+            result = squidsquad_cli.cmd_stop()
+        assert result == 0
+        assert "No agents detected" in capsys.readouterr().out
 
     def test_restart_success(self, capsys):
         with patch.object(squidsquad_cli, "_discover_harness", return_value=8080), \


### PR DESCRIPTION
## Summary

Fixes #10006. `cmd_stop` computed `all_ok = bool(results) and all(...)` so an empty `results: []` (no agents currently registered with the harness) flipped `all_ok` to False and returned exit 1 — defensive teardown scripts like `squidsquad stop && next-step` saw a false failure whenever the squad was already idle. `cmd_status` already treats the same empty-agents condition as success (prints `"No agents detected."`, returns 0), so the two commands disagreed.

## Fix

- Treat empty results as a no-op success: print `"No agents detected."` (wording harmonized with `cmd_status` per Claude fallback review) and `return 0`.
- Non-empty path unchanged: `return 0 if all(r.get("success", False) for r in results) else 1`. Equivalent to the original for the non-empty case (drops the now-redundant `bool(results) and` guard).
- Did **not** touch `cmd_start`. The issue explicitly called this out: asking to start all and getting an empty result is a real anomaly (no roles configured), not a no-op success.

## Review

DeepSeek returned no findings (output below minimum length — diff was small/clean). Per the `feedback_model_router_auto_fallback` rule, spawned a Claude subagent for fallback review. Two warnings flagged, both addressed in `4e9f09fa`:

| # | Finding | Disposition |
|---|---------|-------------|
| 1 | Wording asymmetry vs cmd_status (`"No agents to stop."` vs `"No agents detected."`) | Harmonized to `"No agents detected."` — issue text explicitly asked for parity |
| 2 | Test didn't exercise `result.get("results", [])` default-path (harness response with no `results` key) | Added `test_stop_all_missing_results_key_returns_0` stubbing `{}` |

## Test impact

- `tests/test_squidsquad_cli.py`: 36/36 pass (was 34/34; +2 new — `test_stop_all_empty_results_returns_0` and `test_stop_all_missing_results_key_returns_0`).
- `python tests/run_tests.py`: 50/50 pass / 2 skipped (unchanged).

## Commits

1. `6059920c` — gate counter / change return logic; first regression test for empty `results: []`.
2. `4e9f09fa` — Claude fallback review: harmonize wording, add the missing-key test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)