### PR TITLE
PRD-A/A2c: l4_op_processor — per-slot L4 op application (#10489)

### DIFF
--- a/references/scripts/l4_op_processor.py
+++ b/references/scripts/l4_op_processor.py
@@ -1,0 +1,152 @@
+"""L4 op processor — per-slot op application (#10489, PRD-A Story A2c).
+
+Given a slot's L1-L3 source body and an ordered list of ``L4Op`` records
+(from ``l4_parser.parse_l4_file``), produce the per-slot LINKED composite
+by applying each op in source order.
+
+Pure additive — no compose.py wiring this PR. A2f (#10492) wires this into
+``deploy_alias_v2``.
+
+Op semantics (TRD §3.3 + §4.2):
+
+- ``append`` — appends ``op.body_text`` to the end of the slot.
+- ``replace`` (whole-slot, no target) — replaces the entire slot body
+  with ``op.body_text``. Per PRD-A §3.3 this is legal only on the
+  Responsibility slot AND mutually exclusive with other ops in the same
+  slot; A2c does NOT enforce either constraint (deferred to A2e).
+- ``replace step:cycle/<id>`` — substitutes the targeted step's body
+  verbatim. The step heading line is preserved; only the body between
+  it and the next ``### step:cycle/...`` line (or slot end) is replaced.
+- ``insert-before step:cycle/<id>`` — inserts ``op.body_text`` BEFORE
+  the targeted ``### step:cycle/<id>`` heading line.
+- ``insert-after step:cycle/<id>`` — inserts ``op.body_text`` AFTER
+  the targeted step's body (i.e., before the next ``### step:cycle/...``
+  heading or slot end).
+
+If a step-targeted op names a step ID that isn't present in the current
+slot content, ``L4OpTargetNotFound`` is raised — this is a hard error
+because the L1-L3 source has diverged from the L4 file's expectations.
+A2e is expected to validate target-step presence pre-application; A2c's
+raise here is the runtime backstop.
+
+Multi-op ordering: ops are applied sequentially in source order. Each op
+sees the result of the previous op. This means an ``insert-after`` on a
+step can land BETWEEN an earlier ``insert-after`` and the next step — by
+design, source-order is the contract.
+"""
+
+import re
+
+
+class L4OpTargetNotFound(KeyError):
+    """Raised when a step-targeted op names a step_id not in slot content."""
+
+
+# A step heading is ``### step:cycle/<id>`` at line start, where <id> is
+# the same alphanumeric+``_-`` grammar enforced by l4_parser._OP_RE. The
+# heading consumes its trailing newline so slicing leaves the body clean.
+_STEP_HEADING_RE = re.compile(
+    r"^### step:cycle/([A-Za-z0-9_-]+)\s*$", re.MULTILINE
+)
+
+
+def apply_l4_ops(slot_content, l4_ops):
+    """Apply ``l4_ops`` to ``slot_content`` in source order.
+
+    Returns the resulting per-slot LINKED body as a string. Pure and
+    deterministic — no I/O, no side effects.
+    """
+    content = slot_content
+    for op in l4_ops:
+        op_type = op.op_type
+        target = op.target_step_id
+        body = op.body_text
+
+        if op_type == "replace" and target is None:
+            content = body
+        elif op_type == "append":
+            content = _apply_append(content, body)
+        elif op_type == "replace":
+            content = _apply_replace_step(content, target, body)
+        elif op_type == "insert-before":
+            content = _apply_insert_before_step(content, target, body)
+        elif op_type == "insert-after":
+            content = _apply_insert_after_step(content, target, body)
+        else:
+            # Defensive: l4_parser only produces the four legal op_types,
+            # so this branch is unreachable from parsed input. Raising
+            # here makes a future grammar-extension error loud rather
+            # than silently dropping the op.
+            raise ValueError(f"unknown L4 op_type: {op_type!r}")
+    return content
+
+
+def _apply_append(content, body):
+    """Append ``body`` to end of slot. Adds a separating newline if needed."""
+    if not content:
+        return body
+    if not content.endswith("\n"):
+        content = content + "\n"
+    return content + body
+
+
+def _find_step_region(content, step_id):
+    """Locate ``### step:cycle/<step_id>`` and return slice indices.
+
+    Returns ``(heading_start, body_start, body_end)`` where:
+    - ``heading_start`` — index of the ``#`` that starts the heading line.
+    - ``body_start`` — index just past the heading's trailing newline.
+    - ``body_end`` — index of the next ``### step:cycle/...`` heading
+      line OR the end of ``content`` if this is the last step.
+
+    Raises ``L4OpTargetNotFound`` if no heading matching ``step_id`` is
+    found in ``content``.
+    """
+    for m in _STEP_HEADING_RE.finditer(content):
+        if m.group(1) == step_id:
+            heading_start = m.start()
+            # Body starts just past the heading line's newline. If the
+            # heading is the last line and has no trailing newline,
+            # m.end() already points past it.
+            body_start = m.end()
+            if body_start < len(content) and content[body_start] == "\n":
+                body_start += 1
+            # Body ends at the next step heading (any step_id) or end.
+            next_m = _STEP_HEADING_RE.search(content, body_start)
+            body_end = next_m.start() if next_m else len(content)
+            return heading_start, body_start, body_end
+    raise L4OpTargetNotFound(
+        f"L4 op targets `step:cycle/{step_id}` but no such step heading "
+        f"is present in slot content."
+    )
+
+
+def _apply_replace_step(content, step_id, new_body):
+    """Replace the targeted step's body, preserving its heading line."""
+    _, body_start, body_end = _find_step_region(content, step_id)
+    return content[:body_start] + _ensure_trailing_newline(new_body) + content[body_end:]
+
+
+def _apply_insert_before_step(content, step_id, body):
+    """Insert ``body`` before the targeted step's heading line."""
+    heading_start, _, _ = _find_step_region(content, step_id)
+    return content[:heading_start] + _ensure_trailing_newline(body) + content[heading_start:]
+
+
+def _apply_insert_after_step(content, step_id, body):
+    """Insert ``body`` after the targeted step's body (before next step or slot end)."""
+    _, _, body_end = _find_step_region(content, step_id)
+    # body_end points at the next ``### step:cycle/...`` heading start
+    # (or len(content)). Inserting right at body_end places the new
+    # content between this step's body and the next step's heading.
+    insertion = _ensure_trailing_newline(body)
+    return content[:body_end] + insertion + content[body_end:]
+
+
+def _ensure_trailing_newline(text):
+    """Guarantee ``text`` ends with a newline so adjacent content stays on its own line."""
+    if not text:
+        return text
+    if text.endswith("\n"):
+        return text
+    return text + "\n"

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -119,6 +119,7 @@ STATIC_TEST_MODULES = [
     "test_process_utils",
     "test_assemble_cache",
     "test_l4_parser",
+    "test_l4_op_processor",
 ]
 
 

--- a/tests/test_l4_op_processor.py
+++ b/tests/test_l4_op_processor.py
@@ -1,0 +1,262 @@
+"""Tests for references/scripts/l4_op_processor.py (#10489, PRD-A Story A2c)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import l4_op_processor as op_proc  # noqa: E402
+from l4_parser import L4Op  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SLOT_WITH_THREE_STEPS = (
+    "### step:cycle/boot\n"
+    "boot body line 1\n"
+    "boot body line 2\n"
+    "\n"
+    "### step:cycle/pickup\n"
+    "pickup body\n"
+    "\n"
+    "### step:cycle/work\n"
+    "work body\n"
+)
+
+
+def _op(op_type, target=None, body=""):
+    """Build an L4Op fixture matching the parser's dataclass shape."""
+    return L4Op(op_type=op_type, target_step_id=target, body_text=body)
+
+
+# ---------------------------------------------------------------------------
+# AC: each op type round-trip
+# ---------------------------------------------------------------------------
+
+def test_no_ops_returns_content_unchanged():
+    assert op_proc.apply_l4_ops("base content\n", []) == "base content\n"
+
+
+def test_append_op_appends_to_end_of_slot():
+    out = op_proc.apply_l4_ops(SLOT_WITH_THREE_STEPS, [_op("append", body="appended footer\n")])
+    assert out.endswith("appended footer\n")
+    # And the original content is intact in front.
+    assert out.startswith("### step:cycle/boot\n")
+
+
+def test_append_to_empty_slot_uses_op_body_as_whole_content():
+    out = op_proc.apply_l4_ops("", [_op("append", body="only line\n")])
+    assert out == "only line\n"
+
+
+def test_append_inserts_separating_newline_when_slot_lacks_one():
+    out = op_proc.apply_l4_ops("no trailing newline", [_op("append", body="X\n")])
+    assert out == "no trailing newline\nX\n"
+
+
+def test_whole_slot_replace_no_target_replaces_everything():
+    out = op_proc.apply_l4_ops(SLOT_WITH_THREE_STEPS, [_op("replace", body="totally new slot body\n")])
+    assert out == "totally new slot body\n"
+
+
+def test_replace_step_substitutes_only_targeted_body():
+    new_body = "REPLACED PICKUP BODY\n"
+    out = op_proc.apply_l4_ops(SLOT_WITH_THREE_STEPS, [_op("replace", target="pickup", body=new_body)])
+    # Heading preserved.
+    assert "### step:cycle/pickup\n" in out
+    # New body present.
+    assert "REPLACED PICKUP BODY\n" in out
+    # Old body gone.
+    assert "pickup body\n" not in out
+    # Adjacent steps untouched.
+    assert "### step:cycle/boot\nboot body line 1\nboot body line 2\n" in out
+    assert "### step:cycle/work\nwork body\n" in out
+
+
+def test_replace_step_first_step_in_slot():
+    out = op_proc.apply_l4_ops(SLOT_WITH_THREE_STEPS, [_op("replace", target="boot", body="NEW BOOT\n")])
+    assert "### step:cycle/boot\nNEW BOOT\n" in out
+    assert "boot body line 1" not in out
+
+
+def test_replace_step_last_step_in_slot():
+    out = op_proc.apply_l4_ops(SLOT_WITH_THREE_STEPS, [_op("replace", target="work", body="NEW WORK\n")])
+    assert out.endswith("### step:cycle/work\nNEW WORK\n")
+    assert "work body" not in out
+
+
+def test_insert_before_step_places_body_before_heading():
+    out = op_proc.apply_l4_ops(
+        SLOT_WITH_THREE_STEPS, [_op("insert-before", target="pickup", body="PRE-PICKUP\n")]
+    )
+    # New body appears right before the pickup heading.
+    assert "PRE-PICKUP\n### step:cycle/pickup\n" in out
+    # Adjacent steps' bodies untouched.
+    assert "### step:cycle/boot\nboot body line 1\nboot body line 2\n" in out
+    assert "### step:cycle/work\nwork body\n" in out
+
+
+def test_insert_before_first_step_keeps_step_after_inserted_body():
+    out = op_proc.apply_l4_ops(
+        SLOT_WITH_THREE_STEPS, [_op("insert-before", target="boot", body="HEADER\n")]
+    )
+    assert out.startswith("HEADER\n### step:cycle/boot\n")
+
+
+def test_insert_after_step_places_body_before_next_step():
+    out = op_proc.apply_l4_ops(
+        SLOT_WITH_THREE_STEPS, [_op("insert-after", target="pickup", body="POST-PICKUP\n")]
+    )
+    # New body appears between pickup body and work heading.
+    assert "pickup body\n\nPOST-PICKUP\n### step:cycle/work\n" in out
+
+
+def test_insert_after_last_step_appends_to_slot_end():
+    out = op_proc.apply_l4_ops(
+        SLOT_WITH_THREE_STEPS, [_op("insert-after", target="work", body="POST-WORK\n")]
+    )
+    assert out.endswith("POST-WORK\n")
+
+
+# ---------------------------------------------------------------------------
+# AC: multi-op scenarios applied in source order
+# ---------------------------------------------------------------------------
+
+def test_multiple_ops_apply_in_source_order():
+    """Two replaces on different steps + one append should compose."""
+    ops = [
+        _op("replace", target="boot", body="NEW BOOT\n"),
+        _op("replace", target="work", body="NEW WORK\n"),
+        _op("append", body="FOOTER\n"),
+    ]
+    out = op_proc.apply_l4_ops(SLOT_WITH_THREE_STEPS, ops)
+    assert "### step:cycle/boot\nNEW BOOT\n" in out
+    assert "### step:cycle/pickup\npickup body\n" in out
+    assert "### step:cycle/work\nNEW WORK\n" in out
+    assert out.endswith("FOOTER\n")
+
+
+def test_two_replaces_on_same_step_later_wins():
+    """Source order means a later op overwrites an earlier op on the same target."""
+    ops = [
+        _op("replace", target="pickup", body="FIRST WINS\n"),
+        _op("replace", target="pickup", body="ACTUALLY LAST\n"),
+    ]
+    out = op_proc.apply_l4_ops(SLOT_WITH_THREE_STEPS, ops)
+    assert "ACTUALLY LAST" in out
+    assert "FIRST WINS" not in out
+
+
+def test_insert_after_then_insert_after_stacks_in_source_order():
+    """Two insert-afters on the same step stack: the second lands between the first insertion and the next step."""
+    ops = [
+        _op("insert-after", target="pickup", body="FIRST\n"),
+        _op("insert-after", target="pickup", body="SECOND\n"),
+    ]
+    out = op_proc.apply_l4_ops(SLOT_WITH_THREE_STEPS, ops)
+    # By design, "insert-after step:pickup" finds the pickup region and
+    # inserts at body_end. After the first op, body_end now sits AFTER
+    # "FIRST\n" because that became part of pickup's body region. So the
+    # second insertion lands after FIRST — stack order matches source order.
+    assert "pickup body\n\nFIRST\nSECOND\n### step:cycle/work\n" in out
+
+
+def test_insert_before_then_replace_targets_post_insert_content():
+    """An insert-before that prepends new content should not break a subsequent replace on the same target."""
+    ops = [
+        _op("insert-before", target="work", body="PREFACE\n"),
+        _op("replace", target="work", body="REPLACED WORK\n"),
+    ]
+    out = op_proc.apply_l4_ops(SLOT_WITH_THREE_STEPS, ops)
+    assert "PREFACE\n### step:cycle/work\nREPLACED WORK\n" in out
+    assert "work body" not in out
+
+
+def test_whole_slot_replace_then_append_composes():
+    """Whole-slot replace + append: replace overwrites; append adds to the new slot."""
+    ops = [
+        _op("replace", body="WHOLE SLOT NEW\n"),
+        _op("append", body="FOOTER\n"),
+    ]
+    out = op_proc.apply_l4_ops(SLOT_WITH_THREE_STEPS, ops)
+    assert out == "WHOLE SLOT NEW\nFOOTER\n"
+
+
+def test_order_independence_for_disjoint_targets():
+    """Replaces on disjoint steps commute (final content same regardless of order)."""
+    ops_a = [
+        _op("replace", target="boot", body="NEW BOOT\n"),
+        _op("replace", target="work", body="NEW WORK\n"),
+    ]
+    ops_b = list(reversed(ops_a))
+    out_a = op_proc.apply_l4_ops(SLOT_WITH_THREE_STEPS, ops_a)
+    out_b = op_proc.apply_l4_ops(SLOT_WITH_THREE_STEPS, ops_b)
+    assert out_a == out_b
+
+
+# ---------------------------------------------------------------------------
+# Edge cases: missing target, hyphenated id, single-step slot
+# ---------------------------------------------------------------------------
+
+def test_replace_step_missing_target_raises():
+    with pytest.raises(op_proc.L4OpTargetNotFound):
+        op_proc.apply_l4_ops(
+            SLOT_WITH_THREE_STEPS, [_op("replace", target="nonexistent", body="x\n")]
+        )
+
+
+def test_insert_before_missing_target_raises():
+    with pytest.raises(op_proc.L4OpTargetNotFound):
+        op_proc.apply_l4_ops(
+            SLOT_WITH_THREE_STEPS, [_op("insert-before", target="nope", body="x\n")]
+        )
+
+
+def test_insert_after_missing_target_raises():
+    with pytest.raises(op_proc.L4OpTargetNotFound):
+        op_proc.apply_l4_ops(
+            SLOT_WITH_THREE_STEPS, [_op("insert-after", target="nope", body="x\n")]
+        )
+
+
+def test_hyphenated_step_id_targetable():
+    content = "### step:cycle/pickup-2\nbody-2\n"
+    out = op_proc.apply_l4_ops(content, [_op("replace", target="pickup-2", body="NEW\n")])
+    assert out == "### step:cycle/pickup-2\nNEW\n"
+
+
+def test_single_step_slot_replace_keeps_heading():
+    content = "### step:cycle/only\nold\n"
+    out = op_proc.apply_l4_ops(content, [_op("replace", target="only", body="new\n")])
+    assert out == "### step:cycle/only\nnew\n"
+
+
+def test_step_id_with_underscores_targetable():
+    content = "### step:cycle/my_step_id\nbody\n"
+    out = op_proc.apply_l4_ops(content, [_op("replace", target="my_step_id", body="new\n")])
+    assert out == "### step:cycle/my_step_id\nnew\n"
+
+
+def test_body_without_trailing_newline_is_normalized():
+    """Op bodies missing a trailing newline still produce well-formed output.
+
+    Note: the blank-line separator between pickup and work in the input
+    is part of pickup's body region, so the replace removes it. The
+    insertion still gets a guaranteed trailing newline.
+    """
+    out = op_proc.apply_l4_ops(
+        SLOT_WITH_THREE_STEPS, [_op("replace", target="pickup", body="no newline")]
+    )
+    assert "### step:cycle/pickup\nno newline\n### step:cycle/work\n" in out
+
+
+def test_unknown_op_type_raises():
+    """Defensive: an L4Op with an unrecognized op_type should not silently no-op."""
+    bad_op = L4Op(op_type="frobnicate", target_step_id=None, body_text="x")
+    with pytest.raises(ValueError, match="unknown L4 op_type"):
+        op_proc.apply_l4_ops("content\n", [bad_op])


### PR DESCRIPTION
## Planning contract

Acceptance contract is the AC list in the issue body of #10489 (PRD-A Story A2c). No PM-side `CONTEXT-10489.md` exists for this story (small additive function; PRD-A coexistence rules in [[compose-link-stage]] §3.3 + §4.2 govern). Verifier will produce `.squidsquad/qa/planning/TEST-PLAN-10489.md` during verification per the #9184 workflow. Cited per #8950 Gate #4 requirement.

## Summary

PRD-A Story A2c ([[compose-link-stage]] §3.3 + §4.2). New pure-Python module `references/scripts/l4_op_processor.py` providing `apply_l4_ops(slot_content, l4_ops) -> str`. Consumes `L4Op` records from A2b's `l4_parser`, produces the per-slot LINKED composite. Pure additive — no compose.py wiring this PR (A2d emits the six-slot output, A2e validates, A2f wires into `deploy_alias_v2`).

## What landed

- `references/scripts/l4_op_processor.py` (~120 lines):
  - `apply_l4_ops(slot_content, l4_ops)` — sequential, in source order.
  - Op dispatch: `append` / whole-slot `replace` / step-targeted `replace|insert-before|insert-after`.
  - Step regions located via `^### step:cycle/<id>$` MULTILINE regex; body runs from heading-end to the next step heading or slot end.
  - Whole-slot `replace` (no target) replaces entire slot content. A2c does NOT enforce the Responsibility-only + mutual-exclusivity constraints — deferred to A2e per the issue body.
  - `_apply_replace_step` preserves the heading line; only the body between it and the next step is replaced.
  - `_apply_insert_before_step` slices at heading start. `_apply_insert_after_step` slices at body end (= next step's heading start or slot end).
  - `_ensure_trailing_newline` normalizes op bodies missing a trailing newline so adjacent content stays on its own line.
  - `L4OpTargetNotFound` raised when a step-targeted op names an id not present in slot content. Hard error (not silent no-op).
  - Defensive `ValueError("unknown L4 op_type: …")` if a future grammar extension reaches A2c without a dispatch arm.
- `tests/test_l4_op_processor.py` (~260 lines, 26 tests).
- `tests/run_tests.py`: registered `test_l4_op_processor` in `STATIC_TEST_MODULES`.

## AC mapping

| AC | Where |
|---|---|
| `apply_l4_ops(slot_content, l4_ops) -> str` | `references/scripts/l4_op_processor.py:62` |
| `### replace step:cycle/<id>` substitutes the targeted step's body verbatim | `_apply_replace_step` + `test_replace_step_substitutes_only_targeted_body` |
| `### insert-before step:cycle/<id>` inserts L4 body before targeted step | `_apply_insert_before_step` + `test_insert_before_step_places_body_before_heading` |
| `### insert-after step:cycle/<id>` inserts L4 body after | `_apply_insert_after_step` + `test_insert_after_step_places_body_before_next_step` + `test_insert_after_last_step_appends_to_slot_end` |
| `### append` adds L4 body to end of slot | `_apply_append` + `test_append_op_appends_to_end_of_slot` |
| Multiple ops in same slot applied in order | `test_multiple_ops_apply_in_source_order` + `test_two_replaces_on_same_step_later_wins` + `test_insert_after_then_insert_after_stacks_in_source_order` |
| Whole-slot `### replace` replaces entire slot body (mutual-exclusivity deferred to A2e) | `test_whole_slot_replace_no_target_replaces_everything` + `test_whole_slot_replace_then_append_composes` (composition still works; enforcement is A2e's) |
| Order-independence checks (disjoint targets commute) | `test_order_independence_for_disjoint_targets` |

## Tests

`python -m pytest tests/test_l4_op_processor.py` — 26 passed in 0.08s.

Closes #10489