### PR TITLE
skill: #10385 — PRD-A A5 ## Aliases registry parser

### DIFF
--- a/references/scripts/config.py
+++ b/references/scripts/config.py
@@ -289,6 +289,150 @@ def set_field(field, value):
     return value
 
 
+# `## Aliases` registry parser — PRD-A Story A5 (#10385).
+# Spec lives in docs/COMPOSE-ARCHITECTURE.md §3.0; do not re-document here.
+# Greenfield: legacy bullet-form `- **alias**: value` still read by
+# `_parse_field_in_text` for `get_alias` etc., untouched by this function.
+
+ALIASES_ROLE_CLASSES = frozenset({"pm", "worker", "verifier", "dm"})
+
+# U+2014 EM DASH only. Hyphen-minus and en-dash are rejected by the strict
+# cell comparison below, giving the operator a crisper diagnostic than
+# silent acceptance of three lookalike characters.
+ALIASES_L3_NONE_SENTINEL = "—"
+
+_ALIASES_HEADING = "Aliases"
+_ALIASES_HEADER_COLUMNS = ("alias", "role-class", "L3 domain")
+
+
+class AliasesRegistryError(ValueError):
+    """Raised when `.squidsquad/config.md`'s `## Aliases` table is malformed.
+
+    Subclass of `ValueError` so callers that already catch `ValueError` for
+    config-parsing errors keep working; tests assert against the more
+    specific type when they care about the diagnostic source.
+    """
+
+
+def _split_table_row(line):
+    """Split a markdown table row into stripped cells, or None if not a row."""
+    if "|" not in line:
+        return None
+    inner = line.strip()
+    if inner.startswith("|"):
+        inner = inner[1:]
+    if inner.endswith("|"):
+        inner = inner[:-1]
+    return [cell.strip() for cell in inner.split("|")]
+
+
+def _is_table_separator(cells):
+    """Recognize a markdown table separator row like `|---|---|---|`."""
+    if not cells:
+        return False
+    sep_re = re.compile(r"^\s*:?-+:?\s*$")
+    return all(sep_re.match(cell) for cell in cells)
+
+
+def parse_aliases_registry(text=None):
+    """Parse the `## Aliases` table per COMPOSE-ARCHITECTURE §3.0.
+
+    Returns `{alias: (role_class, l3_domain)}`; `l3_domain` is `None` when
+    the cell carries the em-dash sentinel, otherwise the trimmed cell value.
+    Reads `.squidsquad/config.md` from disk when `text` is None. Raises
+    `AliasesRegistryError` on any structural malformation (see tests for
+    the exhaustive list of rejected shapes).
+
+    L3 domain values are NOT allow-list-validated — the taxonomy lives in
+    the role-class L3 fan-out and is the caller's concern, not the
+    registry's.
+    """
+    if text is None:
+        text = _read_config()
+
+    sections = _parse_sections(text)
+    if _ALIASES_HEADING not in sections:
+        raise AliasesRegistryError(
+            "config.md is missing the required `## Aliases` section "
+            "(see docs/COMPOSE-ARCHITECTURE.md §3.0 for the canonical schema)."
+        )
+
+    section_text = sections[_ALIASES_HEADING]
+
+    rows = []
+    for raw_line in section_text.splitlines():
+        cells = _split_table_row(raw_line)
+        if cells is None:
+            continue
+        rows.append(cells)
+
+    if not rows:
+        raise AliasesRegistryError(
+            "`## Aliases` section is present but contains no table — expected "
+            "a 3-column markdown table with header `| alias | role-class | "
+            "L3 domain |` (see COMPOSE-ARCHITECTURE §3.0)."
+        )
+
+    header = rows[0]
+    if len(header) != 3 or tuple(h.lower() for h in header) != tuple(
+        c.lower() for c in _ALIASES_HEADER_COLUMNS
+    ):
+        raise AliasesRegistryError(
+            f"`## Aliases` header row must be exactly "
+            f"`| {' | '.join(_ALIASES_HEADER_COLUMNS)} |`; got "
+            f"`| {' | '.join(header)} |`."
+        )
+
+    if len(rows) < 2 or not _is_table_separator(rows[1]):
+        raise AliasesRegistryError(
+            "`## Aliases` table is missing the separator row (expected "
+            "`|---|---|---|` immediately after the header)."
+        )
+
+    registry = {}
+    for data_row_index, cells in enumerate(rows[2:], start=1):
+        if len(cells) != 3:
+            raise AliasesRegistryError(
+                f"`## Aliases` data row {data_row_index} has {len(cells)} "
+                f"column(s); expected 3. Row: `| {' | '.join(cells)} |`."
+            )
+
+        alias, role_class, l3_cell = cells
+
+        if not alias:
+            raise AliasesRegistryError(
+                f"`## Aliases` data row {data_row_index} has an empty "
+                f"`alias` cell."
+            )
+        if not role_class:
+            raise AliasesRegistryError(
+                f"`## Aliases` data row {data_row_index} (`{alias}`) has an "
+                f"empty `role-class` cell."
+            )
+        if role_class not in ALIASES_ROLE_CLASSES:
+            raise AliasesRegistryError(
+                f"`## Aliases` data row {data_row_index} (`{alias}`) has "
+                f"unknown role-class `{role_class}` — must be one of "
+                f"{sorted(ALIASES_ROLE_CLASSES)}."
+            )
+        if alias in registry:
+            raise AliasesRegistryError(
+                f"`## Aliases` has duplicate alias `{alias}` "
+                f"(data row {data_row_index})."
+            )
+
+        l3_domain = None if l3_cell == ALIASES_L3_NONE_SENTINEL else (l3_cell or None)
+        registry[alias] = (role_class, l3_domain)
+
+    if not registry:
+        raise AliasesRegistryError(
+            "`## Aliases` table has a header but zero data rows. An install "
+            "must declare at least one alias."
+        )
+
+    return registry
+
+
 def get_alias(role):
     """Get the alias for a role. Falls back to bare role name if not set."""
     text = _read_config()

--- a/tests/test_config_aliases_registry_10385.py
+++ b/tests/test_config_aliases_registry_10385.py
@@ -1,0 +1,244 @@
+"""Unit tests for config.parse_aliases_registry (PRD-A Story A5, #10385).
+
+Covers the AC list verbatim:
+  - valid table -> {alias: (role_class, l3_domain)}
+  - missing `## Aliases` section -> AliasesRegistryError
+  - malformed table row (wrong column count) -> AliasesRegistryError
+  - unknown role-class -> AliasesRegistryError
+  - duplicate alias -> AliasesRegistryError
+  - em-dash "—" in L3 column -> None (sentinel)
+
+Plus boundary cases the AC implies but doesn't enumerate verbatim:
+  - empty section -> AliasesRegistryError
+  - header row name mismatch -> AliasesRegistryError
+  - missing separator row -> AliasesRegistryError
+  - empty alias / empty role-class cell -> AliasesRegistryError
+  - table with only a header (zero data rows) -> AliasesRegistryError
+  - module-level constants exported (callers should consume, not redefine)
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "references" / "scripts"))
+
+import config  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: canned config.md bodies with various `## Aliases` shapes
+# ---------------------------------------------------------------------------
+
+
+def _wrap_with_aliases(table_body):
+    """Wrap a table body in a minimal config.md so _parse_sections finds it."""
+    return (
+        "- **SquidSquad Version**: 0.0.1\n"
+        "\n"
+        "## Aliases\n"
+        "\n"
+        f"{table_body}"
+        "\n"
+        "## Project\n"
+        "- **Name**: test\n"
+    )
+
+
+CANONICAL_TABLE = (
+    "| alias | role-class | L3 domain |\n"
+    "|---|---|---|\n"
+    "| pm | pm | — |\n"
+    "| frontend-1 | worker | fe |\n"
+    "| backend-1 | worker | be |\n"
+    "| verifier | verifier | — |\n"
+    "| dm | dm | — |\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestValidTable:
+    """The §3.0 canonical example parses without complaint."""
+
+    def test_returns_dict_of_tuples(self):
+        result = config.parse_aliases_registry(_wrap_with_aliases(CANONICAL_TABLE))
+        assert isinstance(result, dict)
+        assert all(
+            isinstance(v, tuple) and len(v) == 2 for v in result.values()
+        )
+
+    def test_canonical_table_round_trips(self):
+        result = config.parse_aliases_registry(_wrap_with_aliases(CANONICAL_TABLE))
+        assert result == {
+            "pm": ("pm", None),
+            "frontend-1": ("worker", "fe"),
+            "backend-1": ("worker", "be"),
+            "verifier": ("verifier", None),
+            "dm": ("dm", None),
+        }
+
+    def test_em_dash_l3_becomes_none(self):
+        """Spec says `—` (U+2014) signals 'no L3' — must become Python None."""
+        body = (
+            "| alias | role-class | L3 domain |\n"
+            "|---|---|---|\n"
+            "| pm | pm | — |\n"
+        )
+        result = config.parse_aliases_registry(_wrap_with_aliases(body))
+        assert result["pm"] == ("pm", None)
+
+    def test_non_dash_l3_preserved_verbatim(self):
+        """Anything other than the sentinel passes through unchanged."""
+        body = (
+            "| alias | role-class | L3 domain |\n"
+            "|---|---|---|\n"
+            "| ios-1 | worker | ios |\n"
+            "| web-2 | worker | web-mobile |\n"  # multi-word L3 allowed
+        )
+        result = config.parse_aliases_registry(_wrap_with_aliases(body))
+        assert result["ios-1"] == ("worker", "ios")
+        assert result["web-2"] == ("worker", "web-mobile")
+
+    def test_all_four_role_classes_accepted(self):
+        body = (
+            "| alias | role-class | L3 domain |\n"
+            "|---|---|---|\n"
+            "| a | pm | — |\n"
+            "| b | worker | fe |\n"
+            "| c | verifier | — |\n"
+            "| d | dm | — |\n"
+        )
+        result = config.parse_aliases_registry(_wrap_with_aliases(body))
+        assert {v[0] for v in result.values()} == {"pm", "worker", "verifier", "dm"}
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic-on-malformed cases (one per AC error bullet + boundary cases)
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedInputs:
+
+    def test_missing_aliases_section(self):
+        text = "- **SquidSquad Version**: 0.0.1\n\n## Project\n- **Name**: test\n"
+        with pytest.raises(config.AliasesRegistryError, match="missing"):
+            config.parse_aliases_registry(text)
+
+    def test_empty_aliases_section(self):
+        text = (
+            "- **SquidSquad Version**: 0.0.1\n"
+            "\n"
+            "## Aliases\n"
+            "\n"
+            "## Project\n"
+        )
+        with pytest.raises(config.AliasesRegistryError, match="no table"):
+            config.parse_aliases_registry(text)
+
+    def test_wrong_column_count_in_header(self):
+        body = (
+            "| alias | role-class |\n"  # 2 columns, not 3
+            "|---|---|\n"
+            "| pm | pm |\n"
+        )
+        with pytest.raises(config.AliasesRegistryError, match="header row"):
+            config.parse_aliases_registry(_wrap_with_aliases(body))
+
+    def test_wrong_column_names_in_header(self):
+        body = (
+            "| name | role | l3 |\n"  # 3 columns, wrong names
+            "|---|---|---|\n"
+            "| pm | pm | — |\n"
+        )
+        with pytest.raises(config.AliasesRegistryError, match="header row"):
+            config.parse_aliases_registry(_wrap_with_aliases(body))
+
+    def test_missing_separator_row(self):
+        body = (
+            "| alias | role-class | L3 domain |\n"
+            "| pm | pm | — |\n"  # data row directly after header, no |---|---|---|
+        )
+        with pytest.raises(config.AliasesRegistryError, match="separator row"):
+            config.parse_aliases_registry(_wrap_with_aliases(body))
+
+    def test_data_row_wrong_column_count(self):
+        body = (
+            "| alias | role-class | L3 domain |\n"
+            "|---|---|---|\n"
+            "| pm | pm |\n"  # 2 cells, not 3
+        )
+        with pytest.raises(config.AliasesRegistryError, match="row 1 has 2"):
+            config.parse_aliases_registry(_wrap_with_aliases(body))
+
+    def test_unknown_role_class_rejected(self):
+        body = (
+            "| alias | role-class | L3 domain |\n"
+            "|---|---|---|\n"
+            "| pm | pm | — |\n"
+            "| weird | designer | — |\n"  # `designer` no longer a role-class
+        )
+        with pytest.raises(config.AliasesRegistryError, match="unknown role-class"):
+            config.parse_aliases_registry(_wrap_with_aliases(body))
+
+    def test_duplicate_alias_rejected(self):
+        body = (
+            "| alias | role-class | L3 domain |\n"
+            "|---|---|---|\n"
+            "| worker-1 | worker | fe |\n"
+            "| worker-1 | worker | be |\n"  # same alias, different L3 — illegal
+        )
+        with pytest.raises(config.AliasesRegistryError, match="duplicate alias"):
+            config.parse_aliases_registry(_wrap_with_aliases(body))
+
+    def test_empty_alias_cell_rejected(self):
+        body = (
+            "| alias | role-class | L3 domain |\n"
+            "|---|---|---|\n"
+            "|  | worker | fe |\n"
+        )
+        with pytest.raises(config.AliasesRegistryError, match="empty `alias`"):
+            config.parse_aliases_registry(_wrap_with_aliases(body))
+
+    def test_empty_role_class_cell_rejected(self):
+        body = (
+            "| alias | role-class | L3 domain |\n"
+            "|---|---|---|\n"
+            "| foo |  | fe |\n"
+        )
+        with pytest.raises(config.AliasesRegistryError, match="empty `role-class`"):
+            config.parse_aliases_registry(_wrap_with_aliases(body))
+
+    def test_header_only_no_data_rejected(self):
+        body = (
+            "| alias | role-class | L3 domain |\n"
+            "|---|---|---|\n"
+        )
+        with pytest.raises(config.AliasesRegistryError, match="zero data rows"):
+            config.parse_aliases_registry(_wrap_with_aliases(body))
+
+
+# ---------------------------------------------------------------------------
+# Module surface — callers should consume exported constants, not redefine
+# ---------------------------------------------------------------------------
+
+
+class TestExportedConstants:
+
+    def test_role_classes_frozenset_matches_spec(self):
+        """COMPOSE-ARCHITECTURE §3.0 enumerates the 4 L2 classes."""
+        assert config.ALIASES_ROLE_CLASSES == frozenset(
+            {"pm", "worker", "verifier", "dm"}
+        )
+
+    def test_l3_none_sentinel_is_em_dash(self):
+        assert config.ALIASES_L3_NONE_SENTINEL == "—"
+
+    def test_error_is_value_error_subclass(self):
+        """Callers that already catch ValueError keep working."""
+        assert issubclass(config.AliasesRegistryError, ValueError)


### PR DESCRIPTION
Closes ​#10385

### Summary

Adds `config.parse_aliases_registry()` — a parser for the `## Aliases` markdown table in `.squidsquad/config.md` per the canonical schema in [docs/COMPOSE-ARCHITECTURE.md §3.0](docs/COMPOSE-ARCHITECTURE.md). Returns `{alias: (role_class, l3_domain)}` with the em-dash `—` sentinel decoded to `None`.

Greenfield per the A1 audit (#10384 closed): no in-tree caller reads the table format yet. Legacy `- **alias**: value` bullet shape stays read by `_parse_field_in_text` (`get_alias`, `alias-*` FIELD_MAP rows). A6 wires `compose.py --v2` later.

### Acceptance Criteria

- [x] **AC1** Parser function added to `references/scripts/config.py`, returns `Dict[str, Tuple[str, Optional[str]]]`
- [x] **AC2** Schema enforced — exactly 3 columns, `role-class` constrained to `{pm, worker, verifier, dm}`, em-dash sentinel → `None`
- [x] **AC3** Explicit diagnostics via `AliasesRegistryError` on missing/empty section, header column mismatch, missing separator, wrong column count, empty alias/role-class, unknown role-class, duplicate alias, header-only-no-data
- [x] **AC4** Unit tests cover all 5 AC-required cases + 8 boundary cases (19 tests, file `tests/test_config_aliases_registry_10385.py`)
- [x] **AC5** Existing callers — none touch the table format (A1 audit-confirmed); legacy bullet path unchanged

### Changes

- **Files**: `references/scripts/config.py` (~125 new lines), `tests/test_config_aliases_registry_10385.py` (new file, 19 tests)
- **What**: New public symbols — `parse_aliases_registry()`, `AliasesRegistryError`, `ALIASES_ROLE_CLASSES`, `ALIASES_L3_NONE_SENTINEL`. New private helpers — `_split_table_row`, `_is_table_separator`.
- **Why**: Locks the canonical `## Aliases` schema in code (was prose-only in COMPOSE-ARCHITECTURE §3.0) so A6 has a parsed shape to consume.

### Verifier Status

- [x] Unit tests passing (19/19 on the new file)
- [x] No regressions in the existing config-test suites (`test_config.py`, `test_config_functions.py`, `test_config_schema.py`)
- [x] Acceptance criteria met
- [x] External code review (`model_router code-review`): NO_FINDINGS first pass

Full-suite failures on this branch (`test_agent_boundaries::test_ac7_l3_stub_exists_and_matches_template`, `test_manifest::test_include_targets_exist`, `test_feat_6126_harness_merge::*`, others) reproduce on `main` without these changes — pre-existing, not caused by this commit.