### PR TITLE
docs: TRD final-pass — Claude-audit fixes across 5 architecture docs

### DIFF
--- a/docs/AGENT-RUNTIME.md
+++ b/docs/AGENT-RUNTIME.md
@@ -267,8 +267,8 @@ Removed under v2 (collectively 20 catalog entries):
 
 - **Lifecycle ticks**: `cycle-start`, `cycle-end` — local to the agent, no other agent cares.
 - **Git activity**: `git-pull`, `git-push`, `git-commit`, `branch-checkout` — local side effects, recorded in git itself.
-- **PR activity**: `pr-create`, `pr-merge`, `pr-merged` — recorded in forge; if relevant to another role, harness translates to `assigned-to`.
-- **Tracker activity**: `status-transition`, `tracker-comment` — recorded in forge as source of truth; if relevant to another role, harness translates to `assigned-to`.
+- **PR activity**: `pr-create`, `pr-merge`, `pr-merged` — recorded in forge; if relevant to another alias, harness translates to `assigned-to`.
+- **Tracker activity**: `status-transition`, `tracker-comment` — recorded in forge as source of truth; if relevant to another alias, harness translates to `assigned-to`.
 - **Harness internal**: `compose-completed`, `agent-health` — harness sees these in its own state; if action needed, harness emits `assigned-to`.
 - **Speculative RECOGNIZED entries**: `verification-passed`, `verification-failed`, `phase-change`, `request-merge`, `stop-requested`, `shipped`, `version-bump` — never emitted under v1, dead weight.
 
@@ -392,7 +392,7 @@ At-least-once delivery: cursor advances only after a successful ack. Crashed age
 
 #### Role-based filtering
 
-Under v2 the filter collapses to a single rule: **every role reacts only to `assigned-to`**. Specificity moves to `event_context` and the alias-match care filter (§7.4). There is no per-role event-type allowlist in the v2 catalog because the v2 catalog itself collapses to 3 signal concepts (§4.2) — multi-type filtering is moot once the catalog has one routing signal.
+Under v2 the filter collapses to a single rule: **every role-class reacts only to `assigned-to`**. Specificity moves to `event_context` and the alias-match care filter (§7.4). There is no per-role-class event-type allowlist in the v2 catalog because the v2 catalog itself collapses to 3 signal concepts (§4.2) — multi-type filtering is moot once the catalog has one routing signal.
 
 ```mermaid
 graph TD
@@ -403,7 +403,7 @@ graph TD
     ALL --> DM["dm: assigned-to (care filter on alias)"]
 ```
 
-> **v1 loop-mode legacy**. Today's loop-mode codebase still has a per-role event-type allowlist (client-side filter in `cycle_pre.py` via `_ROLE_EVENT_TYPES` dict; roles not in the dict receive all events). That filter exists because loop mode still emits the broader v1 catalog (lifecycle ticks, git/PR/tracker activity, etc. — see §4.2 "What is OUT of the v2 catalog"). The filter is retired as the v2 catalog migration completes (see §8); the diagram above is the v2 target.
+> **v1 loop-mode legacy**. Today's loop-mode codebase still has a per-role-class event-type allowlist (client-side filter in `cycle_pre.py` via `_ROLE_EVENT_TYPES` dict; role-classes not in the dict receive all events). That filter exists because loop mode still emits the broader v1 catalog (lifecycle ticks, git/PR/tracker activity, etc. — see §4.2 "What is OUT of the v2 catalog"). The filter is retired as the v2 catalog migration completes (see §8); the diagram above is the v2 target.
 
 ### 4.4 ExternalActivityDetector (EAD)
 
@@ -411,7 +411,7 @@ EAD is the bridge from forge → bus. It runs inside the harness on a polling lo
 
 1. Polls GitHub via REST API (`gh api repos/<owner>/<repo>/issues?since=<last_seen_iso>&state=all&per_page=100`).
 2. Diffs against last-seen timestamp on disk.
-3. For each changed issue, maps to a target role per a rule table (status label changes, comments, PR state changes).
+3. For each changed issue, maps to a target alias per a rule table (status label changes, comments, PR state changes).
 4. Emits one `assigned-to` per (forge change, target_alias) pair into the deque.
 5. Records the new last-seen timestamp so it doesn't re-emit on restart.
 
@@ -636,7 +636,7 @@ Both are idempotent against already-handled issues (e.g., transitioning a closed
 
 ### 6.4 Improvement subloop (loop mode)
 
-In loop mode, when a cycle finds no work in the queue (no pending-test, no pending-ship, no nudges to process, no human input), the cycle is **quiet**. Quiet cycles run an improvement scan as their creative phase — the same activity event mode triggers via §7.6's drained-queue path. The trigger is "the cycle wrapper fired and found nothing else to do," not a separate timer; throttling, ownership per role, and output routing all match §7.6.
+In loop mode, when a cycle finds no work in the queue (no pending-test, no pending-ship, no nudges to process, no human input), the cycle is **quiet**. Quiet cycles run an improvement scan as their creative phase — the same activity event mode triggers via §7.6's drained-queue path. The trigger is "the cycle wrapper fired and found nothing else to do," not a separate timer; throttling, ownership per role-class, and output routing all match §7.6.
 
 See §7.6 for the substantive scan rules; this section's purpose is to anchor that those rules are not event-mode-exclusive.
 
@@ -678,7 +678,7 @@ Agents may delegate work to subagents via the Agent tool. This subsection descri
 - Reserve Opus 4.7 for complex reasoning, multi-step planning, architectural review, or work that requires holding many constraints simultaneously.
 - The parent agent's own model is independent of subagent model choice.
 
-**Per-role overrides** (L3 content authored alongside the role's other L3 sub-skills; takes effect by appearing later in compose's `(slot, ordinal)` order than the L1 default):
+**Per-role-class overrides** (L3 content authored alongside the role-class's other L3 sub-skills; takes effect by appearing later in compose's `(slot, ordinal)` order than the L1 default):
 
 - `worker` (and variants like `skill`): subagent spawns default to Sonnet — the heavy thinking is in the parent. (Authority: memory rule `feedback_skill_sonnet_subagents`.)
 - `dm`: subagent spawns default to Sonnet — `dm`'s work is mostly mechanical packaging. (Authority: memory rule `feedback_dm_sonnet_subagents`.)
@@ -742,7 +742,9 @@ Two-tier backoff: 5s → 30s → 60s. A drained queue stabilizes at 60s after �
 
 Nudge format is literal `NUDGE\n` with no payload — the agent always does `GET /events/for/{role}?since=cursor` to find out what's new. False positives (a `NUDGE` arriving when no relevant events exist) are harmless because the GET returns `[]`.
 
-`event_poll`'s lifecycle is harness-owned: `boot_agent(role)` spawns it sequentially after `thin_launcher` has been launched and before the harness awaits the `booted` handshake (see §7.2 boot diagram), the health poller watches its PID, and the harness respawns it on death while `intent=running`. `event_poll` discovers the harness port via the same mechanism documented for agents in §4.7 — reads `.squidsquad/.harness-port` from its CWD, walking up to 5 parent directories if needed. The harness does not pass a `--port` argument; the discovery file is sufficient and avoids stale-port hardcoding if the harness restarts on a different port. On harness restart, any `event_poll` orphaned by the prior harness exits when its `--wait` parent pipe closes; the new harness re-spawns it as part of the §7.2 boot sequence for each `intent=running` agent. event_poll does not attempt independent reconnect — it dies with the harness it was spawned by.
+`event_poll`'s lifecycle is harness-owned: the health poller watches its PID and the harness respawns it on death while `intent=running`. `event_poll` discovers the harness port via the same mechanism documented for agents in §4.7 — reads `.squidsquad/.harness-port` from its CWD, walking up to 5 parent directories if needed. The harness does not pass a `--port` argument; the discovery file is sufficient and avoids stale-port hardcoding if the harness restarts on a different port. On harness restart, any `event_poll` orphaned by the prior harness exits when its `--wait` parent pipe closes; the new harness re-spawns it as part of the boot sequence for each `intent=running` agent. event_poll does not attempt independent reconnect — it dies with the harness it was spawned by.
+
+`event_poll`'s spawn ordering relative to the rest of the boot sequence is canonical in [HARNESS-ARCH.md §7.2](HARNESS-ARCH.md). In summary: `event_poll` spawns as a harness-direct sibling of the `thin_launcher → claude` chain (not a descendant), begins polling immediately on spawn, and is unaffected by the `booted` handshake (which gates routed-work delivery, not `event_poll` activity).
 
 ### 7.1 The nudge contract
 
@@ -803,56 +805,21 @@ sequenceDiagram
 
 ### 7.2 Boot sequence
 
+For the full process spawn ordering across harness, launcher, claude, and event_poll, see [HARNESS-ARCH.md §7.2](HARNESS-ARCH.md). This section focuses on the **agent-side boot** — what the `claude` process does once it's running.
+
 The harness tracks each agent with two distinct fields in `.squidsquad/.harness-state.json`:
 - **`intent`** = what the operator wants (`running` | `stopping` | `stopped`)
 - **`status`** = what the agent is actually doing (`booting` | `ready` | `stopping` | `stopped` | `crashed`)
 
 These move independently. The operator sets `intent`; the harness updates `status` as it observes lifecycle transitions.
 
-```mermaid
-sequenceDiagram
-    autonumber
-    actor Op as Operator/Harness
-    participant H as Harness
-    participant TL as thin_launcher
-    participant C as claude.exe (agent)
-    participant EP as event_poll
-    participant WS as working-state.md
+**Agent-side boot steps** (what the `claude` process does after it starts):
 
-    Op->>H: start agent (role)
-    H->>H: write intent=running, status=booting<br/>in .harness-state.json
-    H->>TL: spawn (cmd.exe → thin_launcher role)
-    H->>EP: spawn (event_poll --wait)
-    TL->>TL: write .claude-pid<br/>(cmd.exe PID)
-    TL->>C: spawn claude.exe
-    Note over C: Boot bootstrap runs<br/>(common/boot-bootstrap.md)<br/>status still = booting
-
-    C->>H: POST /events {type: booted,<br/>role, pid, clone_path, version}
-    H->>H: validate intent==running<br/>(reject if stopping/stopped)
-    H->>H: write status=ready<br/>(transition: booting → ready)
-    H-->>C: 200 OK + event_id
-
-    C->>H: GET /events/cursor/{role}
-    H-->>C: {cursor: <id> | null}
-
-    C->>WS: read working-state.md
-    WS-->>C: state (active task, key decisions)
-
-    alt working-state has active task matching cursor
-        C->>C: resume work
-    else working-state shows task already done
-        C->>H: POST /events {type: ack-cursor, event_id, role}
-        Note over C,H: advance past stale events
-    else clean state
-        C->>H: GET /events/for/{role}?since=cursor
-        H-->>C: [any queued events]
-        Note over C: process per §7.1 walk if any,<br/>otherwise enter idle wait
-    end
-
-    Note over C,EP: Agent now status=ready.<br/>Next nudge wakes it.
-```
-
-event_poll begins polling immediately on spawn; the harness's deque retains events from boot onward so any work the agent should pick up is durably available — but cursor-clean handshake (`booted`) happens before the harness considers the agent ready to receive routed work via `POST /work/assign`. The race window is bounded by the deque maxlen=1000 and the typical sub-second boot delay.
+1. Read the composed `CLAUDE.md` (already on disk in the agent's clone dir at boot — written by the compose pipeline).
+2. Read `.squidsquad/<alias>/working-state.md` for crash-recovery context (active task, key decisions).
+3. Emit `booted` event (`POST /events {type: booted, role, pid, clone_path, version}`) — this is the cursor-clean handshake. The harness transitions `status: booting → ready` on receipt.
+4. Read events at cursor (`GET /events/for/{role}?since=cursor`) or wait for nudge if queue is empty.
+5. Enter ready state — process queued events per §7.1 walk, then idle-wait for next nudge.
 
 #### Agent state machine
 
@@ -870,7 +837,7 @@ stateDiagram-v2
 ```
 
 State semantics:
-- **`booting`** — `intent=running`, subprocess spawned, `booted` event NOT yet received. Health poller does NOT count agent as alive yet (boot-grace window applies). Any `assigned-to` events for the role queue but are NOT delivered until status flips to `ready`.
+- **`booting`** — `intent=running`, subprocess spawned, `booted` event NOT yet received. Health poller does NOT count agent as alive yet (boot-grace window applies). Any `assigned-to` events for the alias queue but are NOT delivered until status flips to `ready`.
 - **`ready`** — `intent=running`, `booted` received, agent listening for nudges. Steady-state "alive". Both idle and actively-working agents are `ready`.
 - **`stopping`** — `intent=stopping`; harness emits `assigned-to(role, event_context="stop-intent")` so the agent finishes current work and emits `ack-stop`. Timeout: 30s grace → SIGTERM → 10s → SIGKILL.
 - **`stopped`** — process is dead AND `intent=stopped`. Terminal until operator restarts.
@@ -1057,13 +1024,13 @@ flowchart TD
 
 **Throttle** (time-based, NOT token-counting): at most one subloop per agent per N minutes (default 30, matching the old `/loop` cadence — so observable improvement-scan frequency stays the same as loop mode). `.squidsquad/<alias>/.subloop-last-run` records the last-fire timestamp; the agent checks this file's age before triggering.
 
-**What the subloop does** (role-specific, one bounded task per fire):
+**What the subloop does** (role-class-specific, one bounded task per fire):
 - **pm**: pipeline sentinel + improvement scan (process gaps, stalled items, doc drift)
 - **verifier**: TEST-PLAN backlog catch-up
 - **worker**: doc-scan or test-coverage scan on owned modules
 - **dm**: doc realignment + CHANGELOG hygiene + version-bump readiness
 
-Subloop output may emit a new `assigned-to` (e.g., pm-subloop files a bug and routes it). That nudges the owning role into work — via the same `/work/assign` path everything else uses.
+Subloop output may emit a new `assigned-to` (e.g., pm-subloop files a bug and routes it). That nudges the owning alias into work — via the same `/work/assign` path everything else uses.
 
 ---
 
@@ -1077,11 +1044,11 @@ Subloop output may emit a new `assigned-to` (e.g., pm-subloop files a bug and ro
 event-driven: no    # global — applies to all agents
 ```
 
-There is no per-role override and no runtime mode-detection — mode is settled at compose time for every agent in the install. An install is either entirely event-driven or entirely loop-mode at any given moment; mixed states only exist transiently during a recompose roll-out (some agents restarted, others not yet — §8.2). The installer writes `event-driven: no` as the default at install time (per INSTALLER-ARCH §4.8 Phase 5 step 1). The operator subsequently edits this field to flip modes per §8.2.
+There is no per-role-class override and no runtime mode-detection — mode is settled at compose time for every agent in the install. An install is either entirely event-driven or entirely loop-mode at any given moment; mixed states only exist transiently during a recompose roll-out (some agents restarted, others not yet — §8.2). The installer writes `event-driven: no` as the default at install time (per INSTALLER-ARCH §4.8 Phase 5 step 1). The operator subsequently edits this field to flip modes per §8.2.
 
 **How mode selection actually works** (compose-time only):
 
-`compose.py` reads `event-driven:` and produces a *mode-specific* composed CLAUDE.md for each role. The manifest choice (`includes.yml` vs `includes-events.yml`) is made at compose time. The procedural fragments split by mode:
+`compose.py` reads `event-driven:` and produces a *mode-specific* composed CLAUDE.md for each role-class. The manifest choice (`includes.yml` vs `includes-events.yml`) is made at compose time. The procedural fragments split by mode:
 
 - **Loop mode** — `roles/<role>/ralph-loop-overview.md` is inlined into the composed CLAUDE.md at compose time.
 - **Event mode** — uses a **two-tier mechanism**. `boot-bootstrap` (one of the sub-skills the event manifest declares) IS inlined at compose time. But `boot-bootstrap` contains Read-tool instructions that **load the `common-events/*.md` fragments** (`l1-base`, `event-driven-workflow`, `cursor-management`, `forge-read-pattern`, `idle-cooldown-loop`, `comment-handling`) **at agent session start**, not at compose time. The `common-events/*` files are therefore not in the composed CLAUDE.md body — they enter the agent's context on boot via `boot-bootstrap`'s Read calls.
@@ -1164,7 +1131,7 @@ PM's inbox is disambiguated by `event_context`. The full set in use:
 - From the `tracker.py` auto-routing table (§7.3): `"planning-needed"`, `"human-needed"` (for `* → pending-human-review|setup` transitions), `"unowned-rejection"` (fallback for rejected items with no `role:*` label), `"unowned-approval"` (fallback for approved items with no `role:*` label).
 - From the catalog-trim translators (§8.5): `"compose-needed"` (recompose required), `"agent-down"` (health-poller observed an agent stall).
 - From EAD: `"human-comment"` (forge comment by a human author).
-- From agents calling `/work/assign` directly: `"process-concern"` for ad-hoc routing of cross-role process issues to PM; `"route-help"` for mis-route recovery (an agent received work it doesn't own and re-routed to PM for triage — see §7.3).
+- From agents calling `/work/assign` directly: `"process-concern"` for ad-hoc routing of cross-role-class process issues to PM; `"route-help"` for mis-route recovery (an agent received work it doesn't own and re-routed to PM for triage — see §7.3).
 
 PM agents recognize this set as their care-filter; new values added in future require both an emitter update and an entry in this list.
 
@@ -1199,7 +1166,7 @@ PM agents recognize this set as their care-filter; new values added in future re
 - **Nudge**: a single stdin line written by `event_poll` to wake a Claude session via the Monitor tool.
 - **Cursor**: per-alias harness-owned pointer to "events tended through here."
 - **EAD**: ExternalActivityDetector — the harness's forge poller that translates forge state changes into `assigned-to` events.
-- **Care filter**: the per-role decision of whether to act on an event or skip it.
+- **Care filter**: the per-role-class decision of whether to act on an event or skip it.
 - **Improvement subloop**: time-throttled self-care work the agent runs when its queue is empty. Applies in both modes — quiet cycles in loop mode (§6.4) and drained-queue detection in event mode (§7.6).
 
 ### 10.2 Related docs

--- a/docs/AGENT-RUNTIME.md
+++ b/docs/AGENT-RUNTIME.md
@@ -58,7 +58,7 @@ Every agent in an install runs in the same mode — there is one global mode for
 
 | Mode | What wakes the agent | Event-bus relationship | When to use |
 |---|---|---|---|
-| **Loop (polling)** | Cron timer (`/loop 30m execute one Ralph Loop cycle`) | **Emit-only** — agents may publish transient events for observability, but do NOT consume from the bus and do NOT maintain a cursor. Work queue + mechanical reactions both derive from tracker state. | Battle-tested fallback; works without the harness; current default |
+| **Loop (polling)** | Cron timer (e.g. `/loop 30m execute one Ralph Loop cycle` — interval per-install, see §6.2) | **Emit-only** — agents may publish transient events for observability, but do NOT consume from the bus and do NOT maintain a cursor. Work queue + mechanical reactions both derive from tracker state. | Battle-tested fallback; works without the harness; current default |
 | **Event-driven (nudge)** | A nudge from the harness, delivered via the Claude Monitor tool's stdin | **Emit + consume** — agents subscribe with a cursor; nudges + per-event reactions both originate from the bus. | Target steady-state; lower latency; no idle token burn |
 
 The cycle wrapper (pre → creative → post) is the same in both modes — only *what initiates the wrapper* and *where reactions derive from* differs. In loop mode the wrapper fires once per `/loop` timer tick. In event mode it fires once **per cared event** during a nudge-walk; a single nudge can produce multiple cycle wrappers (one per cared event) or zero (if every event in the batch is filtered out by the care filter). See §7.1 for the per-event sequence.
@@ -108,7 +108,7 @@ flowchart LR
 
 ## 3. The agent process tree (shared)
 
-Both modes use the same per-agent subprocess shape. Differences are inside the Claude session, not in the tree.
+Both modes use the same `cmd → thin_launcher → claude` core. **Event mode additionally spawns a sibling `event_poll` process** for the nudge contract (the dashed `Poll` sibling and harness-API edges in §3.2 below are event-mode-only). Loop mode runs only the core triple; `event_poll` is not spawned, and the harness-API edges originating from it do not exist. Differences are otherwise inside the Claude session, not in the tree.
 
 ### 3.1 System overview
 
@@ -171,7 +171,7 @@ flowchart TB
         TL["thin_launcher.py<br/>· writes .claude-pid<br/>· singleton enforcement (#8692)<br/>· spawns claude, waits for exit"]
         Claude["claude (the agent)<br/>· runs composed CLAUDE.md<br/>· has Monitor tool built in"]
         Monitor["Monitor tool<br/>(inside claude)<br/>reads stdin → wakes session"]
-        Poll["event_poll.py --wait --role <role> --target stdout<br/>(separate sibling process)<br/>· polls harness for events<br/>· writes one nudge line per batch"]
+        Poll["event_poll.py --wait --role <role> --target stdout<br/>(separate sibling process — EVENT MODE ONLY)<br/>· polls harness for events<br/>· writes one nudge line per batch"]
 
         Cmd --> TL
         TL --> Claude
@@ -180,7 +180,7 @@ flowchart TB
     end
 
     HarnessAPI[("Harness HTTP API")]
-    Poll -- "GET /events/for/{role}<br/>?since=cursor" --> HarnessAPI
+    Poll -- "GET /events/for/{role}<br/>?since=cursor<br/>(event mode only)" --> HarnessAPI
     Claude -- "POST /events<br/>(booted, ack)<br/>POST /work/assign" --> HarnessAPI
 ```
 
@@ -219,7 +219,7 @@ In loop mode, `event_poll` is not spawned — only `cmd → thin_launcher → cl
 
 The event bus is the harness HTTP API at port `7373` (default). Both modes use it:
 
-- **In loop mode**: optional observability layer. Agents emit events for diagnostics; pre-cycle reads recent events and applies mechanical reactions (e.g., PR merge → status transition). When the harness is down, agents fall back silently to git-only coordination.
+- **In loop mode**: emit-only observability layer (per §2 mutual exclusivity). Agents may emit events for diagnostics, but they do NOT consume from the bus and do NOT maintain a cursor. Pre-cycle mechanical reactions (e.g., PR merge → status transition) derive from tracker state changes since last cycle (§6.3) — never from event reads. When the harness is down, emits silently no-op.
 - **In event-driven mode**: load-bearing. The bus is how the harness wakes the agent in the first place. When the harness is down, event-mode agents sit idle until it recovers (see §8.4); falling back to loop mode is a manual operator action (recompose + restart), not an automatic runtime path.
 
 ### 4.1 Architectural commitments (locked principles)
@@ -244,6 +244,8 @@ In v2 the catalog collapses to **3 signal concepts / 4 catalog entries**:
 | **`ack-stop`** | agent → harness | Agent has accepted a stop intent and is checkpointing | `{event_id, result}` |
 
 `ack-cursor` and `ack-stop` are sub-types of one concept (receipt confirmation) — shipped in `#9873-A`. Three signal concepts, four catalog entries.
+
+> **Naming note**: The `role` field in `booted` / `ack-cursor` payloads is the agent's **alias** value, preserved under the field-name `role` for code-compat with the wire format. Same pattern as `{role}` in HTTP path parameters (see §4.3). Field rename to `alias` is in the same family as #10358. `ack-stop.result` enum values are tracked as §9 Q11.
 
 #### Signal-flow at a glance
 
@@ -362,7 +364,7 @@ The endpoints throughout this section use `{role}` in path parameters (e.g., `GE
 ```mermaid
 sequenceDiagram
     participant ES as .event-state.json<br/>(harness-owned)
-    participant CP as cycle_pre.py / event_poll
+    participant CP as event_poll (event mode) /<br/>cycle_pre.py (event mode only)
     participant H as Harness
     participant CPO as cycle_post.py / agent ack
 
@@ -449,7 +451,7 @@ Two-tier backoff: 10s → 30s → 60s. A quiet period stabilizes at 60s after �
 
 | State | Polls/hr | Calls/hr (incl. 1–3 follow-ups per change) | % of quota |
 |---|---|---|---|
-| Steady-state quiet | ~120 | ~120 | 2% |
+| Steady-state quiet (60s ceiling) | ~60 | ~60 | 1% |
 | Steady-state active | ~360 | ~360–720 | 7–14% |
 | Worst-case burst (10 changes/poll, sustained) | ~360 | ~3600 | 72% |
 
@@ -1105,7 +1107,7 @@ In **loop mode**, the harness's reachability is not a boot gate at all — loop-
 
 ### 8.5 Migration from loop → event mode (v2 closure plan)
 
-The v2 build ships as 5 grouped PRs. The **letters** (A–F) are logical-grouping identifiers — they cluster related work; the **numbers** (1–5) are the dependency-driven implementation order. The two orderings differ on purpose: e.g., Group A is the foundation and ships first, but Group B (cursor wire) is held until after C has landed so its wire-format changes don't conflict with EAD restart-safety.
+The v2 build ships as 6 grouped PRs. The **letters** (A–F) are logical-grouping identifiers — they cluster related work; the **numbers** (1–6) are the dependency-driven implementation order. The two orderings differ on purpose: e.g., Group A is the foundation and ships first, but Group B (cursor wire) is held until after C has landed so its wire-format changes don't conflict with EAD restart-safety.
 
 | # | Group | What it does | Risk |
 |---|---|---|---|
@@ -1154,7 +1156,14 @@ PM agents recognize this set as their care-filter; new values added in future re
 | Q9 | `compose.py` changes for v2 | Trim catalog, retire emit calls, add `compose-needed` translator |
 | Q10 | Migration plan | Feature flag `event-driven: yes/no` in `.squidsquad/config.md` |
 
-> Net-new open questions surfaced during the loop+event merge (this doc): NONE so far. Add below as they surface.
+> Net-new open questions surfaced during the loop+event merge (this doc): listed below.
+
+| # | Question | Status |
+|---|---|---|
+| Q11 | `ack-stop.result` enum values | Open — target shape `'checkpointed' \| 'aborted' \| 'drained'`; not yet locked. Pin alongside harness stop-path spec. |
+| Q12 | `role:*` label rewrite timing | Open — the §7.3 routing table assumes the issue's `role:*` label reflects the target alias for the *new* state at the moment of `/work/assign`. The rewrite mechanism (who rewrites; whether `tracker.py transition` carries a state-machine table from `(new-state, prior role:*)` → `new role:*`) is unspecified. Block on `tracker.py transition` spec; see #10358 family. |
+| Q13 | `emitter_alias` derivation for self-assign invariant | Open — §7.3 says the harness rejects `assigned-to` where `target_alias == emitter_alias`, but the `/work/assign` request shape (§7.3 sequence diagram) carries no `emitter_alias` field. Target mechanism likely an `X-Squidsquad-Alias` request header set by `tracker.py` (and by direct callers); EAD-emitted events would set `emitter_alias = '__ead__'` exempt from the check. Pin alongside group D (alias-existence validation, §8.5). |
+
 
 ---
 
@@ -1166,7 +1175,7 @@ PM agents recognize this set as their care-filter; new values added in future re
 - **Nudge**: a single stdin line written by `event_poll` to wake a Claude session via the Monitor tool.
 - **Cursor**: per-alias harness-owned pointer to "events tended through here."
 - **EAD**: ExternalActivityDetector — the harness's forge poller that translates forge state changes into `assigned-to` events.
-- **Care filter**: the per-role-class decision of whether to act on an event or skip it.
+- **Care filter**: the per-alias decision of whether to act on an event or skip it. In v2 the filter is `target_alias == my_alias`; see §7.4.
 - **Improvement subloop**: time-throttled self-care work the agent runs when its queue is empty. Applies in both modes — quiet cycles in loop mode (§6.4) and drained-queue detection in event mode (§7.6).
 
 ### 10.2 Related docs
@@ -1196,14 +1205,14 @@ PM agents recognize this set as their care-filter; new values added in future re
   - **Terminology**: removed all current-repo concrete-instance references (no `skill`, no `dev`, no "concrete-install snapshot" framing). The doc uses only the four L2 categorical role names: `pm`, `verifier`, `worker`, `dm` — sourced from the L2 capability layer (`agent-boundaries`), which is the canonical name source. *(Per later revisions: L2 is **Role** in the L1-L4 compose model and `agent-boundaries` was retired — see PR #10359. This entry preserves the then-current framing as historical context.)* Terminology table simplified to 4 rows with no concrete-instance column; role-filtering diagram drops the per-install qualifier and uses categorical names directly; stack-specific specialization is noted as `worker`/`verifier` variants rather than as alternative role names.
   - **Mode flag**: dropped per-role event-driven config (`event-driven-pm: yes` etc.). `event-driven:` is now a single global flag for the install — the whole squad runs in loop mode together or event-driven mode together. §8.1 rewritten; §8.2 mode-flip steps now install-wide; §8.3 boot decision tree simplified to one ConfigGate before the harness probe. Rationale: keeps the harness contract uniform (load-bearing for everyone, or observational for everyone), avoids the cross-role coordination puzzle of mixed modes.
 - **2026-05-23 (rev 7) — post-rev-6 DS verification + §7.6 diagram fix.** DS round-7 verification found 2 actionable findings (1 MED, 1 LOW); both applied: §8.1 clarified that mixed modes are not *configurable* but degraded fallback can produce a transient mixed-mode state per-agent (the previous wording falsely implied install-wide uniformity even under fallback); §8.4 reworded to distinguish the configured `event-driven: no` path (loop mode by design) from the `event-driven: yes` + probe-fail fallback path (the prior "regardless of config" wording collapsed the two). Also: §7.6 subloop diagram nodes now use quoted-label form ({"…"}, ["…"]) so unquoted parentheses can't break Mermaid rendering. The "sub-skill" terminology is retained as the canonical compose-fragment term and is distinct from the "skill" agent-role term that was removed in rev 6 (DS flagged as info, accepted as intentional). DS artifact: `.squidsquad/pm/planning/REVIEW-AGENT-RUNTIME-DEEPSEEK-7.md`.
-- **2026-05-23 (rev 8) — final convergence + cadence-math fixes.** DS round-8 confirmed all R7 fixes correct and returned 2 LOW math errors: EAD cadence "≈3 minutes" → "≈2 minutes" (correct: 6 polls × 10/20/30/60/90/120s = 120s = 2 min); event_poll cadence "≈2.5 minutes idle" → "≈1.75 minutes idle" (correct: 6 polls × 5/10/15/45/75/105s = 105s ≈ 1.75 min). Both fixed. The doc is now mathematically and architecturally converged. DS artifact: `.squidsquad/pm/planning/REVIEW-AGENT-RUNTIME-DEEPSEEK-8.md`.
+- **2026-05-23 (rev 8) — final convergence + cadence-math fixes.** DS round-8 confirmed all R7 fixes correct and returned 2 LOW math errors: EAD cadence "≈3 minutes" → "≈2 minutes" (correct: 3 polls at 10s + 3 polls at 30s = 120s = 2 min to reach the 60s ceiling); event_poll cadence "≈2.5 minutes idle" → "≈1.75 minutes idle" (correct: 3 polls at 5s + 3 polls at 30s = 105s ≈ 1.75 min). Both fixed. The doc is now mathematically and architecturally converged. DS artifact: `.squidsquad/pm/planning/REVIEW-AGENT-RUNTIME-DEEPSEEK-8.md`.
 - **2026-05-25 (rev 9) — post-#6274 `qa` → `verifier` rename + loop/event mutual-exclusivity on event-bus axis + vault invocation polish.** Three coordinated edits:
   - **Role rename**: post-#6274 (shipped 2026-05-23) the canonical role is `verifier`, not `qa`. Swept all instance-level references in this doc (Terminology table, §2.1 latency-floor example, §3.1 + §3.2 mermaid subgraph and tree labels, §4.3 role-filtering diagram, §7.3 verification-needed sequence diagram + routing table, §7.5 EAD safety-net sequence diagram, §7.6 subloop role list). Wire-format strings updated too: `target_role:qa` → `target_alias:verifier`, `role:qa` → `role:verifier`, `event_context:"qa-rejected"` → `event_context:"verifier-rejected"`, `GET /events/for/qa` → `GET /events/for/verifier`. Note: live code (`references/scripts/triage.py`, `cycle_pre.py:614`) still emits `qa-rejected` — doc now describes architectural target; code task to skill.
   - **Loop/event mutual exclusivity** (§2 + §4.5 + §4.6 + §6.1 + §6.3 + §7 lead): loop mode is now documented as emit-only on the event bus (no consume, no cursor); event mode is the exclusive home for bus consumption + cursor logic. Loop-mode mechanical reactions derive from tracker state changes since last cycle (timestamp dedup in working-state.md), not from event-bus reads. Rationale: keeps the harness contract uniform — loop is observational-only, event is load-bearing.
   - **Vault invocation** (§6.1 diagram + §6.6 new sub-section): named the four Phase 2 vault touchpoints + boot-time BRIEFING read + the inline-vs-subagent execution lane principle (heavy sub-skills `vault-remember` and `vault-synthesis` run on the `sonnet` tier via background subagent; light ones `vault-protocol` and `vault-optimize` stay inline). Cross-references VAULT-ARCH §7 for the lane principle's full rationale.
   - **Vault flag retirement** (§6.1 diagram): dropped the `· read vault-remember + vault-optimize flags` line from Phase 1 and the `· advance event cursor` line from Phase 3 (both per the above changes). The vault-remember/vault-optimize `Enabled` flags in `config.md` are being retired; both sub-skills are always-on and self-gate via their per-cycle conditions. Code task to skill.
 - **2026-05-25 (rev 10) — class vs alias as routing primitive + responsibility.md / permission-table retirement.** Architectural simplification arc:
-  - **Class vs alias** (Terminology refactor + wire-format swap): role classes (pm/dm/worker/verifier) are categorical and have uniform L2/L3 + bus contract per class; aliases are per-agent unique names from `config.md` `## Aliases`. An install may have 1..N agents per class — e.g., 2 frontend + 2 backend worker-class agents named `frontend-1`, `frontend-2`, `backend-1`, `backend-2` (four worker-class agents, four distinct aliases). Specialty/skill (FE/BE/iOS/etc.) lives in SOUL.md + L4, not in a separate class. Wire-format field `target_role` renamed to `target_alias` across all 16 catalog + sequence-diagram + routing-table references; care filter is now `target_alias == my_alias`; EAD emits one assigned-to per (forge change, target_alias) pair.
+  - **Class vs alias** (Terminology refactor + wire-format swap): role classes (pm/dm/worker/verifier) are categorical and have uniform L2/L3 + bus contract per class; aliases are per-agent unique names from `config.md` `## Aliases`. An install may have 1..N agents per class — e.g., 2 frontend + 2 backend worker-class agents named `frontend-1`, `frontend-2`, `backend-1`, `backend-2` (four worker-class agents, four distinct aliases). Specialty/skill (FE/BE/iOS/etc.) lives in SOUL.md + L4, not in a separate class. *(Note: §1 Terminology now locates specialty in **L3 (the domain layer)** instead — see `feedback-l3-specialty-layering`. This rev-10 entry preserves the as-of-rev-10 framing; current canonical statement is §1.)* Wire-format field `target_role` renamed to `target_alias` across all 16 catalog + sequence-diagram + routing-table references; care filter is now `target_alias == my_alias`; EAD emits one assigned-to per (forge change, target_alias) pair.
   - **`responsibility.md` retired**: the file's prose responsibility narrative was ~90% redundant with L2/L3 (which compose into each agent's CLAUDE.md anyway); the only load-bearing content was the `## Bus contract` section. Permission tables are being retired entirely (next bullet), so `responsibility.md` has no remaining purpose. Marked for code-task deletion.
   - **Permission table retired**: the harness no longer maintains a class-from-class `accepts assigned-to from:` permission table. Rationale: it duplicated discipline that already lives in each agent's L2/L3/L4 + SOUL.md; it conflicted with §4.1's "harness is a transport bus, not an orchestrator" principle; and the human-team analogy (mis-routed tickets get pushed back, no security guard at the assignment desk) applies. Replaced with two minimal harness checks: (1) target-alias existence (404 if unknown) and (2) self-assign invariant (rejected by structure, not by permission). Mis-route recovery happens at the agent layer: receiving agent recognizes out-of-domain work and re-assigns via the same `/work/assign` call to the correct alias; if recipient is unknown, routes to `pm` with `event_context="route-help"`.
   - §7.3 `/work/assign permission model` subsection replaced with `/work/assign validation + mis-route recovery`. §7.4 care filter section drops the L2-derived permission-table mention. §8.5 Group D row repurposed from "L2-derived permissions" to "alias-existence validation". §9 Q2 and Q6 updated to match.

--- a/docs/COMPOSE-ARCHITECTURE.md
+++ b/docs/COMPOSE-ARCHITECTURE.md
@@ -122,7 +122,7 @@ flowchart TB
     L4["<b>L4 — Project</b><br/>Per-install + role-class customizations.<br/>replace / insert / append ops on L1-L3.<br/><i>.squidsquad/project/&lt;role-class&gt;.md</i>"]
   end
   L3 --> L4
-  L4 -->|"compose.py deploy &lt;role&gt;"| OUT["<b>.squidsquad/&lt;role&gt;/CLAUDE.md</b><br/>composed output — DO NOT EDIT"]
+  L4 -->|"compose.py deploy &lt;alias&gt; (per §1: alias-valued)"| OUT["<b>.squidsquad/&lt;alias&gt;/CLAUDE.md</b><br/>composed output — DO NOT EDIT"]
 ```
 
 ---
@@ -462,7 +462,7 @@ flowchart TB
   MP --> Sort
   ME --> Sort[Stable sort by<br/>slot_index, ordinal]
   Sort --> Base[L1-L3 base composition<br/>built in memory]
-  Base --> L4Walk["Read .squidsquad/project/&lt;role&gt;.md<br/>(one file; H2 slot sections + H3 op blocks)"]
+  Base --> L4Walk["Read .squidsquad/project/&lt;role-class&gt;.md<br/>(one file per role-class — per §3.3;<br/>H2 slot sections + H3 op blocks)"]
   L4Walk --> L4Group[Group L4 ops by slot]
   L4Group --> L4Apply[Within each slot, apply ops:<br/>1. all replace<br/>2. all insert-before / insert-after<br/>3. all append]
   L4Apply --> Validate{Validate:<br/>L4 targets resolve?<br/>DRY ok? no orphans?}
@@ -936,7 +936,9 @@ This section is intentionally short — most vault detail belongs in `references
    2.3 Why this matters (the seam discipline)
 
 ## 3. Soul
-   (SOUL.md inlined verbatim)
+   3.1 L1 voice baseline           (slot: soul, ord: 10)
+   3.2 L2 role-class persona       (slot: soul, ord: 20 — sourced from SOUL.md shorthand per §5.3)
+   3.3 L4 append (optional)        (composed only when L4's ## Soul has ### append blocks)
 
 ## 4. Instructions
    4.1 On boot
@@ -985,7 +987,9 @@ This section is intentionally short — most vault detail belongs in `references
    2.3 Why this matters (the seam discipline)
 
 ## 3. Soul
-   (SOUL.md inlined verbatim)
+   3.1 L1 voice baseline           (slot: soul, ord: 10)
+   3.2 L2 role-class persona       (slot: soul, ord: 20 — sourced from SOUL.md shorthand per §5.3)
+   3.3 L4 append (optional)        (composed only when L4's ## Soul has ### append blocks)
 
 ## 4. Instructions
    4.1 On boot
@@ -1148,7 +1152,7 @@ This eliminates two problems v1 created: (a) sub-skill bodies bloated composed C
 
 Today's standalone H2 sections like `## What You Must Never Do`, `## File Conventions`, `## Status Line` are **also folded** under v2 — but with the reference-only discipline applied:
 
-- **"Never do" prohibitions that apply broadly** fold into **Identity** as "Boundaries" (one or two short lists at the bottom of the Identity section). These are orchestration-layer assertions about the agent's overall character — short, top-level, emitted verbatim.
+- **"Never do" prohibitions that apply broadly** fold into **Identity** as "Boundaries" — a terminal anchor sub-section of the L1 Identity content (the last L1-L3 fragment in the identity slot). These are orchestration-layer assertions about the agent's overall character — short, top-level, emitted verbatim. L4 `### append` blocks on `## Identity` land **after** the Boundaries anchor per §3.3 (Boundaries itself stays L1-immutable; L4 prohibitions are added below it).
 - **"Never do" prohibitions that are step-specific** are NOT inlined into the composed CLAUDE.md. Under v2, step-specific prohibitions live in the **sub-skill** that owns the step (e.g. "Never amend a published commit" lives in the `git-commit` sub-skill's source file, not in the composed orchestration). The step reference in §4.2 pulls them in implicitly when the model invokes the sub-skill. Step-specific prohibitions are part of SquidSquad's **shipped behaviour layer** — they are not the intended target of L4 `replace` ops, and projects that need to lift a prohibition file the change upstream against the SquidSquad repo rather than overriding it per-install. Compose does not block a `replace` op pointed at a prohibition-bearing step (the op grammar in §3.3 is structurally permissive), but `l4-curation`'s elicitation dialog routes such requests to the upstream feature-request path.
 - **File conventions** fold into **Project Context** when they're project-shaped (most are). When they're sub-skill-shaped (e.g. "verifier writes `TEST-PLAN-<n>.md` under `.squidsquad/verifier/planning/`"), they live in the relevant sub-skill's source file.
 - **Status Line description** folds into **Project Context** — it's a project-display fact, not an instruction.
@@ -1187,7 +1191,7 @@ SquidSquad agents support two wake mechanisms: **event-driven** (a harness-manag
 
 `compose.py:_load_manifest` reads `config.get_wake_mode()` (a global flag — there is no per-role wake mode; see AGENT-RUNTIME §8.1) and chooses the manifest; `_resolve_includes_with_manifest` then renders the chosen manifest in full. There are **no mode-conditional directives inside fragments** — the manifest is the gate. The agent receives one fully-resolved CLAUDE.md whose §4.2 is shaped for exactly one mode. Mid-session mode flips do not exist; an operator flipping `.squidsquad/config.md` from `polling` to `event-driven` (or vice versa) takes effect on the next compose+restart.
 
-> **Compose-time inline vs runtime Read — two-tier mechanism for `common-events/`.** The `includes-events.yml` manifest's sub-skills (`boot-bootstrap`, the event-mode cycle-runner sibling, etc.) ARE inlined into the composed CLAUDE.md at compose time, same as polling-mode sub-skills. But one of those inlined sub-skills — `boot-bootstrap` — contains Read-tool instructions that pull the `common-events/*` fragments (`l1-base`, `event-driven-workflow`, `cursor-management`, `forge-read-pattern`, `idle-cooldown-loop`, `comment-handling`) into context **at agent session start**, not at compose time. So the manifest selection is compose-time (which sub-skills get inlined); the `common-events/` fragments themselves are runtime-loaded (they sit on disk, not in any composed CLAUDE.md body). This two-tier shape is intentional: it keeps the composed CLAUDE.md small while still letting event-mode add ~6 fragments of behavior. The catalog's `common-events/` section header documents this; this paragraph is the spec.
+> **Compose-time reference vs runtime Read — two-tier mechanism for `common-events/`.** The `includes-events.yml` manifest's sub-skills (`boot-bootstrap`, the event-mode cycle-runner sibling, etc.) appear as `→ run sub-skill: <name>` **references** in the composed CLAUDE.md at compose time — bodies are NEVER inlined (per §4.1 step 4 + §6.2.1; the catalog is the resolution gate). What's compose-time-selected is *which sub-skills get referenced* (the manifest decides). One of those referenced sub-skills — `boot-bootstrap` — contains Read-tool instructions that pull the `common-events/*` fragments (`l1-base`, `event-driven-workflow`, `cursor-management`, `forge-read-pattern`, `idle-cooldown-loop`, `comment-handling`) into the agent's context **at agent session start**, not at compose time. So the two-tier shape is: (1) the manifest selection at compose time chooses which sub-skill references emit into CLAUDE.md; (2) the `common-events/*` fragments those sub-skills Read are loaded at runtime (they sit on disk, never in any composed CLAUDE.md body). The thin-orchestration invariant holds for both modes: composed CLAUDE.md is references-only.
 
 ```mermaid
 flowchart LR
@@ -1282,24 +1286,31 @@ When the agent receives a new instruction, it walks this decision tree:
 4. Is the instruction not an instruction at all — but a project context fact?
    → Add prose under ## Project Context (append-only; no H3 op grammar).
 
-5. Does the instruction require functionality that maps to a NEW sub-skill
-   not yet in the catalog?
-   → Stop. This is shipped-content work, not L4 customization.
-     a. Check the catalog (sub-skill-catalog.md) and disk
-        (references/sub-skills/) for an existing sub-skill that covers
-        the need — usually one exists and the instruction can become a
-        cycle/insert-after that references it.
-     b. If genuinely no existing sub-skill fits, the agent surfaces
-        this to the human as a "feature request against the SquidSquad
-        repo" — new sub-skills are part of shipped L1-L3 behaviour and
-        must be authored upstream, then released, then composed in.
-     c. Do NOT write an L4 op that references a sub-skill name not
-        already in the catalog — §4.5 catalog-drift validation will
-        reject it, and the failure mode is confusing (compose error,
-        not a clear "you can't add new sub-skills here"). (This is the
-        same gate as §4.5 — the catalog is consulted at compose time;
-        sub-skill name resolution failures abort the compose with a
-        clear error pointing at the offending L4 op.)
+5. Does the instruction require functionality that maps to a **sub-skill
+   not already catalogued in sub-skill-catalog.md**?
+   → Stop. **Authoring a new sub-skill** is shipped-content work, not L4
+   customization. Distinguish from "introducing a new REFERENCE to a
+   sub-skill that IS catalogued but isn't currently referenced anywhere
+   in L1-L3" — that case IS L4-legal (per §11.2 G7) and resolves cleanly
+   through §4.5 catalog gate. The forbidden case is referencing a
+   sub-skill name with no catalog entry.
+     a. Check the catalog (sub-skill-catalog.md) for an existing entry.
+        If the sub-skill IS catalogued, an L4 op referencing it is legal
+        (the catalog is the gate, not the L1-L3 reference set) — proceed
+        with the appropriate insert-before / insert-after / append.
+     b. If the sub-skill is NOT in the catalog and disk
+        (references/sub-skills/) doesn't have a fitting source either,
+        the agent surfaces this to the human as a "feature request
+        against the SquidSquad repo" — new sub-skills (catalog entry +
+        source file) are part of shipped L1-L3 behaviour and must be
+        authored upstream, then released, then composed in.
+     c. Do NOT write an L4 op that references a sub-skill name with no
+        catalog entry — §4.5 catalog-resolution validation will reject
+        it, and the failure mode is confusing (compose error, not a clear
+        "you can't add new sub-skills here"). (This is the same gate as
+        §4.5 — the catalog is consulted at compose time; sub-skill name
+        resolution failures abort the compose with a clear error pointing
+        at the offending L4 op.)
 ```
 
 If the agent cannot decide between `replace` and `insert-after` (e.g. the new instruction is ambiguous), the agent **asks the human a single clarifying question** before persisting.
@@ -1494,7 +1505,7 @@ New sub-skill: `references/sub-skills/common/compose-output-review.md`. Composed
 
 The checklist (suggested initial content):
 
-1. **Heading-level check** — Did my source change introduce a new H2 section in any composed output? If yes, does it belong as an H2 under one of the five canonical sections, or should it be H3+ inside an existing section?
+1. **Heading-level check** — Did my source change introduce a new H2 section in any composed output? If yes, does it belong as an H2 under one of the six canonical sections (Identity / Responsibility / Soul / Instructions / Project Context / Vault per §5), or should it be H3+ inside an existing section?
 2. **DRY check** — Did I introduce content that already exists in another L1-L4 layer? Use `grep -r` to confirm.
 3. **Step-ID stability** — Did I rename or remove any step IDs? If yes, did I follow the §6.1 breaking-change protocol?
 4. **L4 resolution** — Did I delete or rename a step that L4 H3 blocks target? If yes, find them (grep `.squidsquad/project/*.md` for the step ID) and update them.
@@ -1568,7 +1579,7 @@ This collapses today's two-system memory architecture (per-user memory + L4) int
 - **G4** — ✅ CLOSED (2026-05-29). [`VAULT-ARCH.md`](VAULT-ARCH.md) covers entity types (§4), wikilink grammar (§4.5), confidence levels (§4.4), and the relationship to `vault-protocol.md` (§7). The remaining "slot contract" gap is closed by making the slot **L1-exclusive** (§3.3 + §5.6) — only the L1 short-descriptor pattern is valid; L2-L4 cannot author this slot. Guardrail rationale: the vault contract is a framework feature that should not fragment across roles/domains/installs without a concrete customization pattern. Revisit when a real customization need surfaces; the framing then is "introduce L2 vault customization with constraints X/Y/Z" rather than "open up arbitrary append".
 - ~~**G5** — L4 file naming collision rules~~ **CLOSED** — see §7.3. There is exactly one L4 file per role-class, named `<role-class>.md` (e.g. `pm.md`, `fe-worker.md`, `be-worker.md` in installs with worker specialization; `pm.md`, `worker.md`, `verifier.md`, `dm.md` in installs without). The filename IS the role-class identity — collision is structurally impossible since each role-class has exactly one expected filename.
 - **G6** — ✅ CLOSED (v2). Subagent usage rules now in [AGENT-RUNTIME §6.7](AGENT-RUNTIME.md#67-subagent-invocation-rules) (default-model + per-role-class overrides + spawn-vs-inline + prompt hygiene + parallelism + trust-but-verify). L3 `replace` overlays on the L1 default cover the per-role-class Sonnet defaults for `worker`/`dm`. Rules originally added to COMPOSE §6.6 then relocated to AGENT-RUNTIME because they describe runtime behavior, not compose mechanics.
-- **G7** — Sub-skill reference resolution semantics for L4. Open: can L4 *insert* a new step that references a sub-skill not yet referenced anywhere in L1-L3? Yes per §4.5 (catalog is the source of truth, not the L1-L3 reference set), but the L4-write decision tree in §7.2 should explicitly cover the "introduce a new sub-skill reference" case.
+- **G7** — Sub-skill reference resolution semantics for L4. **CLOSED**: L4 can introduce a new reference to a *catalogued* sub-skill (e.g., one never before referenced from L1-L3); §4.5 catalog gate handles this cleanly. L4 cannot introduce a reference to an *uncatalogued* sub-skill name (compose rejects at §4.5 validation). §7.2 step 5 now disambiguates these two cases explicitly.
 
 Each open gap is filed for explicit closure in §12.
 
@@ -1627,11 +1638,11 @@ Total: ~14 sub-PRs. Comparable to event-arch v2's implementation epic (6 PRs in 
 ## 13a. Revision log
 
 - **2026-05-23 (v1.3)** — shipped under #9968 cycle 1616 (commit `8b33aebd`). Established the L1-L4 composition pipeline and 5-section composed-output structure. Treated sub-skill bodies as inlined content within the composed CLAUDE.md.
-- **2026-05-23 (v2 draft)** — reframe: composed CLAUDE.md becomes a **thin orchestration layer** that references sub-skills rather than inlining them. Aligns with the Claude-skills direction locked in #9968 cycle 1619. Substantive changes: §1 goal + new model diagram; §3.1 DRY now explicitly covers sub-skill bodies as single-source; §4.1 emits references not inline; §5.3 Instructions section is references-only; §6.2 sub-procedures are sub-skills (with their own catalog entry), not folded into step bodies; §5.6 worked examples clarified as step-reference TOCs; §14 references updated for the archived event docs and the new `sub-skill-catalog.md` / `sub-skill-guide.md` companions.
+- **2026-05-23 (v2 draft)** — reframe: composed CLAUDE.md becomes a **thin orchestration layer** that references sub-skills rather than inlining them. Aligns with the Claude-skills direction locked in #9968 cycle 1619. Substantive changes: §1 goal + new model diagram; §3.1 DRY now explicitly covers sub-skill bodies as single-source; §4.1 emits references not inline; §5.4 Instructions section is references-only (renumbered from §5.3 in later passes); §6.2 sub-procedures are sub-skills (with their own catalog entry), not folded into step bodies; §5.7 worked examples clarified as step-reference TOCs (renumbered from §5.6); §14 references updated for the archived event docs and the new `sub-skill-catalog.md` / `sub-skill-guide.md` companions.
 - **2026-05-23 (v2 draft, R1 fixes)** — DS round-1 surfaced 5 findings (2 HIGH, 1 MED, 2 LOW). Applied: §1 non-goals "see EVENT-ARCHITECTURE.md" → "see AGENT-RUNTIME.md" (stale ref); §13 glossary "Sub-procedure" entry updated to v2 (no longer says "written inline at H4 level"; added a "Sub-skill" entry for clarity); §4.1 step 1 clarifies the sub-skill reference is body-extracted, not a frontmatter field; §6.5 `common/boot-bootstrap.md` → `references/sub-skills/common/boot-bootstrap.md` (full path); §5.2 "Inlined directly" → "Emitted verbatim" with explicit note that Soul is orchestration-layer content, not a sub-skill (avoids confusion with v1 inline-sub-skill anti-pattern). DS artifact: `.squidsquad/pm/planning/REVIEW-COMPOSE-ARCH-DEEPSEEK-1.md`.
 - **2026-05-23 (v2 draft, R2 fix + CONVERGED)** — DS round-2 confirmed all R1 fixes applied and returned 1 LOW residual finding (CONVERGED with the fix). §3.2 emit-rule clarified: "emits the literal content of each" was unqualified and would have led implementers to inline sub-skill bodies in the `instructions` slot (the v1 anti-pattern). Rewrote to specify that non-instructions slots are emitted verbatim while the `instructions` slot is emitted as sub-skill *references* per §4.1 step 4. DS artifact: `.squidsquad/pm/planning/REVIEW-COMPOSE-ARCH-DEEPSEEK-2.md`.
 - **2026-05-23 (v2 draft, fill-out pass)** — Filled in under-specified areas and closed two of the §11.2 gaps. Substantive additions: NEW §4.5 specifies sub-skill reference resolution (compose validates every `→ run sub-skill: <name>` ref against catalog + source + skill-registry; aborts on unresolved or catalog drift); §6.1 step ID grammar formalized with BNF + character set + nesting depth + global-uniqueness rule, and the step↔sub-skill mapping (1:1 default, N:1 allowed, 1:N forbidden) made explicit (closes G1); §6.3 constraints reframed for v2 (step-specific prohibitions live in the owning sub-skill, not inlined into composed orchestration); NEW §6.6 subagent usage rules — default Sonnet for `worker`/`dm`, parent-context for `pm`/`verifier`, spawn-vs-inline, prompt hygiene, trust-but-verify (closes G6); NEW §10.3 sub-skill catalog maintenance (hand-authored, single source of truth, compose validates drift); §5.1 swapped concrete-instance leak to L2 categorical names (`pm`/`verifier`/`worker`/`dm`) per the AGENT-RUNTIME rev-6 terminology lock; §11.2 marks G1+G6 closed, adds G7 (L4 introducing new sub-skill refs).
-- **2026-05-23 (v2 draft, R3 fixes)** — DS round 3 surfaced 5 findings on the fill-out pass (1 HIGH BNF contradiction, 4 MED). All applied: §6.1 BNF `(/segment)*` "max depth 3" → `(/segment)?` matching the prose "one nesting level"; §4.5 step 1 cross-ref to step grammar fixed (was §6.1 which is step ID grammar; correct ref is §4.1 step 4 + §5.3 for reference grammar); §6.6 L3 "replace overlays" rewritten — `replace` is L4-only, L3 overrides happen via natural `(slot, ordinal)` ordering; §4.5 step 4 catalog-drift cross-ref clarified — that's an in-pipeline compose check, distinct from §8 source-output sync gates. Also: doc-wide naming pass to match AGENT-RUNTIME rev 6 — all remaining concrete-instance references in prose, diagrams, and §5.6 worked-example TOCs use the L2 categorical names `pm`/`verifier`/`worker`/`dm`. DS artifact: `.squidsquad/pm/planning/REVIEW-COMPOSE-ARCH-DEEPSEEK-3.md`.
+- **2026-05-23 (v2 draft, R3 fixes)** — DS round 3 surfaced 5 findings on the fill-out pass (1 HIGH BNF contradiction, 4 MED). All applied: §6.1 BNF `(/segment)*` "max depth 3" → `(/segment)?` matching the prose "one nesting level"; §4.5 step 1 cross-ref to step grammar fixed (was §6.1 which is step ID grammar; correct ref is §4.1 step 4 + §5.3 for reference grammar); §6.6 L3 "replace overlays" rewritten — `replace` is L4-only, L3 overrides happen via natural `(slot, ordinal)` ordering; §4.5 step 4 catalog-drift cross-ref clarified — that's an in-pipeline compose check, distinct from §8 source-output sync gates. Also: doc-wide naming pass to match AGENT-RUNTIME rev 6 — all remaining concrete-instance references in prose, diagrams, and §5.7 worked-example TOCs use the L2 categorical names `pm`/`verifier`/`worker`/`dm`. DS artifact: `.squidsquad/pm/planning/REVIEW-COMPOSE-ARCH-DEEPSEEK-3.md`.
 - **2026-05-23 (v2 draft, capability removal)** — §2 L2 row dropped the `references/sub-skills/capabilities/` reference; the L2 diagram node updated to point at `references/sub-skills/common/` only. Rationale: SquidSquad no longer has a "capability" framework — tool/MCP/CLI configuration is per-agent post-install via the §7 runtime L4 write flow. See [INSTALLER-ARCH.md §8](INSTALLER-ARCH.md) for the replacement model. The existing `references/sub-skills/capabilities/` directory and `common/capability-check.md` are slated for removal as architectural deadwood.
 
 ---

--- a/docs/COMPOSE-ARCHITECTURE.md
+++ b/docs/COMPOSE-ARCHITECTURE.md
@@ -22,7 +22,7 @@ Establish a single source of truth for how SquidSquad **composes** the per-agent
 >
 > CLI flag names in this codebase (`--role`, `SQUIDSQUAD_ROLE`, `cycle.py status-bar <role>`, `compose.py deploy <role>`) accept **alias** values, not role-class names — the `<role>` parameter name predates the alias/role-class distinction and is preserved for code-compat. Callers (including the installer's Phase 6 invocation, see INSTALLER-ARCH §4.9) pass the install-time alias (e.g. `pm`, `frontend-1`, `verifier`) as the argument. Compose internally resolves the alias → role-class via `.squidsquad/config.md`'s `## Aliases` registry to find the right L4 file. See [AGENT-RUNTIME §4.3 Vocabulary note](AGENT-RUNTIME.md) and [HARNESS-ARCH §9](HARNESS-ARCH.md).
 
-The composed CLAUDE.md is a **thin orchestration layer** — it declares an agent's identity, soul, ordered step references, project context, and vault description. It does **not** contain the bodies of sub-skills; instead it references them by name from [`sub-skill-catalog.md`](sub-skill-catalog.md). Sub-skill bodies live in their authored sources under `references/sub-skills/` (plain markdown fragments). A **project-scoped Claude-skills installer** that materializes each sub-skill into the project's local `.claude/skills/<name>/SKILL.md` is target-state but not yet shipped — see §4.5.1 Gap.
+The composed CLAUDE.md is a **thin orchestration layer** — it declares an agent's identity, soul, ordered step references, project context, and vault slot content. It does **not** contain the bodies of sub-skills; instead it references them by name from [`sub-skill-catalog.md`](sub-skill-catalog.md). Sub-skill bodies live in their authored sources under `references/sub-skills/` (plain markdown fragments). A **project-scoped Claude-skills installer** that materializes each sub-skill into the project's local `.claude/skills/<name>/SKILL.md` is target-state but not yet shipped — see §4.5.1 Gap.
 
 The composition must:
 
@@ -78,7 +78,7 @@ flowchart LR
 
 - Redesigning the L1-L4 *responsibility model* itself — that landed in #9925 and is preserved as-is.
 - Defining the event bus, harness lifecycle, or agent state machine — see [`AGENT-RUNTIME.md`](AGENT-RUNTIME.md).
-- Replacing the role concept itself (pm / verifier / worker / dm — see [AGENT-RUNTIME.md](AGENT-RUNTIME.md) Terminology) — those are stable.
+- Replacing the role-class concept itself (pm / verifier / worker / dm — see [AGENT-RUNTIME.md](AGENT-RUNTIME.md) Terminology) — those are stable.
 - Specifying the wizard install flow beyond compose hooks — see `WIZARD.md`.
 
 ---
@@ -89,12 +89,12 @@ Four layers, in shipping/precedence order:
 
 | Layer | Purpose | Authoring location | Authored by |
 |---|---|---|---|
-| **L1** — Base | What ANY SquidSquad agent is. Universal baseline: identity foundation, core principles, tracker protocol, cycle runner transport, inter-agent communication via forge (§5.1.1). Every role on every install starts from here. | `references/sub-skills/common/` (sub-skills L1 references) and the L1 portion of role source files | SquidSquad maintainers (shipped) |
-| **L2** — Role | Role-specific behaviours: `pm` coordinates, `verifier` verifies, `dm` packages, `worker` implements. The role-defining contract (responsibility, role-specific instructions, role-specific tone). | `references/roles/<role>/instructions.md` + `references/roles/<role>/SOUL.md` + `references/sub-skills/roles/<role>/` | SquidSquad maintainers (shipped) |
-| **L3** — Variant (role + domain) | Per-stack or per-domain specialization of a role: a `worker` for the android stack, a `verifier` for the web stack, etc. Same role contract narrowed to a domain. | `references/roles/<role>/<domain>/` (e.g. `roles/worker/android/`, `roles/verifier/web/`) | SquidSquad maintainers (shipped) |
-| **L4** — Project (per-install + role-class) | **Long-living** project-local customizations of one role-class for this install. Permanent or load-bearing facts about THIS project that diverge from default SquidSquad behaviour — not short-term cycle state. Sourced from human conversation in the deployed project. Includes project-specific instructions, project context (durable facts), identity overlays. (Does NOT include `vault` — L1-exclusive per §3.3.) | `.squidsquad/project/<role-class>.md` (project-local, not distributed) | Agent (via human conversation), persisted by `compose.py` |
+| **L1** — Base | What ANY SquidSquad agent is. Universal baseline: identity foundation, core principles, tracker protocol, cycle runner transport, inter-agent communication via forge (§5.1.1). Every role-class on every install starts from here. | `references/sub-skills/common/` (sub-skills L1 references) and the L1 portion of role source files | SquidSquad maintainers (shipped) |
+| **L2** — Role | Role-class-specific behaviours: `pm` coordinates, `verifier` verifies, `dm` packages, `worker` implements. The role-class-defining contract (responsibility, role-class-specific instructions, role-class-specific tone). | `references/roles/<role>/instructions.md` + `references/roles/<role>/SOUL.md` + `references/sub-skills/roles/<role>/` | SquidSquad maintainers (shipped) |
+| **L3** — Variant (role-class + domain) | Per-stack or per-domain specialization of a role-class: a `worker` for the android stack, a `verifier` for the web stack, etc. Same role-class contract narrowed to a domain. | `references/roles/<role>/<domain>/` (e.g. `roles/worker/android/`, `roles/verifier/web/`) | SquidSquad maintainers (shipped) |
+| **L4** — Project (per-install + role-class) | **Long-living** project-local customizations of one role-class for this install. Permanent or load-bearing facts about THIS project that diverge from default SquidSquad behaviour — not short-term cycle state. Sourced from human conversation in the deployed project. Includes project-specific instructions, project context (durable facts), identity overlays. (Does NOT include the `vault` slot — vault slot is L1-exclusive per §3.3.) | `.squidsquad/project/<role-class>.md` (project-local, not distributed) | Agent (via human conversation), persisted by `compose.py` |
 
-**Each layer is *more specific* than the previous**: L1 = every agent → L2 = this role → L3 = this role + this domain → L4 = this role + this domain + this install. Cross-cutting sub-skills like `vault-protocol`, `improvement-scan`, `git-commit`, `agent-lifecycle` live in `references/sub-skills/common/` and are **referenced from** the appropriate layer (usually L1) — they aren't a layer themselves; they're shared procedures that layered instructions invoke.
+**Each layer is *more specific* than the previous**: L1 = every agent → L2 = this role-class → L3 = this role-class + this domain → L4 = this role-class + this domain + this install. Cross-cutting sub-skills like `vault-protocol`, `improvement-scan`, `git-commit`, `agent-lifecycle` live in `references/sub-skills/common/` and are **referenced from** the appropriate layer (usually L1) — they aren't a layer themselves; they're shared procedures that layered instructions invoke.
 
 **Key invariant** — L1-L3 are part of the SquidSquad repo and ship globally. L4 is *generated and maintained per-install* by the agent in response to human instruction in the deployed project. L4 is the **long-living memory of how this project diverges from default SquidSquad behaviour** — permanent project traits, standing human preferences, and load-bearing facts. Short-term state (current phase, in-flight PRs, today's blockers, cycle counters) is **NOT** L4 — it belongs in `.squidsquad/vault/BRIEFING.md` (the working short-term summary) or the tracker itself.
 
@@ -133,7 +133,7 @@ flowchart TB
 
 Compose has **two distinct input axes**, easy to conflate:
 
-- **L1-L4 content layers** (this section's main subject) — *what* the agent reads in its composed CLAUDE.md. Layered by specificity (universal → role → variant → project-local). Files: `references/sub-skills/`, `references/roles/<role>/`, and `.squidsquad/project/<role-class>.md` (the per-role-class L4 file).
+- **L1-L4 content layers** (this section's main subject) — *what* the agent reads in its composed CLAUDE.md. Layered by specificity (universal → role-class → variant → project-local). Files: `references/sub-skills/`, `references/roles/<role>/`, and `.squidsquad/project/<role-class>.md` (the per-role-class L4 file).
 - **`.squidsquad/config.md`** — the install's **configuration**, not a content layer. Lives at `<project-root>/.squidsquad/config.md` (the **install root** = the project root directory that contains the `.squidsquad/` directory). It is a sibling of `.squidsquad/project/` and `.squidsquad/<alias>/`, NOT under `project/` — distinct from L4 files. **Format**: markdown body with structured fields as `- **Field**: value` bullets at the top (parsed by `config.py`), followed by an optional `## Aliases` H2 section listing each install-time alias → role-class + L3 domain mapping (used by `compose.py` for alias-existence validation and by `tracker.py` for routing). It declares install-level parameters: `Workers:` (the roster), `Iteration Interval`, top-level `event-driven:` mode flag, `Improvement Scanning:`, feature toggles, and the `squidsquad_version:` install-time stamp (read at upgrade time per INSTALLER-ARCH §10 step 2). Compose reads `config.md` to make compose-time *decisions* — which manifest to load (polling vs event per §6.5), what placeholder values to substitute, which roles exist for `compose.py deploy-all`, etc.
 
 The two axes interact at compose time. Examples:
@@ -198,7 +198,7 @@ flowchart LR
         L4A["one file, multiple<br/>H2 sections — each<br/>declares an op against<br/>one slot (§3.3)"]
     end
 
-    Gather{{"<b>Link</b> (§4.1–§4.5)<br/><br/>1. Gather all L1-L4 files for target role<br/>2. Group by slot<br/>3. Sort each group by ordinal<br/>4. Apply L4 ops<br/>&nbsp;&nbsp;&nbsp;(append / insert-before /<br/>&nbsp;&nbsp;&nbsp;insert-after / replace)<br/>5. Validate sub-skill refs"}}
+    Gather{{"<b>Link</b> (§4.1–§4.5)<br/><br/>1. Gather all L1-L4 files for target role-class<br/>2. Group by slot<br/>3. Sort each group by ordinal<br/>4. Apply L4 ops<br/>&nbsp;&nbsp;&nbsp;(append / insert-before /<br/>&nbsp;&nbsp;&nbsp;insert-after / replace)<br/>5. Validate sub-skill refs"}}
 
     L1A & L1B & L1C --> Gather
     L2A & L2B & L2C --> Gather
@@ -229,7 +229,7 @@ flowchart LR
 
 **Read this diagram from left to right**: each layer holds *many* files; each file declares one slot via frontmatter; compose gathers + groups + sorts, applies L4 ops, and the result lands in one of six composed sections. The same composed section is fed by files from multiple layers — Identity in the composed output is the concatenation of every `slot: identity` file from L1 + L2 + L3 (in ordinal order), then any L4 op applied on top.
 
-**Why this model** — sub-skills, role-specific fragments, and cross-cutting content can each live in their own source file with their own frontmatter, but still land in the right composed section. L4 ops target slots + step IDs (not source filenames), so reorganizing L1-L3 files doesn't break L4 customizations.
+**Why this model** — sub-skills, role-class-specific fragments, and cross-cutting content can each live in their own source file with their own frontmatter, but still land in the right composed section. L4 ops target slots + step IDs (not source filenames), so reorganizing L1-L3 files doesn't break L4 customizations.
 
 ---
 
@@ -253,7 +253,7 @@ step-ids: [step:cycle/<name>, step:boot/<name>, ...]  # for instructions slot on
 >
 > May be replaced by a regular `.md` with explicit frontmatter; the shorthand is equivalent, not load-bearing.
 >
-> (Responsibility-slot content used to have a parallel shorthand at `references/sub-skills/roles/<role>/responsibility.md`. That file is retired per §5.5; responsibility content now lives in the role's L2 source via explicit `slot: responsibility` frontmatter, not via filename convention. The shorthand is gone.)
+> (Responsibility-slot content used to have a parallel shorthand at `references/sub-skills/roles/<role>/responsibility.md`. That file is retired per §5.5; responsibility content now lives in the role-class's L2 source via explicit `slot: responsibility` frontmatter, not via filename convention. The shorthand is gone.)
 
 Ordinals are integers, non-dense (gaps allowed). Authors use gaps of 10 (e.g. 10, 20, 30) so future inserts don't require renumbering.
 
@@ -333,13 +333,13 @@ Not every op is legal on every slot. The soul slot is identity, not instruction,
 | `project-context` | append only | **L4-only slot** — L1-L3 cannot author this slot (no cross-install layer can know about a specific project — see §5.5). Compose rejects any L1-L3 source file with `slot: project-context` frontmatter. L4 entries seeded by installer Phase 1 + accumulated at runtime by `l4-curation`. |
 | `vault` | N/A (L1-exclusive — L4 cannot contain a `## Vault` section at all) | **Scope of "L1-exclusive"**: refers to *the composed `## Vault` section text in CLAUDE.md* — the short framework-shipped slot describing the vault contract (PARAG model, entity types, wikilink grammar, confidence levels). It does NOT refer to the on-disk vault knowledge store at `.squidsquad/vault/`, which is read/written at runtime by agents via vault sub-skills (see `references/sub-skills/common/vault-protocol.md` and VAULT-ARCH). The "Legal ops" column reflects what L4 H3 blocks may target; for vault specifically, this differs from other "no legal ops" rows — vault sections in L4 are *structurally forbidden*, not just op-restricted. Compose rejects any L2/L3/L4 source file with `slot: vault` frontmatter. (L1 fragments still compose via the normal `(slot, ordinal)` ordering — that's fragment combination, not an op.) Guardrail (2026-05-29): per-role / per-domain / per-project customization is currently disallowed to keep the vault contract stable; revisit if a concrete customization pattern emerges. See G4. |
 
-Compose **must reject** any L4 file whose section structure violates these constraints. Examples of rejections: a `### replace` (any form) H3 under `## Soul`; a bare `### replace` (no target) under any slot except `## Responsibility`; a step-targeted `### replace step:cycle/<step-id>` under `## Responsibility` (no step IDs to target there); any `## Vault` section in an L4 file (vault is L1-exclusive — see §5.6 + G4). Compose **also rejects** any L1-L3 source file that declares `slot: project-context` (Project Context is L4-exclusive — see §5.5), and any L2/L3/L4 source file that declares `slot: vault` (Vault is L1-exclusive — see §5.6).
+Compose **must reject** any L4 file whose section structure violates these constraints. Examples of rejections: a `### replace` (any form) H3 under `## Soul`; a bare `### replace` (no target) under any slot except `## Responsibility`; a step-targeted `### replace step:cycle/<step-id>` under `## Responsibility` (no step IDs to target there); any `## Vault` section in an L4 file (vault slot is L1-exclusive — see §5.6 + G4). Compose **also rejects** any L1-L3 source file that declares `slot: project-context` (Project Context is L4-exclusive — see §5.5), and any L2/L3/L4 source file that declares `slot: vault` (vault slot is L1-exclusive — see §5.6).
 
 > **Vault differs from other "no legal ops" rows.** For most slots, "no legal ops" means L4 may not perform any H3 op on that slot's content. Vault is stricter: a `## Vault` H2 section in an L4 file is *structurally forbidden* — compose rejects the entire L4 source file if it contains one. The N/A in the table is not "the slot exists but L4 has no ops to perform on it"; it means the slot must not appear in L4 at all.
 
 #### 3.4 Soul slot — semantic-merge precedence
 
-The soul slot encodes a role's identity (values, tone, professional posture). Because identity is not safe to overwrite positionally, soul L4 is restricted to append-only (per §3.3 above). At compose time, the L4 `## Soul` section content is concatenated after the shipped L1–L3 soul content within the slot.
+The soul slot encodes a role-class's identity (values, tone, professional posture). Because identity is not safe to overwrite positionally, soul L4 is restricted to append-only (per §3.3 above). At compose time, the L4 `## Soul` section content is concatenated after the shipped L1–L3 soul content within the slot.
 
 The composed CLAUDE.md therefore presents both views: shipped soul first, project-local append second. When an agent reads the composed soul section and notices that the L4 append contradicts the shipped L1–L3 soul, **the L4 append wins**. This semantic-merge precedence is a runtime rule the agent applies when interpreting its own composed identity, not a compose-time rewrite — the shipped soul stays on disk for traceability, and the precedence is settled by ordering convention (L4 last) plus an explicit precedence note that the soul slot emits at the L4 append boundary.
 
@@ -393,7 +393,7 @@ Compose is a **two-stage compiler**: **link** then **assemble**.
 
 | Stage | What it does | Determinism |
 |---|---|---|
-| **Link** (§4.1–§4.5) | Gather L1-L4 sources by slot, filter by role, sort by `(slot_index, ordinal)`, apply L4 ops (replace / insert-before / insert-after / append), validate sub-skill references. Produces the raw **linked** composite per slot. | Deterministic — given `(role, wake-mode, source-tree-hash, L4-tree-hash)`, the linked output is bit-stable. |
+| **Link** (§4.1–§4.5) | Gather L1-L4 sources by slot, filter by role-class, sort by `(slot_index, ordinal)`, apply L4 ops (replace / insert-before / insert-after / append), validate sub-skill references. Produces the raw **linked** composite per slot. | Deterministic — given `(role-class, wake-mode, source-tree-hash, L4-tree-hash)`, the linked output is bit-stable. |
 | **Assemble** (§4.6) | Each linked slot body is rewritten by an agent into a single coherent voice — eliminates contradictions, conditional negations, awkward insertions left over from op layering. Produces the final agent-consumable **assembled** prose. | Stochastic on first run; cached by `(linked-body, slot-purpose, model-id)` hash, so deterministic from the caller's POV across re-deploys with unchanged inputs. |
 
 Runtime agents read the **assembled** output (`.squidsquad/<alias>/CLAUDE.md`). The **linked** output is preserved as a sibling artifact (`.squidsquad/<alias>/CLAUDE.linked.md`) for audit, debugging, and fallback when the assemble pass fails. Both are git-tracked.
@@ -405,7 +405,7 @@ Runtime agents read the **assembled** output (`.squidsquad/<alias>/CLAUDE.md`). 
 Compose processes L1-L3 deterministically:
 
 1. **Collect**: walk `references/sub-skills/`, `references/roles/<role>/`. For each file with frontmatter, read its `slot` and `ordinal`. For files in the `instructions` slot, also extract the sub-skill name referenced in the file body (e.g. from `→ run sub-skill: <name>` directives) — this is a body-extracted reference, not a frontmatter field. Files whose frontmatter declares an L4-exclusive slot (`slot: project-context`) or a higher-layer-only slot (e.g., `slot: vault` from L2-L4) are **rejected with a diagnostic — compose aborts** with a clear error pointing at the offending file. This is a validation rule, not a silent skip — invalid frontmatter blocks composition entirely so the operator can fix the source.
-2. **Filter by role**: each file may declare which roles it applies to (via `roles:` frontmatter list; default = all). Files not applicable to the current role are dropped.
+2. **Filter by role-class**: each file may declare which role-classes it applies to (via `roles:` frontmatter list; default = all). Files not applicable to the current role-class are dropped.
 3. **Sort**: stable sort by `(slot_index, ordinal)`. `slot_index` is a fixed enum: identity=0, responsibility=1, soul=2, instructions=3, project-context=4, vault=5.
 4. **Emit orchestration**: under the appropriate top-level section header, emit each file's orchestration content verbatim. Inside the `instructions` slot, step bodies are **references to sub-skills by name** (e.g. `→ run sub-skill: pipeline-sentinel`) rather than inlined sub-skill content. The catalog of available sub-skills lives at [`sub-skill-catalog.md`](sub-skill-catalog.md) — composed CLAUDE.md never duplicates it.
 
@@ -426,7 +426,7 @@ After the L1-L3 base is in memory, compose reads exactly one L4 file: `.squidsqu
 3. Validate:
    - every `step:` reference resolves to a real L1-L3 step ID;
    - no two `replace` H3 blocks target the same ID;
-   - H3 op-types are legal for the enclosing slot per §3.3 per-slot constraints (e.g., `### replace` in any form is forbidden under `## Soul`, `## Identity`, and `## Project Context`; bare `### replace` (no target) is forbidden under `## Instructions` (only step-targeted `replace` is legal there); step-targeted `### replace step:…` is forbidden under `## Responsibility` (no step IDs to target); `## Vault` is forbidden entirely in L4 — vault is L1-exclusive per §3.3 + §5.6);
+   - H3 op-types are legal for the enclosing slot per §3.3 per-slot constraints (e.g., `### replace` in any form is forbidden under `## Soul`, `## Identity`, and `## Project Context`; bare `### replace` (no target) is forbidden under `## Instructions` (only step-targeted `replace` is legal there); step-targeted `### replace step:…` is forbidden under `## Responsibility` (no step IDs to target); `## Vault` is forbidden entirely in L4 — vault slot is L1-exclusive per §3.3 + §5.6);
    - every L4 `append` block under `## Instructions` contains at least one `→ run sub-skill: <name>` reference resolvable against the catalog (§4.5) — arbitrary prose without a reference aborts compose with a clear error.
 
 If validation fails, compose **aborts with a diagnostic** naming the offending H3 block. No partial output is written.
@@ -443,9 +443,9 @@ L4 is not instructions-only. Project customization spans every slot:
 | `soul` | A soul overlay tightening a default trait (e.g. "More formal tone in customer-facing communication.") |
 | `instructions` | Project-specific cycle step ("On every cycle, also check `incidents.md` for open SEV1 tickets.") |
 | `project-context` | "Production deploys go through `infra/deploy.sh`, not `gh`. Use the bundled script for any deployment work." |
-| `vault` | *(not L4-authorable — vault is L1-exclusive per §3.3 + §5.6. Projects that need bespoke vault behaviour file a framework feature request.)* |
+| `vault` | *(not L4-authorable — vault slot is L1-exclusive per §3.3 + §5.6. Projects that need bespoke vault behaviour file a framework feature request.)* |
 
-Op grammar varies per slot (see §3.3 "Per-slot op constraints"): `instructions` accepts all four ops (`append` / `insert-before` / `insert-after` / `replace`); `responsibility` accepts `append` plus a whole-slot `replace` (no step targeting); `identity` and `soul` are append-only; `project-context` is L4-exclusive append-only (L1-L3 reject); `vault` is L1-exclusive append-only (L2-L4 reject). This makes L4 the **single project-level customization mechanism** — there is no other place where deployed projects add or override behaviour — *except* the vault slot, which is framework-owned for now (see §5.6 + G4).
+Op grammar varies per slot (see §3.3 "Per-slot op constraints"): `instructions` accepts all four ops (`append` / `insert-before` / `insert-after` / `replace`); `responsibility` accepts `append` plus a whole-slot `replace` (no step targeting); `identity` and `soul` are append-only; `project-context` is L4-exclusive append-only (L1-L3 reject); `vault` slot is L1-exclusive (L2-L4 reject). This makes L4 the **single project-level customization mechanism** — there is no other place where deployed projects add or override behaviour — *except* the vault slot, which is framework-owned for now (see §5.6 + G4).
 
 ### 4.4 End-to-end pipeline (link + assemble)
 
@@ -487,7 +487,7 @@ flowchart TB
 
 `CLAUDE.linked.md` is written **only on full success**, alongside `CLAUDE.md` and `CLAUDE.conflicts.md`, in a single atomic write. There is no scenario where `CLAUDE.linked.md` exists without a successful `CLAUDE.md`.
 
-**Link stage determinism**: through `EmitLinked`, the pipeline is fully deterministic — given `(role, wake-mode, source-tree-hash, L4-tree-hash)`, the linked composite is bit-stable. **Assemble stage determinism**: the first uncached run is stochastic (LLM rewrite), but the result is cached by `hash(linked-body, slot-purpose, model-id)`; subsequent re-deploys with unchanged inputs reuse the cached assembled body and produce bit-stable output. First-run drift between equivalent rewrites is the irreducible trade-off for collapsing the layered linked output into coherent prose.
+**Link stage determinism**: through `EmitLinked`, the pipeline is fully deterministic — given `(role-class, wake-mode, source-tree-hash, L4-tree-hash)`, the linked composite is bit-stable. **Assemble stage determinism**: the first uncached run is stochastic (LLM rewrite), but the result is cached by `hash(linked-body, slot-purpose, model-id)`; subsequent re-deploys with unchanged inputs reuse the cached assembled body and produce bit-stable output. First-run drift between equivalent rewrites is the irreducible trade-off for collapsing the layered linked output into coherent prose.
 
 ### 4.5 Link: Sub-skill reference resolution
 
@@ -683,7 +683,7 @@ The link stage and the assemble stage are both load-bearing under this contract.
 
 ## 5. Composed-output structure
 
-Every role's composed `CLAUDE.md` has exactly **six top-level H2 sections**, in this order:
+Every role-class's composed `CLAUDE.md` has exactly **six top-level H2 sections**, in this order:
 
 ```
 # <Role> Agent
@@ -700,7 +700,7 @@ No other H2 may appear at the document top level. (Sub-sections at H3+ are unres
 
 ### 5.1 Identity
 
-- What this agent's primary function is (role-specific: "pm coordinates the squad", "verifier verifies worker output", etc.).
+- What this agent's primary function is (role-class-specific: "pm coordinates the squad", "verifier verifies worker output", etc.).
 - Team membership ("You are a SquidSquad agent on a four-role team: pm, verifier, worker, dm — see [AGENT-RUNTIME.md](AGENT-RUNTIME.md) Terminology section.").
 - Lifecycle governance ("Your wake mechanism — polling or event-driven — is determined by the harness. The harness owns all start/stop/restart authority.").
 - Team-awareness: who the other roles are and what they do (one short paragraph each).
@@ -752,7 +752,7 @@ sequenceDiagram
 
 ### 5.2 Responsibility
 
-The role-boundary contract: **what this role does, what it does NOT do, and why it matters.** Distinct from Identity (which is the short "what this agent is" headline) and from Soul (which is values/voice). Responsibility is the explicit enumeration of role scope that prevents drift into other roles' lanes.
+The role-class boundary contract: **what this role-class does, what it does NOT do, and why it matters.** Distinct from Identity (which is the short "what this agent is" headline) and from Soul (which is values/voice). Responsibility is the explicit enumeration of role-class scope that prevents drift into other role-classes' lanes.
 
 Typical structure within the section:
 
@@ -769,20 +769,20 @@ Typical structure within the section:
 (one paragraph framing the seam this role holds)
 ```
 
-**Responsibility is not a sub-skill.** Sub-skills are focused units of how-to (per [`sub-skill-catalog.md`](sub-skill-catalog.md)); responsibility is identity-layer content that defines *who the role is*, not *how it does things*. It is therefore composed as a dedicated slot — not via the sub-skill catalog.
+**Responsibility is not a sub-skill.** Sub-skills are focused units of how-to (per [`sub-skill-catalog.md`](sub-skill-catalog.md)); responsibility is identity-layer content that defines *who the role-class is*, not *how it does things*. It is therefore composed as a dedicated slot — not via the sub-skill catalog.
 
 **Authoring across layers:**
 
-- **L1** — universal team-discipline base (e.g. "every SquidSquad agent declines out-of-scope work by routing to the correct role, not by leaving it stalled").
-- **L2** — the role-specific does/doesn't/why contract. This is the primary authoring location for each role's responsibility content.
+- **L1** — universal team-discipline base (e.g. "every SquidSquad agent declines out-of-scope work by routing to the correct alias, not by leaving it stalled").
+- **L2** — the role-class-specific does/doesn't/why contract. This is the primary authoring location for each role-class's responsibility content.
 - **L3** — variant-specific additions (e.g. a frontend-specialized worker may add stack-specific "does NOT" rules around backend work).
-- **L4** — optional. Project-local installs may `append` extra role-boundary rules (e.g. "this project's PM also owns release-note review") OR `replace` the whole slot to fully redefine the role for an unusual install. See §3.3 per-slot op constraints.
+- **L4** — optional. Project-local installs may `append` extra role-class boundary rules (e.g. "this project's PM also owns release-note review") OR `replace` the whole slot to fully redefine the role-class for an unusual install. See §3.3 per-slot op constraints.
 
-The composed section stacks all L1-L3 responsibility content in `(slot, ordinal)` order (per §3.2), then applies any L4 op. With no L4 responsibility section, the role inherits L1-L3 unchanged.
+The composed section stacks all L1-L3 responsibility content in `(slot, ordinal)` order (per §3.2), then applies any L4 op. With no L4 responsibility section, the role-class inherits L1-L3 unchanged.
 
-> **Whole-slot `replace` on responsibility is an escape hatch, not a default tool.** Unlike `soul` (which is append-only with §3.4 semantic-merge precedence so shipped persona stays on disk), an L4 `### replace` on `## Responsibility` **silently discards the entire L1-L3 responsibility block** for that role — including L1's universal team-discipline base ("decline by routing to the correct role") and L2's role-specific does/does-NOT/why contract. The `l4-curation` elicitation dialog must surface this consequence to the human before persisting any whole-slot replace on responsibility, and route most "I want to change PM's boundaries" requests toward `append` instead. Whole-slot replace is intended for genuinely unusual installs where the shipped role contract doesn't apply (e.g. a single-human project that has no DM at all), not for incremental tweaks.
+> **Whole-slot `replace` on responsibility is an escape hatch, not a default tool.** Unlike `soul` (which is append-only with §3.4 semantic-merge precedence so shipped persona stays on disk), an L4 `### replace` on `## Responsibility` **silently discards the entire L1-L3 responsibility block** for that role-class — including L1's universal team-discipline base ("decline by routing to the correct alias") and L2's role-class-specific does/does-NOT/why contract. The `l4-curation` elicitation dialog must surface this consequence to the human before persisting any whole-slot replace on responsibility, and route most "I want to change PM's boundaries" requests toward `append` instead. Whole-slot replace is intended for genuinely unusual installs where the shipped role-class contract doesn't apply (e.g. a single-human project that has no DM at all), not for incremental tweaks.
 
-The team-awareness baseline (role roster — who else is on the team) lives in §5.1 Identity, *not* in this slot. Responsibility is the *self*-awareness content (what THIS role does and does NOT do); Identity carries the *team*-awareness content (who other roles are). The decline-and-route discipline that formerly lived in the retired `agent-boundaries` sub-skill is folded into this slot's "does NOT do" sub-section as the rule "decline out-of-scope work by routing to the role that owns it, never by leaving it stalled."
+The team-awareness baseline (role roster — who else is on the team) lives in §5.1 Identity, *not* in this slot. Responsibility is the *self*-awareness content (what THIS role-class does and does NOT do); Identity carries the *team*-awareness content (who other role-classes are). The decline-and-route discipline that formerly lived in the retired `agent-boundaries` sub-skill is folded into this slot's "does NOT do" sub-section as the rule "decline out-of-scope work by routing to the alias that owns it, never by leaving it stalled."
 
 ### 5.3 Soul
 
@@ -791,7 +791,7 @@ The agent's professional identity, voice, perspective. **A regular L1-L4 slot, n
 **Authoring across layers:**
 
 - **L1** — universal voice baseline (e.g. "speak in first person; never invent claims you cannot verify").
-- **L2** — role-specific persona. The conventional authoring filename is `references/roles/<role>/SOUL.md`, which compose treats as **shorthand for a file with `slot: soul, ordinal: 1` frontmatter**. No magic — just a documented filename convention so the source file is easy to find. A regular `.md` with explicit `slot: soul` frontmatter under `references/sub-skills/` or `references/roles/<role>/` works identically.
+- **L2** — role-class-specific persona. The conventional authoring filename is `references/roles/<role>/SOUL.md`, which compose treats as **shorthand for a file with `slot: soul, ordinal: 1` frontmatter**. No magic — just a documented filename convention so the source file is easy to find. A regular `.md` with explicit `slot: soul` frontmatter under `references/sub-skills/` or `references/roles/<role>/` works identically.
 - **L3** — variant-specific persona adjustments (e.g. a frontend-specialized worker's voice). Same frontmatter mechanism.
 - **L4** — optional. Lives inside the per-role-class L4 file (`.squidsquad/project/<role-class>.md`) under a `## Soul` H2 section per §3.3. The legacy `*-soul-directives.md` multi-file L4 pattern is deprecated (see §7.3).
 
@@ -865,7 +865,7 @@ Why no sub-skill: statusline writes are too granular (a single `cycle.py status-
 
 ### 5.5 Project Context
 
-Project-shaped descriptive facts — *what is true about this project / role*, not *how the role does work*. Concretely the slot covers:
+Project-shaped descriptive facts — *what is true about this project / role-class*, not *how the role-class does work*. Concretely the slot covers:
 
 - **Domain / audience** — what this project is, who uses it, what kind of project it is.
 - **Repositories of record, external systems, sensitive constraints, project-specific tone-or-language notes** — anything that's a project-level fact the agent needs to know but isn't an instruction.
@@ -895,12 +895,22 @@ L4 op grammar for this slot is **`append`-only** per §3.3 — no targeted ops, 
 
 ### 5.6 Vault
 
+> **Vault terminology** — this doc and VAULT-ARCH use three distinct terms; conflating them is the source of long-running audit confusion:
+>
+> | Term | What it is | Authored by | Read by |
+> |---|---|---|---|
+> | **vault slot** | The `## Vault` H2 section in composed CLAUDE.md — short framework-shipped prose describing the vault contract | L1 only (this slot is L1-exclusive per §3.3) | Runtime agents at boot |
+> | **vault store** | The on-disk knowledge store at `.squidsquad/vault/` (markdown notes organized via PARAG) | All agents at runtime via vault sub-skills (vault-remember, etc.) | All agents at runtime |
+> | **vault contract** | The framework-owned design spec — PARAG taxonomy, entity types, wikilink grammar, confidence levels | SquidSquad framework (`references/sub-skills/common/vault-protocol.md` + VAULT-ARCH) | Vault sub-skills + agents that read the slot |
+>
+> When this doc says "vault" without a qualifier, assume the most specific applicable term from context. When the meaning is structurally significant (e.g., "L1-exclusive"), the qualifier is mandatory.
+
 - A short description of the shared memory layer the agent reads/writes.
 - Wikilink format reminder, entity model, confidence levels.
 
-**Vault slot is L1-exclusive.** L2 / L3 / L4 do NOT author this slot — compose rejects any `slot: vault` fragment from those layers (per §3.3). The rationale: the vault is a SquidSquad framework feature with a precise contract (PARAG model, entity types, wikilink grammar, confidence levels — see [`VAULT-ARCH.md`](VAULT-ARCH.md)). Per-role, per-domain, or per-project customization of the slot body would fragment that contract before we have a clear customization pattern to standardize on. Projects that need bespoke vault behaviour file a framework feature request — see G4. Guardrail dated 2026-05-29; revisit when a real customization need surfaces.
+**Vault slot is L1-exclusive.** L2 / L3 / L4 do NOT author this slot — compose rejects any `slot: vault` fragment from those layers (per §3.3). The rationale: the vault contract is a SquidSquad framework feature with a precise spec (PARAG model, entity types, wikilink grammar, confidence levels — see [`VAULT-ARCH.md`](VAULT-ARCH.md)). Per-role, per-domain, or per-project customization of the vault slot body would fragment that contract before we have a clear customization pattern to standardize on. Projects that need bespoke vault behaviour file a framework feature request — see G4. Guardrail dated 2026-05-29; revisit when a real customization need surfaces.
 
-This section is intentionally short — most vault detail belongs in `references/sub-skills/common/vault-protocol.md` (per-cycle usage contract) and [`VAULT-ARCH.md`](VAULT-ARCH.md) (vault architecture: PARAG model, entity types, sub-skills, scripts, cycle integration).
+This section is intentionally short — most vault detail belongs in `references/sub-skills/common/vault-protocol.md` (per-cycle usage contract) and [`VAULT-ARCH.md`](VAULT-ARCH.md) (vault store architecture: PARAG model, entity types, sub-skills, scripts, cycle integration).
 
 ### 5.7 Worked example: pm composed CLAUDE.md TOC (both modes)
 
@@ -1173,7 +1183,7 @@ SquidSquad agents support two wake mechanisms: **event-driven** (a harness-manag
 **Architectural rule** (matches today's `compose.py` implementation per #8697): the two modes are **two parallel manifests selected at compose time**, not a runtime branch.
 
 - `references/roles/<role>/includes.yml`        — polling manifest (default)
-- `references/roles/<role>/includes-events.yml` — event-driven manifest. If the role hasn't been ported to event mode yet and this file is absent while `event-driven: yes` is set globally, compose silently uses the polling manifest for that role; this is a **per-role compose-time** fallback distinct from the operator-level mode flip in AGENT-RUNTIME §8.2.
+- `references/roles/<role>/includes-events.yml` — event-driven manifest. If the role-class hasn't been ported to event mode yet and this file is absent while `event-driven: yes` is set globally, compose silently uses the polling manifest for that role-class; this is a **per-role-class compose-time** fallback distinct from the operator-level mode flip in AGENT-RUNTIME §8.2.
 
 `compose.py:_load_manifest` reads `config.get_wake_mode()` (a global flag — there is no per-role wake mode; see AGENT-RUNTIME §8.1) and chooses the manifest; `_resolve_includes_with_manifest` then renders the chosen manifest in full. There are **no mode-conditional directives inside fragments** — the manifest is the gate. The agent receives one fully-resolved CLAUDE.md whose §4.2 is shaped for exactly one mode. Mid-session mode flips do not exist; an operator flipping `.squidsquad/config.md` from `polling` to `event-driven` (or vice versa) takes effect on the next compose+restart.
 
@@ -1198,7 +1208,7 @@ Mode flip = recompose + agent restart, never mid-session. The two outputs differ
 
 - Keeps fragment bodies clean — no `{% if event %}…{% else %}…{% endif %}` ladders in human-authored prose.
 - Lets each mode evolve its sub-skill set independently (event mode pulls in `common-events/*`; polling pulls in `roles/<role>/ralph-loop-overview` + sentinel + check-in).
-- Composes deterministically — given (role, wake-mode), the output is bit-stable; reviewable in PRs without runtime context.
+- Composes deterministically — given (role-class, wake-mode), the output is bit-stable; reviewable in PRs without runtime context.
 - Matches harness reality — the harness decides mode at agent-spawn time; trying to defer that decision into the agent process adds complexity for no gain.
 
 **Why event is treated as the canonical/primary track** (even though both manifests are first-class):
@@ -1211,25 +1221,25 @@ Mode flip = recompose + agent restart, never mid-session. The two outputs differ
 **Why polling is kept as a fully maintained parallel manifest, not deleted**:
 
 - Polling has proven stable across harness outages — it does not depend on a live harness HTTP endpoint.
-- The polling manifest is the documented compose-time fallback when `includes-events.yml` is absent for a role (e.g. a new role not yet ported to event mode).
+- The polling manifest is the documented compose-time fallback when `includes-events.yml` is absent for a role-class (e.g. a new role-class not yet ported to event mode).
 - Polling stays available as the **manual recovery target** when event-mode is failing for any reason (harness wedged, event-bus regression, etc.). Recovery is an explicit operator action — flip `event-driven: no` in `.squidsquad/config.md`, recompose, restart. There is no automatic runtime fallback (see AGENT-RUNTIME §8.4).
 - Operators may explicitly select polling via `.squidsquad/config.md` (`event-driven: no`) while debugging the event bus, or until event mode reaches GA in their install.
 
-**Authoring discipline**: both manifests must stay in sync on what an agent *does* — same status transitions, same comment etiquette, same vault behaviors. Only the *how* differs (event stream vs `/loop` tick). The two `5.7.x` worked examples should diff only on §4.2; if a non-§4.2 section diverges between modes, that is a bug, not a feature.
+**Authoring discipline**: both manifests must stay in sync on what an agent *does* — same status transitions, same comment etiquette, same vault store behaviors. Only the *how* differs (event stream vs `/loop` tick). The two `5.7.x` worked examples should diff only on §4.2; if a non-§4.2 section diverges between modes, that is a bug, not a feature.
 
 **Current development convention** (as of this doc — pre-event-GA): every role's `includes.yml` and `includes-events.yml` are both maintained, but most installs ship with `.squidsquad/config.md` `event-driven: no` so the polling manifest is what gets composed in production. The event manifest is exercised in CI and on opt-in installs; it becomes the default once event mode reaches GA. This lets us iterate the event-mode authoring (and lets reviewers diff the two flavored outputs) without forcing production fleets onto event mode before it is proven.
 
 ### 6.6 Subagent invocation rules — moved to AGENT-RUNTIME §6.7
 
-Subagent usage rules (default model selection, per-role overrides, spawn-vs-inline, prompt hygiene, trust-but-verify, parallelism) are runtime behavior — they describe how an agent uses the Agent tool while it's running, not compose-time mechanics. The rules now live in [AGENT-RUNTIME.md §6.7](AGENT-RUNTIME.md#67-subagent-invocation-rules).
+Subagent usage rules (default model selection, per-role-class overrides, spawn-vs-inline, prompt hygiene, trust-but-verify, parallelism) are runtime behavior — they describe how an agent uses the Agent tool while it's running, not compose-time mechanics. The rules now live in [AGENT-RUNTIME.md §6.7](AGENT-RUNTIME.md#67-subagent-invocation-rules).
 
-The L1-L3 authoring location for these rules remains compose-side: the default-model paragraph is authored once at L1 (e.g. `references/sub-skills/common/subagent-defaults.md` with `slot: identity`). Per-role L3 files (under `references/sub-skills/roles/<role>/`) declare their own slot-`identity` content that emits later in `(slot, ordinal)` order — effectively overriding the default for that role at compose time. The composition mechanism is no different from any other L1-L3 source; see §3.2 for the general slot+ordinal contract.
+The L1-L3 authoring location for these rules remains compose-side: the default-model paragraph is authored once at L1 (e.g. `references/sub-skills/common/subagent-defaults.md` with `slot: identity`). Per-role-class L3 files (under `references/sub-skills/roles/<role>/`) declare their own slot-`identity` content that emits later in `(slot, ordinal)` order — effectively overriding the default for that role-class at compose time. The composition mechanism is no different from any other L1-L3 source; see §3.2 for the general slot+ordinal contract.
 
 ---
 
 ## 7. Runtime L4 writes by the agent
 
-The agent (any role) writes to L4 at runtime in response to human instructions in the deployed project. This section covers the *write path* — the structural compose mechanics, the safety gates, and the audit trail. The *upstream dialog* (how the agent detects a customization request, elicits scope and rationale from the human, and chooses the right L4 bucket) is owned by `references/sub-skills/common/l4-curation.md` — see §7.7 for the boundary.
+The agent (of any role-class) writes to L4 at runtime in response to human instructions in the deployed project. This section covers the *write path* — the structural compose mechanics, the safety gates, and the audit trail. The *upstream dialog* (how the agent detects a customization request, elicits scope and rationale from the human, and chooses the right L4 bucket) is owned by `references/sub-skills/common/l4-curation.md` — see §7.7 for the boundary.
 
 ### 7.1 The trigger
 
@@ -1241,7 +1251,7 @@ When the human gives the agent a new instruction in conversation:
 
 These are project-specific instruction changes. They don't belong in L1-L3 (which ships globally) — they belong in L4 (which is project-local).
 
-The `l4-curation` sub-skill defines the detection patterns (durable vs one-off, customization vs feature request) and the elicitation dialog (role + bucket + why + edge cases + draft + approval). By the time §7.2's decision tree fires, the curation sub-skill has already produced a well-scoped request with an identified bucket; §7.2 just classifies the structural op.
+The `l4-curation` sub-skill defines the detection patterns (durable vs one-off, customization vs feature request) and the elicitation dialog (role-class + bucket + why + edge cases + draft + approval). By the time §7.2's decision tree fires, the curation sub-skill has already produced a well-scoped request with an identified bucket; §7.2 just classifies the structural op.
 
 **Conflict pre-emption (paired with §4.6 assemble-pass conflict resolution).** Before drafting any new L4 op, `l4-curation` MUST read the linked composite for the target slot and check whether the new entry would materially contradict existing L1-L3 prose. The assemble pass (§4.6) WILL detect such conflicts at compose time and prefer the higher layer, but a clean L4 author avoids creating them in the first place. When `l4-curation` detects a likely conflict, it must:
 
@@ -1368,7 +1378,7 @@ Every L4 write is:
 
 - A separate file in `.squidsquad/project/`.
 - Committed as its own git commit on main with message `<role>: L4 write — <slot>/<op>/<target>` and a body quoting the human directive verbatim.
-- Logged in the role's iteration file for the cycle that performed the write.
+- Logged in the alias's iteration file for the cycle that performed the write.
 - Reversible: a human can `git revert` the L4 commit, or the agent can produce a counter-L4 file (`replace` with empty body, or matching `insert-before` removal).
 
 The composed `.squidsquad/<alias>/CLAUDE.md` for **every alias** of the affected role-class regenerates on each L4 write (compose runs as a post-commit hook for files in `.squidsquad/project/`). Two `worker`-class instances sharing one L4 file produce two regenerated CLAUDE.md files at their respective alias paths.
@@ -1445,7 +1455,7 @@ A GitHub Actions check (or local pre-commit hook) inspects every PR:
 
 - Commits the diff to main as a follow-up commit: `dm: post-merge recompose for #<PR>`.
 - Comments on the original PR with the diff for traceability.
-- Files a `severity:low` bug against the role that owned the PR — they should have run compose before pushing.
+- Files a `severity:low` bug against the alias that owned the PR — they should have run compose before pushing.
 
 ### 8.3 Pre-ship gate
 
@@ -1546,18 +1556,18 @@ This collapses today's two-system memory architecture (per-user memory + L4) int
 
 1. ~~**Soul overlay semantics**~~ **CLOSED** — see §3.3 per-slot op constraints + §3.4. Soul L4 is append-only (no targeted ops). The composed CLAUDE.md presents shipped soul + L4 append in order; on semantic conflict between them, L4 wins at the agent's interpretation layer. The shipped soul stays on disk for traceability; only the agent's runtime interpretation is overridden.
 2. ~~**L4 conflict resolution**~~ **CLOSED** — see §3.3 + §7.3. Each agent class has exactly one L4 file; within that file, two `### replace step:cycle/<step-id>` H3 blocks targeting the same step is a validation error and aborts compose. The author resolves the conflict by editing the file.
-3. ~~**Multi-role L4 files**~~ **CLOSED** — see §3.3 + §7.3. L4 is **one file per agent class** (`.squidsquad/project/<role>.md`); role-scoping is the filename. There is no multi-role L4; cross-role customizations expand to one per-role file.
+3. ~~**Multi-role-class L4 files**~~ **CLOSED** — see §3.3 + §7.3. L4 is **one file per agent class** (`.squidsquad/project/<role>.md`); role-class-scoping is the filename. There is no multi-role-class L4; cross-role-class customizations expand to one per-role-class file.
 4. ~~**L4 versioning**~~ **CLOSED** — see §6.1 "Renaming a step ID". Compose-time migration emits a warning when it sees an L4 H3 block targeting an old (renamed) step ID, and offers an auto-rewrite or aborts pending operator confirmation.
 5. **Composed output as derived artifact** — should `.squidsquad/<alias>/CLAUDE.md` be `.gitignore`d (always regenerated, never committed) instead of committed-and-diffed? (Trade-off: gitignore eliminates §8.1 PR-check entirely but loses easy historical review.)
 
 ### 11.2 Known gaps in this doc
 
 - **G1** — ✅ CLOSED (v2). Step ID grammar formalized in §6.1 (BNF + character set + nesting depth + global uniqueness rule).
-- **G2** — Compose's role-filter (§4.1 step 2) is sketched but not fully specified: what does the `roles:` frontmatter list support beyond literal role names? (e.g. wildcards like `*`, role classes like `worker:*`.) For v2, only literal role names are supported; wildcards/classes are deferred.
+- **G2** — Compose's role-class filter (§4.1 step 2) is sketched but not fully specified: what does the `roles:` frontmatter list support beyond literal role-class names? (e.g. wildcards like `*`, role classes like `worker:*`.) For v2, only literal role-class names are supported; wildcards/classes are deferred.
 - **G3** — Boot/cycle/shutdown sub-slot boundaries inside `instructions` are still informal. v2 working definition: `boot` = one-time session-start work; `cycle` = repeated work (per `/loop` tick in polling mode, per nudge in event mode — see [AGENT-RUNTIME.md](AGENT-RUNTIME.md)); `shutdown` = clean-stop work. Formal acceptance tests for sub-slot membership are a follow-up.
-- **G4** — ✅ CLOSED (2026-05-29). [`VAULT-ARCH.md`](VAULT-ARCH.md) covers entity types (§4), wikilink grammar (§4.5), confidence levels (§4.4), and the relationship to `vault-protocol.md` (§7). The remaining "slot contract" gap is closed by making the slot **L1-exclusive** (§3.3 + §5.6) — only the L1 short-descriptor pattern is valid; L2-L4 cannot author this slot. Guardrail rationale: the vault is a framework feature whose contract should not fragment across roles/domains/installs without a concrete customization pattern. Revisit when a real customization need surfaces; the framing then is "introduce L2 vault customization with constraints X/Y/Z" rather than "open up arbitrary append".
+- **G4** — ✅ CLOSED (2026-05-29). [`VAULT-ARCH.md`](VAULT-ARCH.md) covers entity types (§4), wikilink grammar (§4.5), confidence levels (§4.4), and the relationship to `vault-protocol.md` (§7). The remaining "slot contract" gap is closed by making the slot **L1-exclusive** (§3.3 + §5.6) — only the L1 short-descriptor pattern is valid; L2-L4 cannot author this slot. Guardrail rationale: the vault contract is a framework feature that should not fragment across roles/domains/installs without a concrete customization pattern. Revisit when a real customization need surfaces; the framing then is "introduce L2 vault customization with constraints X/Y/Z" rather than "open up arbitrary append".
 - ~~**G5** — L4 file naming collision rules~~ **CLOSED** — see §7.3. There is exactly one L4 file per role-class, named `<role-class>.md` (e.g. `pm.md`, `fe-worker.md`, `be-worker.md` in installs with worker specialization; `pm.md`, `worker.md`, `verifier.md`, `dm.md` in installs without). The filename IS the role-class identity — collision is structurally impossible since each role-class has exactly one expected filename.
-- **G6** — ✅ CLOSED (v2). Subagent usage rules now in [AGENT-RUNTIME §6.7](AGENT-RUNTIME.md#67-subagent-invocation-rules) (default-model + per-role overrides + spawn-vs-inline + prompt hygiene + parallelism + trust-but-verify). L3 `replace` overlays on the L1 default cover the per-role Sonnet defaults for `worker`/`dm`. Rules originally added to COMPOSE §6.6 then relocated to AGENT-RUNTIME because they describe runtime behavior, not compose mechanics.
+- **G6** — ✅ CLOSED (v2). Subagent usage rules now in [AGENT-RUNTIME §6.7](AGENT-RUNTIME.md#67-subagent-invocation-rules) (default-model + per-role-class overrides + spawn-vs-inline + prompt hygiene + parallelism + trust-but-verify). L3 `replace` overlays on the L1 default cover the per-role-class Sonnet defaults for `worker`/`dm`. Rules originally added to COMPOSE §6.6 then relocated to AGENT-RUNTIME because they describe runtime behavior, not compose mechanics.
 - **G7** — Sub-skill reference resolution semantics for L4. Open: can L4 *insert* a new step that references a sub-skill not yet referenced anywhere in L1-L3? Yes per §4.5 (catalog is the source of truth, not the L1-L3 reference set), but the L4-write decision tree in §7.2 should explicitly cover the "introduce a new sub-skill reference" case.
 
 Each open gap is filed for explicit closure in §12.
@@ -1566,7 +1576,7 @@ Each open gap is filed for explicit closure in §12.
 
 ## 12. Closure plan (implementation epic)
 
-Once this doc is merged, the implementation epic spawns these sub-PRs in order. Each is filed as its own task issue against the assigned role.
+Once this doc is merged, the implementation epic spawns these sub-PRs in order. Each is filed as its own task issue against the assigned alias.
 
 | # | Title | Owner | Depends on |
 |---|---|---|---|

--- a/docs/HARNESS-ARCH.md
+++ b/docs/HARNESS-ARCH.md
@@ -245,11 +245,32 @@ Crash transitions: `booting → crashed` (boot failure — `booted` event never 
 
 ### 7.2 Spawn (`boot_agent`)
 
-1. Read agent's clone path from the in-memory `AgentState` (which the harness populated at boot from `.squidsquad/.harness-state.json`'s per-alias `clone_path` field — see §7.5). The installer-written `.squidsquad/.local-config` is the source-of-truth at install/boot time; once the harness is up, `.harness-state.json` is the operational source.
-2. Spawn platform-appropriate launcher → `thin_launcher.py` → `claude`.
-3. Spawn sibling `event_poll.py --wait --role <role> --target stdout` process. `event_poll` begins polling on spawn; the durable deque covers boot-time events. The `booted` handshake (step 4) gates whether the agent is considered ready to receive routed work, not whether `event_poll` is active.
-4. Wait for `booted` event from agent (cursor-clean handshake).
-5. Update `.squidsquad/.harness-state.json` with the new PID + boot time.
+This is the **canonical step-by-step ordering** for the agent boot sequence. All other docs defer here for process-spawn ordering.
+
+1. Resolve clone path for the alias from in-memory `AgentState` (loaded from `.squidsquad/.harness-state.json` at harness start; on first boot, populated from `.squidsquad/.local-config` per §7.2 "First-boot discovery" below).
+2. Spawn the platform-appropriate launcher (`wt.exe` / Terminal / x-terminal-emulator) → `thin_launcher.py` in the agent's clone dir.
+3. `thin_launcher.py` writes its PID to `.squidsquad/<alias>/.claude-pid` (sentinel: "harness has spawned this alias"), then spawns `claude` (Anthropic CLI) as its child.
+4. **In parallel** with steps 2–3, the harness spawns the sibling `event_poll.py --wait --role <alias> --target stdout` directly (not under the launcher chain). `event_poll` begins polling the harness HTTP API immediately on spawn. **Note**: `event_poll` and `claude` are siblings — neither is the other's parent. The harness owns both.
+5. The harness awaits the `booted` event from the agent (cursor-clean handshake). Until `booted` arrives, the agent is in `status=booting`; any `assigned-to` events queued for this alias remain in the harness deque and are delivered only after `status=ready`.
+6. On `booted` receipt, agent transitions `status=booting → ready`. Routed work (`POST /work/assign`) is now deliverable. The harness then updates `.squidsquad/.harness-state.json` with the new PID + boot time.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant H as Harness
+    participant L as Launcher (wt.exe / Terminal)
+    participant TL as thin_launcher.py
+    participant C as claude.exe
+    participant EP as event_poll.py
+    H->>L: spawn launcher in clone dir
+    L->>TL: launch thin_launcher
+    TL->>TL: write .claude-pid
+    TL->>C: spawn claude (child)
+    H->>EP: spawn event_poll (sibling — parallel)
+    EP->>H: GET /events/for/<alias> (begins polling)
+    C->>H: POST /events { type: booted }
+    H->>H: status: booting → ready
+```
 
 #### First-boot discovery
 
@@ -307,7 +328,7 @@ Two fields, not one, so recovery semantics are explicit: after a host reboot the
 
 **PID fields**: the state file always carries `claude_pid` and `terminal_pid` as separate fields — they are independently useful for diagnostics (which process is Claude vs. which is the terminal wrapper) and for singleton checks (harness checks `claude_pid` liveness directly). The API response's post-#10358 single `pid` field (see §4.1) is a derived view computed from these two state-file fields, not a replacement for them.
 
-Atomic writes (`.tmp` + `mv`). On harness restart, the file is read; each agent is checked for liveness (PIDs still alive?); intents are preserved. Note: the outer agent key is the **alias** (e.g. `skill`, `verifier`); each agent's *categorical* role is not currently persisted in this file — it's derived from `.squidsquad/config.md` at boot. Source of truth: `HarnessState.save_state()` in `references/scripts/harness.py`.
+Atomic writes (`.tmp` + `mv`). On harness restart, the file is read; each agent is checked for liveness (PIDs still alive?); intents are preserved. Note: the outer agent key is the **alias** (e.g. `skill`, `verifier`); each agent's *categorical* role-class is not currently persisted in this file — it's derived from `.squidsquad/config.md` at boot. Source of truth: `HarnessState.save_state()` in `references/scripts/harness.py`.
 
 ---
 
@@ -331,7 +352,7 @@ When the port file is missing, the harness is treated as not running. Event-bus 
 
 ## 9. State files (summary)
 
-Per-agent directories under `.squidsquad/` are keyed by **alias**, not by the L2 categorical role (which can have multiple aliases per install — e.g. the `worker` role aliased as `skill` here, `frontend`/`backend` elsewhere). The alias is the install-time name the operator assigned to an agent instance, and is what shows up as a directory on disk. The harness-owned files in the top-level `.squidsquad/` directory hold per-alias state internally (e.g. `.squidsquad/.harness-state.json` keys agents by alias).
+Per-agent directories under `.squidsquad/` are keyed by **alias**, not by the L2 categorical role-class (which can have multiple aliases per install — e.g. the `worker` role-class aliased as `skill` here, `frontend`/`backend` elsewhere). The alias is the install-time name the operator assigned to an agent instance, and is what shows up as a directory on disk. The harness-owned files in the top-level `.squidsquad/` directory hold per-alias state internally (e.g. `.squidsquad/.harness-state.json` keys agents by alias).
 
 | File | Owner | Persisted | Purpose |
 |---|---|---|---|
@@ -531,6 +552,7 @@ In landing order:
 
 ## 15. Revision log
 
+- **2026-05-30 (v5)** — Root-cause fix #3: boot sequence cross-doc fragmentation. §7.2 designated canonical authoritative source for agent boot sequence; expanded from 5 to 6 prose steps with explicit parallel-spawn language; added Mermaid sequence diagram (first and only process-spawn diagram in the docs). AGENT-RUNTIME §7.0 spawn-ordering sentence removed and replaced with cross-reference. AGENT-RUNTIME §7.2 full sequence diagram removed; replaced with agent-side-only 5-step list + cross-reference to this section.
 - **2026-05-30 (v4)** — PR #10378 round-5 audit pass. H1: moved `event_poll.py` INTO the §14.1 "Before" tree as an explicit sibling subtree under harness (was blockquote-only). H2: added "First-boot discovery" subsection in §7.2 documenting `.local-config` as the bootstrap source when `.harness-state.json` does not exist. M1: tightened §2 start.sh trigger wording to "unreachable (port file missing or HTTP probe fails)" — removes ambiguous "not running OR". M2: updated §9 `.event-state.json` Purpose column to explicitly exclude the deque (deque is in-memory only per §5.1).
 - **2026-05-30 (v3)** — PR #10378 round-4 audit pass. H1: annotated `event_poll.py` as a separate sibling subtree in §14.1 (was absent from the "Before" tree). Cross/INSTALLER M1: tightened §2 start.sh trigger wording to distinguish "not running OR unreachable" from "running-and-reachable" upgrade path. M1: added one-time `boot_agent(role)` alias-value clarification on first occurrence in §3 (rename tracked in #10358). H2 (§9 `.event-state.json` row): pre-existing on this branch — no change needed.
 - **2026-05-27 (v2)** — Added §14 proposed-simplification block. End-to-end validated by experiment scripts under `references/experiments/`. Status banner updated to reflect that the doc now contains both descriptive (§§1–13) and proposal (§14) content.

--- a/docs/HARNESS-ARCH.md
+++ b/docs/HARNESS-ARCH.md
@@ -69,11 +69,11 @@ All endpoints serve from `http://127.0.0.1:<port>`. Localhost-only; no authentic
 
 | Method | Path | Purpose | Returns |
 |---|---|---|---|
-| GET | `/status` | Harness liveness + code version + intent summary | `{version, code_version, agents: [...], harness_state}` |
+| GET | `/status` | Harness liveness + code version + intent summary | `{version, code_version, agents: [...], harness_state}` — `version` is the harness wire-protocol version (integer); `code_version` is the harness build identifier (git short-SHA or package version string) |
 | GET | `/` | Root — alias for `/status` (legacy convenience) | Same as `/status` |
-| GET | `/agents` | List all known agents + their current state | `[{role, alias, intent, pid, clone_path, boot_time, ...}]` |
-| GET | `/agents/{role}` | Single agent state | `{role, alias, intent, pid, clone_path, boot_time, last_seen}` |
-| GET | `/agents/{role}/health` | PID-based liveness probe for one agent | `{role, alias, alive, pid, last_seen}` |
+| GET | `/agents` | List all known agents + their current state | `[{role, alias, intent, status, pid, clone_path, boot_time, ...}]` |
+| GET | `/agents/{role}` | Single agent state | `{role, alias, intent, status, pid, clone_path, boot_time, last_seen}` |
+| GET | `/agents/{role}/health` | PID-based liveness probe for one agent | `{role, alias, alive, intent, status, pid, last_seen}` |
 | GET | `/agents/{role}/config` | Per-agent install config (clone path, etc.) | `{clone_path, ...}` |
 | POST | `/agents/{role}/start` | Set intent=running, spawn if not alive | `{ok, role, alias, action}` |
 | POST | `/agents/{role}/stop` | Set intent=stopping; cooperative shutdown | `{ok, role, alias}` |
@@ -195,11 +195,12 @@ default state: active (10s between polls)
   3 consecutive empty polls at 10s? → step up to 30s
   3 more consecutive empty polls at 30s? → step up to 60s (ceiling)
   changes return after any backoff? → reset to 10s
-  hard floor: 5s   (avoid forge rate-limit)
   hard ceiling: 60s
 ```
 
-Two-tier backoff: 10s → 30s → 60s. A drained queue stabilizes at 60s after ≥6 consecutive empty polls (~2 minutes idle).
+The cadence floor is 10s — the documented backoff never reduces below the default active interval. A hard 5s floor is reserved at the implementation level as a rate-limit safety guard for any future burst-on-event refinement, but no rule today drives the cadence below 10s.
+
+Three-stage cadence: 10s → 30s → 60s (two backoff transitions). A drained queue stabilizes at 60s after ≥6 consecutive empty polls (~2 minutes idle).
 
 ### 6.3 Restart safety
 
@@ -280,10 +281,12 @@ sequenceDiagram
 
 Every 5 seconds, for each agent with intent=`running`:
 
-1. Read `.claude-pid` from agent's `.squidsquad/<alias>/.claude-pid`.
-2. Check process liveness (`OpenProcess` on Windows, `kill -0` on POSIX).
+1. Read `claude_pid` (and `terminal_pid` for diagnostics) from in-memory `AgentState` — loaded at boot from `.harness-state.json`'s per-alias record (§7.5). The on-disk `.squidsquad/<alias>/.claude-pid` file is the singleton handle written by `thin_launcher` (contents = `cmd.exe` / shell PID, per §9); it is NOT what health-poll reads.
+2. Check process liveness of `claude_pid` (`OpenProcess` on Windows, `kill -0` on POSIX). The §5.5 "per-agent `claude` PID" check refers to this in-memory `claude_pid` value, not the `.claude-pid` file.
 3. If dead AND intent=`running`: re-spawn (auto-respawn).
 4. If dead AND intent=`stopping` or `restarting`: handle per intent.
+
+> **PID-source disambiguation** (recap): three distinct PID locations exist today — (a) `.squidsquad/<alias>/.claude-pid` on disk = `cmd.exe`/shell wrapper PID, written by `thin_launcher`, used by `thin_launcher`'s own singleton check; (b) `.harness-state.json` → per-alias `claude_pid` = the `claude.exe` PID resolved via descendant walk; (c) `.harness-state.json` → per-alias `terminal_pid` = wrapper PID, kept for diagnostics. Health-poll uses (b). Under the §14 proposal, (a) goes away — `thin_launcher` is deleted and the harness owns `claude_pid` resolution directly.
 
 ### 7.4 Cooperative exit (exit-42)
 
@@ -308,7 +311,7 @@ One file per install (at the install root). Persisted across harness restarts. S
     "<alias>": {
       "intent": "running",
       "intent_set_at": "2026-05-25T18:30:00Z",
-      "status": "running",
+      "status": "ready",
       "boot_time": "2026-05-25T18:00:00Z",
       "clone_path": "D:/Dev/Dev/SquidSquad-2",
       "claude_pid": 23456,
@@ -367,6 +370,8 @@ Per-agent directories under `.squidsquad/` are keyed by **alias**, not by the L2
 
 All harness-owned files are atomic-write (`.tmp` + `mv`) and persisted across restarts. The deque is the one piece of harness state that is NOT persisted.
 
+> **Reserved alias — `human`:** the alias `human` is a virtual queue target — it never corresponds to a spawned agent process. Only `GET /queue/human` (and the human work-queue filter in §4.4) reference it; the harness does not run lifecycle, health-poll, or PID tracking for it.
+
 > **Vocabulary note — `role` vs `alias`:** the codebase (FastAPI routes, `AgentState.role`, event-poll `--role` flag, `SQUIDSQUAD_ROLE` env var) uses the identifier `role` everywhere; the §4 HTTP API path-parameter `{role}` reflects that. **In every one of those places, the value is actually the alias** (e.g. `skill`, `verifier`, `human`) — not the L2 categorical role (`pm`/`qa`/`worker`/`dm`). The naming predates the alias concept and is misleading. The doc keeps the literal `{role}` token in §4 only where it faithfully tracks the code; everywhere else (on-disk paths, state-file shapes, cursor maps) it uses `<alias>` because that's the only thing actually keyed in those structures. A code-level rename `role` → `alias` would close the mismatch; it's filed as #10358 (sibling to the bundled #10182 architectural-decisions task) and is on hold pending PR #10357 merging and #10182 progressing.
 
 ---
@@ -379,7 +384,7 @@ When the harness restarts (operator-driven or after a crash):
 2. **Verify live PIDs** — for each agent with intent=`running`, check if the recorded PID is still alive.
    - Alive: resume monitoring.
    - Dead: respawn (since intent=`running`).
-   After this initial PID verification pass populates the in-memory `AgentState` with liveness flags, subsequent per-spawn singleton checks (see §14.2) consult the loaded in-memory state, not the state file directly.
+   Today, per-spawn singleton checks live inside `thin_launcher.py` and consult the on-disk `.claude-pid` + descendant walk (§9, §14.2 "Today" column). Under the §14 proposal those checks move into the harness and consult the loaded in-memory `AgentState` directly — see §14.2.
 3. **Read `.squidsquad/.event-state.json`** — recover cursors and in-flight events.
 4. **Rebuild empty deque** — past events are lost; new events accumulate from the restart point forward.
 5. **Resume EAD** — read `ead_last_seen`; forge poll resumes from that timestamp (5-minute fallback if file missing/corrupt).
@@ -481,7 +486,7 @@ harness
 >
 > **`event_poll.py` does not live inside the `wt.exe` chain.** It is a **separate sibling subtree** spawned by `boot_agent` directly (see §7.2 step 3): `harness → python.exe (event_poll.py)`. The `wt.exe` ancestry shown is the launcher-and-claude chain only; `event_poll` runs in parallel under the harness process, not under `wt.exe`.
 
-Two processes per agent, down from five. TTY still provided by `wt.exe`, so subscription billing is preserved.
+Two processes per agent in the launcher chain (`wt.exe` + `claude.exe`), down from five (`wt → bash → python(thin_launcher) → cmd → claude`). The sibling `event_poll.py` subtree under the harness exists in both pictures and is excluded from this count. TTY still provided by `wt.exe`, so subscription billing is preserved.
 
 ### 14.2 What `thin_launcher.py` does today, and where each piece moves
 
@@ -544,7 +549,7 @@ In landing order:
 1. Productize `references/experiments/resolve_claude.py` into `references/scripts/resolve_claude.py`. Add tests for each shim variant (real or fixture).
 2. Add helper to `boot_remote.py` (Windows) that constructs the `wt new-tab … claude.exe …` argv. POSIX equivalents follow.
 3. Move the singleton check into `harness.py:start_agent` (uses existing `AgentState`).
-4. Move post-spawn PID resolution into `boot_remote.boot_agent` (process snapshot + filter).
+4. Move post-spawn PID resolution into `boot_remote.boot_agent` (process snapshot + filter). The parameter rename `role` → `alias` per the §3 caveat / #10358 lands in the same change.
 5. Cut the spawn path over to direct-claude. Validate live on `skill` agent first.
 6. Once stable: delete `thin_launcher.py`, `tests/test_thin_launcher_10101.py`, and dead references in `boot_remote.py`.
 

--- a/docs/INSTALLER-ARCH.md
+++ b/docs/INSTALLER-ARCH.md
@@ -100,7 +100,7 @@ Three commitments:
 | `.squidsquad/vault/` | Shared memory layer skeleton (BRIEFING.md + the five vault dirs: projects/, areas/, resources/, archives/, galaxy/). Vault architecture documented in [`VAULT-ARCH.md`](VAULT-ARCH.md). |
 | `.squidsquad/.local-config` | Per-clone alias→path mapping for `start.sh` to sync clones. Installer-scaffolded; harness reads it at boot to populate per-alias `clone_path` into in-memory `AgentState` (see HARNESS-ARCH §7.2 step 1 + §7.5). At runtime the harness's `.harness-state.json` is the operational source; `.local-config` is the install-time source of truth. |
 | `~/.squidsquad/secrets` | API keys for external models (restricted permissions, never committed to repo) |
-| `~/.squidsquad/clones/` | Per-alias clone-path registry. One file per alias (`pm`, each worker, each verifier, `dm`) whose contents is the absolute path to that alias's clone. Always created — clone isolation is mandatory (see §1.2), not a configurable mode. |
+| `~/.squidsquad/clones/` | Per-alias clone-path registry. One file per alias (filename = alias literal, no extension — e.g. `~/.squidsquad/clones/pm`, `~/.squidsquad/clones/frontend-1`); file contents = the absolute path to that alias's clone. Always created — clone isolation is mandatory (see §1.2), not a configurable mode. |
 | **Forge (GitHub)** | Issue labels created via `gh label create` — status/role/type/priority/severity taxonomy |
 | **Git commit** | Single atomic install commit on `main` (or the operator's chosen branch) |
 
@@ -226,7 +226,19 @@ Once approved, the installer:
 
 1. **Cleans up** any prior partial state (if a previous interrupted install left artifacts).
 2. **Serializes the install spec** to a temporary location for the scaffold step.
-3. **Scaffolds `.squidsquad/`** — creates the per-alias agent dirs (CLAUDE.md placeholders, working-state.md skeletons, planning/, iterations/), vault skeleton, project-local L4 directory, and `.squidsquad/config.md`. `.squidsquad/config.md` includes the **`squidsquad_version:` field** stamped from `references/VERSION` (pulled in Phase 5 step 0; read at upgrade time per §10 step 1). No per-alias `SOUL.md` files (the v1 sidecar is retired; SOUL.md content is composed into `CLAUDE.md §3 Soul` per [COMPOSE-ARCHITECTURE.md §5.3](COMPOSE-ARCHITECTURE.md)). No tool/MCP wiring (per §8).
+3. **Scaffolds `.squidsquad/`** — creates the per-alias agent dirs (CLAUDE.md placeholders, working-state.md skeletons, planning/, iterations/), vault skeleton, project-local L4 directory, `.squidsquad/config.md` (including the **`## Aliases` H2 section** mapping each chosen alias to its role-class and L3 domain), and the **`squidsquad_version:` field** read from `references/VERSION` already present in the installer source tree (fresh install runs from within the pulled SquidSquad sources; upgrade re-reads this same file per §10 step 1). No per-alias `SOUL.md` files (the v1 sidecar is retired; SOUL.md content is composed into `CLAUDE.md §3 Soul` per [COMPOSE-ARCHITECTURE.md §5.3](COMPOSE-ARCHITECTURE.md)). No tool/MCP wiring (per §8).
+
+   Schema example for `## Aliases`:
+   ```markdown
+   ## Aliases
+   | alias | role-class | L3 domain |
+   |---|---|---|
+   | pm | pm | — |
+   | frontend-1 | worker | fe |
+   | backend-1 | worker | be |
+   | verifier | verifier | — |
+   | dm | dm | — |
+   ```
 4. **Seeds L4 Project Context** — for each role-class in the chosen preset, writes the Phase 1 project-intake answers (domain, audience, primary language/stack, repositories of record, external systems, project-specific tone notes) into `.squidsquad/project/<role-class>.md` under the `## Project Context` H2 section. This is the single unified L4 file per role-class (per [COMPOSE-ARCHITECTURE.md §3.3 + §7.3](COMPOSE-ARCHITECTURE.md) and the "two complementary sources" callout in [§5.5](COMPOSE-ARCHITECTURE.md)). Other L4 slots (Identity / Soul / Instructions / etc.) start empty at install time and are populated at runtime by the `l4-curation` sub-skill (per [COMPOSE-ARCHITECTURE.md §7](COMPOSE-ARCHITECTURE.md)).
 
    > **Historical context (no installer code needed):** earlier installs used a multi-file L4 seed pattern (`references/sub-skills/project/<role>-instructions.md`, `<role>-responsibility.md`, `<role>-soul-directives.md`, `shared-*.md`, `setup-upgrade-gate.md`). That pattern is retired and replaced by the unified `<role-class>.md` model above. The installer does **not** carry migration code for the legacy pattern — fresh installs never see it, and existing installs are migrated by a separate one-time tool (out of scope for this doc). This callout exists only to disambiguate the docs; an implementer reading §4.8 should write the unified-file path and not the legacy multi-file path.
@@ -244,7 +256,7 @@ python references/scripts/compose.py deploy <role>
 
 `compose.py` reads the L1-L3 sub-skill sources + L4 project-local files and emits `.squidsquad/<alias>/CLAUDE.md` per the [compose pipeline](COMPOSE-ARCHITECTURE.md). The output path is **alias-keyed**: `compose.py deploy <alias>` writes to `.squidsquad/<alias>/CLAUDE.md`, regardless of role-class. The composed output is a thin orchestration layer that references sub-skills — see [COMPOSE-ARCHITECTURE.md §4.5](COMPOSE-ARCHITECTURE.md). (The CLI's positional parameter is shown as `<role>` for code-compat — its value is always the alias; the rename to `<alias>` is tracked in [#10358](https://github.com/WallyDoodlez/SquidSquad/issues/10358).) The compose helper takes the alias as its positional argument and internally resolves the role-class (from the alias→class mapping in `.squidsquad/config.md`'s `## Aliases` registry) to pick the correct L4 file. Two aliases of the same role-class share an L4 file by design — see COMPOSE-ARCHITECTURE §3.3.
 
-**Current-state caveat**: as of today, the project-scoped Claude-skills installer that materializes sub-skill references into invokable Skill tool entries is **not yet shipped** (COMPOSE-ARCHITECTURE §4.5.1, tracked in #10362). The composed CLAUDE.md emits sub-skill references either way; until the Skills installer ships, agents resolve `→ run sub-skill: <name>` by reading the catalog-recorded source file and executing its instructions in-context. The composition output format is stable; only the *invocation mechanism* differs between today and target state.
+**Current-state caveat**: as of today, the project-scoped Claude-skills installer that materializes sub-skill references into invokable Skill tool entries is **not yet shipped** (COMPOSE-ARCHITECTURE §4.5.1, tracked in #10362). The composed CLAUDE.md emits sub-skill references either way; until the Skills installer ships, agents resolve `→ run sub-skill: <name>` by looking up `<name>` in [`sub-skill-catalog.md`](sub-skill-catalog.md) to find the source-file path (under `references/sub-skills/`) and executing that file's instructions in-context. The composition output format is stable; only the *invocation mechanism* differs between today and target state.
 
 Two aliases of the same role-class produce byte-identical composed output by design — same L1-L4 sources, same compose pipeline. The output path differs by alias (`.squidsquad/<alias>/CLAUDE.md`); the content is shared per class. See COMPOSE-ARCHITECTURE §3.3.
 
@@ -274,8 +286,7 @@ The full `.squidsquad/` tree post-install. PM and DM dirs are always present (si
 │   ├── working-state.md         # crash-recovery checkpoint (skeleton)
 │   ├── enhancements.md          # product backlog seed
 │   ├── planning/                # RESEARCH/CONTEXT artifacts
-│   ├── iterations/              # iter-N.md cycle logs
-│   └── migrations/              # legacy migration logs
+│   └── iterations/              # iter-N.md cycle logs
 ├── <worker-role>/               # one per worker in the preset (default: worker)
 │   ├── CLAUDE.md
 │   ├── working-state.md
@@ -448,10 +459,10 @@ flowchart LR
 
    The installer calls the harness's per-agent lifecycle endpoints in sequence:
    ```
-   POST /agents/{role}/stop    # graceful stop; harness handles ack-stop / timeout
-   POST /agents/{role}/start   # boot with new composed CLAUDE.md
+   POST /agents/<alias>/stop    # graceful stop; harness handles ack-stop / timeout
+   POST /agents/<alias>/start   # boot with new composed CLAUDE.md
    ```
-   for each agent. Calls today are `POST /agents/<alias>/stop` and `POST /agents/<alias>/start` — the URL-template token is named `{role}` in the source code for legacy compatibility, but the value is always the alias (e.g. `pm`, `frontend-1`, `verifier`). The token-name rename to `{alias}` is tracked in HARNESS-ARCH §4.1 + #10358; the value semantics are stable and won't change with the rename. If the harness is not running, the installer instead invokes `start.sh` from the repo root (which reads `.squidsquad/.local-config` to find clone paths, boots the harness, which in turn boots the agents). `start.sh` is a thin shell wrapper that invokes `squidsquad_cli.py start` with the right environment — see HARNESS-ARCH §2 for the underlying entry point. The installer uses `start.sh` for parity with how operators boot the harness manually. Either way, the next session each agent starts is reading the new composed CLAUDE.md. In event-driven mode the harness also respawns each agent's `event_poll.py` sidecar on agent restart (per [HARNESS-ARCH.md §7.2](HARNESS-ARCH.md) `boot_agent`); the installer doesn't need to manage `event_poll` directly.
+   for each agent (e.g. `pm`, `frontend-1`, `verifier`). The URL-template token is named `{role}` in the source code for legacy compatibility, but the value is always the alias; the token-name rename to `{alias}` is tracked in HARNESS-ARCH §4.1 + #10358 (value semantics are stable and won't change with the rename). If the harness is not running, the installer instead invokes `start.sh` from the repo root (which reads `.squidsquad/.local-config` to find clone paths, boots the harness, which in turn boots the agents). `start.sh` is a thin shell wrapper that invokes `squidsquad_cli.py start` with the right environment — see HARNESS-ARCH §2 for the underlying entry point. The installer uses `start.sh` for parity with how operators boot the harness manually. Either way, the next session each agent starts is reading the new composed CLAUDE.md. In event-driven mode the harness also respawns each agent's `event_poll.py` sidecar on agent restart (per [HARNESS-ARCH.md §7.2](HARNESS-ARCH.md) `boot_agent`); the installer doesn't need to manage `event_poll` directly.
 
    **In-flight-work handling.** Before stopping each agent, the harness checks whether the agent has an active iteration (i.e., it is in the creative phase between `cycle_pre.py` and `cycle_post.py`). If so, the harness waits for the agent's `ack-stop` event — the agent finishes its current iteration, calls `cycle_post.py` (which commits and pushes `.squidsquad/<alias>/working-state.md` + any in-flight changes), and then exits via the normal exit-42 path. If the iteration does not complete within a configurable timeout (default 5 minutes), the harness logs a warning and proceeds with the stop; on next boot the agent reads `.squidsquad/<alias>/working-state.md` to recover from the checkpoint (see AGENT-RUNTIME §5 state-persistence map + §6.5 context-pressure exit-42 model). No in-flight state is lost because `.squidsquad/<alias>/working-state.md` is the durable checkpoint that survives restarts.
 
@@ -495,7 +506,7 @@ During upgrade, the items below are preserved — never bulk-overwritten or rege
 ### 10.3 What's regenerated
 
 - `.squidsquad/<alias>/CLAUDE.md` — composed orchestration. The Soul section (§3) is recomposed from the latest `references/roles/<role-class>/SOUL.md` source plus any L4 `## Soul` append, per [COMPOSE-ARCHITECTURE.md §3.2 + §5.3](COMPOSE-ARCHITECTURE.md). No separate per-alias SOUL.md file exists (sidecar retired).
-- `.squidsquad/config.md` `squidsquad_version:` field — updated to the current installer version after a successful walk (the only field the installer writes outside the three-gate model — it's updated by the installer itself *after* all migrations in the walk have completed successfully (not unconditionally; failure at any gate aborts the walk and the version field is not bumped); everything else moves through migrations). Migration files MUST NOT modify the `squidsquad_version:` field directly — that's the installer's sole write surface for this field. Migrations that need to react to a missing or pre-1.0 stamp should write a separate marker key (e.g., `squidsquad_version_migration_applied: v1.2`) that the installer reads after the walk and uses to determine the final version stamp.
+- `.squidsquad/config.md` `squidsquad_version:` field — updated to the current installer version after a successful walk. This is the only field the installer writes outside the three-gate model **during upgrade** — it's updated by the installer itself *after* all migrations in the walk have completed successfully (not unconditionally; failure at any gate aborts the walk and the version field is not bumped); every other change during upgrade moves through migrations. (Fresh-install writes are a distinct write surface, not gated — see §4.8 step 4 for L4 Project-Context seeding and §10.2 for the fresh-vs-upgrade distinction.) Migration files MUST NOT modify the `squidsquad_version:` field directly — that's the installer's sole write surface for this field. Migrations that need to react to a missing or pre-1.0 stamp should write a separate marker key (e.g., `squidsquad_version_migration_applied: v1.2`) that the installer reads after the walk and uses to determine the final version stamp.
 
 ### 10.4 Edge cases
 
@@ -526,7 +537,7 @@ The installer is designed to be safe to re-run:
 
 ### 11.2 Interrupted install recovery
 
-If the installer is interrupted mid-Phase-5 (filesystem partially scaffolded), re-running detects the partial state and offers a "clean rebuild" option that selectively deletes all files and directories under `.squidsquad/` **except** the preserved items listed in §11.3 (`vault/`, `project/`, per-alias `working-state.md`, `iterations/`, `planning/`), then starts Phase 5 fresh.
+If the installer is interrupted mid-Phase-5 (filesystem partially scaffolded), re-running detects the partial state and offers a "clean rebuild" option that selectively deletes all files and directories under `.squidsquad/` **except** the preserved items listed in §11.3 (`vault/`, `project/`, per-alias `working-state.md`, `iterations/`, `planning/`), then starts Phase 5 fresh. `.squidsquad/config.md` is **wiped and re-synthesized** from Phase 1 + Phase 2 outputs (the prior partial config is the broken artifact of the interrupted run and is not preserved — the conversational answers are still available in the installer's in-session state for re-synthesis).
 
 If the installer is interrupted between Phase 7 and Phase 8 (forge labels created, no commit yet), re-running detects the no-commit state and offers to commit the existing scaffold rather than redoing it.
 
@@ -546,7 +557,6 @@ Across both upgrade and clean-rebuild, these are always preserved:
 - **G2** — L4 backfill from the human's auto-memory directory (`~/.claude/projects/<repo>/memory/`) — referenced from [COMPOSE-ARCHITECTURE.md §10.4](COMPOSE-ARCHITECTURE.md) but not yet implemented as an installer step. Open: should the installer offer to import these on upgrade, or is this a separate one-off tool?
 - **G3** — Multi-tenant install (one repo hosting multiple SquidSquad teams) — likely deferred. Today's model is one SquidSquad install per repo.
 - **G4** — Atomic install across Phase 5–8. Today the scaffold (Phase 5) writes locally before the commit (Phase 8); a hard crash between them leaves the filesystem written but no git history. The interrupted-install recovery path in §11.2 handles this, but the model isn't truly atomic.
-- **G5** — ✅ MOOT (rev: capability removal). The previous concern about "capability hot-swap at install time" is no longer applicable — tool/MCP/CLI configuration is per-agent post-install per §8, not an install-time concern. Adding or swapping a tool is a runtime L4 write, not a re-run-the-installer flow.
 
 ---
 

--- a/docs/INSTALLER-ARCH.md
+++ b/docs/INSTALLER-ARCH.md
@@ -7,7 +7,7 @@
 
 ## 1. Goal & scope
 
-The SquidSquad installer turns a fresh git repo into a working multi-agent setup. It runs as an **ephemeral Claude Code agent** that walks the user through configuration, generates `.squidsquad/`, composes per-role CLAUDE.md outputs, sets up the tracker, and boots the harness.
+The SquidSquad installer turns a fresh git repo into a working multi-agent setup. It runs as an **ephemeral Claude Code agent** that walks the user through configuration, generates `.squidsquad/`, composes per-role-class CLAUDE.md outputs, sets up the tracker, and boots the harness.
 
 ### 1.1 Terminology — categorical roles vs team preset
 
@@ -236,7 +236,7 @@ Writes land in the target repo's working tree (`.squidsquad/` appears in `git st
 
 ### 4.9 Phase 6 — Compose per-role CLAUDE.md
 
-For each role in the chosen team preset (PM, each worker, each verifier, DM), the installer invokes:
+For each alias in the chosen team preset (PM, each worker, each verifier, DM), the installer invokes:
 
 ```bash
 python references/scripts/compose.py deploy <role>
@@ -354,11 +354,11 @@ Key contracts:
 
 ## 8. Tool/MCP/CLI setup is per-agent and post-install
 
-SquidSquad's install does NOT pre-wire tool integrations. There is no "capability" concept in the install — no design-tool selection, no delivery-target selection, no MCP/CLI bundling per role. The installer leaves every agent **tool-naked at first boot**.
+SquidSquad's install does NOT pre-wire tool integrations. There is no "capability" concept in the install — no design-tool selection, no delivery-target selection, no MCP/CLI bundling per role-class. The installer leaves every agent **tool-naked at first boot**.
 
 ### 8.1 Why
 
-The space of role × tool combinations is large and project-specific (designer worker uses Figma here, Sketch there, local HTML somewhere else; a `worker` may need `kubectl` here, `gcloud` there, neither in a third install). Predefining role+capability bundles would either be too narrow to cover real installs, or too broad to be useful. Trying to capture it via PM-driven "choose your capabilities" conversation at install time produces vague, low-fidelity decisions before the human knows what they need.
+The space of role-class × tool combinations is large and project-specific (designer worker uses Figma here, Sketch there, local HTML somewhere else; a `worker` may need `kubectl` here, `gcloud` there, neither in a third install). Predefining role-class+capability bundles would either be too narrow to cover real installs, or too broad to be useful. Trying to capture it via PM-driven "choose your capabilities" conversation at install time produces vague, low-fidelity decisions before the human knows what they need.
 
 ### 8.2 The model: agent learns its own tools post-install
 
@@ -381,7 +381,7 @@ API keys and secrets stay in `~/.squidsquad/secrets` (created by the installer's
 
 - No `capabilities/` sub-skill set in the install scaffold.
 - No `setup.md` walk per tool.
-- No `common/capability-check` sub-skill in any role's compose manifest.
+- No `common/capability-check` sub-skill in any role-class's compose manifest.
 - No `Capabilities:` section in `.squidsquad/config.md`.
 
 The existing `references/sub-skills/capabilities/` directory and `common/capability-check.md` are slated for removal — they are architectural deadwood from the prior model. Tracker: follow-up issue against the worker class (default-preset assignee: `skill`) when this doc lands.
@@ -427,7 +427,7 @@ flowchart LR
 
 **Steps:**
 
-1. **Pull**: latest SquidSquad sources into `references/` (L1-L3 sub-skills, role files, manifests, helper scripts, and any new `migrations/v*-to-v*.md` files shipped with this release).
+1. **Pull**: latest SquidSquad sources into `references/` (L1-L3 sub-skills, role-class files, manifests, helper scripts, and any new `migrations/v*-to-v*.md` files shipped with this release).
 2. **Read installed version**: one-line read of `.squidsquad/config.md`'s `squidsquad_version:` field (written at install time per §3.2 + §4.8). If the operator's `squidsquad_version:` field is absent — possible on installs predating the version-stamp convention — treat as `pre-1.0` and walk all migration files in order.
 
    **Version sources**: `installed-version` reads from `.squidsquad/config.md`'s `squidsquad_version:` field. `installer-version` reads from `references/VERSION` *after* step 1's pull — meaning it reflects the source the operator pulled in this upgrade session, not the version of the running installer binary. If the operator's installer binary is older than what's on `main`, step 1's pull still refreshes `references/VERSION` to current main, so the comparison always reflects what they're upgrading *to*.
@@ -439,7 +439,7 @@ flowchart LR
    3. **Compose dry-run**: `compose.py deploy-all --check` validates the migrated content composes cleanly before any write
    
    Migrations are stepped through one at a time — failure at any gate aborts that step (and the rest of the walk) cleanly; nothing partial is written.
-4. **Recompose**: `compose.py deploy-all` regenerates every role's CLAUDE.md from the now-current source + migrated L4. The composed outputs reflect both the new sub-skill versions and the migrated L4 customizations. `deploy-all` iterates the alias roster from `.squidsquad/config.md`'s `## Aliases` registry and runs `compose.py deploy <alias>` for each (see COMPOSE-ARCHITECTURE §8.2).
+4. **Recompose**: `compose.py deploy-all` regenerates every role-class's CLAUDE.md from the now-current source + migrated L4. The composed outputs reflect both the new sub-skill versions and the migrated L4 customizations. `deploy-all` iterates the alias roster from `.squidsquad/config.md`'s `## Aliases` registry and runs `compose.py deploy <alias>` for each (see COMPOSE-ARCHITECTURE §8.2).
 5. **Restart**: each affected agent so they pick up the new CLAUDE.md. The installer is an ephemeral Claude Code session but has full Bash tooling — it makes these HTTP calls via `curl` (or equivalent) against the harness's localhost port (read from `.squidsquad/.harness-port` per [HARNESS-ARCH.md §6](HARNESS-ARCH.md)). "Ephemeral" refers to lifetime, not capability: the installer can do anything its Claude Code tooling permits before it exits at Phase 9.
 
    The harness remains the sole lifecycle authority — agents are never spawned outside it. The installer's upgrade-flow restarts happen through the harness's public HTTP API; the installer is just another localhost client of the same endpoints the operator uses. See HARNESS-ARCH §2.

--- a/docs/VAULT-ARCH.md
+++ b/docs/VAULT-ARCH.md
@@ -108,7 +108,7 @@ Galaxy is the **compounding** layer: every decision the squad makes and every le
 Note movement is rare and almost always one-directional:
 
 - **`projects/` → `archives/`** — when a project completes or is abandoned, the note's `status:` flips to `archived` and either an agent or `vault_optimize.py prune-scan` moves the file. Project notes are not deleted; the historical context matters.
-- **`galaxy/` → `archives/`** — `vault_optimize.py prune-scan` auto-archives galaxy notes that are (a) `status: superseded`, or (b) stale **and** orphaned (no inbound wikilinks for longer than the staleness threshold in `.squidsquad/config.md`). Archived galaxy notes get a `<!-- archived: [[name]] moved to archives/ -->` breadcrumb appended to every note that linked to them, so the link graph degrades gracefully.
+- **`galaxy/` → `archives/`** — `vault_optimize.py prune-scan` auto-archives galaxy notes that are (a) `status: superseded`, or (b) stale **and** orphaned (no inbound wikilinks for longer than the staleness threshold in `.squidsquad/config.md`). Wikilinks pointing at the archived note continue to resolve by filename match (per §4.5 — the resolver scans `.squidsquad/vault/**`, not a specific folder), so the link graph remains valid across the move. `vault_optimize.py _rewrite_wikilinks_after_archive` appends an optional `<!-- archived: [[name]] moved to archives/ -->` breadcrumb to each linking note for human-reader hygiene (Obsidian path display, etc.); the breadcrumb is cosmetic, not load-bearing for resolution.
 - **`areas/` and `resources/`** — generally stay put. Areas are stable by definition; resources stay as long as someone might look them up. Both can be manually archived if the squad decides they're dead weight, but `vault_optimize.py` does not touch them automatically.
 
 There is no automatic *promotion* path (e.g., a `learning-*` note that turns out to be a fundamental pattern is rewritten or split manually; the script doesn't second-guess). The trim-or-graduate rule in §5 covers the **BRIEFING → galaxy** edge case, where lines trimmed from BRIEFING.md become new galaxy notes rather than being deleted.
@@ -169,8 +169,11 @@ updated: YYYY-MM-DD
 status: active | archived | superseded
 confidence: high | medium | low       # see §4.4
 source: conversation | review | observation | research
+owner: pm | worker | verifier | dm | shared   # primary author role-class (see Ownership note below)
 ---
 ```
+
+**Ownership note** (`owner:` field): authored role-class of the note's content. Used today by the §10.3 ownership-distribution inventory and the §11.1 #5855 audit verdicts that depend on it. The `vault-protocol` source file still lists pre-#6274 values (`qa`, `skill`) — a sync pass to the post-#6274 names (`verifier`, `worker`) is tracked in #10098. Notes that observably benefit multiple role-classes use `owner: shared`.
 
 **Tag convention** (for searchability):
 
@@ -196,9 +199,9 @@ source: conversation | review | observation | research
 |---|---|
 | `high → medium` | 60 days since last `updated:` |
 | `medium → low` | 120 days since last `updated:` |
-| `low → ?` | **Terminal — no further decay.** Note stays at `low`, remains in its current folder, and still contributes to relevance scoring at reduced weight (`high`=10, `medium`=6, `low`=3 in `vault_optimize.py compute-relevance`). |
+| `low → ?` | **Terminal — no further decay.** Note stays at `low` and still contributes to relevance scoring at reduced weight (`high`=10, `medium`=6, `low`=3 in `vault_optimize.py compute-relevance`). The note remains in its current folder *unless* prune-scan archives it for being stale + orphaned (§7.3 step 1 / §3.3) — decay terminality only blocks further `confidence:` transitions, not folder moves driven by orphan-pruning. |
 
-A changelog entry is appended to the note body on each decay step, so the decay history is visible without `git blame`.
+A changelog entry is appended to the note body on each decay step, so the decay history is visible without `git blame`. **Decay steps do NOT modify `updated:`** — the decay clock keys off the last *human or agent semantic edit*, not the decay event itself. So `medium → low` at 120 days means 120 days since the last semantic `updated:` value, not 60 days after a prior `high → medium` decay step.
 
 **Opt-out**: notes tagged `evergreen` are exempt from decay entirely. Use for content where staleness is meaningless — enduring style preferences, fundamental architectural commitments.
 
@@ -240,6 +243,22 @@ The staleness check is special — it runs every cycle including quiet cycles, a
 
 ---
 
+## 6. Templates
+
+Vault templates live at `references/vault-templates/` and are the seed content for new notes. One template per entity folder plus `BRIEFING.md`:
+
+| Template | Used by | Purpose |
+|---|---|---|
+| `briefing.md` | `vault-init` (§7.1), `vault-remember` BRIEFING staleness check (§7.2) | Initial `BRIEFING.md` skeleton + section order |
+| `projects/<entity>.md` | `vault-create` for `type: project` | Frontmatter + body skeleton for project notes |
+| `areas/<entity>.md` | `vault-create` for `type: area` | Area-note skeleton (e.g., `human-profile.md` bootstrap) |
+| `resources/<entity>.md` | `vault-create` for `type: resource` | Resource-note skeleton |
+| `galaxy/decision.md` / `pattern.md` / `learning.md` / `style.md` | `vault-create` for galaxy types | Per-prefix skeletons; copied verbatim then frontmatter-filled and body-edited |
+
+Templates are framework-shipped (not operator-written) and are only consulted by `vault-protocol` sub-skill operations — never read at runtime. `vault_entity.py` (§8.4) is the script that materializes a template into a new note. Templates are not subject to the §4 frontmatter spec themselves; their job is to produce notes that conform.
+
+---
+
 ## 7. The sub-skills
 
 All vault behavior is encoded as markdown fragments under `references/sub-skills/`. Each fragment is inlined into the consuming agent's composed `CLAUDE.md` by `compose.py`. Four distinct sub-skills are described below; `vault-protocol` ships with a read-only variant (`vault-protocol-slim`) — see §7.1.
@@ -271,7 +290,7 @@ Each sub-skill's **Cycle integration** line below names its lane.
 
 **Outputs**: New or updated `.squidsquad/vault/**/*.md` notes; never deletes.
 
-**Source-vs-spec drift**: source file still references the dropped `owner` and `links` frontmatter fields, the dropped `source: code` value, and the unimplemented "auto-maintain `links` frontmatter" behavior. Sync tracked in #10098.
+**Source-vs-spec drift**: source file still references the dropped `links` frontmatter field, the dropped `source: code` value, the unimplemented "auto-maintain `links` frontmatter" behavior, and the pre-#6274 `owner:` enum values (`qa`, `skill` instead of `verifier`, `worker`). Sync tracked in #10098.
 
 **Read-only variant** (`references/sub-skills/common/vault-protocol-slim.md`): the same protocol with all write operations removed — just session-start `BRIEFING.md` reading and the four `vault-search` modes. Composed by `compose.py` for roles where vault writes are not appropriate; the base-name-to-slim-variant mapping is a composition concern (see [`COMPOSE-ARCHITECTURE.md`](COMPOSE-ARCHITECTURE.md)).
 
@@ -282,23 +301,24 @@ Each sub-skill's **Cycle integration** line below names its lane.
 **Behavior**: End-of-cycle reflection. Runs two responsibilities in order:
 
 1. **BRIEFING.md staleness check** — runs every cycle, including quiet cycles. Compares `BRIEFING.md` key fields (version, active agents, current priorities) against `.squidsquad/config.md` and the tracker; updates any stale field. Staleness fixes do NOT consume the write budget.
-2. **Reflection** — gated by a quiet-cycle check (skipped if the cycle did no real work). Evaluates this cycle's iteration log for vault-worthy candidates in four categories: DECISIONS, PATTERNS, LEARNINGS, PROJECT CONTEXT. Each candidate runs through four deterministic gates IN ORDER: (1) write budget remaining (default 2 per cycle, per `.squidsquad/config.md` `Vault Remember > Writes Per Cycle`), (2) dedup-check against existing notes by title + tags, (3) reusability beyond this cycle, (4) would a fresh agent benefit? Only candidates passing all four are written. When more than 2 pass, priority is decisions > learnings > patterns; surplus is deferred to iteration-log notes as `Vault-worthy but deferred (budget): <description>`. Behavioral or personality directives are explicitly out of scope — those go to soul-shepherd (observed signals) or L4 (explicit directives), not the vault.
+2. **Reflection** — gated by a quiet-cycle check (skipped if the cycle did no real work). Evaluates this cycle's iteration log for vault-worthy candidates in five galaxy categories: DECISIONS, PATTERNS, LEARNINGS, STYLES, plus PROJECT CONTEXT (which targets `projects/` updates, not a galaxy prefix). Each candidate runs through four deterministic gates IN ORDER: (1) write budget remaining (default 2 per cycle, per `.squidsquad/config.md` `Vault Remember > Writes Per Cycle`), (2) dedup-check against existing notes by title + tags, (3) reusability beyond this cycle, (4) would a fresh agent benefit? Only candidates passing all four are written. When more than 2 pass, priority is decisions > learnings > patterns; surplus is deferred to iteration-log notes as `Vault-worthy but deferred (budget): <description>`. Behavioral or personality directives are explicitly out of scope — those go to soul-shepherd (observed signals) or L4 (explicit directives), not the vault.
 
 **Cycle integration**: Post-cycle Step 4b. Gated by the per-cycle quiet check only — always-on, no feature toggle (the 4-gate filter already provides sufficient noise control; a blunt on/off flag on top earns no use case). **Lane**: background subagent (`sonnet`). The consuming agent hands the iteration log + write-budget + dedup-tool access to the subagent; the subagent runs the 4-gate evaluation and returns a structured list of `{action: write|update|skip, path, type, body, reason}` decisions plus the resulting note paths. The reflection transcript stays out of the consuming agent's context.
 
 **Scripts used** (from §8): `vault_remember.py is-quiet`/`reset-writes`/`write-budget`/`inc-writes`/`briefing-budget` (gating and accounting), `vault_check.py dedup-check` (gate 2). (The legacy `config.py get vault-remember` enabled-flag read has been retired — the sub-skill is always-on and self-gates per its own per-cycle conditions.)
 
-**Outputs**: Up to 2 new `.squidsquad/vault/galaxy/*.md` notes per cycle (`decision-*`/`pattern-*`/`learning-*`), optional `BRIEFING.md` staleness updates, iteration-log notes for deferred candidates.
+**Outputs**: Up to 2 new `.squidsquad/vault/galaxy/*.md` notes per cycle (`decision-*` / `pattern-*` / `learning-*` / `style-*`), optional `projects/*.md` updates from the PROJECT CONTEXT category, optional `BRIEFING.md` staleness updates, iteration-log notes for deferred candidates.
 
 ### 7.3 `vault-optimize`
 
 **Path**: `references/sub-skills/common/vault-optimize.md`
 
-**Behavior**: Quiet-cycle housekeeping. Runs after the improvement-scan check (if the scan ran this cycle, optimize skips). Activates only when the vault has 20+ notes. Invokes `vault_optimize.py run`, which performs three bundled operations:
+**Behavior**: Quiet-cycle housekeeping. Runs after the improvement-scan check (if the scan ran this cycle, optimize skips). Activates only when the vault has 20+ notes. Invokes `vault_optimize.py run`, which performs four bundled operations:
 
 1. **Prune** — auto-archive galaxy notes that are both stale (60+ days since `updated:`) and orphaned (no inbound wikilinks). Notes created today are never pruned.
 2. **Confidence decay** — apply the §4.4 decay rules (high → medium at 60 days, medium → low at 120 days, terminal at `low`). Notes tagged `evergreen` are exempt.
-3. **Relevance scoring** — compute link-count + recency + confidence scores, write to `.squidsquad/vault/.relevance-index.json` (gitignored).
+3. **Reindex** — walk all notes, rebuild the wikilink graph (inbound/outbound adjacency) used by prune-orphan-detection and relevance scoring.
+4. **Relevance scoring** — compute link-count + recency + confidence scores, write to `.squidsquad/vault/.relevance-index.json` (gitignored).
 
 The sub-skill also exposes a pending-questions queue: optimization-surfaced questions that need human input (e.g., "should these similar notes be merged?") are added via `vault_optimize.py add-question`, surfaced in the status bar, and mentioned in the next agent check-in.
 
@@ -324,7 +344,7 @@ When triggered, the synthesis runs in five steps:
 
 Postures need explicit human approval before becoming active scan criteria for other agents — they are never auto-approved. Single-agent patterns are not postures; convergence across agents is the defining property.
 
-**Cycle integration**: Quiet cycle, sub-skill composed only for the agent designated as synthesizer. Gated by the 5-consecutive-quiet-cycle counter and the 10+ galaxy-note threshold. **Lane**: background subagent (`sonnet`). The synthesizer agent hands the recent-notes set to the subagent; the subagent runs theme/convergence detection and returns at most one posture descriptor `{name, principle, source-notes, body}` for the consuming agent to write via `vault-create` (plus the pending-review task body). Cross-note reasoning transcript stays out of the consuming agent's context.
+**Cycle integration**: Quiet cycle, sub-skill composed only for PM (the designated synthesizer role; pluggability across role-classes is not implemented today). Gated by the 5-consecutive-quiet-cycle counter and the 10+ galaxy-note threshold. **Lane**: background subagent (`sonnet`). The synthesizer agent hands the recent-notes set to the subagent; the subagent runs theme/convergence detection and returns at most one posture descriptor `{name, principle, source-notes, body}` for the consuming agent to write via `vault-create` (plus the pending-review task body). Cross-note reasoning transcript stays out of the consuming agent's context.
 
 **Scripts used** (from §8): `vault_check.py` Level 1 (after creating the posture note), `tracker.py create-task` (file the pending-review task).
 
@@ -389,7 +409,7 @@ Deterministic gates for vault-remember reflection. Subcommands:
 
 ## 9. Cycle integration
 
-The vault is touched at four points in a cycle:
+The vault is touched at three points in a cycle (boot, creative, post-cycle); pre-cycle is intentionally not a touch — see §9.2. §9.5 covers how vault writes ride the cycle's git commit, which is a packaging concern rather than a separate touch.
 
 ### 9.1 Session start (boot)
 
@@ -406,17 +426,19 @@ The vault is touched at four points in a cycle:
 
 ### 9.4 Post-cycle (mechanical wrap)
 
+> Step labels (Step 4a, 4b, …) in this section reference the post-cycle sequence enumerated in [AGENT-RUNTIME.md §6.1](AGENT-RUNTIME.md). This doc only describes the vault-touching steps; non-vault post-cycle steps (status transitions, tracker comments, iteration logs, commits) live there.
+
 In order:
 
 1. **vault-remember Step 4b** (every cycle, gated):
    - Staleness check on BRIEFING.md (always runs, ignores quiet gate, doesn't consume budget).
    - Quiet-cycle gate via `vault_remember.py is-quiet`.
-   - If active: reflection across 4 categories (DECISIONS / PATTERNS / LEARNINGS / PROJECT CONTEXT), four gates per candidate, up to 2 writes.
+   - If active: reflection across 5 categories (DECISIONS / PATTERNS / LEARNINGS / STYLES / PROJECT CONTEXT), four gates per candidate, up to 2 writes.
 
 2. **vault-optimize** (quiet cycles, vault ≥20 notes, after improvement scan):
    - Prune + decay + reindex + relevance scoring via `vault_optimize.py run`.
 
-3. **vault-synthesis** (PM only, every 5th quiet cycle, vault ≥10 galaxy notes):
+3. **vault-synthesis** (PM only, after 5 consecutive quiet cycles — counter resets on real work — vault ≥10 galaxy notes):
    - Cross-agent pattern detection; writes at most 1 `pattern-posture-*` note; files pending human-review task.
 
 The agent's working-state holds two relevant counters: the synthesis counter (per `vault-synthesis.md`) and the write counter (per `vault_remember.py`).
@@ -444,7 +466,7 @@ The vault is designed to be **non-blocking and degradation-tolerant** — no vau
 | **BRIEFING.md token budget exhausted** | `vault_remember.py briefing-budget` returns 0. New content cannot be added without trimming; trimmed content moves to a galaxy note (per `vault-remember.md` "trim-or-graduate" rule). No hard failure. |
 | **vault-init re-run on already-initialized vault** | Idempotent per `vault-protocol.md` §Vault Initialization. Creates only what's missing; never overwrites existing notes or `BRIEFING.md`. |
 | **`cycle_post.py` crashes after vault write but before commit** | Uncommitted vault files remain in the working tree. Next `cycle_pre.py` `git pull` would surface them; if no conflict they get committed in the next successful cycle_post. |
-| **vault-optimize prunes a note an agent still references** | Pruned notes move to `archives/`, not deleted. Wikilinks to archived notes resolve (still in vault tree) but `vault_check.py check-wikilinks` doesn't track folder moves — broken-link warnings may appear until the agent updates the link. |
+| **vault-optimize prunes a note an agent still references** | Pruned notes move to `archives/`, not deleted. Wikilinks to archived notes continue to resolve by filename match anywhere under `.squidsquad/vault/` (§4.5), and `vault_check.py check-wikilinks` is filename-only so no broken-link warning fires. The optional breadcrumb appended by `_rewrite_wikilinks_after_archive` (§3.3) lets a human reader see that the target moved; resolution does not depend on it. |
 | **`vault-synthesis` produces a posture an agent later disagrees with** | Posture notes are written with `confidence: medium` and require a pending PM task → human approval before becoming "active scan criteria." Until approved, they're informational notes only. |
 
 ### 9.7 What the vault does NOT do today
@@ -467,7 +489,7 @@ What is actually in `.squidsquad/vault/` right now in this repo:
 
 | Location | Count | Notes |
 |---|---|---|
-| `BRIEFING.md` | 1 (88 lines) | Active context, last updated cycle ~1499 per content |
+| `BRIEFING.md` | 1 (88 lines) | Active context, last updated cycle ~1499 per content; carries `status: active` in its header so it is counted in the §10.5 status distribution |
 | `projects/` | 2 | `agent-communication-layer.md`, `squidsquad.md` |
 | `areas/` | 2 | `human-profile.md`, `code-conventions.md` |
 | `resources/` | 1 | `cli-anything-research.md` |
@@ -486,12 +508,14 @@ What is actually in `.squidsquad/vault/` right now in this repo:
 
 ### 10.3 Ownership distribution (across whole vault, 33 notes total)
 
-| `owner:` value | Count |
-|---|---|
-| `pm` | 13 |
-| `skill` | 12 |
-| `skill-lead` | 6 |
-| `pm-lead` | 2 |
+| `owner:` value | Whole-vault count | Galaxy-only count (of 28) |
+|---|---|---|
+| `pm` | 13 | 9 |
+| `skill` | 12 | 11 |
+| `skill-lead` | 6 | 6 |
+| `pm-lead` | 2 | 2 |
+
+The galaxy-only column is what §11.1 row 1 references; whole-vault includes the `projects/`, `areas/`, `resources/` notes that also carry `owner:`.
 
 **Two owner-label conventions are in use** (`skill` vs `skill-lead`; `pm` vs `pm-lead`). The spec in `vault-protocol.md` says `owner: pm | skill | qa | dm | shared`, so the `-lead` suffix variant is non-spec and looks like organic drift — agents have been writing `<role>-lead` (their tracker-comment role tag) instead of the spec'd bare role-class name. Not flagged in any open issue today; recorded here for traceability.
 

--- a/docs/VAULT-ARCH.md
+++ b/docs/VAULT-ARCH.md
@@ -19,21 +19,31 @@ This doc describes:
 - What is actually present in this repo's vault as of the snapshot date
 - Known gaps between the spec and the live behavior
 
-It does NOT describe per-agent-role access (read/write); that lives in [`AGENT-RUNTIME.md`](AGENT-RUNTIME.md) and [`COMPOSE-ARCHITECTURE.md`](COMPOSE-ARCHITECTURE.md) where the per-role `includes.yml` mapping is composed.
+It does NOT describe per-role-class access (read/write); that lives in [`AGENT-RUNTIME.md`](AGENT-RUNTIME.md) and [`COMPOSE-ARCHITECTURE.md`](COMPOSE-ARCHITECTURE.md) where the per-role-class `includes.yml` mapping is composed.
 
-**Vault slot authorship is L1-exclusive** (guardrail dated 2026-05-29). The composed `## Vault` section in every agent's CLAUDE.md is authored entirely by L1 fragments shipped from this repo — L2 / L3 / L4 cannot contribute `slot: vault` content. The contract documented here (PARAG model, entity types, wikilink grammar, confidence levels) is framework-owned and is not customizable per-role, per-domain, or per-install. Projects that need bespoke vault behaviour file a framework feature request — see [`COMPOSE-ARCHITECTURE.md`](COMPOSE-ARCHITECTURE.md) §3.3, §5.6, and §11.2 G4 for the policy and revisit conditions.
+**Vault slot authorship is L1-exclusive** (guardrail dated 2026-05-29). The composed `## Vault` section in every agent's CLAUDE.md is authored entirely by L1 fragments shipped from this repo — L2 / L3 / L4 cannot contribute `slot: vault` content. The contract documented here (PARAG model, entity types, wikilink grammar, confidence levels) is framework-owned and is not customizable per-role-class, per-domain, or per-install. Projects that need bespoke vault behaviour file a framework feature request — see [`COMPOSE-ARCHITECTURE.md`](COMPOSE-ARCHITECTURE.md) §3.3, §5.6, and §11.2 G4 for the policy and revisit conditions.
 
 It does NOT describe:
 
 - Proposed fixes for the gaps in §11 (out of scope; planned for follow-up under #5855)
-- How vault content gets into composed CLAUDE.md (see [COMPOSE-ARCHITECTURE.md](COMPOSE-ARCHITECTURE.md) §5.5)
+- How vault slot content gets into composed CLAUDE.md (see [COMPOSE-ARCHITECTURE.md](COMPOSE-ARCHITECTURE.md) §5.5)
 - The L4 project-local layer in `.squidsquad/project/` (different system; see [COMPOSE-ARCHITECTURE.md](COMPOSE-ARCHITECTURE.md) §3)
 
 ---
 
 ## 2. What the vault is
 
-The vault is a **shared, git-tracked, per-install knowledge store** at `.squidsquad/vault/`. It holds institutional knowledge that outlives any single cycle, task, or session — decisions, learnings, patterns, project context, ongoing concerns, and human preferences as the agents have observed them.
+> **Vault terminology** — this doc and COMPOSE-ARCHITECTURE use three distinct terms; conflating them is the source of long-running audit confusion:
+>
+> | Term | What it is | Authored by | Read by |
+> |---|---|---|---|
+> | **vault slot** | The `## Vault` H2 section in composed CLAUDE.md — short framework-shipped prose describing the vault contract | L1 only (this slot is L1-exclusive per COMPOSE-ARCHITECTURE §3.3) | Runtime agents at boot |
+> | **vault store** | The on-disk knowledge store at `.squidsquad/vault/` (markdown notes organized via PARAG) | All agents at runtime via vault sub-skills (vault-remember, etc.) | All agents at runtime |
+> | **vault contract** | The framework-owned design spec — PARAG taxonomy, entity types, wikilink grammar, confidence levels | SquidSquad framework (`references/sub-skills/common/vault-protocol.md` + this doc) | Vault sub-skills + agents that read the slot |
+>
+> When this doc says "vault" without a qualifier, assume the most specific applicable term from context. When the meaning is structurally significant (e.g., "L1-exclusive"), the qualifier is mandatory.
+
+The vault store is a **shared, git-tracked, per-install knowledge store** at `.squidsquad/vault/`. It holds institutional knowledge that outlives any single cycle, task, or session — decisions, learnings, patterns, project context, ongoing concerns, and human preferences as the agents have observed them.
 
 Three properties define it:
 
@@ -443,9 +453,9 @@ For completeness, behaviors that some readers might expect but that are not impl
 
 - **No automatic propagation across SquidSquad installs.** Each install has its own vault; there is no shared/federated layer. (See `project_memory_layer_vision` in PM auto-memory for an aspirational note on cross-install sharing; not implemented.)
 - **No queryable index or embedded search.** All search is `grep` over the markdown files (per the 4 search modes in `vault-protocol.md` §vault-search).
-- **No machine-learning on vault content.** No embedding store, no semantic search, no RAG. Confidence levels and tags are agent-assigned, not computed.
+- **No machine-learning on vault store content.** No embedding store, no semantic search, no RAG. Confidence levels and tags are agent-assigned, not computed.
 - **No write-ahead log or transactional guarantees.** Writes are file overwrites + git commits.
-- **No per-note access control.** Read/write is at the role level (full vs slim variant), not the note level.
+- **No per-note access control.** Read/write is at the role-class level (full vs slim variant), not the note level.
 
 ---
 
@@ -483,7 +493,7 @@ What is actually in `.squidsquad/vault/` right now in this repo:
 | `skill-lead` | 6 |
 | `pm-lead` | 2 |
 
-**Two owner-label conventions are in use** (`skill` vs `skill-lead`; `pm` vs `pm-lead`). The spec in `vault-protocol.md` says `owner: pm | skill | qa | dm | shared`, so the `-lead` suffix variant is non-spec and looks like organic drift — agents have been writing `<role>-lead` (their tracker-comment role tag) instead of the spec'd bare role name. Not flagged in any open issue today; recorded here for traceability.
+**Two owner-label conventions are in use** (`skill` vs `skill-lead`; `pm` vs `pm-lead`). The spec in `vault-protocol.md` says `owner: pm | skill | qa | dm | shared`, so the `-lead` suffix variant is non-spec and looks like organic drift — agents have been writing `<role>-lead` (their tracker-comment role tag) instead of the spec'd bare role-class name. Not flagged in any open issue today; recorded here for traceability.
 
 ### 10.4 Confidence distribution (galaxy notes, 28 total)
 
@@ -511,7 +521,7 @@ No notes are `archived` or `superseded` — consistent with the empty `archives/
 | `decision-phase-4-event-ack-lifecycle-deferred.md` | 2026-05-21 |
 | `learning-broadcast-deque-cannot-have-in-stream-gaps.md` | 2026-05-19 |
 
-Oldest galaxy notes are dated 2026-04-25 (vault initialization), e.g. `decision-deterministic-testing.md`, `decision-comprehension-test-pipeline.md`, `decision-branch-per-feature-workflow.md`.
+Oldest galaxy notes are dated 2026-04-25 (vault store initialization), e.g. `decision-deterministic-testing.md`, `decision-comprehension-test-pipeline.md`, `decision-branch-per-feature-workflow.md`.
 
 ### 10.7 Vault templates
 
@@ -622,7 +632,7 @@ Consequences today:
 Closing this gap requires:
 
 1. **Sub-skill source split** — the `references/sub-skills/common/vault-remember.md` body becomes two parts: a short stub composed into the consuming agent (defines the "spawn subagent at Step 4b with these inputs and apply the returned write list" contract) and a longer subagent prompt template stored separately (the actual 4-gate reflection instructions, loaded only by the subagent). Same split for `vault-synthesis.md`.
-2. **Compose-time awareness** — `compose.py` must know to compose the stub into the role's CLAUDE.md but leave the subagent prompt at its source path for the spawned subagent to read.
+2. **Compose-time awareness** — `compose.py` must know to compose the stub into the role-class's CLAUDE.md but leave the subagent prompt at its source path for the spawned subagent to read.
 3. **Subagent contract** — defined by the structured return shape on each sub-skill's §7 entry (vault-remember returns `{action, path, type, body, reason}` per candidate; vault-synthesis returns at most one posture descriptor).
 4. **Model pin** — `sonnet` per §7's rationale; honor `feedback_skill_sonnet_subagents` / `feedback_dm_sonnet_subagents` consistency.
 


### PR DESCRIPTION
## Summary

Final-pass Claude opus audit applied to all 5 SquidSquad TRDs per the two-tier audit pipeline (`feedback_audit_pipeline`): DeepSeek primary during iteration, Claude opus once before declaring settled.

- **51 findings applied** across the doc set (1 dismissed as audit hallucination).
- All 5 TRDs now Claude-final-pass complete.

## What's in this branch

| Commit | Doc | Findings |
|---|---|---|
| `28cfbda7` | VAULT-ARCH | 13 (4H/6M/3L) — missing §6 numbering, wikilink-on-archive triad, `style` galaxy type, `owner:` field |
| `4aa90f27` | INSTALLER-ARCH | 9 (2H/4M/3L) — phantom "step 0", three-gate scope, `## Aliases` schema |
| `17b43d35` | HARNESS-ARCH | 10 (3H/5M/3L; 1 dismissed) — status enum value, `.claude-pid` triple-meaning, `status` field in API responses |
| `13518f57` | AGENT-RUNTIME | 12 (3H/6M/3L) — `event_poll` event-mode-only spawn, §4 loop-mode mutual-exclusivity, §8.5 PR count |
| `6963dabb` | COMPOSE-ARCH | 7 (last session) — §6.5 ARE-inlined contradiction, §5.7 (slot,ordinal) breakdown |
| `44306a78` | (root-cause) | 3 architectural disambiguations (terminology, vault, boot-sequence) |

## Audit pipeline rationale

Both DeepSeek and Claude were run; the two found complementary defects:
- DS: pattern-matched flags (terminology overload, vault concept overload, boot sequence fragmentation) — most resolved by the root-cause pass.
- Claude: genuine architectural contradictions DS missed (e.g., COMPOSE §6.5 "ARE inlined" callout directly contradicted the v2 thesis stated in §1/§3.1/§4.1/§5.4/§6.2/§6.2.1/glossary).

Saved as memory rule `feedback_audit_pipeline.md`: DS during iteration, Claude opus final-pass before declaring TRD settled. Two-tier complementary, both required.

## Out of scope

- Three open spec items logged as §9 open questions in AGENT-RUNTIME (Q11 ack-stop.result enum, Q12 role:* label rewrite timing, Q13 emitter_alias derivation) — gap-marking per plan-first rule rather than inventing mechanism.
- L4 file slim treatment for worker.md / verifier.md / dm.md (only pm.md done last session).
- Move to PRD-shaping phase per `project_trd_prd_delivery_model`.

## Test plan

- [ ] Verify each commit's doc compiles clean (markdown, no broken cross-refs)
- [ ] Spot-check 1-2 HIGH fixes per doc against the audit report
- [ ] Confirm no L2/L3/L4 vault authoring slipped past the L1-exclusive guardrail
- [ ] Audit reports preserved at `C:/Users/naaht/audit-tmp/claude_output_final_*.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)