### PR TITLE
fix(event_bus): _discover_port honors SQUIDSQUAD_DIR at call time (#10516)

### DIFF
--- a/references/scripts/event_bus.py
+++ b/references/scripts/event_bus.py
@@ -37,6 +37,19 @@ def _resolve_squid_dir() -> Path:
     return Path(raw).expanduser()
 
 
+# Module-level capture is kept for backwards compatibility with callers
+# that grep this attribute (e.g. ``test_9398_squidsquad_dir_env_var.py``
+# expects ``event_bus.SQUID_DIR`` to be the value resolved when the
+# module loads, and ``patch.object(event_bus, 'SQUID_DIR', …)`` is used
+# by ``test_event_bus.py`` to redirect emits to a tmp dir). Internal
+# call sites that need a runtime ``SQUIDSQUAD_DIR`` read the env var at
+# call time and fall back to this ``SQUID_DIR`` — see ``_discover_port``
+# for the pattern. ``_resolve_squid_dir()`` itself is only used to
+# initialise ``SQUID_DIR`` here at import time; it is intentionally NOT
+# re-called from ``_discover_port`` because its fallback is
+# ``REPO_ROOT / ".squidsquad"`` rather than the patchable
+# ``SQUID_DIR``, which would silently break the existing test fixtures
+# (#10516).
 SQUID_DIR = _resolve_squid_dir()
 
 # Timeout: 500ms — never blocks agent cycle
@@ -50,9 +63,19 @@ def _discover_port():
     distributes the port file to all clone directories at boot
     (harness.py lifespan), so parent-dir walk is unnecessary.
 
+    Resolution order (#10516):
+
+    1. ``SQUIDSQUAD_DIR`` env var if set at call time — honors a runtime
+       override without requiring an ``importlib`` reload.
+    2. Module-level ``SQUID_DIR`` — the value captured when the module
+       loaded; what tests that ``patch.object(event_bus, 'SQUID_DIR', …)``
+       expect to control.
+
     Returns port number or None if not discoverable.
     """
-    port_file = SQUID_DIR / ".harness-port"
+    raw = (os.environ.get("SQUIDSQUAD_DIR") or "").strip()
+    squid_dir = Path(raw).expanduser() if raw else SQUID_DIR
+    port_file = squid_dir / ".harness-port"
     if port_file.exists():
         try:
             return int(port_file.read_text(encoding="utf-8").strip())

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -145,6 +145,36 @@ class TestDiscoverPort:
         result = event_bus._discover_port()
         assert result is None
 
+    def test_runtime_squidsquad_dir_env_change_honored_10516(self, tmp_path, monkeypatch):
+        """#10516: a SQUIDSQUAD_DIR change set AFTER event_bus was imported
+        must be picked up by _discover_port() without a module reload.
+
+        The module-level SQUID_DIR captures the import-time env; this test
+        asserts that the runtime env wins, so test harnesses + future
+        dynamic-dispatch callers don't have to importlib-reload.
+        """
+        # Distinct dirs so we can prove which one was consulted.
+        env_squid = tmp_path / "env-squid" / ".squidsquad"
+        env_squid.mkdir(parents=True)
+        (env_squid / ".harness-port").write_text("18080", encoding="utf-8")
+
+        module_squid = tmp_path / "module-squid" / ".squidsquad"
+        module_squid.mkdir(parents=True)
+        (module_squid / ".harness-port").write_text("19090", encoding="utf-8")
+
+        monkeypatch.setattr(event_bus, "SQUID_DIR", module_squid)
+        # SQUIDSQUAD_DIR is the squid dir itself (the function does not
+        # append .squidsquad to the env value).
+        monkeypatch.setenv("SQUIDSQUAD_DIR", str(env_squid))
+
+        # Env wins.
+        assert event_bus._discover_port() == 18080
+
+        # When the env var is cleared mid-process, fall back to the
+        # module-level SQUID_DIR (preserves the pre-#10516 test surface).
+        monkeypatch.delenv("SQUIDSQUAD_DIR")
+        assert event_bus._discover_port() == 19090
+
 
 class TestGenerateId:
     """Tests for _generate_id() function. Widened to 16 hex + nonce per #9415."""


### PR DESCRIPTION
## Summary

Fixes ​#10516 (self-filed during cycle 1445 improvement scan). `event_bus.SQUID_DIR` was captured at module-import time, so any code path that set `SQUIDSQUAD_DIR` AFTER `event_bus` was first imported saw zero effect. The existing `test_9398_squidsquad_dir_env_var.py` worked around this with a full `importlib` reload — itself evidence of the foot-gun. Production launcher sets `SQUIDSQUAD_DIR` before Python starts so this never bit production; flagged as low priority for future dynamic-dispatch / integration callers.

## Change

`_discover_port()` (L66-83) now reads `SQUIDSQUAD_DIR` from `os.environ` on each call and falls back to the module-level `SQUID_DIR` when the env var is unset.

## Why a fallback chain instead of always re-resolving

The obvious cleaner fix — refactor `_discover_port()` to call `_resolve_squid_dir()` — silently breaks existing tests:

- `tests/test_event_bus.py` uses `patch_dirs` fixture: `patch.object(event_bus, 'SQUID_DIR', tmp)` to redirect emits.
- `_resolve_squid_dir()` can't see that patched attribute; its fallback is `REPO_ROOT / '.squidsquad'`.
- So calling `_resolve_squid_dir()` from `_discover_port` would make the `patch_dirs` fixture stop working: emits would land on the real repo's `.squidsquad` instead of the tmp dir.

Inlining the env read with the `SQUID_DIR` fallback gives us both:
- **Runtime env override**: env wins when set at call time.
- **Test-patchable module attribute**: existing `patch.object` callers see no change.
- **Production behavior unchanged**: env is set before Python starts, both paths return the same value.

## What landed

- `references/scripts/event_bus.py`:
  - `_discover_port` docstring documents the resolution order.
  - Comment block above `SQUID_DIR` accurately describes the duplication and why `_resolve_squid_dir()` is intentionally NOT re-called from `_discover_port` (DS finding 1 fix).
- `tests/test_event_bus.py`:
  - New `test_runtime_squidsquad_dir_env_change_honored_10516` — two tmp squid dirs with distinct port files (18080 / 19090); `monkeypatch.setenv` AFTER import; asserts env wins, then `monkeypatch.delenv` asserts module-level fallback restored.

## DeepSeek code review

1 warning: the initial comment above `SQUID_DIR` claimed *"Internal call sites use `_resolve_squid_dir()` directly"* — factually wrong. Internal call sites duplicate the env-read inline because `_resolve_squid_dir()`'s fallback would defeat the patchable `SQUID_DIR`. Comment rewritten to describe the actual architecture and the reason for the duplication.

DS confirmed the four other review concerns (back-compat preserved, `os.environ.get` consistency, `monkeypatch.setenv` interaction with module-level `os` import, `Path(raw).expanduser()` on Windows UNC / trailing slashes) are clean.

## Tests

- `python -m pytest tests/test_event_bus.py tests/test_9398_squidsquad_dir_env_var.py` → 35 passed (was 34; +1 regression test).
- Full `python tests/run_tests.py` integration suite green (52/52). Pre-existing 20 static failures in unrelated modules unchanged.

## Coexistence

No public-API change. Production callers see no behavior change. Test fixtures preserved.

Closes ​#10516.
