### PR TITLE
docs: #10363 cross-doc consistency sweep — VAULT + COMPOSE + INSTALLER + HARNESS

### DIFF
--- a/docs/COMPOSE-ARCHITECTURE.md
+++ b/docs/COMPOSE-ARCHITECTURE.md
@@ -792,8 +792,8 @@ This section is intentionally short — most vault detail belongs in `references
    4.2 Per nudge (idle → walk → idle — see AGENT-RUNTIME §7.1 for the canonical contract)
        1. Wake on nudge             (step:cycle/wake)
                                     — Monitor receives `NUDGE\n` from the
-                                      sibling `event_poll.py --wait --role <role>
-                                      --target stdout` process
+                                      harness-managed `event_poll.py --wait --role <role>
+                                      --target stdout` sidecar process
        2. Read cursor + events      (step:cycle/read-cursor)
                                     — GET /events/cursor/{role},
                                       GET /events/for/{role}?since=cursor
@@ -974,7 +974,7 @@ Migration from today's mixed numbering is mechanical (one-time renumber as part 
 
 ### 6.5 Wake-mode handling — two parallel manifests, compose-time selection
 
-SquidSquad agents support two wake mechanisms: **event-driven** (a sibling `event_poll.py` polls the harness with adaptive backoff and writes a literal `NUDGE\n` line to stdout whenever new events arrive past the agent's cursor; Monitor wakes the agent, which then walks all events past its cursor and acks once at the end — see AGENT-RUNTIME §7.0 / §7.1) and **polling** (the agent reschedules itself via `/loop` at a fixed interval and runs a full Ralph Loop cycle on each fire). They produce identical *outcomes* but very different `instructions/cycle` shapes.
+SquidSquad agents support two wake mechanisms: **event-driven** (a harness-managed `event_poll.py` sidecar polls the harness with adaptive backoff and writes a literal `NUDGE\n` line to stdout whenever new events arrive past the agent's cursor; Monitor wakes the agent, which then walks all events past its cursor and acks once at the end — see AGENT-RUNTIME §7.0 / §7.1) and **polling** (the agent reschedules itself via `/loop` at a fixed interval and runs a full Ralph Loop cycle on each fire). They produce identical *outcomes* but very different `instructions/cycle` shapes.
 
 **Architectural rule** (matches today's `compose.py` implementation per #8697): the two modes are **two parallel manifests selected at compose time**, not a runtime branch.
 

--- a/docs/HARNESS-ARCH.md
+++ b/docs/HARNESS-ARCH.md
@@ -80,7 +80,9 @@ All endpoints serve from `http://127.0.0.1:<port>`. Localhost-only; no authentic
 | POST | `/agents/all/stop` | Stop all running agents | `{ok, stopped: [...]}` |
 | POST | `/shutdown` | Graceful harness shutdown (status 202) | Async; harness exits after returning |
 
-> **Response-shape status:** the response shapes above are **aspirational** — they document the target shape that lands with **#10358** (the `role` → `alias` code rename). Today `AgentState.to_dict()` returns a `role` field (whose value is the alias) but no separate `alias` field. `pid` is shorthand for `claude_pid` + `terminal_pid`, which the code returns as separate fields. Existing clients that read these endpoints should treat the alias as the value of `role` and read `claude_pid` directly until #10358 ships.
+> **Response-shape status:** the response shapes above are **aspirational** — they document the target shape that lands with **#10358** (the `role` → `alias` code rename). **Today's actual return shape**: `AgentState.to_dict()` returns a `role` field (whose value is the alias; no separate `alias` field), plus `claude_pid` and `terminal_pid` as separate fields (no shorthand `pid` field). Existing clients should treat the alias as the value of `role` and read `claude_pid` + `terminal_pid` separately until #10358 ships. The "target shape" framing also applies to §9 (Vocabulary note) — both sections describe the post-rename state.
+>
+> **Path-parameter vocabulary on lifecycle endpoints:** `{role}` on `POST /agents/{role}/start|stop|restart` and `GET /agents/{role}/*` accepts the **alias** value (same convention as event-bus endpoints §4.2). The naming predates the alias concept; the rename to `{alias}` is in #10358. There is no class-level lifecycle endpoint — every lifecycle call targets one specific alias.
 
 ### 4.2 Event bus endpoints
 
@@ -155,7 +157,7 @@ event_id = sha256(timestamp + alias + event_type + payload + nonce)[:16]
 
 | Task | Cadence | Purpose |
 |---|---|---|
-| `ack-cursor consumer` | event-driven | Drains the ack-cursor queue, advances cursors, persists to `.squidsquad/.event-state.json` |
+| `ack-cursor consumer` | event-driven | Drains the ack-cursor queue, advances cursors, persists cursor positions to `.squidsquad/.event-state.json` (the deque itself remains in-memory only, per §5.1) |
 | `timeout_scan` | every 30s | Re-delivers in-flight events that have been pending past their TTL |
 | `health_poll` | every 5s | Per-agent PID liveness check (`OpenProcess` on Windows, `kill -0` on POSIX) |
 | `EAD poller` | adaptive (10s active / 30s idle, 60s ceiling) | Polls forge for state changes; see §6 |

--- a/docs/HARNESS-ARCH.md
+++ b/docs/HARNESS-ARCH.md
@@ -398,6 +398,8 @@ EAD's polling loop hard-codes the GitHub `gh api` shape. Non-GitHub backends (Fo
 
 ## 14. Proposed simplification: `wt → claude` direct spawn
 
+> **Scope reminder:** §§1–13 describe the harness as it exists in code today. §14 is a **proposed simplification — not implemented**. The current process tree (with `thin_launcher.py` as a load-bearing intermediate) is documented in [AGENT-RUNTIME.md §3.2](AGENT-RUNTIME.md) and remains authoritative for the current runtime. AGENT-RUNTIME describes the current state; this section describes a target. If §14 lands, AGENT-RUNTIME §3.2 ships an updated process tree in the same change.
+
 The current per-agent spawn chain on Windows is `wt.exe → bash → thin_launcher.py → cmd.exe → claude.exe` (five processes). Most of the layering exists for historical reasons; the only structurally load-bearing piece is `wt.exe` itself, which provides the TTY that keeps claude on the interactive Claude subscription billing model. Piping stdin/stdout to `claude.exe` auto-demotes it to the Agent SDK billing pool, which is separately metered — so any "harness owns claude's I/O over pipes" redesign is closed under the current Anthropic billing model.
 
 What remains achievable: **delete `thin_launcher.py` entirely** and have `wt.exe` invoke `claude.exe` directly.

--- a/docs/HARNESS-ARCH.md
+++ b/docs/HARNESS-ARCH.md
@@ -86,13 +86,16 @@ All endpoints serve from `http://127.0.0.1:<port>`. Localhost-only; no authentic
 
 | Method | Path | Purpose | Returns |
 |---|---|---|---|
-| POST | `/events` | Emit an event (booted, ack-cursor, assigned-to, etc.) | `{ok, event_id}` or 4xx |
-| GET | `/events` | List recent events (debugging) | `[event, ...]` |
+| POST | `/events` | Emit an event (booted, ack-cursor, assigned-to, etc.) — see [AGENT-RUNTIME.md §4.2](AGENT-RUNTIME.md) for payload shapes per event type | `{ok, event_id}` or 4xx |
+| GET | `/events` | List recent events (**debug-only**; not part of agent-facing contract) | `[event, ...]` |
 | GET | `/events/for/{role}` | Read events past the role's cursor | `[event, ...]` or HTTP 410 Gone if cursor evicted |
-| GET | `/events/cursor/{role}` | Current cursor position for a role | `{cursor, role}` (cursor may be `null` on first boot) |
-| POST | `/events/{event_id}/complete` | Mark in-flight event as complete | `{ok}` |
-| GET | `/events/in-flight/{role}` | List events delivered to role but not yet acked | `[event, ...]` |
+| GET | `/events/cursor/{role}` | Current cursor position for a role | `{cursor, role}` (cursor may be `null` on first boot); **HTTP 200 always** (no 404 if cursor null) |
+| GET | `/events/in-flight/{role}` | List events delivered to role but not yet acked (**debug-only**; agents do not consume this in normal operation) | `[event, ...]` |
 | GET | `/events/lifecycle` | Recent lifecycle events for TUI display | `[event, ...]` |
+
+> **Path-parameter vocabulary** (per §9): the `{role}` path parameter on `/events/for/{role}`, `/events/cursor/{role}`, `/events/in-flight/{role}` accepts the **alias** value, not the L2 categorical role. The naming predates the alias concept; rename to `{alias}` ships with [#10358](https://github.com/WallyDoodlez/SquidSquad/issues/10358).
+>
+> **No completion endpoint** (locked, per AGENT-RUNTIME §4.1 principle #4): there is no `POST /events/{event_id}/complete`. The bus uses events, not RPC, for state transitions. Receipt confirmation flows through `ack-cursor` (cursor advance) and `ack-stop` (graceful-shutdown acknowledgement) only — both emitted via `POST /events`. Any design that proposes a completion endpoint is rejected at architecture review.
 
 ### 4.3 Work-queue endpoint
 
@@ -102,6 +105,8 @@ All endpoints serve from `http://127.0.0.1:<port>`. Localhost-only; no authentic
 
 The endpoint wraps the deterministic work-queue logic in `tracker.py work-queue` so TUIs / web UIs can poll over HTTP without spawning a subprocess per refresh. `{alias}` is the install-time agent name; for the human, the alias is `human` (filter is `status:pending-human-*`); for other aliases, the filter is the same one `tracker.py work-queue` produces (priority-sorted approved + in-progress items for that alias).
 
+> **Scope:** `/queue/{alias}` is a **UI-facing convenience endpoint** for TUIs / web UIs / human dashboards — it is NOT part of the agent runtime contract. Agents receive work via the event bus (`assigned-to` events emitted by EAD per [AGENT-RUNTIME.md §6.1](AGENT-RUNTIME.md) and `POST /work/assign` per [AGENT-RUNTIME.md §7.3](AGENT-RUNTIME.md)), not by polling this endpoint. AGENT-RUNTIME deliberately omits this endpoint because agents do not consume it.
+>
 > **Current implementation gap:** the harness today exposes only `/human/queue` (special-cased to human). The generic `/queue/{alias}` shape above is the principled form; the migration is tracked in §13.6.
 
 ---
@@ -259,6 +264,13 @@ One file per install (at the install root). Persisted across harness restarts. S
 }
 ```
 
+**Two distinct fields per agent** (per [AGENT-RUNTIME.md §7.2](AGENT-RUNTIME.md)):
+
+- **`intent`** — what the operator wants. Values: `running` | `stopping` | `restarting` | `stopped`. Transitions are HTTP-API-driven (per §7.1); the harness writes the new intent immediately on `POST /agents/{role}/{start|stop|restart}`.
+- **`status`** — what the agent is actually doing. Values: `booting` | `ready` | `stopping` | `stopped` | `crashed`. Driven by the health poller's observations of process state and by lifecycle events emitted from the agent (`booted`, `ack-stop`). Moves independently of intent.
+
+Two fields, not one, so recovery semantics are explicit: after a host reboot the harness reads this file, sees `intent=running` but no live PID → respawn. If `intent` and `status` were collapsed, the harness couldn't distinguish "operator stopped this" from "this crashed". Full state machine documented in [AGENT-RUNTIME.md §7.2](AGENT-RUNTIME.md).
+
 Atomic writes (`.tmp` + `mv`). On harness restart, the file is read; each agent is checked for liveness (PIDs still alive?); intents are preserved. Note: the outer agent key is the **alias** (e.g. `skill`, `verifier`); each agent's *categorical* role is not currently persisted in this file — it's derived from `.squidsquad/config.md` at boot. Source of truth: `HarnessState.save_state()` in `references/scripts/harness.py`.
 
 ---
@@ -368,9 +380,13 @@ Harness is one-process-per-install on one host. Agents in different clones on th
 
 EAD's polling loop hard-codes the GitHub `gh api` shape. Non-GitHub backends (Forgejo, Gitea, etc.) would need an adapter layer in `forge_adapter.py` and EAD refactoring. Tracker abstraction (`tracker.py`) exists; EAD does not yet use it.
 
-### 13.5 Permission table reads `responsibility.md` (deprecated)
+### 13.5 Permission table reads `responsibility.md` (legacy code being removed)
 
-Per [`decision-class-vs-alias-routing-model`](../.squidsquad/vault/galaxy/decision-class-vs-alias-routing-model.md) (locked 2026-05-25), the harness permission table is being retired in favor of a simpler alias-existence check. Current code still reads `responsibility.md` `## Bus contract` sections at boot and enforces a class-from-class permission table on `POST /work/assign`. Code change tracked in #10182 (bundled task, on hold pending PR #10004 merge).
+**Target architecture** (locked 2026-05-25 per [`decision-class-vs-alias-routing-model`](../.squidsquad/vault/galaxy/decision-class-vs-alias-routing-model.md), and reflected in [AGENT-RUNTIME.md §7.3](AGENT-RUNTIME.md)): the harness performs **one** validation on `/work/assign` — does `target_alias` resolve to a registered agent? Class-from-class permissions are not enforced at the bus layer; process discipline lives in each agent's L2/L3/L4, not in a harness gate.
+
+**Current code** (legacy, removal in progress): still reads `responsibility.md` `## Bus contract` sections at boot and builds a class-from-class permission table that `POST /work/assign` consults. This duplicated discipline that already lives in each agent's composed CLAUDE.md and conflicted with §4.1's "harness is a transport bus, not an orchestrator" principle. The `responsibility.md` files themselves are also being retired (the file's prose narrative was ~90% redundant with L2/L3, and PR #10359 promoted Responsibility to a dedicated compose slot — not a sub-skill).
+
+**Removal task**: #10182 (bundled, on hold pending PR #10004 merge). When that lands the harness's boot sequence drops the permission-table build entirely; `/work/assign` falls back to the alias-existence-only check that this doc already documents as the target.
 
 ### 13.6 Work-queue endpoint is special-cased to human only
 

--- a/docs/INSTALLER-ARCH.md
+++ b/docs/INSTALLER-ARCH.md
@@ -18,7 +18,7 @@ This doc uses the four **categorical role classes** from SquidSquad's architectu
 - **verifiers** — the verification specialists (plural class; typically one, but the model supports multiple).
 - **DM** — the delivery manager (singleton; one per install).
 
-The **team preset** is the concrete roster chosen at install — which actual workers and verifiers to instantiate. The default preset has one worker named `dev` and one verifier named `qa`, alongside the singleton `pm` and `dm`. Other shipped presets include stack-specialized ones (e.g. workers `fe` + `be`, or `web` + `ios` + `api`). Operators may also define custom presets.
+The **team preset** is the concrete roster chosen at install — which actual workers and verifiers to instantiate. The default preset has one worker named `worker` and one verifier named `verifier`, alongside the singleton `pm` and `dm` (post-#6274 rename — see AGENT-RUNTIME §10 revision log). Other shipped presets include stack-specialized ones (e.g. workers `fe` + `be`, or `web` + `ios` + `api`). Operators may also define custom presets.
 
 Throughout this doc, **prose talks about the categorical classes** (PM, workers, verifiers, DM). File-layout examples use `<worker-role>/`, `<verifier-role>/`, `pm/`, `dm/` placeholders since concrete names depend on the chosen preset.
 
@@ -94,7 +94,7 @@ Three commitments:
 
 | Destination | What the installer writes |
 |---|---|
-| `.squidsquad/config.md` | Project config — iter interval, ship threshold, model routing, tracker backend, git workflow. Also includes the install's **SquidSquad version stamp** (`squidsquad_version: <semver>` field; written at Phase 5 from the installer's source release tag; read by the upgrade flow §10 step 1) and the **`## Aliases` registry section** mapping each install-time alias to its role-class + L3 domain (used by the harness for `/work/assign` alias-existence validation — see [AGENT-RUNTIME.md §7.3](AGENT-RUNTIME.md)). |
+| `.squidsquad/config.md` | Project config — iter interval, ship threshold, `event-driven:` mode flag (global; selects polling vs event-driven manifest per [AGENT-RUNTIME.md §2](AGENT-RUNTIME.md) + [COMPOSE-ARCHITECTURE.md §6.5](COMPOSE-ARCHITECTURE.md)), model routing, tracker backend, git workflow. Also includes the install's **SquidSquad version stamp** (`squidsquad_version: <semver>` field; written at Phase 5 from the installer's source release tag; read by the upgrade flow §10 step 1) and the **`## Aliases` registry section** mapping each install-time alias to its role-class + L3 domain (used by the harness for `/work/assign` alias-existence validation — see [AGENT-RUNTIME.md §7.3](AGENT-RUNTIME.md)). |
 | `.squidsquad/<alias>/` | Per-alias agent directory (CLAUDE.md composed, working-state.md skeleton, planning/, iterations/) — one per alias in the chosen team preset: PM, each worker, each verifier, DM. *Note: no separate `SOUL.md` per alias — `SOUL.md` is a filename shorthand for the soul-slot source at `references/roles/<role-class>/SOUL.md`; its content is composed into `CLAUDE.md §3 Soul`. The v1 per-alias sidecar is retired per [COMPOSE-ARCHITECTURE.md §5.3](COMPOSE-ARCHITECTURE.md).* |
 | `.squidsquad/project/` | L4 project-local files — one unified `<role-class>.md` per role-class (pm.md, `<worker-class>.md`, `<verifier-class>.md`, dm.md) with H2 slot sections. Initial `## Project Context` block in each is seeded from Phase 1 conversational answers (per §4.8 step 4); other slots start empty and accumulate at runtime via `l4-curation` (see [COMPOSE-ARCHITECTURE.md §5.5 + §7](COMPOSE-ARCHITECTURE.md)). |
 | `.squidsquad/vault/` | Shared memory layer skeleton (BRIEFING.md + the five vault dirs: projects/, areas/, resources/, archives/, galaxy/). Vault architecture documented in [`VAULT-ARCH.md`](VAULT-ARCH.md). |
@@ -197,7 +197,7 @@ workers: [<worker-role>, …]    # concrete worker names from the preset
 verifiers: [<verifier-role>, …] # concrete verifier names from the preset
 domain: "developer tooling"
 loop_interval: 30
-event_driven: no
+event-driven: no
 tracker_backend: github
 model_routing: { ... }
 git_workflow: { ... }
@@ -259,7 +259,7 @@ The installer prints a one-line confirmation with next steps — typically how t
 
 ## 5. File layout produced
 
-The full `.squidsquad/` tree post-install. PM and DM dirs are always present (singletons); each chosen worker and verifier from the team preset gets its own dir. The names `pm`, `qa`, `dev`, `dm` shown below are the *default-preset* names; other presets use different concrete names (e.g. `fe`, `be`, `web`, `ios` for workers).
+The full `.squidsquad/` tree post-install. PM and DM dirs are always present (singletons); each chosen worker and verifier from the team preset gets its own dir. The names `pm`, `verifier`, `worker`, `dm` shown below are the *default-preset* names (post-#6274 rename — see AGENT-RUNTIME §10 revision log); other presets use different concrete names (e.g. `fe`, `be`, `web`, `ios` for workers).
 
 ```
 .squidsquad/
@@ -271,15 +271,15 @@ The full `.squidsquad/` tree post-install. PM and DM dirs are always present (si
 │   ├── planning/                # RESEARCH/CONTEXT artifacts
 │   ├── iterations/              # iter-N.md cycle logs
 │   └── migrations/              # legacy migration logs
-├── <worker-role>/               # one per worker in the preset (default: dev)
+├── <worker-role>/               # one per worker in the preset (default: worker)
 │   ├── CLAUDE.md
 │   ├── working-state.md
 │   ├── planning/
 │   └── iterations/
-├── <verifier-role>/             # one per verifier in the preset (default: qa); adds qa-log.md
+├── <verifier-role>/             # one per verifier in the preset (default: verifier); adds verifier-log.md
 │   ├── CLAUDE.md
 │   ├── working-state.md
-│   ├── qa-log.md
+│   ├── verifier-log.md
 │   ├── planning/
 │   └── iterations/
 ├── dm/                          # DM (singleton — always present)
@@ -324,6 +324,7 @@ The installer agent never invents behavior the helpers already implement. Every 
 | `references/scripts/compose.py` | Generates `.squidsquad/<role>/CLAUDE.md` from L1-L4 sources — see [COMPOSE-ARCHITECTURE.md](COMPOSE-ARCHITECTURE.md) |
 | `references/scripts/forgejo_setup.py` | Forgejo backend init (alternate tracker; see §9) |
 | `references/scripts/tracker.py` | The tracker abstraction layer — agents use this at runtime; the installer uses its label-creation paths at Phase 5 |
+| `references/scripts/event_poll.py` | Per-agent event-bus sidecar — harness-spawned in event-driven mode, polls the harness HTTP API and writes `NUDGE\n` to stdout when new events arrive past the agent's cursor (see [AGENT-RUNTIME.md §7.0](AGENT-RUNTIME.md)). The installer doesn't invoke it directly; it ships with the SquidSquad source and the harness uses it post-install. Listed here for completeness. |
 | `start.sh` | Post-install boot script — ensures Python deps, syncs all clones, runs the harness |
 
 ---
@@ -430,7 +431,7 @@ flowchart LR
    POST /agents/{role}/stop    # graceful stop; harness handles ack-stop / timeout
    POST /agents/{role}/start   # boot with new composed CLAUDE.md
    ```
-   for each agent. The `{role}` path parameter is the harness's published URL-template name, but the **value passed is the alias** (e.g. `pm`, `frontend-1`, `verifier`) — the harness vocabulary note ([HARNESS-ARCH.md §9](HARNESS-ARCH.md)) explains the legacy parameter-name vs value-semantic mismatch. The full rename to `{alias}` ships with [#10358](https://github.com/WallyDoodlez/SquidSquad/issues/10358). If the harness is not running, the installer instead invokes `start.sh` from the repo root (which boots the harness, which in turn boots the agents per `.local-config`). Either way, the next session each agent starts is reading the new composed CLAUDE.md.
+   for each agent. The `{role}` path parameter is the harness's published URL-template name, but the **value passed is the alias** (e.g. `pm`, `frontend-1`, `verifier`) — the harness vocabulary note ([HARNESS-ARCH.md §9](HARNESS-ARCH.md)) explains the legacy parameter-name vs value-semantic mismatch. The full rename to `{alias}` ships with [#10358](https://github.com/WallyDoodlez/SquidSquad/issues/10358). If the harness is not running, the installer instead invokes `start.sh` from the repo root (which boots the harness, which in turn boots the agents per `.local-config`). Either way, the next session each agent starts is reading the new composed CLAUDE.md. In event-driven mode the harness also respawns each agent's `event_poll.py` sidecar on agent restart (per [HARNESS-ARCH.md §7.2](HARNESS-ARCH.md) `boot_agent`); the installer doesn't need to manage `event_poll` directly.
 
    **In-flight-work handling.** Before stopping each agent, the harness checks whether the agent has an active iteration (i.e., it is in the creative phase between `cycle_pre.py` and `cycle_post.py`). If so, the harness waits for the agent's `ack-stop` event — the agent finishes its current iteration, calls `cycle_post.py` (which commits and pushes `.squidsquad/<alias>/working-state.md` + any in-flight changes), and then exits via the normal exit-42 path. If the iteration does not complete within a configurable timeout (default 5 minutes), the harness logs a warning and proceeds with the stop; on next boot the agent reads `.squidsquad/<alias>/working-state.md` to recover from the checkpoint (see AGENT-RUNTIME §5 state-persistence map + §6.5 context-pressure exit-42 model). No in-flight state is lost because `.squidsquad/<alias>/working-state.md` is the durable checkpoint that survives restarts.
 

--- a/docs/INSTALLER-ARCH.md
+++ b/docs/INSTALLER-ARCH.md
@@ -99,11 +99,12 @@ Three commitments:
 | `.squidsquad/project/` | L4 project-local files — one unified `<role-class>.md` per role-class (pm.md, `<worker-class>.md`, `<verifier-class>.md`, dm.md) with H2 slot sections. Initial `## Project Context` block in each is seeded from Phase 1 conversational answers (per §4.8 step 4); other slots start empty and accumulate at runtime via `l4-curation` (see [COMPOSE-ARCHITECTURE.md §5.5 + §7](COMPOSE-ARCHITECTURE.md)). |
 | `.squidsquad/vault/` | Shared memory layer skeleton (BRIEFING.md + the five vault dirs: projects/, areas/, resources/, archives/, galaxy/). Vault architecture documented in [`VAULT-ARCH.md`](VAULT-ARCH.md). |
 | `.squidsquad/.local-config` | Per-clone alias→path mapping for `start.sh` to sync clones |
-| `.squidsquad/.harness-port`, `.harness-state.json`, `.event-state.json` (at runtime) | Harness-owned runtime files — written when the harness boots, not by the installer. Listed here for completeness; their schemas are documented in [`AGENT-RUNTIME.md`](AGENT-RUNTIME.md) §4–§5. |
 | `~/.squidsquad/secrets` | API keys for external models (restricted permissions, never committed to repo) |
 | `~/.squidsquad/clones/` | Per-alias clone-path registry. One file per alias (`pm`, each worker, each verifier, `dm`) whose contents is the absolute path to that alias's clone. Always created — clone isolation is mandatory (see §1.2), not a configurable mode. |
 | **Forge (GitHub)** | Issue labels created via `gh label create` — status/role/type/priority/severity taxonomy |
 | **Git commit** | Single atomic install commit on `main` (or the operator's chosen branch) |
+
+> **Runtime files (not installer outputs):** `.squidsquad/.harness-port`, `.squidsquad/.harness-state.json`, `.squidsquad/.event-state.json` appear under `.squidsquad/` post-install but are **harness-owned**, written when the harness boots (not by the installer). Schemas are documented in [`HARNESS-ARCH.md`](HARNESS-ARCH.md) §7 + [`AGENT-RUNTIME.md`](AGENT-RUNTIME.md) §5. Listed here as a pointer because operators inspecting the directory post-install will see them.
 
 ---
 
@@ -324,8 +325,9 @@ The installer agent never invents behavior the helpers already implement. Every 
 | `references/scripts/compose.py` | Generates `.squidsquad/<role>/CLAUDE.md` from L1-L4 sources — see [COMPOSE-ARCHITECTURE.md](COMPOSE-ARCHITECTURE.md) |
 | `references/scripts/forgejo_setup.py` | Forgejo backend init (alternate tracker; see §9) |
 | `references/scripts/tracker.py` | The tracker abstraction layer — agents use this at runtime; the installer uses its label-creation paths at Phase 5 |
-| `references/scripts/event_poll.py` | Per-agent event-bus sidecar — harness-spawned in event-driven mode, polls the harness HTTP API and writes `NUDGE\n` to stdout when new events arrive past the agent's cursor (see [AGENT-RUNTIME.md §7.0](AGENT-RUNTIME.md)). The installer doesn't invoke it directly; it ships with the SquidSquad source and the harness uses it post-install. Listed here for completeness. |
 | `start.sh` | Post-install boot script — ensures Python deps, syncs all clones, runs the harness |
+
+> **Runtime-shipped components (not installer-invoked):** the SquidSquad source tree also ships `references/scripts/event_poll.py` (per-agent event-bus sidecar; harness-spawned in event-driven mode — see [AGENT-RUNTIME.md §7.0](AGENT-RUNTIME.md) + [HARNESS-ARCH.md §7.2](HARNESS-ARCH.md)) and `references/scripts/harness.py` itself. The installer does NOT invoke these — they're part of the runtime. They're mentioned here because they live alongside the installer's helper scripts under `references/scripts/` and operators inspecting that directory will see them.
 
 ---
 
@@ -431,7 +433,7 @@ flowchart LR
    POST /agents/{role}/stop    # graceful stop; harness handles ack-stop / timeout
    POST /agents/{role}/start   # boot with new composed CLAUDE.md
    ```
-   for each agent. The `{role}` path parameter is the harness's published URL-template name, but the **value passed is the alias** (e.g. `pm`, `frontend-1`, `verifier`) — the harness vocabulary note ([HARNESS-ARCH.md §9](HARNESS-ARCH.md)) explains the legacy parameter-name vs value-semantic mismatch. The full rename to `{alias}` ships with [#10358](https://github.com/WallyDoodlez/SquidSquad/issues/10358). If the harness is not running, the installer instead invokes `start.sh` from the repo root (which boots the harness, which in turn boots the agents per `.local-config`). Either way, the next session each agent starts is reading the new composed CLAUDE.md. In event-driven mode the harness also respawns each agent's `event_poll.py` sidecar on agent restart (per [HARNESS-ARCH.md §7.2](HARNESS-ARCH.md) `boot_agent`); the installer doesn't need to manage `event_poll` directly.
+   for each agent. The `{role}` path parameter is the harness's published URL-template name, but the **value passed is the alias** (e.g. `pm`, `frontend-1`, `verifier`) — the harness vocabulary note ([HARNESS-ARCH.md §9](HARNESS-ARCH.md)) explains the legacy parameter-name vs value-semantic mismatch. The full rename to `{alias}` is tracked in [#10358](https://github.com/WallyDoodlez/SquidSquad/issues/10358) but is out of scope on that task to limit blast radius (per AGENT-RUNTIME §4.3). If the harness is not running, the installer instead invokes `start.sh` from the repo root (which boots the harness, which in turn boots the agents per `.local-config`). Either way, the next session each agent starts is reading the new composed CLAUDE.md. In event-driven mode the harness also respawns each agent's `event_poll.py` sidecar on agent restart (per [HARNESS-ARCH.md §7.2](HARNESS-ARCH.md) `boot_agent`); the installer doesn't need to manage `event_poll` directly.
 
    **In-flight-work handling.** Before stopping each agent, the harness checks whether the agent has an active iteration (i.e., it is in the creative phase between `cycle_pre.py` and `cycle_post.py`). If so, the harness waits for the agent's `ack-stop` event — the agent finishes its current iteration, calls `cycle_post.py` (which commits and pushes `.squidsquad/<alias>/working-state.md` + any in-flight changes), and then exits via the normal exit-42 path. If the iteration does not complete within a configurable timeout (default 5 minutes), the harness logs a warning and proceeds with the stop; on next boot the agent reads `.squidsquad/<alias>/working-state.md` to recover from the checkpoint (see AGENT-RUNTIME §5 state-persistence map + §6.5 context-pressure exit-42 model). No in-flight state is lost because `.squidsquad/<alias>/working-state.md` is the durable checkpoint that survives restarts.
 

--- a/docs/INSTALLER-ARCH.md
+++ b/docs/INSTALLER-ARCH.md
@@ -428,7 +428,7 @@ flowchart LR
 2. **Confirm**: present the changeset summary in plain language ("This upgrade will update 14 sub-skills, add 2 new ones, and rename `verifier-rejected` → `qa-rejected`. Your L4 customizations are unaffected."). The human approves, edits (e.g. "skip the rename for now"), or aborts. Abort = no changes.
 3. **Pull**: the latest SquidSquad sources from upstream into `references/` (this includes the latest L1-L3 sub-skills, role files, manifests, and helper scripts).
 4. **Recompose**: every role's CLAUDE.md by running `compose.py deploy-all`. The composed outputs reflect the new sub-skill versions.
-5. **Restart**: each affected agent so they pick up the new CLAUDE.md. The installer calls the harness's per-agent lifecycle endpoints in sequence:
+5. **Restart**: each affected agent so they pick up the new CLAUDE.md. The installer is an ephemeral Claude Code session but has full Bash tooling — it makes these HTTP calls via `curl` (or equivalent) against the harness's localhost port (read from `.squidsquad/.harness-port` per HARNESS-ARCH §6). "Ephemeral" refers to lifetime, not capability: the installer can do anything its Claude Code tooling permits before it exits at Phase 9. The installer calls the harness's per-agent lifecycle endpoints in sequence:
    ```
    POST /agents/{role}/stop    # graceful stop; harness handles ack-stop / timeout
    POST /agents/{role}/start   # boot with new composed CLAUDE.md

--- a/docs/VAULT-ARCH.md
+++ b/docs/VAULT-ARCH.md
@@ -276,7 +276,7 @@ Each sub-skill's **Cycle integration** line below names its lane.
 
 **Cycle integration**: Post-cycle Step 4b. Gated by the per-cycle quiet check only — always-on, no feature toggle (the 4-gate filter already provides sufficient noise control; a blunt on/off flag on top earns no use case). **Lane**: background subagent (`sonnet`). The consuming agent hands the iteration log + write-budget + dedup-tool access to the subagent; the subagent runs the 4-gate evaluation and returns a structured list of `{action: write|update|skip, path, type, body, reason}` decisions plus the resulting note paths. The reflection transcript stays out of the consuming agent's context.
 
-**Scripts used** (from §8): `vault_remember.py is-quiet`/`reset-writes`/`write-budget`/`inc-writes`/`briefing-budget` (gating and accounting), `vault_check.py dedup-check` (gate 2). (The legacy `config.py get vault-remember` enabled-flag read is being retired — see follow-up.)
+**Scripts used** (from §8): `vault_remember.py is-quiet`/`reset-writes`/`write-budget`/`inc-writes`/`briefing-budget` (gating and accounting), `vault_check.py dedup-check` (gate 2). (The legacy `config.py get vault-remember` enabled-flag read has been retired — the sub-skill is always-on and self-gates per its own per-cycle conditions.)
 
 **Outputs**: Up to 2 new `.squidsquad/vault/galaxy/*.md` notes per cycle (`decision-*`/`pattern-*`/`learning-*`), optional `BRIEFING.md` staleness updates, iteration-log notes for deferred candidates.
 
@@ -387,7 +387,7 @@ The vault is touched at four points in a cycle:
 
 ### 9.2 Pre-cycle (mechanical)
 
-- No vault read or write. (Earlier revisions had `cycle_pre.py` read `vault-remember` and `vault-optimize` enabled-flags into `cycle-input.json`; those flags are being retired — both sub-skills are always-on and self-gate via their per-cycle conditions.)
+- No vault read or write. (Earlier revisions had `cycle_pre.py` read `vault-remember` and `vault-optimize` enabled-flags into `cycle-input.json`; those flags have been retired — both sub-skills are always-on and self-gate via their per-cycle conditions.)
 
 ### 9.3 Creative phase (agent)
 


### PR DESCRIPTION
## Summary

Closes #10363. Cross-doc consistency fixes on the **non-AGENT-RUNTIME side** of the 4 audits (HARNESS / INSTALLER / VAULT / COMPOSE), per the original issue scope. Also folds in the 2 HIGH HARNESS bugs flagged post-merge from PR #10373's audit (forbidden completion endpoint + undocumented /queue/{alias}).

## Commits (staged per-doc)

| # | SHA | Doc | Scope |
|---|---|---|---|
| 1 | ` 0056c0c6 ` | VAULT-ARCH | Past tense for retired vault-remember / vault-optimize flags |
| 2 | ` b7b5b0a5 ` | COMPOSE-ARCHITECTURE | `event_poll.py` "sibling" → "harness-managed sidecar" |
| 3 | ` b56afa3c ` | INSTALLER-ARCH | `dev`/`qa` → `worker`/`verifier` rename (#6274) + `event_poll.py` integration + `event_driven:` → `event-driven:` |
| 4 | ` 5d8e9e11 ` | HARNESS-ARCH | 9 fixes: 5 from #10363 + 2 HIGH from audit + 3 audit follow-ons |
| 5 | ` cd1230ba ` | INSTALLER + HARNESS | 5 audit fixes: cross-ref structural improvements + internal vocab-note extensions |

## Coverage

**#10363 issue body** (all in-scope findings addressed):
- VAULT-ARCH H1 ✓
- COMPOSE L1 ✓
- INSTALLER H1, M1 (already done), M2, L1 ✓
- HARNESS-ARCH H1, H2, M2, L2 ✓ (AGENT-RUNTIME-side L1 deferred per issue body)

**2 HIGH bugs from PR #10373 audit** (you flagged for post-merge):
- Forbidden ` POST /events/{event_id}/complete ` endpoint — **removed** + architectural lock callout added to HARNESS §4.2 ✓
- Undocumented ` /queue/{alias} ` endpoint — **scope clarified** as UI-facing (not agent runtime contract); AGENT-RUNTIME omission is intentional ✓

**Additional DS audit follow-ons** (from milestone 5 audit batch):
- HARNESS internal H1 (response-shape) ✓ H2 (lifecycle endpoint vocab) ✓ M1 (deque persistence clarity) ✓
- INSTALLER × AGENT-RUNTIME H1 (harness files in §3.2 outputs) ✓ M1 (event_poll.py in §6 helpers) ✓ L1 (#10358 scope alignment) ✓

## Deferred to future tasks

Pre-existing issues surfaced by DS audits that are **not introduced by this PR** and warrant separate treatment:

- **HARNESS × AGENT-RUNTIME H1/H2** — permission-table / responsibility.md retirement-status disagreement (HARNESS says "code change in progress", AGENT-RUNTIME revision log says "retired/marked for deletion"). Needs AGENT-RUNTIME side, out of scope for #10363.
- **HARNESS × AGENT-RUNTIME M1** — thin_launcher.py §14 proposed simplification vs AGENT-RUNTIME §3.2 current state. Needs AGENT-RUNTIME cross-ref note.
- **INSTALLER internal H1** — Upgrade flow agent-restart contradicts ephemeral-installer architectural commitment. Substantive design question.
- **INSTALLER internal H2** — Installer version detection underspecified (no helper script defined). Substantive design gap.

These can land as a separate `#10363-followup` task or be folded into a future installer cleanup.

## Test plan

- [x] All issue-body findings have either a commit or a documented dismissal
- [x] No new contradictions introduced (DS audit-batch verified)
- [x] 2 HIGH post-merge bugs addressed in their respective docs
- [ ] Human review

🤖 Generated with [Claude Code](https://claude.com/claude-code)