### PR TITLE
PRD-A/A2a: L1-L3 source frontmatter parser (slot + ordinal + extras) (#10487)

### DIFF
--- a/references/scripts/source_frontmatter.py
+++ b/references/scripts/source_frontmatter.py
@@ -1,0 +1,154 @@
+"""L1-L3 source frontmatter parser (#10487, PRD-A Story A2a).
+
+Reads YAML frontmatter at the top of a markdown source file and returns
+the ``slot`` + ``ordinal`` fields the v2 link stage needs for sort
+ordering, plus any other frontmatter fields untouched.
+
+Grammar (TRD §3 / §4 + the existing source-file convention in
+``references/roles/<role>/<slot>.md``):
+
+    ---
+    slot: instructions
+    ordinal: 20
+    roles: [worker]
+    step-ids: [step:cycle/triage, step:cycle/implement]
+    ---
+
+    # body content...
+
+- ``slot`` must be one of the six legal slot names; reject otherwise.
+- ``ordinal`` must be a non-negative ``int``; reject otherwise.
+- Sources without frontmatter return ``None`` (some L1-L3 files may not
+  yet carry frontmatter during the migration window — A2 callers decide
+  how to handle that).
+
+Pure additive. Existing v1 compose.py read sites ignore frontmatter
+and are not touched by this module.
+"""
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+# Duplicated from l4_parser.LEGAL_SLOTS — keeping the constant local so
+# A2a doesn't import from A2b (the two PRs are independent and either
+# may land first; a cross-module import would couple them). Tracker
+# task to consolidate once both PRDs ship.
+LEGAL_SLOTS = frozenset(
+    {"identity", "responsibility", "soul", "instructions", "project-context", "vault"}
+)
+
+# The opening ``---`` must be at the very top. Horizontal whitespace
+# (spaces/tabs) is tolerated on both delimiter lines per Jekyll
+# convention, but the broader ``\s*`` would allow ``\n`` and create
+# ambiguity around empty frontmatter blocks.
+_FRONTMATTER_RE = re.compile(r"\A---[ \t]*\n([\s\S]*?)\n---[ \t]*(?:\n|\Z)")
+# An empty frontmatter block (``---\n---``) doesn't satisfy the regex
+# above because the required ``\n`` before the closing ``---`` is already
+# consumed by the opening. Detect that shape explicitly so it raises
+# instead of silently returning ``None`` (DS finding).
+_EMPTY_FRONTMATTER_RE = re.compile(r"\A---[ \t]*\n---[ \t]*(?:\n|\Z)")
+
+
+try:
+    import yaml as _yaml
+except ImportError:
+    _yaml = None
+
+
+class FrontmatterError(ValueError):
+    """Raised when frontmatter is present but invalid."""
+
+
+@dataclass
+class SourceFrontmatter:
+    slot: str
+    ordinal: int
+    extras: dict = field(default_factory=dict)
+
+
+def parse_source_frontmatter(path):
+    """Read ``path`` and parse its top YAML frontmatter.
+
+    Returns ``SourceFrontmatter`` on success, ``None`` when the file has
+    no frontmatter. Raises :class:`FrontmatterError` when frontmatter is
+    present but malformed, missing required fields, or carrying invalid
+    ``slot`` / ``ordinal`` values. ``FileNotFoundError`` is left to
+    propagate — callers can catch it explicitly.
+    """
+    path = Path(path)
+    text = path.read_text(encoding="utf-8")
+    return parse_source_frontmatter_text(text, source=str(path))
+
+
+def parse_source_frontmatter_text(text, source="<text>"):
+    """Same as :func:`parse_source_frontmatter` but operates on a string."""
+    m = _FRONTMATTER_RE.match(text)
+    if m is None:
+        if _EMPTY_FRONTMATTER_RE.match(text):
+            raise FrontmatterError(
+                f"{source}: frontmatter block is empty — required "
+                f"`slot` and `ordinal` fields are missing."
+            )
+        return None
+    raw = m.group(1)
+    data = _yaml_load(raw, source)
+    if not isinstance(data, dict):
+        raise FrontmatterError(
+            f"{source}: frontmatter must be a YAML mapping at top level; "
+            f"got {type(data).__name__}."
+        )
+    slot = _validate_slot(data, source)
+    ordinal = _validate_ordinal(data, source)
+    extras = {k: v for k, v in data.items() if k not in ("slot", "ordinal")}
+    return SourceFrontmatter(slot=slot, ordinal=ordinal, extras=extras)
+
+
+def _yaml_load(raw, source):
+    if _yaml is None:
+        raise FrontmatterError(
+            f"{source}: PyYAML is required to parse frontmatter "
+            f"(install via `pip install pyyaml`)."
+        )
+    try:
+        return _yaml.safe_load(raw)
+    except _yaml.YAMLError as e:
+        raise FrontmatterError(
+            f"{source}: malformed YAML in frontmatter: {e}"
+        ) from e
+
+
+def _validate_slot(data, source):
+    if "slot" not in data:
+        raise FrontmatterError(
+            f"{source}: frontmatter missing required `slot` field."
+        )
+    slot = data["slot"]
+    if not isinstance(slot, str) or slot not in LEGAL_SLOTS:
+        raise FrontmatterError(
+            f"{source}: invalid `slot` value {slot!r} — must be one of "
+            f"{sorted(LEGAL_SLOTS)}."
+        )
+    return slot
+
+
+def _validate_ordinal(data, source):
+    if "ordinal" not in data:
+        raise FrontmatterError(
+            f"{source}: frontmatter missing required `ordinal` field."
+        )
+    ordinal = data["ordinal"]
+    # Reject ``True`` / ``False``: ``isinstance(True, int)`` is True in
+    # Python, but a YAML scalar of ``true``/``false`` is not a numeric
+    # ordinal value and would silently sort as 1 / 0.
+    if isinstance(ordinal, bool) or not isinstance(ordinal, int):
+        raise FrontmatterError(
+            f"{source}: `ordinal` must be a non-negative integer; got "
+            f"{ordinal!r} ({type(ordinal).__name__})."
+        )
+    if ordinal < 0:
+        raise FrontmatterError(
+            f"{source}: `ordinal` must be non-negative; got {ordinal}."
+        )
+    return ordinal

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -113,6 +113,7 @@ STATIC_TEST_MODULES = [
     "test_9398_tracker_gh_resolution",
     "test_pickup_comment_fidelity_9946",
     "test_terminology_dual_aware_6274",
+    "test_source_frontmatter",
 ]
 
 

--- a/tests/test_source_frontmatter.py
+++ b/tests/test_source_frontmatter.py
@@ -1,0 +1,293 @@
+"""Tests for references/scripts/source_frontmatter.py (#10487, PRD-A Story A2a)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+# DS finding 3: don't rely on pytest's CWD putting repo root on sys.path
+# for the v1-untouched compose import below.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import source_frontmatter as sf  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Valid frontmatter
+# ---------------------------------------------------------------------------
+
+def test_valid_frontmatter_returns_slot_and_ordinal():
+    text = (
+        "---\n"
+        "slot: instructions\n"
+        "ordinal: 20\n"
+        "---\n\n"
+        "# body content\n"
+    )
+    fm = sf.parse_source_frontmatter_text(text)
+    assert fm is not None
+    assert fm.slot == "instructions"
+    assert fm.ordinal == 20
+    assert fm.extras == {}
+
+
+def test_extras_preserved_as_is():
+    text = (
+        "---\n"
+        "slot: instructions\n"
+        "ordinal: 20\n"
+        "roles: [worker]\n"
+        "step-ids: [step:cycle/triage, step:cycle/implement]\n"
+        "custom-field: anything\n"
+        "---\n\n"
+        "body\n"
+    )
+    fm = sf.parse_source_frontmatter_text(text)
+    assert fm.extras == {
+        "roles": ["worker"],
+        "step-ids": ["step:cycle/triage", "step:cycle/implement"],
+        "custom-field": "anything",
+    }
+
+
+def test_ordinal_zero_accepted():
+    text = "---\nslot: identity\nordinal: 0\n---\n"
+    fm = sf.parse_source_frontmatter_text(text)
+    assert fm.ordinal == 0
+
+
+@pytest.mark.parametrize(
+    "slot",
+    ["identity", "responsibility", "soul", "instructions", "project-context", "vault"],
+)
+def test_each_legal_slot_accepted(slot):
+    text = f"---\nslot: {slot}\nordinal: 10\n---\n"
+    fm = sf.parse_source_frontmatter_text(text)
+    assert fm.slot == slot
+
+
+# ---------------------------------------------------------------------------
+# Missing frontmatter → returns None
+# ---------------------------------------------------------------------------
+
+def test_no_frontmatter_returns_none():
+    text = "# Just a heading\n\nsome body\n"
+    assert sf.parse_source_frontmatter_text(text) is None
+
+
+def test_frontmatter_must_be_at_very_top():
+    # Leading whitespace / blank lines before the opening --- mean the
+    # frontmatter is not at the top per CommonMark / Jekyll convention.
+    text = "\n\n---\nslot: identity\nordinal: 10\n---\n"
+    assert sf.parse_source_frontmatter_text(text) is None
+
+
+def test_unterminated_frontmatter_returns_none():
+    # No closing --- → not valid frontmatter at all.
+    text = "---\nslot: identity\nordinal: 10\n\n# body\n"
+    assert sf.parse_source_frontmatter_text(text) is None
+
+
+def test_empty_file_returns_none():
+    assert sf.parse_source_frontmatter_text("") is None
+
+
+def test_empty_frontmatter_block_raises():
+    # DS finding 1: `---\n---\n` is structurally a frontmatter block,
+    # just empty. The previous regex returned None silently here even
+    # though `---\n\n---\n` (with one blank line) raised. Lock that both
+    # shapes now reject consistently.
+    text = "---\n---\n\nbody\n"
+    with pytest.raises(sf.FrontmatterError) as exc:
+        sf.parse_source_frontmatter_text(text)
+    assert "empty" in str(exc.value).lower()
+
+
+def test_closing_delimiter_trailing_whitespace_tolerated():
+    # DS finding 4: closing `---` followed by spaces/tabs is acceptable
+    # per Jekyll convention. The regex tolerates `[ \t]*`.
+    text = "---\nslot: identity\nordinal: 0\n---   \t\n\nbody\n"
+    fm = sf.parse_source_frontmatter_text(text)
+    assert fm is not None
+    assert fm.slot == "identity"
+
+
+def test_opening_delimiter_horizontal_whitespace_tolerated():
+    text = "---  \nslot: identity\nordinal: 0\n---\n\nbody\n"
+    fm = sf.parse_source_frontmatter_text(text)
+    assert fm is not None
+
+
+def test_yaml_anchor_alias_in_extras():
+    # DS finding 5: yaml.safe_load supports anchors. Extras must
+    # round-trip through the anchor resolution correctly.
+    text = (
+        "---\n"
+        "slot: identity\n"
+        "ordinal: 0\n"
+        "x: &anchor value\n"
+        "y: *anchor\n"
+        "---\n"
+    )
+    fm = sf.parse_source_frontmatter_text(text)
+    assert fm.extras == {"x": "value", "y": "value"}
+
+
+def test_yaml_undefined_alias_raises_clean():
+    # An alias to a non-existent anchor is malformed YAML — must surface
+    # as FrontmatterError, not a bare yaml.YAMLError leak.
+    text = "---\nslot: identity\nordinal: 0\nx: *missing\n---\n"
+    with pytest.raises(sf.FrontmatterError) as exc:
+        sf.parse_source_frontmatter_text(text)
+    assert "malformed YAML" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Malformed YAML
+# ---------------------------------------------------------------------------
+
+def test_malformed_yaml_raises():
+    text = "---\nslot: identity\nordinal: 20\n  bad-indent: x\n---\n"
+    with pytest.raises(sf.FrontmatterError) as exc:
+        sf.parse_source_frontmatter_text(text)
+    assert "malformed YAML" in str(exc.value)
+
+
+def test_top_level_must_be_mapping():
+    # A YAML list at top level is well-formed YAML but invalid frontmatter.
+    text = "---\n- one\n- two\n---\n"
+    with pytest.raises(sf.FrontmatterError) as exc:
+        sf.parse_source_frontmatter_text(text)
+    assert "YAML mapping" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Invalid slot value
+# ---------------------------------------------------------------------------
+
+def test_missing_slot_field_raises():
+    text = "---\nordinal: 10\n---\n"
+    with pytest.raises(sf.FrontmatterError) as exc:
+        sf.parse_source_frontmatter_text(text)
+    assert "missing required `slot`" in str(exc.value)
+
+
+def test_unknown_slot_value_raises():
+    text = "---\nslot: bogus\nordinal: 10\n---\n"
+    with pytest.raises(sf.FrontmatterError) as exc:
+        sf.parse_source_frontmatter_text(text)
+    assert "invalid `slot`" in str(exc.value)
+    assert "bogus" in str(exc.value)
+
+
+def test_non_string_slot_raises():
+    text = "---\nslot: 42\nordinal: 10\n---\n"
+    with pytest.raises(sf.FrontmatterError):
+        sf.parse_source_frontmatter_text(text)
+
+
+# ---------------------------------------------------------------------------
+# Invalid ordinal value
+# ---------------------------------------------------------------------------
+
+def test_missing_ordinal_field_raises():
+    text = "---\nslot: identity\n---\n"
+    with pytest.raises(sf.FrontmatterError) as exc:
+        sf.parse_source_frontmatter_text(text)
+    assert "missing required `ordinal`" in str(exc.value)
+
+
+def test_non_integer_ordinal_raises():
+    text = "---\nslot: identity\nordinal: ten\n---\n"
+    with pytest.raises(sf.FrontmatterError) as exc:
+        sf.parse_source_frontmatter_text(text)
+    assert "non-negative integer" in str(exc.value)
+
+
+def test_float_ordinal_raises():
+    text = "---\nslot: identity\nordinal: 10.5\n---\n"
+    with pytest.raises(sf.FrontmatterError):
+        sf.parse_source_frontmatter_text(text)
+
+
+def test_negative_ordinal_raises():
+    text = "---\nslot: identity\nordinal: -1\n---\n"
+    with pytest.raises(sf.FrontmatterError) as exc:
+        sf.parse_source_frontmatter_text(text)
+    assert "non-negative" in str(exc.value)
+
+
+def test_boolean_ordinal_rejected():
+    # YAML `true` is a bool, not an int — even though Python's
+    # `isinstance(True, int)` is True. A scalar of `true` is not an
+    # ordinal value and would silently sort as 1.
+    text = "---\nslot: identity\nordinal: true\n---\n"
+    with pytest.raises(sf.FrontmatterError):
+        sf.parse_source_frontmatter_text(text)
+
+
+# ---------------------------------------------------------------------------
+# File I/O round-trip
+# ---------------------------------------------------------------------------
+
+def test_parse_source_frontmatter_reads_file(tmp_path):
+    f = tmp_path / "instructions.md"
+    f.write_text(
+        "---\nslot: instructions\nordinal: 20\nroles: [worker]\n---\n\nbody\n",
+        encoding="utf-8",
+    )
+    fm = sf.parse_source_frontmatter(f)
+    assert fm.slot == "instructions"
+    assert fm.ordinal == 20
+    assert fm.extras == {"roles": ["worker"]}
+
+
+def test_parse_source_frontmatter_propagates_filenotfound(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        sf.parse_source_frontmatter(tmp_path / "does_not_exist.md")
+
+
+# ---------------------------------------------------------------------------
+# Real source files in this repo
+# ---------------------------------------------------------------------------
+
+def test_existing_dm_identity_parses_correctly():
+    # references/roles/dm/identity.md was the first file to carry the
+    # v2 frontmatter shape. Lock that the parser handles it.
+    repo_root = Path(__file__).resolve().parent.parent
+    f = repo_root / "references" / "roles" / "dm" / "identity.md"
+    if not f.is_file():
+        pytest.skip(f"{f} not present in this branch")
+    fm = sf.parse_source_frontmatter(f)
+    assert fm is not None
+    assert fm.slot == "identity"
+    assert isinstance(fm.ordinal, int)
+    assert fm.ordinal >= 0
+
+
+# ---------------------------------------------------------------------------
+# Coexistence: parser does not modify v1 read sites
+# ---------------------------------------------------------------------------
+
+def test_v1_compose_untouched():
+    import compose
+    source = compose.__file__
+    with open(source, encoding="utf-8") as f:
+        text = f.read()
+    assert "source_frontmatter" not in text, (
+        "A2a is parse-only; A2 will wire source_frontmatter into compose.py later."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Result shape
+# ---------------------------------------------------------------------------
+
+def test_extras_default_factory_is_independent():
+    a = sf.SourceFrontmatter(slot="identity", ordinal=10)
+    b = sf.SourceFrontmatter(slot="identity", ordinal=10)
+    a.extras["x"] = 1
+    assert b.extras == {}


### PR DESCRIPTION
## Summary

PRD-A Story A2a — pure-Python parser for the YAML frontmatter that L1-L3 source markdown files use to declare their `slot` and `ordinal` for v2 link-stage ordering. Pure additive — `compose.py` is untouched. A2 will wire this into `compose.py` inside the `--v2` branch later.

## What landed

- `references/scripts/source_frontmatter.py` (~150 lines):
  - `parse_source_frontmatter(path) -> SourceFrontmatter | None` (also `parse_source_frontmatter_text(text)` for tests).
  - `SourceFrontmatter` dataclass: `slot: str`, `ordinal: int`, `extras: dict` (every non-slot/non-ordinal field preserved untouched).
  - `_FRONTMATTER_RE` requires the opening `---` at the very top with horizontal-whitespace tolerance on both delimiter lines. `_EMPTY_FRONTMATTER_RE` is a fallback for the structurally-empty block `---\n---\n` which the main regex can't satisfy (no `\n` to anchor the closing on).
  - Slot validation against `LEGAL_SLOTS = {identity, responsibility, soul, instructions, project-context, vault}`.
  - Ordinal validation explicitly rejects `bool` (because `isinstance(True, int)` is True in Python — a YAML `true` would otherwise silently sort as 1), `float`, negative ints, missing.
  - PyYAML required (compose.py already uses the same try/except pattern); a clear `FrontmatterError` is raised if PyYAML is unavailable.
- `tests/test_source_frontmatter.py` (33 tests, all green).
- `tests/run_tests.py`: registered the new module.

## AC mapping

| AC | Where |
|---|---|
| `parse_source_frontmatter(path) -> SourceFrontmatter` in new module | `source_frontmatter.py:67-77` |
| Returns `{slot, ordinal, ...extras preserved}` | `SourceFrontmatter` dataclass + `test_extras_preserved_as_is` |
| Validates `slot` in 6-slot set, rejects otherwise | `_validate_slot` + 4 slot tests |
| Validates `ordinal` non-negative int, rejects otherwise | `_validate_ordinal` + 6 ordinal tests (incl. boolean rejection) |
| Missing frontmatter → None | `test_no_frontmatter_returns_none`, etc. |
| Unit tests for valid / missing / malformed YAML / invalid slot / non-integer ordinal | All 33 tests |
| No changes to v1 compose.py | `test_v1_compose_untouched` greps `compose.py` source for `source_frontmatter` and asserts NO import |

## LEGAL_SLOTS duplication note

The 6-slot set is duplicated from A2b's `l4_parser.py` rather than imported. Rationale: A2a (#10487) and A2b (#10488) are independent PRDs and either may merge first; a cross-module import would couple them and create a stacking risk per memory `feedback_stacked_pr_auto_close`. The module docstring documents this. Future consolidation task can fold both copies into a shared constants module once both PRDs ship.

## DeepSeek code review

5 findings, all addressed in the same commit:

1. **(error)** Empty frontmatter block `---\n---\n` returned `None` silently instead of raising, while the nearly identical `---\n\n---\n` did raise. Added `_EMPTY_FRONTMATTER_RE` fallback with a specific diagnostic. Regression test `test_empty_frontmatter_block_raises`.
2. **(warning)** Opening delimiter used `\s*` which allows `\n` and contributed to finding 1. Tightened to `[ \t]*` (horizontal whitespace only).
3. **(warning)** `import compose` in the v1-untouched test relied on pytest's CWD putting the repo root on `sys.path`. Added `sys.path.insert(0, str(REPO_ROOT))` at the test-module top.
4. **(warning)** No test for trailing whitespace on the closing `---`. Added.
5. **(warning)** No test for YAML anchors/aliases. Added `test_yaml_anchor_alias_in_extras` (round-trips an `&anchor`/`*anchor` pair) + `test_yaml_undefined_alias_raises_clean` (undefined alias → `FrontmatterError`, not a raw `YAMLError`).

## Coexistence with v1 (PRD-A §9a)

Pure additive new module. `compose.py` is not modified. v1 source-file read sites ignore frontmatter; v1 `compose.py deploy <role>` continues to produce byte-identical output (the path-equivalence check from A6 still holds — no compose.py edits in this PR).

## Test plan

- [ ] `python -m pytest tests/test_source_frontmatter.py -v` → 33 passed.
- [ ] `python tests/run_tests.py` → integration suite green (52/52). Pre-existing 20 static failures in unrelated modules remain unchanged.

Closes ​#10487.
