### PR TITLE
docs: remove 20 L3 variant responsibility.md stubs (pure orphans)

### DIFF
--- a/references/roles/dm/android/responsibility.md
+++ b/references/roles/dm/android/responsibility.md
@@ -1,7 +1,0 @@
-# dm/android — Variant-Specific Responsibility
-
-No variant-specific responsibility narrowing for `dm/android` at this time.
-Refer to L2 at `references/sub-skills/roles/dm/responsibility.md` for the general role scope, and the L1 team roster for cross-role awareness.
-
-<!-- Future variant-specific content will replace this stub. Example shape (illustrative, not a deliverable for #9925):
-     For dev/ios: "iOS dev writes unit tests for delivered features but not end-to-end tests; e2e tests are QA's variant of the iOS test pyramid." -->

--- a/references/roles/dm/fullstack/responsibility.md
+++ b/references/roles/dm/fullstack/responsibility.md
@@ -1,7 +1,0 @@
-# dm/fullstack — Variant-Specific Responsibility
-
-No variant-specific responsibility narrowing for `dm/fullstack` at this time.
-Refer to L2 at `references/sub-skills/roles/dm/responsibility.md` for the general role scope, and the L1 team roster for cross-role awareness.
-
-<!-- Future variant-specific content will replace this stub. Example shape (illustrative, not a deliverable for #9925):
-     For dev/ios: "iOS dev writes unit tests for delivered features but not end-to-end tests; e2e tests are QA's variant of the iOS test pyramid." -->

--- a/references/roles/dm/ios/responsibility.md
+++ b/references/roles/dm/ios/responsibility.md
@@ -1,7 +1,0 @@
-# dm/ios — Variant-Specific Responsibility
-
-No variant-specific responsibility narrowing for `dm/ios` at this time.
-Refer to L2 at `references/sub-skills/roles/dm/responsibility.md` for the general role scope, and the L1 team roster for cross-role awareness.
-
-<!-- Future variant-specific content will replace this stub. Example shape (illustrative, not a deliverable for #9925):
-     For dev/ios: "iOS dev writes unit tests for delivered features but not end-to-end tests; e2e tests are QA's variant of the iOS test pyramid." -->

--- a/references/roles/dm/skill/responsibility.md
+++ b/references/roles/dm/skill/responsibility.md
@@ -1,7 +1,0 @@
-# dm/skill — Variant-Specific Responsibility
-
-No variant-specific responsibility narrowing for `dm/skill` at this time.
-Refer to L2 at `references/sub-skills/roles/dm/responsibility.md` for the general role scope, and the L1 team roster for cross-role awareness.
-
-<!-- Future variant-specific content will replace this stub. Example shape (illustrative, not a deliverable for #9925):
-     For dev/ios: "iOS dev writes unit tests for delivered features but not end-to-end tests; e2e tests are QA's variant of the iOS test pyramid." -->

--- a/references/roles/dm/web/responsibility.md
+++ b/references/roles/dm/web/responsibility.md
@@ -1,7 +1,0 @@
-# dm/web — Variant-Specific Responsibility
-
-No variant-specific responsibility narrowing for `dm/web` at this time.
-Refer to L2 at `references/sub-skills/roles/dm/responsibility.md` for the general role scope, and the L1 team roster for cross-role awareness.
-
-<!-- Future variant-specific content will replace this stub. Example shape (illustrative, not a deliverable for #9925):
-     For dev/ios: "iOS dev writes unit tests for delivered features but not end-to-end tests; e2e tests are QA's variant of the iOS test pyramid." -->

--- a/references/roles/pm/android/responsibility.md
+++ b/references/roles/pm/android/responsibility.md
@@ -1,7 +1,0 @@
-# pm/android — Variant-Specific Responsibility
-
-No variant-specific responsibility narrowing for `pm/android` at this time.
-Refer to L2 at `references/sub-skills/roles/pm/responsibility.md` for the general role scope, and the L1 team roster for cross-role awareness.
-
-<!-- Future variant-specific content will replace this stub. Example shape (illustrative, not a deliverable for #9925):
-     For dev/ios: "iOS dev writes unit tests for delivered features but not end-to-end tests; e2e tests are QA's variant of the iOS test pyramid." -->

--- a/references/roles/pm/fullstack/responsibility.md
+++ b/references/roles/pm/fullstack/responsibility.md
@@ -1,7 +1,0 @@
-# pm/fullstack — Variant-Specific Responsibility
-
-No variant-specific responsibility narrowing for `pm/fullstack` at this time.
-Refer to L2 at `references/sub-skills/roles/pm/responsibility.md` for the general role scope, and the L1 team roster for cross-role awareness.
-
-<!-- Future variant-specific content will replace this stub. Example shape (illustrative, not a deliverable for #9925):
-     For dev/ios: "iOS dev writes unit tests for delivered features but not end-to-end tests; e2e tests are QA's variant of the iOS test pyramid." -->

--- a/references/roles/pm/ios/responsibility.md
+++ b/references/roles/pm/ios/responsibility.md
@@ -1,7 +1,0 @@
-# pm/ios — Variant-Specific Responsibility
-
-No variant-specific responsibility narrowing for `pm/ios` at this time.
-Refer to L2 at `references/sub-skills/roles/pm/responsibility.md` for the general role scope, and the L1 team roster for cross-role awareness.
-
-<!-- Future variant-specific content will replace this stub. Example shape (illustrative, not a deliverable for #9925):
-     For dev/ios: "iOS dev writes unit tests for delivered features but not end-to-end tests; e2e tests are QA's variant of the iOS test pyramid." -->

--- a/references/roles/pm/skill/responsibility.md
+++ b/references/roles/pm/skill/responsibility.md
@@ -1,7 +1,0 @@
-# pm/skill — Variant-Specific Responsibility
-
-No variant-specific responsibility narrowing for `pm/skill` at this time.
-Refer to L2 at `references/sub-skills/roles/pm/responsibility.md` for the general role scope, and the L1 team roster for cross-role awareness.
-
-<!-- Future variant-specific content will replace this stub. Example shape (illustrative, not a deliverable for #9925):
-     For dev/ios: "iOS dev writes unit tests for delivered features but not end-to-end tests; e2e tests are QA's variant of the iOS test pyramid." -->

--- a/references/roles/pm/web/responsibility.md
+++ b/references/roles/pm/web/responsibility.md
@@ -1,7 +1,0 @@
-# pm/web — Variant-Specific Responsibility
-
-No variant-specific responsibility narrowing for `pm/web` at this time.
-Refer to L2 at `references/sub-skills/roles/pm/responsibility.md` for the general role scope, and the L1 team roster for cross-role awareness.
-
-<!-- Future variant-specific content will replace this stub. Example shape (illustrative, not a deliverable for #9925):
-     For dev/ios: "iOS dev writes unit tests for delivered features but not end-to-end tests; e2e tests are QA's variant of the iOS test pyramid." -->

--- a/references/roles/verifier/android/responsibility.md
+++ b/references/roles/verifier/android/responsibility.md
@@ -1,7 +1,0 @@
-# verifier/android — Variant-Specific Responsibility
-
-No variant-specific responsibility narrowing for `verifier/android` at this time.
-Refer to L2 at `references/sub-skills/roles/verifier/responsibility.md` for the general role scope, and the L1 team roster for cross-role awareness.
-
-<!-- Future variant-specific content will replace this stub. Example shape (illustrative, not a deliverable for #9925):
-     For dev/ios: "iOS dev writes unit tests for delivered features but not end-to-end tests; e2e tests are QA's variant of the iOS test pyramid." -->

--- a/references/roles/verifier/fullstack/responsibility.md
+++ b/references/roles/verifier/fullstack/responsibility.md
@@ -1,7 +1,0 @@
-# verifier/fullstack — Variant-Specific Responsibility
-
-No variant-specific responsibility narrowing for `verifier/fullstack` at this time.
-Refer to L2 at `references/sub-skills/roles/verifier/responsibility.md` for the general role scope, and the L1 team roster for cross-role awareness.
-
-<!-- Future variant-specific content will replace this stub. Example shape (illustrative, not a deliverable for #9925):
-     For dev/ios: "iOS dev writes unit tests for delivered features but not end-to-end tests; e2e tests are QA's variant of the iOS test pyramid." -->

--- a/references/roles/verifier/ios/responsibility.md
+++ b/references/roles/verifier/ios/responsibility.md
@@ -1,7 +1,0 @@
-# verifier/ios — Variant-Specific Responsibility
-
-No variant-specific responsibility narrowing for `verifier/ios` at this time.
-Refer to L2 at `references/sub-skills/roles/verifier/responsibility.md` for the general role scope, and the L1 team roster for cross-role awareness.
-
-<!-- Future variant-specific content will replace this stub. Example shape (illustrative, not a deliverable for #9925):
-     For dev/ios: "iOS dev writes unit tests for delivered features but not end-to-end tests; e2e tests are QA's variant of the iOS test pyramid." -->

--- a/references/roles/verifier/skill/responsibility.md
+++ b/references/roles/verifier/skill/responsibility.md
@@ -1,7 +1,0 @@
-# verifier/skill — Variant-Specific Responsibility
-
-No variant-specific responsibility narrowing for `verifier/skill` at this time.
-Refer to L2 at `references/sub-skills/roles/verifier/responsibility.md` for the general role scope, and the L1 team roster for cross-role awareness.
-
-<!-- Future variant-specific content will replace this stub. Example shape (illustrative, not a deliverable for #9925):
-     For dev/ios: "iOS dev writes unit tests for delivered features but not end-to-end tests; e2e tests are QA's variant of the iOS test pyramid." -->

--- a/references/roles/verifier/web/responsibility.md
+++ b/references/roles/verifier/web/responsibility.md
@@ -1,7 +1,0 @@
-# verifier/web — Variant-Specific Responsibility
-
-No variant-specific responsibility narrowing for `verifier/web` at this time.
-Refer to L2 at `references/sub-skills/roles/verifier/responsibility.md` for the general role scope, and the L1 team roster for cross-role awareness.
-
-<!-- Future variant-specific content will replace this stub. Example shape (illustrative, not a deliverable for #9925):
-     For dev/ios: "iOS dev writes unit tests for delivered features but not end-to-end tests; e2e tests are QA's variant of the iOS test pyramid." -->

--- a/references/roles/worker/android/responsibility.md
+++ b/references/roles/worker/android/responsibility.md
@@ -1,7 +1,0 @@
-# worker/android — Variant-Specific Responsibility
-
-No variant-specific responsibility narrowing for `worker/android` at this time.
-Refer to L2 at `references/sub-skills/roles/worker/responsibility.md` for the general role scope, and the L1 team roster for cross-role awareness.
-
-<!-- Future variant-specific content will replace this stub. Example shape (illustrative, not a deliverable for #9925):
-     For dev/ios: "iOS dev writes unit tests for delivered features but not end-to-end tests; e2e tests are QA's variant of the iOS test pyramid." -->

--- a/references/roles/worker/fullstack/responsibility.md
+++ b/references/roles/worker/fullstack/responsibility.md
@@ -1,7 +1,0 @@
-# worker/fullstack — Variant-Specific Responsibility
-
-No variant-specific responsibility narrowing for `worker/fullstack` at this time.
-Refer to L2 at `references/sub-skills/roles/worker/responsibility.md` for the general role scope, and the L1 team roster for cross-role awareness.
-
-<!-- Future variant-specific content will replace this stub. Example shape (illustrative, not a deliverable for #9925):
-     For dev/ios: "iOS dev writes unit tests for delivered features but not end-to-end tests; e2e tests are QA's variant of the iOS test pyramid." -->

--- a/references/roles/worker/ios/responsibility.md
+++ b/references/roles/worker/ios/responsibility.md
@@ -1,7 +1,0 @@
-# worker/ios — Variant-Specific Responsibility
-
-No variant-specific responsibility narrowing for `worker/ios` at this time.
-Refer to L2 at `references/sub-skills/roles/worker/responsibility.md` for the general role scope, and the L1 team roster for cross-role awareness.
-
-<!-- Future variant-specific content will replace this stub. Example shape (illustrative, not a deliverable for #9925):
-     For dev/ios: "iOS dev writes unit tests for delivered features but not end-to-end tests; e2e tests are QA's variant of the iOS test pyramid." -->

--- a/references/roles/worker/skill/responsibility.md
+++ b/references/roles/worker/skill/responsibility.md
@@ -1,7 +1,0 @@
-# worker/skill — Variant-Specific Responsibility
-
-No variant-specific responsibility narrowing for `worker/skill` at this time.
-Refer to L2 at `references/sub-skills/roles/worker/responsibility.md` for the general role scope, and the L1 team roster for cross-role awareness.
-
-<!-- Future variant-specific content will replace this stub. Example shape (illustrative, not a deliverable for #9925):
-     For dev/ios: "iOS dev writes unit tests for delivered features but not end-to-end tests; e2e tests are QA's variant of the iOS test pyramid." -->

--- a/references/roles/worker/web/responsibility.md
+++ b/references/roles/worker/web/responsibility.md
@@ -1,7 +1,0 @@
-# worker/web — Variant-Specific Responsibility
-
-No variant-specific responsibility narrowing for `worker/web` at this time.
-Refer to L2 at `references/sub-skills/roles/worker/responsibility.md` for the general role scope, and the L1 team roster for cross-role awareness.
-
-<!-- Future variant-specific content will replace this stub. Example shape (illustrative, not a deliverable for #9925):
-     For dev/ios: "iOS dev writes unit tests for delivered features but not end-to-end tests; e2e tests are QA's variant of the iOS test pyramid." -->


### PR DESCRIPTION
## Summary

Quiet-cycle improvement scan found 20 pure-orphan stub files at `references/roles/{dm,pm,verifier,worker}/{android,fullstack,ios,skill,web}/responsibility.md`. All 20 are 7-line placeholders that say "No variant-specific responsibility narrowing at this time" and point at L2.

## Gated 3-grep orphan audit

- **0 .yml references** — no manifest pulls them in
- **0 .py references** — no code reads these paths
- **3 .md references** — all in historical planning docs (`.squidsquad/pm/planning/CONTEXT-6274.md` and `CONTEXT-9925.md`). Historical context only.

Per memory rules `feedback_pm_can_delete_orphans` + `feedback_fix_pm_bugs_immediately`, this qualifies for inline PM deletion.

## What this does NOT touch

- **L2 responsibility.md** (`references/sub-skills/roles/<role>/responsibility.md`, 4 files) — those ARE actively manifest-included. Their cleanup is tracked by #10360.
- **includes.yml entries** — also tracked by #10360.
- **L1-L4 source files** — no other changes.

## Test plan

- [x] Gated grep audit (yml / py / md) — clean
- [x] Verify no L3 domain manifest references the files
- [ ] Compose unaffected (no manifest entry pointed at these files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)