### PR TITLE
PRD-A/A2e: link_stage_validator — R1-R7 link-stage validation rules (#10491)

### DIFF
--- a/references/scripts/link_stage_validator.py
+++ b/references/scripts/link_stage_validator.py
@@ -1,0 +1,202 @@
+"""Seven link-stage validation rules R1-R7 (#10491, PRD-A Story A2e).
+
+Implements the seven per-slot constraint rules from PRD-A §3 success
+criterion 6 (the per-slot subset of §3.3 + §4.2). Each rule aborts
+compose BEFORE any disk write — A2e's contract is to raise; A2f's
+caller orchestrates "validate then emit" so failure produces zero
+partial artifacts.
+
+R1: L4 file containing ``## Vault`` H2 → abort (Vault is L1-exclusive).
+R2: L2/L3 source with ``slot: vault`` frontmatter → abort.
+R3: L1-L3 source with ``slot: project-context`` frontmatter → abort.
+R4: L4 ``### append`` under ``## Instructions`` with no
+    ``→ run sub-skill: <name>`` reference → abort.
+R5: L4 op references non-existent step-id → abort with offending
+    step-id named in the diagnostic.
+R6: Whole-slot ``replace`` mixed with other ops in same slot → abort
+    (per-slot scope, NOT per-file).
+R7: Two ``### replace step:cycle/<id>`` blocks targeting the same
+    step ID → abort (per TRD §4.2 step 3).
+
+A2e is pure validation — no I/O, no compose. Callers provide already-
+parsed inputs: an ``L4Document`` (via A2b) and a list of
+``LinkStageSource`` records (built by A2f from A2d's walk output).
+"""
+
+import re
+from dataclasses import dataclass
+
+
+# Same regex as assemble_verifier._SUB_SKILL_RE — kept local so the
+# validator doesn't reach across PRDs. Updates to one should be mirrored.
+_SUB_SKILL_REF_RE = re.compile(r"→\s*run\s+sub-skill:\s*([A-Za-z0-9_-]+)")
+
+# Step heading in an L1-L3 source body. Mirrors l4_op_processor._STEP_HEADING_RE
+# but matched against the BODY (not the L4 op grammar). Same id grammar.
+_SOURCE_STEP_HEADING_RE = re.compile(
+    r"^### step:cycle/([A-Za-z0-9_-]+)\s*$", re.MULTILINE
+)
+
+
+@dataclass
+class LinkStageSource:
+    """One L1-L3 source with the metadata A2e needs to validate it.
+
+    - ``layer``: ``"L1"`` / ``"L2"`` / ``"L3"`` (per LAYERS.md).
+    - ``path``: posix-string path relative to repo root (used in diagnostics).
+    - ``slot``: the slot value from frontmatter (``"identity"`` / etc.).
+    - ``body``: file body with frontmatter stripped.
+    """
+    layer: str
+    path: str
+    slot: str
+    body: str
+
+
+class LinkStageValidationError(ValueError):
+    """Raised when one of the R1-R7 rules is violated.
+
+    The ``rule`` attribute carries the rule label (e.g. ``"R5"``).
+    ``file_path`` and ``step_id`` are set when the diagnostic names them.
+    """
+
+    def __init__(self, rule, message, *, file_path=None, step_id=None):
+        self.rule = rule
+        self.file_path = file_path
+        self.step_id = step_id
+        prefix = f"[{rule}] "
+        if file_path:
+            prefix += f"({file_path}) "
+        super().__init__(prefix + message)
+
+
+def validate_link_stage(l4_doc, sources, *, l4_path=None):
+    """Run all seven rules. Raise ``LinkStageValidationError`` on first violation.
+
+    Rules run in declaration order R1 → R7 so the first message points
+    at the rule the operator should fix first when multiple are wrong.
+
+    Parameters
+    ----------
+    l4_doc : :class:`l4_parser.L4Document`
+        Parsed L4 file (or ``L4Document.empty()`` when there is no L4).
+    sources : list[LinkStageSource]
+        L1-L3 source records. Order doesn't matter to validation.
+    l4_path : str | None
+        Optional path for inclusion in R1/R4/R5/R6/R7 diagnostics.
+    """
+    _check_r1_l4_no_vault_h2(l4_doc, l4_path)
+    _check_r2_l2_l3_no_vault_slot(sources)
+    _check_r3_l1_l3_no_project_context_slot(sources)
+    _check_r4_instructions_append_has_sub_skill_ref(l4_doc, l4_path)
+    _check_r5_l4_step_ids_resolve(l4_doc, sources, l4_path)
+    _check_r6_no_mixed_whole_slot_replace(l4_doc, l4_path)
+    _check_r7_no_duplicate_replace_step_targets(l4_doc, l4_path)
+
+
+def _check_r1_l4_no_vault_h2(l4_doc, l4_path):
+    if "vault" in l4_doc.slots:
+        raise LinkStageValidationError(
+            "R1",
+            "L4 file contains `## Vault` slot. Vault is L1-exclusive "
+            "per §3.3 + §5.6 — projects do not author vault content.",
+            file_path=l4_path,
+        )
+
+
+def _check_r2_l2_l3_no_vault_slot(sources):
+    for src in sources:
+        if src.layer in ("L2", "L3") and src.slot == "vault":
+            raise LinkStageValidationError(
+                "R2",
+                "L2/L3 source declares `slot: vault` in its frontmatter. "
+                "Vault is L1-exclusive per §3.3.",
+                file_path=src.path,
+            )
+
+
+def _check_r3_l1_l3_no_project_context_slot(sources):
+    for src in sources:
+        if src.slot == "project-context":
+            raise LinkStageValidationError(
+                "R3",
+                "L1-L3 source declares `slot: project-context` in its "
+                "frontmatter. Project Context is L4-exclusive per §3.3.",
+                file_path=src.path,
+            )
+
+
+def _check_r4_instructions_append_has_sub_skill_ref(l4_doc, l4_path):
+    instructions_ops = l4_doc.slots.get("instructions", [])
+    for op in instructions_ops:
+        if op.op_type != "append":
+            continue
+        if not _SUB_SKILL_REF_RE.search(op.body_text):
+            raise LinkStageValidationError(
+                "R4",
+                "L4 `### append` under `## Instructions` has no "
+                "`→ run sub-skill: <name>` reference. The thin-orchestration "
+                "invariant requires every appended block under Instructions "
+                "to reference at least one sub-skill (§4.5).",
+                file_path=l4_path,
+            )
+
+
+def _check_r5_l4_step_ids_resolve(l4_doc, sources, l4_path):
+    known_step_ids = _collect_source_step_ids(sources)
+    for slot_name, ops in l4_doc.slots.items():
+        for op in ops:
+            if op.target_step_id is None:
+                continue
+            if op.target_step_id not in known_step_ids:
+                raise LinkStageValidationError(
+                    "R5",
+                    f"L4 op `{op.op_type} step:cycle/{op.target_step_id}` "
+                    f"in slot `## {slot_name}` references a step ID that "
+                    f"is not present in any L1-L3 source.",
+                    file_path=l4_path,
+                    step_id=op.target_step_id,
+                )
+
+
+def _check_r6_no_mixed_whole_slot_replace(l4_doc, l4_path):
+    for slot_name, ops in l4_doc.slots.items():
+        has_whole_slot_replace = any(
+            op.op_type == "replace" and op.target_step_id is None for op in ops
+        )
+        if has_whole_slot_replace and len(ops) > 1:
+            raise LinkStageValidationError(
+                "R6",
+                f"Slot `## {slot_name}` mixes a whole-slot `### replace` "
+                f"(no step target) with other ops. Whole-slot replace is "
+                f"terminal per §4.2 step 2.i.",
+                file_path=l4_path,
+            )
+
+
+def _check_r7_no_duplicate_replace_step_targets(l4_doc, l4_path):
+    for slot_name, ops in l4_doc.slots.items():
+        seen = set()
+        for op in ops:
+            if op.op_type != "replace" or op.target_step_id is None:
+                continue
+            if op.target_step_id in seen:
+                raise LinkStageValidationError(
+                    "R7",
+                    f"Two `### replace step:cycle/{op.target_step_id}` "
+                    f"blocks target the same step ID in slot `## {slot_name}`. "
+                    f"Per TRD §4.2 step 3, each step ID may be the target "
+                    f"of at most one `replace` op per slot.",
+                    file_path=l4_path,
+                    step_id=op.target_step_id,
+                )
+            seen.add(op.target_step_id)
+
+
+def _collect_source_step_ids(sources):
+    """Build the set of step IDs declared by any L1-L3 source body."""
+    ids = set()
+    for src in sources:
+        for m in _SOURCE_STEP_HEADING_RE.finditer(src.body):
+            ids.add(m.group(1))
+    return ids

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -122,6 +122,7 @@ STATIC_TEST_MODULES = [
     "test_l4_op_processor",
     "test_compose_check_a4_10388",
     "test_v2_link_stage",
+    "test_link_stage_validator",
 ]
 
 

--- a/tests/test_link_stage_validator.py
+++ b/tests/test_link_stage_validator.py
@@ -1,0 +1,269 @@
+"""Tests for references/scripts/link_stage_validator.py (#10491, PRD-A A2e)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import link_stage_validator as v  # noqa: E402
+from link_stage_validator import LinkStageSource, LinkStageValidationError  # noqa: E402
+from l4_parser import L4Document, L4Op, parse_l4_text  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _l4_op(op_type, target=None, body=""):
+    return L4Op(op_type=op_type, target_step_id=target, body_text=body)
+
+
+def _l4_doc(slots):
+    """slots: dict[str, list[L4Op]] — convenience constructor."""
+    return L4Document(slots=dict(slots))
+
+
+def _src(layer, path, slot, body=""):
+    return LinkStageSource(layer=layer, path=path, slot=slot, body=body)
+
+
+def _well_formed_sources_with_steps(step_ids):
+    """A minimal L1-L3 source set containing the given step IDs in the instructions slot."""
+    body = "\n".join(f"### step:cycle/{sid}\nbody.\n" for sid in step_ids)
+    return [
+        _src("L1", "references/roles/identity.md", "identity", "Base identity body."),
+        _src("L1", "references/roles/instructions.md", "instructions", body),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# R1: L4 file containing ## Vault H2 → abort
+# ---------------------------------------------------------------------------
+
+def test_r1_l4_with_vault_h2_aborts():
+    doc = _l4_doc({"vault": []})
+    with pytest.raises(LinkStageValidationError) as exc:
+        v.validate_link_stage(doc, [], l4_path=".squidsquad/project/worker.md")
+    assert exc.value.rule == "R1"
+    assert "Vault" in str(exc.value)
+
+
+def test_r1_l4_without_vault_h2_passes():
+    doc = _l4_doc({"identity": [_l4_op("append", body="→ run sub-skill: x")]})
+    v.validate_link_stage(doc, [])  # no raise
+
+
+# ---------------------------------------------------------------------------
+# R2: L2/L3 source with slot: vault → abort
+# ---------------------------------------------------------------------------
+
+def test_r2_l2_source_with_vault_slot_aborts():
+    sources = [_src("L2", "references/roles/worker/oops.md", "vault")]
+    with pytest.raises(LinkStageValidationError) as exc:
+        v.validate_link_stage(L4Document.empty(), sources)
+    assert exc.value.rule == "R2"
+    assert exc.value.file_path == "references/roles/worker/oops.md"
+
+
+def test_r2_l3_source_with_vault_slot_aborts():
+    sources = [_src("L3", "references/roles/worker/skill/oops.md", "vault")]
+    with pytest.raises(LinkStageValidationError) as exc:
+        v.validate_link_stage(L4Document.empty(), sources)
+    assert exc.value.rule == "R2"
+
+
+def test_r2_l1_source_with_vault_slot_passes():
+    """L1 may declare vault — that's the L1-exclusive ownership the rule protects."""
+    sources = [_src("L1", "references/roles/vault.md", "vault", "Vault body.")]
+    v.validate_link_stage(L4Document.empty(), sources)
+
+
+# ---------------------------------------------------------------------------
+# R3: L1-L3 source with slot: project-context → abort
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("layer", ["L1", "L2", "L3"])
+def test_r3_any_l1_l3_source_with_project_context_slot_aborts(layer):
+    sources = [_src(layer, f"references/{layer}/oops.md", "project-context")]
+    with pytest.raises(LinkStageValidationError) as exc:
+        v.validate_link_stage(L4Document.empty(), sources)
+    assert exc.value.rule == "R3"
+
+
+# ---------------------------------------------------------------------------
+# R4: L4 ### append under ## Instructions without sub-skill ref → abort
+# ---------------------------------------------------------------------------
+
+def test_r4_instructions_append_without_sub_skill_ref_aborts():
+    op = _l4_op("append", body="Just prose. No reference.")
+    doc = _l4_doc({"instructions": [op]})
+    with pytest.raises(LinkStageValidationError) as exc:
+        v.validate_link_stage(doc, [])
+    assert exc.value.rule == "R4"
+
+
+def test_r4_instructions_append_with_sub_skill_ref_passes():
+    op = _l4_op("append", body="→ run sub-skill: pipeline-sentinel\n\nbody.")
+    doc = _l4_doc({"instructions": [op]})
+    v.validate_link_stage(doc, [])  # no raise
+
+
+def test_r4_append_under_other_slot_does_not_require_sub_skill_ref():
+    """R4 is Instructions-only; an append on Identity slot doesn't need a sub-skill ref."""
+    op = _l4_op("append", body="Just prose. Identity slot.")
+    doc = _l4_doc({"identity": [op]})
+    v.validate_link_stage(doc, [])
+
+
+# ---------------------------------------------------------------------------
+# R5: L4 op references non-existent step-id → abort with name in diagnostic
+# ---------------------------------------------------------------------------
+
+def test_r5_unknown_step_id_aborts_and_names_it():
+    sources = _well_formed_sources_with_steps(["boot", "work"])
+    bad_op = _l4_op("replace", target="ghost", body="x")
+    doc = _l4_doc({"instructions": [bad_op]})
+    with pytest.raises(LinkStageValidationError) as exc:
+        v.validate_link_stage(doc, sources)
+    assert exc.value.rule == "R5"
+    assert exc.value.step_id == "ghost"
+    assert "ghost" in str(exc.value)
+
+
+def test_r5_known_step_id_passes():
+    sources = _well_formed_sources_with_steps(["boot", "work"])
+    doc = _l4_doc({
+        "instructions": [
+            _l4_op("replace", target="work", body="new body"),
+            _l4_op("insert-after", target="boot", body="extra"),
+        ]
+    })
+    v.validate_link_stage(doc, sources)
+
+
+def test_r5_targetless_op_does_not_trigger():
+    """`append` and whole-slot `replace` have target_step_id=None — never R5."""
+    sources = []  # no step ids at all
+    doc = _l4_doc({
+        "instructions": [_l4_op("append", body="→ run sub-skill: x")],
+        "responsibility": [_l4_op("replace", body="whole-slot replace body")],
+    })
+    v.validate_link_stage(doc, sources)
+
+
+# ---------------------------------------------------------------------------
+# R6: whole-slot replace mixed with other ops in same slot → abort
+# ---------------------------------------------------------------------------
+
+def test_r6_whole_slot_replace_with_another_op_in_same_slot_aborts():
+    doc = _l4_doc({"responsibility": [
+        _l4_op("replace", body="whole new responsibility"),
+        _l4_op("append", body="more"),
+    ]})
+    with pytest.raises(LinkStageValidationError) as exc:
+        v.validate_link_stage(doc, [])
+    assert exc.value.rule == "R6"
+
+
+def test_r6_solo_whole_slot_replace_passes():
+    """A whole-slot replace by itself is legal (mutual exclusivity = no co-ops)."""
+    doc = _l4_doc({"responsibility": [_l4_op("replace", body="new body")]})
+    v.validate_link_stage(doc, [])
+
+
+def test_r6_scope_is_per_slot_not_per_file():
+    """A whole-slot replace in one slot does not affect ops in a different slot."""
+    doc = _l4_doc({
+        "responsibility": [_l4_op("replace", body="new resp body")],
+        "instructions": [_l4_op("append", body="→ run sub-skill: x")],
+    })
+    v.validate_link_stage(doc, [])
+
+
+# ---------------------------------------------------------------------------
+# R7: two replace step:cycle/<id> blocks targeting same step → abort
+# ---------------------------------------------------------------------------
+
+def test_r7_duplicate_replace_target_aborts():
+    sources = _well_formed_sources_with_steps(["work"])
+    doc = _l4_doc({"instructions": [
+        _l4_op("replace", target="work", body="first"),
+        _l4_op("replace", target="work", body="second"),
+    ]})
+    with pytest.raises(LinkStageValidationError) as exc:
+        v.validate_link_stage(doc, sources)
+    assert exc.value.rule == "R7"
+    assert exc.value.step_id == "work"
+
+
+def test_r7_disjoint_replace_targets_pass():
+    sources = _well_formed_sources_with_steps(["boot", "work"])
+    doc = _l4_doc({"instructions": [
+        _l4_op("replace", target="boot", body="x"),
+        _l4_op("replace", target="work", body="y"),
+    ]})
+    v.validate_link_stage(doc, sources)
+
+
+def test_r7_replace_plus_insert_before_same_target_is_legal():
+    """R7 is duplicate REPLACE-on-same-step. An insert-before/after on the same step is fine."""
+    sources = _well_formed_sources_with_steps(["work"])
+    doc = _l4_doc({"instructions": [
+        _l4_op("replace", target="work", body="x"),
+        _l4_op("insert-after", target="work", body="y"),
+    ]})
+    v.validate_link_stage(doc, sources)
+
+
+# ---------------------------------------------------------------------------
+# Cross-rule: empty L4 + clean sources passes
+# ---------------------------------------------------------------------------
+
+def test_empty_l4_and_clean_sources_passes():
+    v.validate_link_stage(L4Document.empty(), _well_formed_sources_with_steps(["boot"]))
+
+
+def test_validation_runs_rules_in_declaration_order_r1_first():
+    """If both R1 and (say) R7 would fire, R1 reported first per declaration order."""
+    sources = _well_formed_sources_with_steps(["work"])
+    doc = _l4_doc({
+        "vault": [],  # triggers R1
+        "instructions": [
+            _l4_op("replace", target="work", body="a"),
+            _l4_op("replace", target="work", body="b"),  # also triggers R7
+        ],
+    })
+    with pytest.raises(LinkStageValidationError) as exc:
+        v.validate_link_stage(doc, sources)
+    assert exc.value.rule == "R1"
+
+
+# ---------------------------------------------------------------------------
+# Integration with A2b's parser (sanity)
+# ---------------------------------------------------------------------------
+
+def test_validates_against_l4doc_parsed_from_text():
+    """End-to-end: parse L4 text via A2b, then validate via A2e."""
+    l4_text = (
+        "## Instructions\n\n"
+        "### append\n\n"
+        "→ run sub-skill: pipeline-sentinel\n\n"
+        "Body.\n"
+    )
+    doc = parse_l4_text(l4_text)
+    v.validate_link_stage(doc, _well_formed_sources_with_steps([]))
+
+
+def test_validates_l4_append_without_sub_skill_ref_via_parser():
+    l4_text = (
+        "## Instructions\n\n"
+        "### append\n\n"
+        "Just prose. No reference.\n"
+    )
+    doc = parse_l4_text(l4_text)
+    with pytest.raises(LinkStageValidationError) as exc:
+        v.validate_link_stage(doc, [])
+    assert exc.value.rule == "R4"


### PR DESCRIPTION
## Planning contract

Acceptance contract is the AC list in the issue body of #10491 (PRD-A Story A2e). The seven rules are anchored in PRD-A §3 success criterion 6 (the per-slot subset of COMPOSE-ARCHITECTURE §3.3 + §4.2). No PM-side `CONTEXT-10491.md` exists for this story. Verifier will produce `.squidsquad/qa/planning/TEST-PLAN-10491.md` during verification per the #9184 workflow. Cited per #8950 Gate #4 requirement.

## Summary

Implements `validate_link_stage(l4_doc, sources, *, l4_path) -> None` raising `LinkStageValidationError` on the first R1-R7 violation. Pure validation — no I/O, no compose. A2f (#10492) is the caller that runs the validator before A2d's `emit_v2_linked`, so any failure produces zero partial artifacts.

## What landed

- `references/scripts/link_stage_validator.py` (~155 lines):
  - `LinkStageSource(layer, path, slot, body)` dataclass — the per-source record callers supply.
  - `LinkStageValidationError(ValueError)` with `.rule`, `.file_path`, `.step_id` attributes for programmatic inspection in addition to a human-readable `str()`.
  - `validate_link_stage(l4_doc, sources, *, l4_path=None)` — entry point. Runs R1 → R7 in declaration order so the first message points at the rule to fix first.
  - Per-rule private helpers (`_check_r1_l4_no_vault_h2`, `_check_r2_l2_l3_no_vault_slot`, ...). Each raises with the appropriate rule label, file path, and (R5/R7) the offending step ID.
  - `_collect_source_step_ids` derives the set of step IDs from source bodies using `^### step:cycle/<id>$` MULTILINE — the same source-of-truth A2c uses, so A2e and A2c agree on what counts as a step.
  - `_SUB_SKILL_REF_RE` kept local (mirrors `assemble_verifier._SUB_SKILL_RE`) so A2e doesn't reach across PRDs.
- `tests/test_link_stage_validator.py` (~265 lines, 24 tests).
- `tests/run_tests.py`: registered `test_link_stage_validator` in `STATIC_TEST_MODULES`.

## AC mapping

| AC | Where |
|---|---|
| R1: L4 file containing `## Vault` H2 → abort | `_check_r1_l4_no_vault_h2` + `test_r1_l4_with_vault_h2_aborts` |
| R2: L2/L3 source with `slot: vault` → abort | `_check_r2_l2_l3_no_vault_slot` + `test_r2_l2_source_…_aborts` + `test_r2_l3_source_…_aborts` + `test_r2_l1_source_with_vault_slot_passes` |
| R3: L1-L3 source with `slot: project-context` → abort | `_check_r3_l1_l3_no_project_context_slot` + parametrized `test_r3_any_l1_l3_source_…_aborts[L1/L2/L3]` |
| R4: L4 `### append` under `## Instructions` without sub-skill ref → abort | `_check_r4_instructions_append_has_sub_skill_ref` + `test_r4_…_without_…_aborts` + `test_r4_…_with_…_passes` + `test_r4_append_under_other_slot_does_not_require…` |
| R5: L4 op references non-existent step-id → abort with step-id named | `_check_r5_l4_step_ids_resolve` + `test_r5_unknown_step_id_aborts_and_names_it` + `test_r5_targetless_op_does_not_trigger` |
| R6: whole-slot replace mixed with other ops in same slot → abort (per-slot, not per-file) | `_check_r6_no_mixed_whole_slot_replace` + `test_r6_…_aborts` + `test_r6_solo_…_passes` + `test_r6_scope_is_per_slot_not_per_file` |
| R7: two `### replace step:cycle/<id>` blocks targeting same step → abort | `_check_r7_no_duplicate_replace_step_targets` + `test_r7_duplicate_replace_target_aborts` + `test_r7_disjoint_…_pass` + `test_r7_replace_plus_insert_before_…_is_legal` |
| All seven rules run BEFORE any disk write — emit zero partial artifacts on any abort | A2e is pure validation; A2f's "validate then emit" sequencing satisfies the "zero partial artifacts" promise |
| Diagnostic names the rule number + offending file/path/step-id | `LinkStageValidationError.__init__` prefixes the message with `[R<n>]` and `(file_path)`; `.rule`, `.file_path`, `.step_id` are programmatic attributes |
| Unit test per rule (negative fixture + verify the abort) | All seven rules have at least one negative test asserting the raise + the `rule` label |

## Tests

`python -m pytest tests/test_link_stage_validator.py` — 24 passed in 0.08s.

## Notes

- Rule ordering means R1 fires first if both R1 and (say) R7 would apply on the same input. The order matches the rule numbering, not severity — operator-friendly because the first message identifies the rule to fix first.
- `LinkStageSource` requires layer + path + slot + body. The body is needed for R5 (step-id resolution from `### step:cycle/<id>` headings). Callers can derive these from A2d's `_parse_all_applicable_sources` output.
- Integration with A2b: a final pair of tests parse L4 text via `parse_l4_text` then validate via `validate_link_stage`, proving the contract holds end-to-end across PRDs.

Closes #10491