### PR TITLE
PRD-B/B3: assemble_verifier — length floor + code-block parity checks (#10442)

### DIFF
--- a/references/scripts/assemble_verifier.py
+++ b/references/scripts/assemble_verifier.py
@@ -1,4 +1,4 @@
-"""Assemble-pass preservation verifier — pure Python (#10441, PRD-B Story B2).
+"""Assemble-pass preservation verifier — pure Python.
 
 Per PRD-B success criterion 3 + TRD §4.6 hard preservation guarantees,
 the assemble pass MUST preserve every sub-skill reference and every
@@ -9,8 +9,13 @@ Grammar (TRD §6.1):
 - Sub-skill refs:  ``→ run sub-skill: <name>``  (arrow is U+2192)
 - Step IDs:        ``step:cycle/<id>``
 
-B3 (#10442) extends this same module with length-floor + code-block
-parity checks; keep B3 additions out of this commit.
+B2 (#10441) added ``verify_preservation`` for sub-skill + step-ID
+multiset checks. B3 (#10442) adds two additional preservation checks
+operating on the same (linked, assembled) pair:
+
+- ``check_length_floor``: guards against pathological truncation.
+- ``check_code_block_parity``: guards against silently-dropped or
+  silently-added code blocks (fenced + inline).
 """
 
 import re
@@ -78,3 +83,75 @@ def verify_preservation(linked, assembled):
         missing_step_ids=missing_steps,
         extra_step_ids=extra_steps,
     )
+
+
+# B3 (#10442) — length floor + code-block parity checks.
+
+# Fenced code-block opener/closer. Required at line start per CommonMark
+# §4.5; three-or-more backticks. We count fence markers and pair them up.
+_FENCE_RE = re.compile(r"^```+", re.MULTILINE)
+
+
+def check_length_floor(linked, assembled, floor=0.8):
+    """Return True iff ``len(assembled) >= floor * len(linked)``.
+
+    Guards against the assemble pass silently truncating output. Empty
+    linked is trivially satisfied (``floor * 0 == 0``), so empty
+    assembled passes only when linked is also empty.
+    """
+    return len(assembled) >= floor * len(linked)
+
+
+def _count_fenced_blocks(text):
+    """Count fenced code blocks (pairs of ```-fence markers at line start)."""
+    return len(_FENCE_RE.findall(text)) // 2
+
+
+def _strip_fenced_blocks(text):
+    """Remove fenced regions so inline-backtick counts don't double-count fences.
+
+    Greedy across newlines; the ``re.DOTALL`` form is needed because
+    fenced regions span lines.
+    """
+    return re.sub(r"```+.*?```+", "", text, flags=re.DOTALL)
+
+
+def _count_inline_backtick_spans(text):
+    """Count inline ``\\`...\\``` spans (single-backtick delimited)."""
+    stripped = _strip_fenced_blocks(text)
+    # Single backticks that are NOT part of a longer backtick run, paired up.
+    # A standalone backtick has neither a backtick neighbor on the left nor
+    # the right. Two such backticks form one inline span.
+    standalone = re.findall(r"(?<!`)`(?!`)", stripped)
+    return len(standalone) // 2
+
+
+def _within_tolerance(linked_count, assembled_count, tolerance):
+    """Return True iff the assembled count is within ``±tolerance`` of linked.
+
+    Uses ``max(linked_count, 1)`` as the denominator so a linked count of
+    0 still yields a meaningful comparison: any nonzero ``assembled_count``
+    is treated as an unbounded change and fails when ``tolerance < 1``.
+    """
+    delta = abs(assembled_count - linked_count)
+    return delta / max(linked_count, 1) <= tolerance
+
+
+def check_code_block_parity(linked, assembled, tolerance=0.1):
+    """Return True iff fenced-block AND inline-backtick counts are both within ``±tolerance``.
+
+    Both checks must pass; a drop or a spike in either count beyond
+    ``tolerance`` fails. Default ``tolerance=0.1`` matches the AC
+    (±10%).
+    """
+    fenced_ok = _within_tolerance(
+        _count_fenced_blocks(linked),
+        _count_fenced_blocks(assembled),
+        tolerance,
+    )
+    inline_ok = _within_tolerance(
+        _count_inline_backtick_spans(linked),
+        _count_inline_backtick_spans(assembled),
+        tolerance,
+    )
+    return fenced_ok and inline_ok

--- a/tests/test_assemble_verifier.py
+++ b/tests/test_assemble_verifier.py
@@ -204,3 +204,148 @@ def test_preservation_result_fields_present():
         "extra_step_ids",
     ):
         assert hasattr(r, attr)
+
+
+# ---------------------------------------------------------------------------
+# B3 (#10442) — length floor
+# ---------------------------------------------------------------------------
+
+def test_length_floor_identity_passes():
+    body = "abc" * 100
+    assert av.check_length_floor(body, body) is True
+
+
+def test_length_floor_empty_linked_empty_assembled_passes():
+    assert av.check_length_floor("", "") is True
+
+
+def test_length_floor_empty_assembled_with_nonempty_linked_fails():
+    """AC: 'empty assembled fails floor' (when linked is non-empty)."""
+    assert av.check_length_floor("x" * 100, "") is False
+
+
+def test_length_floor_at_exactly_0_8x_passes():
+    """AC: 'assembled at exactly 0.8x passes' — boundary is inclusive."""
+    linked = "x" * 100
+    assembled = "y" * 80  # exactly 0.8 * 100
+    assert av.check_length_floor(linked, assembled) is True
+
+
+def test_length_floor_at_0_79x_fails():
+    """AC: '0.79x fails' — strictly below floor."""
+    linked = "x" * 100
+    assembled = "y" * 79
+    assert av.check_length_floor(linked, assembled) is False
+
+
+def test_length_floor_custom_floor_threshold():
+    linked = "x" * 100
+    assembled = "y" * 50
+    assert av.check_length_floor(linked, assembled, floor=0.5) is True
+    assert av.check_length_floor(linked, assembled, floor=0.51) is False
+
+
+def test_length_floor_longer_assembled_passes():
+    """A grown assembled (e.g. compose injected content) trivially satisfies the floor."""
+    assert av.check_length_floor("short", "much longer body here") is True
+
+
+# ---------------------------------------------------------------------------
+# B3 (#10442) — code-block parity (fenced)
+# ---------------------------------------------------------------------------
+
+def _fenced(n, lang=""):
+    """Return a body containing ``n`` well-formed fenced blocks."""
+    return "\n".join(f"```{lang}\nbody {i}\n```" for i in range(n))
+
+
+def test_code_block_parity_identity_passes():
+    body = _fenced(10)
+    assert av.check_code_block_parity(body, body) is True
+
+
+def test_code_block_parity_no_blocks_either_side_passes():
+    assert av.check_code_block_parity("just prose\n", "just prose still\n") is True
+
+
+def test_code_block_parity_fenced_drop_at_tolerance_passes():
+    """10/10 -> 9/10 is exactly 10% drop; at-tolerance boundary passes."""
+    linked = _fenced(10)
+    assembled = _fenced(9)
+    assert av.check_code_block_parity(linked, assembled) is True
+
+
+def test_code_block_parity_fenced_drop_just_over_tolerance_fails():
+    """AC: 'code block count drops by >10% fails' — 10 -> 8 is 20%."""
+    linked = _fenced(10)
+    assembled = _fenced(8)
+    assert av.check_code_block_parity(linked, assembled) is False
+
+
+def test_code_block_parity_fenced_spike_over_tolerance_fails():
+    """Symmetry: a >10% increase also fails."""
+    linked = _fenced(10)
+    assembled = _fenced(12)
+    assert av.check_code_block_parity(linked, assembled) is False
+
+
+def test_code_block_parity_fenced_with_lang_tag_counted():
+    """Language-tagged fences (```python) count like bare fences."""
+    linked = _fenced(5, lang="python") + "\n" + _fenced(5)
+    assembled = linked
+    assert av.check_code_block_parity(linked, assembled) is True
+
+
+# ---------------------------------------------------------------------------
+# B3 (#10442) — code-block parity (inline backticks)
+# ---------------------------------------------------------------------------
+
+def _inline(n):
+    """Return a body with ``n`` inline single-backtick spans."""
+    return " ".join(f"prose `code{i}` more" for i in range(n))
+
+
+def test_code_block_parity_inline_identity_passes():
+    body = _inline(10)
+    assert av.check_code_block_parity(body, body) is True
+
+
+def test_code_block_parity_inline_drop_just_over_tolerance_fails():
+    """AC: 'inline backtick count change >10% fails' — 10 -> 8 is 20%."""
+    linked = _inline(10)
+    assembled = _inline(8)
+    assert av.check_code_block_parity(linked, assembled) is False
+
+
+def test_code_block_parity_inline_spike_just_over_tolerance_fails():
+    linked = _inline(10)
+    assembled = _inline(12)
+    assert av.check_code_block_parity(linked, assembled) is False
+
+
+def test_code_block_parity_inline_does_not_count_fenced_backticks():
+    """Triple-backtick fences must not inflate the inline count."""
+    linked = _fenced(3)  # zero inline spans
+    assembled = _fenced(3) + "\n" + _inline(1)  # one inline span (10 backticks delta if naive)
+    # Inline count goes 0 -> 1; using max(linked,1) denominator, delta=1/1=1.0 > 0.1 → fail.
+    assert av.check_code_block_parity(linked, assembled) is False
+
+
+def test_code_block_parity_mixed_fenced_and_inline_pass():
+    body = _fenced(4) + "\n" + _inline(20)
+    assert av.check_code_block_parity(body, body) is True
+
+
+def test_code_block_parity_custom_tolerance():
+    linked = _inline(10)
+    assembled = _inline(7)
+    # 30% drop: fails at default 0.1, passes at 0.3
+    assert av.check_code_block_parity(linked, assembled) is False
+    assert av.check_code_block_parity(linked, assembled, tolerance=0.3) is True
+
+
+def test_code_block_parity_either_side_failure_fails_combined():
+    """When fenced is OK but inline is off, the combined check still fails."""
+    linked = _fenced(5) + "\n" + _inline(10)
+    assembled = _fenced(5) + "\n" + _inline(7)  # fenced fine, inline -30%
+    assert av.check_code_block_parity(linked, assembled) is False


### PR DESCRIPTION
## Planning contract

The acceptance contract for this story is the AC list in the issue body of #10442 (PRD-B Story B3). No PM-side `CONTEXT-10442.md` exists for this story (it is a small standalone addition to the B2 module). Verifier will produce `.squidsquad/qa/planning/TEST-PLAN-10442.md` during verification per the #9184 workflow. Cited per #8950 Gate #4 requirement.

## Summary

PRD-B Story B3 ([[compose-assemble-stage]] §4.6 hard preservation guarantees). Two new pure-Python checks added alongside B2's `verify_preservation` in `references/scripts/assemble_verifier.py`. Pure additive — no compose.py wiring this PR (B7 owns abort-on-failure, B1 owns the assemble call site).

## What landed

- `references/scripts/assemble_verifier.py` (+90 lines):
  - `check_length_floor(linked, assembled, floor=0.8) -> bool` — `len(assembled) >= floor * len(linked)`. Boundary inclusive (exactly 0.8x passes). Empty linked is trivially satisfied (`0.8 * 0 == 0`).
  - `check_code_block_parity(linked, assembled, tolerance=0.1) -> bool` — fenced count AND inline-span count both must be within `±tolerance`. Combined check; either side failing fails the whole check.
  - `_FENCE_RE` matches `^\`\`\`+` at line start (CommonMark §4.5). Fence markers are counted then paired (`// 2`).
  - `_strip_fenced_blocks` removes `\`\`\`...\`\`\`` regions (`re.DOTALL`) before counting inline backticks so a fenced block doesn't double-count toward the inline count.
  - `_count_inline_backtick_spans` counts standalone single-backticks via `(?<!\`)\`(?!\`)` then pairs them (`// 2`).
  - `_within_tolerance` uses `max(linked_count, 1)` as the denominator — when linked is 0, any nonzero assembled count fails (`delta / 1 == delta > tolerance`).
- `tests/test_assemble_verifier.py` (+145 lines, 20 new tests):
  - Length floor: identity, empty/empty, empty-assembled-with-nonempty-linked, exact 0.8x boundary, 0.79x just below, custom floor threshold, longer-assembled passes.
  - Code-block parity (fenced): identity, no-blocks-either-side, 10/10→9/10 at-tolerance pass, 10/10→8/10 over-tolerance fail, spike fail, language-tagged fences counted.
  - Code-block parity (inline): identity, over-tolerance drop fail, over-tolerance spike fail, fenced-vs-inline cross-counting prevention, mixed bodies pass, custom tolerance, either-side combined-failure.

## AC mapping

| AC | Where |
|---|---|
| `check_length_floor(linked, assembled, floor=0.8) -> bool` | `references/scripts/assemble_verifier.py:97` |
| `check_code_block_parity(linked, assembled, tolerance=0.1) -> bool` | `references/scripts/assemble_verifier.py:139` |
| Both exposed alongside B2's verifier in `assemble_verifier.py` | same module |
| empty assembled fails floor | `test_length_floor_empty_assembled_with_nonempty_linked_fails` |
| assembled at exactly 0.8x passes | `test_length_floor_at_exactly_0_8x_passes` |
| 0.79x fails | `test_length_floor_at_0_79x_fails` |
| code block count drops by >10% fails | `test_code_block_parity_fenced_drop_just_over_tolerance_fails` |
| inline backtick count change >10% fails | `test_code_block_parity_inline_drop_just_over_tolerance_fails` + `_spike_just_over_tolerance_fails` |

## Tests

`python -m pytest tests/test_assemble_verifier.py` — 40 passed (20 pre-existing B2 + 20 new B3).

Closes #10442