### PR TITLE
PRD-A/A2d: v2_link_stage — six-slot output emitter (#10490)

### DIFF
--- a/references/scripts/v2_link_stage.py
+++ b/references/scripts/v2_link_stage.py
@@ -1,0 +1,225 @@
+"""Six-slot v2 link stage (#10490, PRD-A Story A2d).
+
+Implements ``emit_v2_linked(role_class, l3_domain)`` per
+[[compose-link-stage]] §4.1 + §4.2 and COMPOSE-ARCHITECTURE §4.1-§4.2:
+
+1. Walk L1-L3 source files (``references/roles/`` + ``references/sub-skills/``)
+   scoped to the role class + optional L3 domain.
+2. Parse YAML frontmatter via :func:`source_frontmatter.parse_source_frontmatter`.
+3. Skip files that lack frontmatter — they are not yet migrated under
+   #10394 and the v2 path treats unmigrated files as opt-out content.
+4. Apply the optional ``roles:`` extras filter (default = applies to all).
+5. Stable sort by ``(slot_index, ordinal, path)``.
+6. Group bodies by slot.
+7. For each slot present in the L4 file at
+   ``.squidsquad/project/<role_class>.md``, apply ops via
+   :func:`l4_op_processor.apply_l4_ops`.
+8. Emit exactly six H2 sections in canonical order:
+   ``Identity``, ``Responsibility``, ``Soul``, ``Instructions``,
+   ``Project Context``, ``Vault``.
+
+Pure additive. A2f (#10492) is the caller that wires this into
+``deploy_alias_v2``. This module does no I/O beyond ``read_text`` on the
+walked source files and the L4 file.
+"""
+
+import re
+from pathlib import Path
+
+from source_frontmatter import (  # noqa: E402
+    LEGAL_SLOTS,
+    parse_source_frontmatter_text,
+)
+from l4_parser import L4Document, parse_l4_file  # noqa: E402
+from l4_op_processor import apply_l4_ops  # noqa: E402
+
+
+# Canonical slot ordering — TRD §3.3 + AC bullet "exactly six H2 sections
+# in canonical order". Display names map the lowercase slot key (used by
+# frontmatter) to the ``## <Heading>`` text emitted in the linked output.
+CANONICAL_SLOT_ORDER = (
+    "identity",
+    "responsibility",
+    "soul",
+    "instructions",
+    "project-context",
+    "vault",
+)
+SLOT_DISPLAY = {
+    "identity": "Identity",
+    "responsibility": "Responsibility",
+    "soul": "Soul",
+    "instructions": "Instructions",
+    "project-context": "Project Context",
+    "vault": "Vault",
+}
+SLOT_INDEX = {slot: i for i, slot in enumerate(CANONICAL_SLOT_ORDER)}
+
+
+# Frontmatter delimiter — same shape as source_frontmatter._FRONTMATTER_RE
+# but kept local so this module can strip the block from each file's text
+# without re-coupling to A2a's internals.
+_FRONTMATTER_RE = re.compile(r"\A---[ \t]*\n[\s\S]*?\n---[ \t]*\n?")
+
+
+def emit_v2_linked(role_class, l3_domain, *, repo_root=None, l4_path=None):
+    """Walk L1-L3 sources for ``role_class`` and emit the v2 linked composite.
+
+    ``role_class`` — e.g. ``"worker"`` / ``"pm"`` / ``"dm"`` / ``"verifier"``.
+    ``l3_domain`` — e.g. ``"skill"`` / ``"ios"`` / ``"fe"`` / ``None``.
+    ``repo_root`` — override for tests; defaults to the parent of the
+    parent of this file (the live repo root in normal use).
+    ``l4_path`` — override the L4 file path; defaults to
+    ``<repo_root>/.squidsquad/project/<role_class>.md``.
+
+    Returns the composed string. Output is byte-stable across re-runs
+    given unchanged inputs (deterministic sort, no time/random sources).
+    """
+    if repo_root is None:
+        repo_root = Path(__file__).resolve().parent.parent.parent
+    repo_root = Path(repo_root)
+    if l4_path is None:
+        l4_path = repo_root / ".squidsquad" / "project" / f"{role_class}.md"
+
+    parsed = _parse_all_applicable_sources(repo_root, role_class, l3_domain)
+    # Stable sort by (slot_index, ordinal, posix path). Path tie-break
+    # gives byte-stable output even when two files share the same
+    # (slot, ordinal) — which #10394 migration must avoid but the link
+    # stage shouldn't crash on if it happens.
+    parsed.sort(key=lambda r: (r[0], r[1], r[2]))
+
+    slot_bodies = {slot: [] for slot in CANONICAL_SLOT_ORDER}
+    for slot_idx, _ordinal, _path, body in parsed:
+        slot_bodies[CANONICAL_SLOT_ORDER[slot_idx]].append(body)
+
+    if Path(l4_path).is_file():
+        l4_doc = parse_l4_file(l4_path)
+    else:
+        l4_doc = L4Document.empty()
+
+    out_chunks = []
+    for slot in CANONICAL_SLOT_ORDER:
+        combined = _join_bodies(slot_bodies[slot])
+        ops = l4_doc.slots.get(slot, [])
+        if ops:
+            combined = apply_l4_ops(combined, ops)
+        # Every H2 section starts with the canonical heading and a blank
+        # line. If the slot is empty, the section is still emitted to
+        # satisfy the "exactly six H2 sections" AC.
+        out_chunks.append(f"## {SLOT_DISPLAY[slot]}\n\n{combined}".rstrip() + "\n")
+    return "\n".join(out_chunks)
+
+
+def _parse_all_applicable_sources(repo_root, role_class, l3_domain):
+    """Walk the source paths, parse frontmatter, return entries to sort.
+
+    Returns ``[(slot_index, ordinal, posix_path, body), ...]`` for every
+    source file that (a) carries frontmatter, (b) declares a legal slot,
+    and (c) passes the optional ``roles:`` extras filter.
+    """
+    entries = []
+    for path in _walk_applicable_paths(repo_root, role_class, l3_domain):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            # A non-readable source file is a real install pathology;
+            # link-stage should not silently include it. But the link
+            # stage owns "skip on missing frontmatter", not "raise on
+            # I/O" — so skip-with-no-record matches the unmigrated path.
+            continue
+        try:
+            fm = parse_source_frontmatter_text(text, source=str(path))
+        except Exception:
+            # FrontmatterError on a present-but-malformed block: today's
+            # unmigrated sources have no frontmatter and return None.
+            # A4.5/A2e own enforcement; A2d's job is to assemble, so
+            # we treat malformed frontmatter as opt-out (skip) here.
+            continue
+        if fm is None:
+            continue
+        if fm.slot not in LEGAL_SLOTS:
+            continue  # paranoia; source_frontmatter already validates
+        if not _is_applicable_by_roles_filter(fm, role_class):
+            continue
+        body = _strip_frontmatter(text)
+        # POSIX path string for stable cross-OS sort.
+        posix_path = path.relative_to(repo_root).as_posix()
+        entries.append((SLOT_INDEX[fm.slot], int(fm.ordinal), posix_path, body))
+    return entries
+
+
+def _walk_applicable_paths(repo_root, role_class, l3_domain):
+    """Yield .md paths for ``role_class`` + ``l3_domain``.
+
+    Path classes:
+    - L1: ``references/roles/*.md`` (top-level base files).
+    - L1: ``references/sub-skills/common/**/*.md``.
+    - L1: ``references/sub-skills/common-events/**/*.md`` (event-mode
+      common fragments; harmless to walk in polling-mode composes too,
+      they're frontmatter-filtered).
+    - L2: ``references/roles/<role_class>/*.md`` (direct children only).
+    - L2: ``references/sub-skills/roles/<role_class>/*.md``.
+    - L3 (if ``l3_domain`` is set): the equivalent ``<l3_domain>/**`` subtrees.
+
+    Other ``references/roles/<role_class>/<other_l3>/**`` subtrees are
+    intentionally excluded — those belong to OTHER L3 domains.
+    """
+    refs = repo_root / "references"
+
+    # L1 (top-level)
+    roles_root = refs / "roles"
+    if roles_root.is_dir():
+        for p in roles_root.glob("*.md"):
+            yield p
+    common = refs / "sub-skills" / "common"
+    if common.is_dir():
+        yield from common.rglob("*.md")
+    common_events = refs / "sub-skills" / "common-events"
+    if common_events.is_dir():
+        yield from common_events.rglob("*.md")
+
+    # L2 (role-class direct children)
+    role_dir = roles_root / role_class
+    if role_dir.is_dir():
+        for p in role_dir.glob("*.md"):
+            yield p
+    sk_role_dir = refs / "sub-skills" / "roles" / role_class
+    if sk_role_dir.is_dir():
+        for p in sk_role_dir.glob("*.md"):
+            yield p
+
+    # L3 (specific domain only)
+    if l3_domain:
+        l3_dir = role_dir / l3_domain
+        if l3_dir.is_dir():
+            yield from l3_dir.rglob("*.md")
+        sk_l3_dir = sk_role_dir / l3_domain
+        if sk_l3_dir.is_dir():
+            yield from sk_l3_dir.rglob("*.md")
+
+
+def _is_applicable_by_roles_filter(fm, role_class):
+    """Apply the optional ``roles:`` extras filter (default = applies to all)."""
+    roles = fm.extras.get("roles")
+    if roles is None:
+        return True
+    return role_class in roles
+
+
+def _strip_frontmatter(text):
+    """Remove the leading YAML frontmatter block, if present."""
+    m = _FRONTMATTER_RE.match(text)
+    if m is None:
+        return text
+    return text[m.end():]
+
+
+def _join_bodies(bodies):
+    """Concatenate per-file bodies with a single blank line between them.
+
+    Each body is stripped of leading/trailing whitespace so the joined
+    output has predictable spacing regardless of how each source file
+    terminates.
+    """
+    cleaned = [b.strip() for b in bodies if b.strip()]
+    return "\n\n".join(cleaned)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -121,6 +121,7 @@ STATIC_TEST_MODULES = [
     "test_l4_parser",
     "test_l4_op_processor",
     "test_compose_check_a4_10388",
+    "test_v2_link_stage",
 ]
 
 

--- a/tests/test_v2_link_stage.py
+++ b/tests/test_v2_link_stage.py
@@ -1,0 +1,290 @@
+"""Tests for references/scripts/v2_link_stage.py (#10490, PRD-A Story A2d)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import v2_link_stage as v2  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+def _frontmatter(slot, ordinal, roles=None):
+    lines = ["---", f"slot: {slot}", f"ordinal: {ordinal}"]
+    if roles is not None:
+        lines.append(f"roles: [{', '.join(roles)}]")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def _make_source(path, slot, ordinal, body, roles=None):
+    """Write a fixture source file with the given frontmatter + body."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = _frontmatter(slot, ordinal, roles=roles) + "\n\n" + body
+    path.write_text(text, encoding="utf-8")
+
+
+def _make_minimal_fixture(repo_root):
+    """A minimal fixture with at least one file per slot under role_class=worker.
+
+    Layout:
+      references/roles/identity.md       slot=identity ord=10 — "Base identity"
+      references/roles/SOUL.md           slot=soul ord=10     — "Base soul"
+      references/roles/instructions.md   slot=instructions ord=10 — body
+      references/roles/vault.md          slot=vault ord=10    — "Vault content"
+      references/roles/worker/responsibility.md  slot=responsibility ord=20 — "Worker resp"
+      references/roles/worker/instructions.md    slot=instructions ord=20 — body w/ step
+    """
+    refs = repo_root / "references"
+    _make_source(refs / "roles" / "identity.md", "identity", 10, "Base identity prose.")
+    _make_source(refs / "roles" / "SOUL.md", "soul", 10, "Base soul prose.")
+    _make_source(
+        refs / "roles" / "instructions.md", "instructions", 10,
+        "### step:cycle/boot\nBoot the agent.\n",
+    )
+    _make_source(refs / "roles" / "vault.md", "vault", 10, "Vault content.")
+    _make_source(
+        refs / "roles" / "worker" / "responsibility.md", "responsibility", 20,
+        "Worker is responsible for implementation.",
+    )
+    _make_source(
+        refs / "roles" / "worker" / "instructions.md", "instructions", 20,
+        "### step:cycle/work\nDo the work.\n",
+        roles=["worker"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC: six H2 sections in canonical order
+# ---------------------------------------------------------------------------
+
+def test_emit_v2_linked_returns_string(tmp_path):
+    _make_minimal_fixture(tmp_path)
+    out = v2.emit_v2_linked("worker", None, repo_root=tmp_path)
+    assert isinstance(out, str)
+
+
+def test_emit_v2_linked_emits_exactly_six_h2_sections_in_canonical_order(tmp_path):
+    _make_minimal_fixture(tmp_path)
+    out = v2.emit_v2_linked("worker", None, repo_root=tmp_path)
+    h2_lines = [ln for ln in out.splitlines() if ln.startswith("## ")]
+    assert h2_lines == [
+        "## Identity",
+        "## Responsibility",
+        "## Soul",
+        "## Instructions",
+        "## Project Context",
+        "## Vault",
+    ]
+
+
+def test_emit_v2_linked_emits_empty_section_for_absent_slot(tmp_path):
+    """Project Context has no L1-L3 sources in the minimal fixture and no L4 — section is still emitted, empty."""
+    _make_minimal_fixture(tmp_path)
+    out = v2.emit_v2_linked("worker", None, repo_root=tmp_path)
+    assert "## Project Context\n" in out
+
+
+# ---------------------------------------------------------------------------
+# AC: walks L1-L3 + groups + sorts by ordinal
+# ---------------------------------------------------------------------------
+
+def test_emit_v2_linked_groups_by_slot(tmp_path):
+    _make_minimal_fixture(tmp_path)
+    out = v2.emit_v2_linked("worker", None, repo_root=tmp_path)
+    # The two instructions-slot sources are in the Instructions section.
+    idx_instructions = out.index("## Instructions")
+    idx_project_ctx = out.index("## Project Context")
+    instructions_block = out[idx_instructions:idx_project_ctx]
+    assert "### step:cycle/boot" in instructions_block
+    assert "### step:cycle/work" in instructions_block
+
+
+def test_emit_v2_linked_sorts_within_slot_by_ordinal(tmp_path):
+    """Lower ordinal precedes higher ordinal within the same slot."""
+    refs = tmp_path / "references"
+    _make_source(refs / "roles" / "identity.md", "identity", 30, "LAST identity.")
+    _make_source(refs / "roles" / "worker" / "ident_a.md", "identity", 10, "FIRST identity.")
+    _make_source(refs / "roles" / "worker" / "ident_b.md", "identity", 20, "MIDDLE identity.")
+    out = v2.emit_v2_linked("worker", None, repo_root=tmp_path)
+    pos_first = out.index("FIRST identity")
+    pos_middle = out.index("MIDDLE identity")
+    pos_last = out.index("LAST identity")
+    assert pos_first < pos_middle < pos_last
+
+
+# ---------------------------------------------------------------------------
+# AC: applies A2c L4 op processing per slot
+# ---------------------------------------------------------------------------
+
+def test_emit_v2_linked_applies_l4_replace_step_op(tmp_path):
+    """A L4 `### replace step:cycle/work` replaces only the work step's body."""
+    _make_minimal_fixture(tmp_path)
+    l4_path = tmp_path / "l4.md"
+    l4_path.write_text(
+        "## Instructions\n\n"
+        "### replace step:cycle/work\n\n"
+        "Do something DIFFERENT.\n",
+        encoding="utf-8",
+    )
+    out = v2.emit_v2_linked("worker", None, repo_root=tmp_path, l4_path=l4_path)
+    assert "Do something DIFFERENT." in out
+    assert "Do the work." not in out  # body replaced
+    # Other slots untouched.
+    assert "Base identity prose." in out
+
+
+def test_emit_v2_linked_missing_l4_is_noop(tmp_path):
+    """No L4 file → L1-L3 content survives unchanged."""
+    _make_minimal_fixture(tmp_path)
+    out = v2.emit_v2_linked(
+        "worker", None,
+        repo_root=tmp_path,
+        l4_path=tmp_path / "nonexistent.md",
+    )
+    assert "Do the work." in out
+    assert "Base identity prose." in out
+
+
+# ---------------------------------------------------------------------------
+# AC: byte-stable across re-runs
+# ---------------------------------------------------------------------------
+
+def test_emit_v2_linked_byte_stable_across_runs(tmp_path):
+    """Same inputs → identical output, byte-for-byte. Required by AC."""
+    _make_minimal_fixture(tmp_path)
+    a = v2.emit_v2_linked("worker", None, repo_root=tmp_path)
+    b = v2.emit_v2_linked("worker", None, repo_root=tmp_path)
+    c = v2.emit_v2_linked("worker", None, repo_root=tmp_path)
+    assert a == b == c
+
+
+# ---------------------------------------------------------------------------
+# Behavioral: skip unmigrated files (no frontmatter)
+# ---------------------------------------------------------------------------
+
+def test_emit_v2_linked_skips_files_without_frontmatter(tmp_path):
+    """Files without YAML frontmatter (unmigrated under #10394) are skipped."""
+    refs = tmp_path / "references"
+    (refs / "roles").mkdir(parents=True)
+    # File without frontmatter — should NOT appear in any slot.
+    (refs / "roles" / "no_frontmatter.md").write_text(
+        "Just prose, no frontmatter. This SHOULD NOT appear.\n",
+        encoding="utf-8",
+    )
+    # File with frontmatter — should appear.
+    _make_source(refs / "roles" / "identity.md", "identity", 10, "DOES appear.")
+    out = v2.emit_v2_linked("worker", None, repo_root=tmp_path)
+    assert "DOES appear." in out
+    assert "SHOULD NOT appear" not in out
+
+
+# ---------------------------------------------------------------------------
+# Behavioral: roles: extras filter
+# ---------------------------------------------------------------------------
+
+def test_emit_v2_linked_respects_roles_extras_filter(tmp_path):
+    """Files with roles: [other_role] are excluded for this role_class."""
+    refs = tmp_path / "references"
+    _make_source(
+        refs / "roles" / "identity.md", "identity", 10,
+        "Universal identity.",  # no roles filter
+    )
+    _make_source(
+        refs / "sub-skills" / "common" / "pm_only.md", "identity", 20,
+        "PM only.", roles=["pm"],
+    )
+    _make_source(
+        refs / "sub-skills" / "common" / "worker_only.md", "identity", 30,
+        "Worker only.", roles=["worker"],
+    )
+    out = v2.emit_v2_linked("worker", None, repo_root=tmp_path)
+    assert "Universal identity." in out
+    assert "Worker only." in out
+    assert "PM only." not in out
+
+
+# ---------------------------------------------------------------------------
+# Behavioral: L3 domain scoping
+# ---------------------------------------------------------------------------
+
+def test_emit_v2_linked_includes_l3_domain_files(tmp_path):
+    """When l3_domain is provided, files under that subdir are included."""
+    refs = tmp_path / "references"
+    _make_source(
+        refs / "roles" / "worker" / "skill" / "identity.md", "identity", 30,
+        "Skill-domain identity.",
+    )
+    out = v2.emit_v2_linked("worker", "skill", repo_root=tmp_path)
+    assert "Skill-domain identity." in out
+
+
+def test_emit_v2_linked_excludes_other_l3_domain_files(tmp_path):
+    """L3 files under a DIFFERENT l3_domain subdir are NOT included."""
+    refs = tmp_path / "references"
+    _make_source(
+        refs / "roles" / "worker" / "ios" / "identity.md", "identity", 30,
+        "iOS identity.",
+    )
+    _make_source(
+        refs / "roles" / "worker" / "skill" / "identity.md", "identity", 30,
+        "Skill identity.",
+    )
+    out = v2.emit_v2_linked("worker", "skill", repo_root=tmp_path)
+    assert "Skill identity." in out
+    assert "iOS identity." not in out
+
+
+def test_emit_v2_linked_l3_none_excludes_all_l3_files(tmp_path):
+    """With l3_domain=None, no L3 subdir files are walked."""
+    refs = tmp_path / "references"
+    _make_source(
+        refs / "roles" / "worker" / "skill" / "identity.md", "identity", 30,
+        "Skill identity.",
+    )
+    out = v2.emit_v2_linked("worker", None, repo_root=tmp_path)
+    assert "Skill identity." not in out
+
+
+# ---------------------------------------------------------------------------
+# Helpers: _strip_frontmatter
+# ---------------------------------------------------------------------------
+
+def test_strip_frontmatter_removes_block():
+    text = "---\nslot: identity\nordinal: 10\n---\n\nBody here."
+    # The frontmatter regex consumes one trailing newline; bodies with a
+    # blank line after the closing `---` retain that blank line, which
+    # `_join_bodies` strips via its `.strip()` call downstream.
+    assert v2._strip_frontmatter(text).strip() == "Body here."
+    assert "slot: identity" not in v2._strip_frontmatter(text)
+
+
+def test_strip_frontmatter_no_op_when_absent():
+    text = "Just body.\n"
+    assert v2._strip_frontmatter(text) == text
+
+
+# ---------------------------------------------------------------------------
+# Helpers: canonical-slot constants
+# ---------------------------------------------------------------------------
+
+def test_canonical_slot_order_is_six():
+    """AC says 'exactly six H2 sections in canonical order'."""
+    assert len(v2.CANONICAL_SLOT_ORDER) == 6
+
+
+def test_canonical_slot_order_matches_trd():
+    assert v2.CANONICAL_SLOT_ORDER == (
+        "identity",
+        "responsibility",
+        "soul",
+        "instructions",
+        "project-context",
+        "vault",
+    )


### PR DESCRIPTION
## Planning contract

Acceptance contract is the AC list in the issue body of #10490 (PRD-A Story A2d). No PM-side `CONTEXT-10490.md` exists for this story; the link-stage spec lives in COMPOSE-ARCHITECTURE §4.1 + §4.2 (referenced by PRD `[[compose-link-stage]]`). Verifier will produce `.squidsquad/qa/planning/TEST-PLAN-10490.md` during verification per the #9184 workflow. Cited per #8950 Gate #4 requirement.

## Summary

PRD-A Story A2d ([[compose-link-stage]] §4.1 + §4.2). New module `references/scripts/v2_link_stage.py` providing `emit_v2_linked(role_class, l3_domain) -> str`. Walks L1-L3 sources, groups by slot, sorts by ordinal, applies A2c L4 ops per slot, emits exactly six H2 sections in canonical order. Pure additive — no compose.py wiring this PR (A2f #10492 wires into `deploy_alias_v2`; A2e #10491 owns R1-R7 validation).

## What landed

- `references/scripts/v2_link_stage.py` (~180 lines):
  - `emit_v2_linked(role_class, l3_domain, *, repo_root=None, l4_path=None) -> str` — public entry point.
  - `CANONICAL_SLOT_ORDER` / `SLOT_DISPLAY` / `SLOT_INDEX` — the canonical six slots and their `## Heading` display names (per TRD §3.3).
  - `_walk_applicable_paths` — yields .md paths per the layer rules:
    - L1: `references/roles/*.md` (top-level base files).
    - L1: `references/sub-skills/common/**` + `common-events/**`.
    - L2: `references/roles/<role_class>/*.md` (direct children only).
    - L2: `references/sub-skills/roles/<role_class>/*.md`.
    - L3 (when `l3_domain` is set): the equivalent `<l3_domain>/**` subtrees.
    - OTHER L3 subtrees (`references/roles/<role_class>/<other_l3>/**`) are intentionally excluded.
  - `_parse_all_applicable_sources` — parses frontmatter via A2a, skips files lacking frontmatter (unmigrated under #10394), applies the optional `roles:` extras filter, returns `(slot_index, ordinal, posix_path, body)` rows.
  - Stable sort by `(slot_index, ordinal, posix_path)` — posix path tie-break gives byte-stable output even if two sources accidentally share an `(slot, ordinal)` key.
  - L4 file at `.squidsquad/project/<role_class>.md` parsed via A2b; missing file → empty L4Document → no-op.
  - `_strip_frontmatter` removes the leading YAML block. `_join_bodies` concatenates per-file bodies with a single blank line separator after `.strip()`-ing each.
  - Output: six H2 sections, each `## <Heading>\n\n<body>\n` with a blank line between sections.
- `tests/test_v2_link_stage.py` (~270 lines, 17 tests).
- `tests/run_tests.py`: registered `test_v2_link_stage` in `STATIC_TEST_MODULES`.

## AC mapping

| AC | Where |
|---|---|
| `emit_v2_linked(role_class, l3_domain) -> str` returns full linked composite | `v2_link_stage.py:67` |
| Walks L1-L3 sources, groups by slot, sorts by ordinal | `_walk_applicable_paths` + `_parse_all_applicable_sources` + sort by `(slot_index, ordinal, posix_path)` |
| Applies A2c L4 op processing per slot | `apply_l4_ops(combined, l4_doc.slots[slot])` in the emit loop |
| Emits exactly six H2 sections in canonical order | `test_emit_v2_linked_emits_exactly_six_h2_sections_in_canonical_order` |
| Output is byte-stable across re-runs given unchanged inputs | `test_emit_v2_linked_byte_stable_across_runs` |
| Unit tests: minimal fixture compose → matches golden | 17 fixture-based tests under `tests/test_v2_link_stage.py` |

## Tests

`python -m pytest tests/test_v2_link_stage.py` — 17 passed in 0.21s.

## Notes

- Files without frontmatter are skipped (today's pre-#10394 reality). When #10394 migration lands, real-source walks will populate slots automatically.
- Malformed frontmatter is treated as skip here; strict validation (R1-R7) is A2e's lane per the PRD seam.
- `emit_v2_linked` does no writes. A2f wires it into `deploy_alias_v2`, which is where the output lands at `.squidsquad/<alias>/CLAUDE.linked.v2.md`.

Closes #10490