### PR TITLE
skill: #10348 — health_check._read_interval catches SystemExit + drops dead imports

### DIFF
--- a/references/scripts/health_check.py
+++ b/references/scripts/health_check.py
@@ -23,10 +23,7 @@ Exit codes:
 
 import io
 import json
-import os
-import platform
 import re
-import subprocess
 import sys
 import time
 from pathlib import Path
@@ -61,8 +58,12 @@ HEALTH_EMOJI = {
 def _read_interval():
     """Read the iteration interval from config.md. Default 30.
 
-    Uses config.py get_field (section-aware via FIELD_MAP) to avoid
-    matching unrelated 'Minutes' occurrences in other config sections.
+    Catches `SystemExit` because `config.get_field` calls `sys.exit(1)`
+    when the field is absent and not in `_FIELD_DEFAULTS`, same for
+    `_read_config()` on missing config.md. SystemExit is a BaseException,
+    not an Exception, so a narrow `except Exception` would miss it (#10348).
+    KeyboardInterrupt deliberately propagates — Ctrl+C must abort, not
+    silently fall through to the default.
     """
     try:
         sys.path.insert(0, str(SCRIPT_DIR))
@@ -70,7 +71,7 @@ def _read_interval():
         val = get_field("interval")
         if val:
             return int(val)
-    except (ImportError, ValueError, TypeError):
+    except (SystemExit, Exception):
         pass
     return 30
 

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -113,6 +113,26 @@ class TestReadInterval:
         with patch("config.get_field", return_value=""):
             assert health_check._read_interval() == 30
 
+    def test_system_exit_returns_default(self):
+        """#10348 regression: config.get_field calls sys.exit(1) when the
+        field is absent. SystemExit is a BaseException, not an Exception,
+        so the previous narrow `except (ImportError, ValueError, TypeError)`
+        let the exit propagate and aborted the script. The widened catch
+        must now fall through to the 30-minute default.
+        """
+        with patch("config.get_field", side_effect=SystemExit(1)):
+            assert health_check._read_interval() == 30
+
+    def test_keyboard_interrupt_propagates(self):
+        """#10348: KeyboardInterrupt must NOT be swallowed — Ctrl+C should
+        abort, not silently fall through to the default. Locks in the
+        narrow `(SystemExit, Exception)` catch against future drift toward
+        `BaseException`, which would also swallow KeyboardInterrupt.
+        """
+        with patch("config.get_field", side_effect=KeyboardInterrupt):
+            with pytest.raises(KeyboardInterrupt):
+                health_check._read_interval()
+
 
 class TestParseCurrentState:
     def test_valid_state(self):


### PR DESCRIPTION
Closes ​#10348

### Summary

`config.get_field` calls `sys.exit(1)` (raising `SystemExit`, a `BaseException`) when the requested field is absent from `config.md`. `health_check._read_interval` previously caught only `(ImportError, ValueError, TypeError)`, so the exit propagated up and aborted the script — the documented 30-minute fallback never fired.

This widens the catch to `(SystemExit, Exception)`: covers the bug case plus every standard `Exception` subclass, while letting `KeyboardInterrupt` and `GeneratorExit` propagate so Ctrl+C still aborts. Per DS-review iter1 feedback, this is narrower than the `except BaseException` precedent in `cycle_post._config_get` (which would silently swallow Ctrl+C).

Also drops three dead imports (`os`, `platform`, `subprocess`) from the issue body's 'out of scope but observed' cleanup.

### Acceptance Criteria

- [x] `_read_interval` returns the 30-minute default when `config.get_field` raises `SystemExit` (regression test `test_system_exit_returns_default`)
- [x] `KeyboardInterrupt` continues to propagate (regression test `test_keyboard_interrupt_propagates`)
- [x] Pre-existing catches for `ImportError`, `ValueError`, `TypeError` still fall through to the default (existing tests unchanged)
- [x] Dead imports `os` / `platform` / `subprocess` removed

### Changes

- **Files**: `references/scripts/health_check.py` (4-line change in `_read_interval`, 3 lines removed from imports, docstring updated); `tests/test_health_check.py` (+2 tests in `TestReadInterval`)
- **What**: One catch clause widened to `(SystemExit, Exception)`, docstring updated to call out deliberate `KeyboardInterrupt` propagation, three unused imports deleted.
- **Why**: Restore the documented 30-minute fallback behavior on missing `Iteration Interval` field; mirror the cycle_post precedent but narrower to avoid the Ctrl+C-eating side effect.

### Verifier Status

- [x] Unit tests passing (41/41 in `test_health_check.py`)
- [x] Acceptance criteria met
- [x] External code review converged: iter1 (DeepSeek) flagged BaseException-too-broad → iter2 (Claude subagent fallback per model_router auto-fallback rule) NO_FINDINGS

Full-suite errors on this branch (`test_agent_boundaries`, `test_manifest`, `test_feat_6126_harness_merge`, one transient `test_04_shipped_and_closed` gh-API flake) reproduce on `main` without these changes — pre-existing, not caused by this commit.