### PR TITLE
docs: move subagent invocation rules from COMPOSE §6.6 → AGENT-RUNTIME §6.7 (#10365)

### DIFF
--- a/docs/AGENT-RUNTIME.md
+++ b/docs/AGENT-RUNTIME.md
@@ -666,6 +666,43 @@ The model pin for subagent-lane sub-skills is the **`sonnet`** tier — see [`VA
 
 For the full vault architecture (storage model, frontmatter spec, scripts, cycle integration detail beyond what this sub-section captures), see [`VAULT-ARCH.md`](VAULT-ARCH.md) — §7 for sub-skills, §9 for cycle integration, §11 for known gaps.
 
+### 6.7 Subagent invocation rules
+
+Agents may delegate work to subagents via the Agent tool. This subsection describes the **runtime rules** for spawning, model selection, prompt hygiene, and result handling. The L1-L3 source authoring of these rules (which slot, which ordinal) is documented in [`COMPOSE-ARCHITECTURE.md`](COMPOSE-ARCHITECTURE.md) §3.2 — the rules compose into each agent's CLAUDE.md via the regular `(slot, ordinal)` mechanism.
+
+**Default model selection** (L1 baseline, applies to all roles):
+
+- Use the lightest model that can do the job. Sonnet 4.6 is the default for mechanical or scoped subtasks (file searches, summarization, lint passes, narrow research).
+- Reserve Opus 4.7 for complex reasoning, multi-step planning, architectural review, or work that requires holding many constraints simultaneously.
+- The parent agent's own model is independent of subagent model choice.
+
+**Per-role overrides** (L3 content authored alongside the role's other L3 sub-skills; takes effect by appearing later in compose's `(slot, ordinal)` order than the L1 default):
+
+- `worker` (and variants like `skill`): subagent spawns default to Sonnet — the heavy thinking is in the parent. (Authority: memory rule `feedback_skill_sonnet_subagents`.)
+- `dm`: subagent spawns default to Sonnet — `dm`'s work is mostly mechanical packaging. (Authority: memory rule `feedback_dm_sonnet_subagents`.)
+- `pm`, `verifier`: use the L1 default — pick per task.
+
+**When to spawn vs inline**:
+
+- **Spawn** when the work is genuinely parallelizable (multiple independent investigations) OR when the output volume would blow the parent's context window (large grep/scan results).
+- **Inline** for small lookups (known file path, single grep), narrow questions, anything the parent already has context for.
+
+**Prompt hygiene**:
+
+- Subagent prompts must be self-contained. The subagent doesn't see the parent's conversation; brief it like a smart colleague who just walked in.
+- Include exact file paths, line numbers, and what specifically to change/check. Don't write "based on your findings, fix the bug" — that delegates the synthesis the parent should already have done.
+- Ask for a length cap when one is appropriate ("report in under 200 words") — keeps the subagent's response from re-bloating the parent's context.
+
+**Trust but verify**:
+
+- A subagent's summary describes what it *intended* to do, not necessarily what it did.
+- When a subagent writes or edits code, the parent verifies the actual diff before reporting the work as done.
+
+**Parallelism**:
+
+- Independent subagent calls go in a single tool-use batch (one message, multiple Agent calls) so they run concurrently.
+- Sequential dependencies are sequential — don't parallelize when output of A feeds B.
+
 ---
 
 ## 7. Event-driven mode in detail

--- a/docs/COMPOSE-ARCHITECTURE.md
+++ b/docs/COMPOSE-ARCHITECTURE.md
@@ -1024,44 +1024,11 @@ Mode flip = recompose + agent restart, never mid-session. The two outputs differ
 
 **Current development convention** (as of this doc — pre-event-GA): every role's `includes.yml` and `includes-events.yml` are both maintained, but most installs ship with `config.md` `event-driven: no` so the polling manifest is what gets composed in production. The event manifest is exercised in CI and on opt-in installs; it becomes the default once event mode reaches GA. This lets us iterate the event-mode authoring (and lets reviewers diff the two flavored outputs) without forcing production fleets onto event mode before it is proven.
 
-### 6.6 Subagent usage rules
+### 6.6 Subagent invocation rules — moved to AGENT-RUNTIME §6.7
 
-Agents may delegate work to subagents via the Agent tool. Under v2, subagent guidance composes deterministically into agent CLAUDE.md as orchestration content (not as a sub-skill body — subagent-spawning is decision logic the orchestration owns).
+Subagent usage rules (default model selection, per-role overrides, spawn-vs-inline, prompt hygiene, trust-but-verify, parallelism) are runtime behavior — they describe how an agent uses the Agent tool while it's running, not compose-time mechanics. The rules now live in [AGENT-RUNTIME.md §6.7](AGENT-RUNTIME.md#67-subagent-invocation-rules).
 
-**Default model selection** (L1 baseline, applies to all roles):
-
-- Use the lightest model that can do the job. Sonnet 4.6 is the default for mechanical or scoped subtasks (file searches, summarization, lint passes, narrow research).
-- Reserve Opus 4.7 for complex reasoning, multi-step planning, architectural review, or work that requires holding many constraints simultaneously.
-- The parent agent's own model is independent of subagent model choice.
-
-**Per-role overrides** (L3 content authored alongside the role's other L3 sub-skills; takes effect by appearing later in compose's `(slot, ordinal)` order than the L1 default):
-
-- `worker` (and variants like `skill`): subagent spawns default to Sonnet — the heavy thinking is in the parent. (Authority: memory rule `feedback_skill_sonnet_subagents`.)
-- `dm`: subagent spawns default to Sonnet — `dm`'s work is mostly mechanical packaging. (Authority: memory rule `feedback_dm_sonnet_subagents`.)
-- `pm`, `verifier`: use the L1 default — pick per task.
-
-**When to spawn vs inline**:
-
-- **Spawn** when the work is genuinely parallelizable (multiple independent investigations) OR when the output volume would blow the parent's context window (large grep/scan results).
-- **Inline** for small lookups (known file path, single grep), narrow questions, anything the parent already has context for.
-
-**Prompt hygiene**:
-
-- Subagent prompts must be self-contained. The subagent doesn't see the parent's conversation; brief it like a smart colleague who just walked in.
-- Include exact file paths, line numbers, and what specifically to change/check. Don't write "based on your findings, fix the bug" — that delegates the synthesis the parent should already have done.
-- Ask for a length cap when one is appropriate ("report in under 200 words") — keeps the subagent's response from re-bloating the parent's context.
-
-**Trust but verify**:
-
-- A subagent's summary describes what it *intended* to do, not necessarily what it did.
-- When a subagent writes or edits code, the parent verifies the actual diff before reporting the work as done.
-
-**Parallelism**:
-
-- Independent subagent calls go in a single tool-use batch (one message, multiple Agent calls) so they run concurrently.
-- Sequential dependencies are sequential — don't parallelize when output of A feeds B.
-
-**L1-L3 authoring location for these rules**: the default-model paragraph is authored once at L1 (e.g. `references/sub-skills/common/subagent-defaults.md`, slot `identity`). Per-role L3 files (under `references/sub-skills/roles/<role>/`) declare their own slot-`identity` content that emits later in `(slot, ordinal)` order — effectively overriding the default bullet for that role at compose time.
+The L1-L3 authoring location for these rules remains compose-side: the default-model paragraph is authored once at L1 (e.g. `references/sub-skills/common/subagent-defaults.md` with `slot: identity`). Per-role L3 files (under `references/sub-skills/roles/<role>/`) declare their own slot-`identity` content that emits later in `(slot, ordinal)` order — effectively overriding the default for that role at compose time. The composition mechanism is no different from any other L1-L3 source; see §3.2 for the general slot+ordinal contract.
 
 ---
 
@@ -1383,7 +1350,7 @@ This collapses today's two-system memory architecture (per-user memory + L4) int
 - **G3** — Boot/cycle/shutdown sub-slot boundaries inside `instructions` are still informal. v2 working definition: `boot` = one-time session-start work; `cycle` = repeated work (per `/loop` tick in polling mode, per nudge in event mode — see [AGENT-RUNTIME.md](AGENT-RUNTIME.md)); `shutdown` = clean-stop work. Formal acceptance tests for sub-slot membership are a follow-up.
 - **G4** — ✅ PARTIALLY CLOSED (2026-05-24). [`VAULT-ARCH.md`](VAULT-ARCH.md) now covers entity types (§4), wikilink grammar (§4.5), confidence levels (§4.4), and the relationship to `vault-protocol.md` (§7). What remains open here: defining the *slot contract* (what content fragments are valid under `slot: vault` in L1-L4 sources, beyond the short descriptor pattern in §5.5).
 - ~~**G5** — L4 file naming collision rules~~ **CLOSED** — see §7.3. There is exactly one L4 file per role-class, named `<role-class>.md` (e.g. `pm.md`, `fe-worker.md`, `be-worker.md` in installs with worker specialization; `pm.md`, `worker.md`, `verifier.md`, `dm.md` in installs without). The filename IS the role-class identity — collision is structurally impossible since each role-class has exactly one expected filename.
-- **G6** — ✅ CLOSED (v2). Subagent usage rules now in §6.6 (default-model + per-role overrides + spawn-vs-inline + prompt hygiene + parallelism + trust-but-verify). L3 `replace` overlays on the L1 default cover the per-role Sonnet defaults for `worker`/`dm`.
+- **G6** — ✅ CLOSED (v2). Subagent usage rules now in [AGENT-RUNTIME §6.7](AGENT-RUNTIME.md#67-subagent-invocation-rules) (default-model + per-role overrides + spawn-vs-inline + prompt hygiene + parallelism + trust-but-verify). L3 `replace` overlays on the L1 default cover the per-role Sonnet defaults for `worker`/`dm`. Rules originally added to COMPOSE §6.6 then relocated to AGENT-RUNTIME because they describe runtime behavior, not compose mechanics.
 - **G7** — Sub-skill reference resolution semantics for L4. Open: can L4 *insert* a new step that references a sub-skill not yet referenced anywhere in L1-L3? Yes per §4.5 (catalog is the source of truth, not the L1-L3 reference set), but the L4-write decision tree in §7.2 should explicitly cover the "introduce a new sub-skill reference" case.
 
 Each open gap is filed for explicit closure in §12.


### PR DESCRIPTION
## Summary

Closes #10365. Moves subagent invocation rules from `COMPOSE-ARCHITECTURE.md §6.6` to `AGENT-RUNTIME.md §6.7`. The rules describe runtime behavior (how an agent uses the Agent tool while running), not compose mechanics — they belong in the runtime doc.

## Changes

| File | Change |
|---|---|
| **AGENT-RUNTIME.md** | NEW §6.7 "Subagent invocation rules" with the full ruleset (model selection, per-role overrides, spawn-vs-inline, prompt hygiene, trust-but-verify, parallelism). Cross-refs COMPOSE §3.2 for L1-L3 source-authoring story. |
| **COMPOSE-ARCHITECTURE.md §6.6** | Brief pointer to AGENT-RUNTIME §6.7. Kept the L1-L3 authoring story (which IS compose-time): the default-model paragraph composes via `references/sub-skills/common/subagent-defaults.md` with `slot: identity`; per-role L3 overrides via natural (slot, ordinal) ordering. |
| **COMPOSE-ARCHITECTURE.md §11.2 G6** | Closure note updated to point at AGENT-RUNTIME §6.7 as the new home; notes the relocation rationale. |

## What stays unchanged

- AGENT-RUNTIME's existing §6.6 (Vault touchpoints within Phase 2) — untouched; the new section is §6.7 after it
- Existing §6.6 cross-refs inside AGENT-RUNTIME — these reference AGENT-RUNTIME's own §6.6 (Vault touchpoints), not COMPOSE's
- Revision log entries — historical, kept as-is
- L1-L3 source authoring — content unchanged, just docs split between spec home (AGENT-RUNTIME) and composition mechanism (COMPOSE)

## Test plan

- [x] AGENT-RUNTIME §6.7 contains the full ruleset
- [x] COMPOSE §6.6 is now a pointer + L1-L3 authoring story
- [x] G6 closure in §11.2 points at new home
- [x] No internal cross-refs orphaned
- [ ] Human review

🤖 Generated with [Claude Code](https://claude.com/claude-code)