### PR TITLE
fix(diagnostics): two-tier lock around log_entry rotate+append (#10523)

### DIFF
--- a/references/scripts/diagnostics.py
+++ b/references/scripts/diagnostics.py
@@ -15,6 +15,8 @@ Usage:
 import json
 import subprocess
 import sys
+import threading
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 
@@ -85,8 +87,55 @@ except ImportError:
 LOG_FILE = DIAGNOSTICS_DIR / "diagnostic.jsonl"
 
 
+# Per-process thread lock. msvcrt.locking on Windows is per-PROCESS, so two
+# threads in the same process that try to lock the same byte range raise
+# EDEADLK ("Resource deadlock avoided"). The threading lock handles
+# intra-process serialization; the file lock below handles inter-process.
+_LOG_THREAD_LOCK = threading.Lock()
+
+
+@contextmanager
+def _log_lock():
+    """Hold an exclusive advisory lock around the log-write critical section
+    (#10523). Cross-platform two-tier:
+
+    1. ``_LOG_THREAD_LOCK`` serializes threads within the same process.
+    2. ``fcntl.flock`` (POSIX) / ``msvcrt.locking`` (Windows) serializes
+       writers across processes via a sibling ``.lock`` file.
+
+    Both tiers are required: file locks alone race between threads in the
+    same process; thread locks alone race between agents in different
+    processes.
+    """
+    DIAGNOSTICS_DIR.mkdir(parents=True, exist_ok=True)
+    lock_path = LOG_FILE.with_suffix(".lock")
+    with _LOG_THREAD_LOCK:
+        # ``a`` mode creates the file if missing and never truncates it.
+        f = open(lock_path, "a", encoding="utf-8")
+        try:
+            if sys.platform == "win32":
+                import msvcrt
+                msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
+                try:
+                    yield
+                finally:
+                    # LK_LOCK/LK_UNLCK are position-based on Windows; seek
+                    # back to the locked range before releasing.
+                    f.seek(0, 2)
+                    msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+                fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+                try:
+                    yield
+                finally:
+                    fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+        finally:
+            f.close()
+
+
 def log_entry(severity, source, message, context=None):
-    """Append a diagnostic entry to the log file."""
+    """Append a diagnostic entry to the log file. Thread- and process-safe."""
     DIAGNOSTICS_DIR.mkdir(parents=True, exist_ok=True)
 
     entry = {
@@ -101,12 +150,17 @@ def log_entry(severity, source, message, context=None):
         except json.JSONDecodeError:
             entry["context"] = {"raw": context}
 
-    # Auto-rotate before write if over cap (#5385)
-    if LOG_FILE.exists() and LOG_FILE.stat().st_size > MAX_LOG_BYTES:
-        rotate()
+    # Hold an exclusive lock around the rotate-if-needed + append (#10523).
+    # Without it, two writers can both observe size > MAX_LOG_BYTES, both
+    # call ``rotate``, and the second ``atomic_write_text`` swaps in a stale
+    # last-500 snapshot, silently losing the first writer's truncated tail.
+    with _log_lock():
+        # Auto-rotate before write if over cap (#5385)
+        if LOG_FILE.exists() and LOG_FILE.stat().st_size > MAX_LOG_BYTES:
+            rotate()
 
-    with open(LOG_FILE, "a", encoding="utf-8") as f:
-        f.write(json.dumps(entry) + "\n")
+        with open(LOG_FILE, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
 
     return entry
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -126,6 +126,89 @@ class TestRotate:
         assert "after rotation" in content
 
 
+class TestConcurrentLogEntry10523:
+    """#10523: concurrent log_entry calls must serialize via the advisory
+    file lock so the rotate-if-needed + append window can't race.
+    """
+
+    def test_no_writes_lost_under_thread_concurrency(self, tmp_path):
+        log_dir = tmp_path / "diagnostics"
+        log_dir.mkdir()
+        log_file = log_dir / "diagnostic.jsonl"
+
+        import threading
+
+        N = 30  # 30 threads × 1 entry each
+        start = threading.Barrier(N)
+
+        def worker(i):
+            start.wait()
+            diagnostics.log_entry("info", "concurrency", f"entry-{i}")
+
+        # Patch ONCE at the test boundary (patch.object is not thread-safe;
+        # per-thread patches race on the module attribute and lose writes).
+        with patch.object(diagnostics, "DIAGNOSTICS_DIR", log_dir), \
+             patch.object(diagnostics, "LOG_FILE", log_file):
+            threads = [threading.Thread(target=worker, args=(i,)) for i in range(N)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        lines = log_file.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == N, (
+            f"expected {N} entries, got {len(lines)} — concurrent appends "
+            f"raced (lock didn't serialize)"
+        )
+        # Each line must parse cleanly — no torn JSON from interleaved writes.
+        for line in lines:
+            json.loads(line)
+        # Every worker's entry is present (no silent drops).
+        messages = {json.loads(line)["message"] for line in lines}
+        assert messages == {f"entry-{i}" for i in range(N)}
+
+    def test_rotate_under_concurrency_keeps_consistent_tail(self, tmp_path):
+        # Simulate the rotate-while-writing race: pre-seed a log file just
+        # over the byte cap so every concurrent worker takes the rotate
+        # branch. The lock must serialize them so we never end up with a
+        # double-truncated file.
+        log_dir = tmp_path / "diagnostics"
+        log_dir.mkdir()
+        log_file = log_dir / "diagnostic.jsonl"
+
+        # Pre-seed with 600 entries (> 500, will be rotated to last 500).
+        seed = [json.dumps({"seed": i}) for i in range(600)]
+        log_file.write_text("\n".join(seed) + "\n", encoding="utf-8")
+
+        import threading
+
+        N = 20
+        start = threading.Barrier(N)
+
+        def worker(i):
+            start.wait()
+            diagnostics.log_entry("info", "concurrent-rotate", f"new-{i}")
+
+        with patch.object(diagnostics, "DIAGNOSTICS_DIR", log_dir), \
+             patch.object(diagnostics, "LOG_FILE", log_file), \
+             patch.object(diagnostics, "MAX_LOG_BYTES", 10):  # always rotate
+            threads = [threading.Thread(target=worker, args=(i,)) for i in range(N)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        lines = log_file.read_text(encoding="utf-8").strip().splitlines()
+        # Every new entry must be present — no writer lost its append to a
+        # double-truncating peer.
+        new_messages = set()
+        for line in lines:
+            entry = json.loads(line)
+            if entry.get("source") == "concurrent-rotate":
+                new_messages.add(entry["message"])
+        assert new_messages == {f"new-{i}" for i in range(N)}
+
+
 class TestSanitizeConfig:
     def test_redacts_repo_field(self):
         config_text = "- **Repo**: github.com/secret/repo\n- **Name**: MyApp\n"


### PR DESCRIPTION
## Summary

Fixes ​#10523 (self-filed during cycle 1447 improvement scan). `diagnostics.log_entry` did `stat → rotate → open-append` as three independent steps. Under concurrent multi-agent writers, two writers could both observe size > 1MB, both call `rotate()`, and the second `atomic_write_text` swap in a stale last-500 snapshot — silently losing the first writer's truncated tail.

## Change

New `_log_lock()` context manager. Two-tier:

1. **`_LOG_THREAD_LOCK` (`threading.Lock`)** — serializes threads in the same process. Required because `msvcrt.locking` on Windows is per-PROCESS; two threads in the same process trying to lock the same byte range raise `OSError(EDEADLK, 'Resource deadlock avoided')`.
2. **File lock on a sibling `.lock` file** — `fcntl.flock` on POSIX, `msvcrt.locking` on Windows. Serializes writers across processes.

`log_entry` wraps the `rotate-if-needed + open-append` block in `_log_lock()`. Single-threaded callers see one `Lock.__enter__/__exit__` and one `flock`/`msvcrt` round-trip per call — all existing tests pass unchanged.

## Why two tiers (and not just one)

- **File lock alone** races between threads in the same process — Windows `msvcrt.locking` is per-process; the first failing dev iteration of this PR raised `EDEADLK` from the second thread.
- **Thread lock alone** races between different agent processes (the common multi-agent SquidSquad case the scan finding called out as the dormant defect).

Both are required.

## Tests

New `TestConcurrentLogEntry10523` class in `tests/test_diagnostics.py`:

1. `test_no_writes_lost_under_thread_concurrency` — 30 threads × 1 entry each, `threading.Barrier(N)` for synchronized start. Asserts (a) line count == N, (b) every line parses as JSON (no torn writes), (c) every per-thread `entry-{i}` message is present.
2. `test_rotate_under_concurrency_keeps_consistent_tail` — pre-seeds 600 entries (over the 500-cap), 20 threads with `MAX_LOG_BYTES` patched to 10 so every iteration takes the rotate branch. Asserts every `new-{i}` survives the concurrent rotation.

`patch.object` applied ONCE at the test boundary (outside the worker), not per-thread. `patch.object` is not thread-safe — per-thread patches race on the module attribute and lose writes; the initial 29/30 failure during dev was caused by exactly that, not the lock.

## DeepSeek code review

I asked DS to specifically trace 4 concerns about the implementation:

1. msvcrt position-based unlock correctness (`f.seek(0, 2)` before `LK_UNLCK`)
2. Resource cleanup if `open(lock_path, ...)` itself raises
3. Thread/file lock ordering deadlocks with `rotate()` or `read_entries()`
4. `LOG_FILE.with_suffix('.lock')` if `LOG_FILE` has no suffix

Result: **NO_FINDINGS** — all four concerns confirmed clean. DS additionally traced the line-by-line evolution through the 20-worker rotate test and confirmed every `new-{i}` survives.

## Coexistence

No public-API change. The CLI surface is unchanged. Single-threaded callers pay one `Lock.__enter__/__exit__` + one `flock`/`msvcrt.locking` round-trip per call. Existing 37 diagnostics tests pass unchanged.

## Test plan

- [ ] `python -m pytest tests/test_diagnostics.py -v` → 39 passed (was 37; +2 concurrency regression tests).
- [ ] `python tests/run_tests.py` → integration suite green (52/52). Pre-existing 20 static failures in unrelated modules remain unchanged.

Closes ​#10523.
