### PR TITLE
PRD-B/B1: assemble_pass — per-slot LLM call scaffolding (#10444)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ references/scripts/migrate_*.py.bak
 .[0-9]*-phase*-*review*.md
 .[0-9]*-fixup*.diff
 .[0-9]*-fixup*review*.md
+
+# Per-call tempdirs created by assemble_pass.assemble_slot (#10444 B1).
+# Must live under .squidsquad/ to pass model_router's sandbox check.
+.squidsquad/tmp/

--- a/references/prompts/assemble.md.j2
+++ b/references/prompts/assemble.md.j2
@@ -1,0 +1,31 @@
+You are a technical editor rewriting a slot of layered agent instructions into a single coherent voice.
+
+## Task
+
+{{ context }}
+
+## Linked input
+
+{{ file_contents }}
+
+## Instructions
+
+The text above is the LINKED composite for ONE slot of an agent's instructions. It is mechanically assembled from multiple layers (L1 = SquidSquad-shipped baseline, L2 = role-specific overlay, L3 = domain specialization, L4 = project-specific). Your job is to rewrite this body into one coherent, non-redundant statement the agent can read top-to-bottom without reconciling overlapping prose.
+
+CRITICAL RULES — these are LOAD-BEARING and verified by a preservation pass on your output:
+
+- **PRESERVE every `→ run sub-skill: <name>` reference.** Each appearance in the linked input must appear in your output. Same name, same count (multisets must match — duplicate references must remain duplicated). No new references; no dropped references.
+- **PRESERVE every `step:cycle/<id>` reference.** Same multiset rule.
+- **PRESERVE every fenced code block** (```​…```). Do not modify, reorder, or add fenced blocks. Inline code spans (`like this`) must also be preserved within ±10%.
+- **PRESERVE markdown structure** at the heading level (H3 step headings remain H3, etc.).
+- **DO NOT** introduce new sub-skill names, step IDs, file paths, or code that wasn't in the linked input.
+- **DO NOT** alter the meaning of any behavioral instruction. You may improve wording, deduplicate, and resolve "do X / actually don't do X" into a single statement that aligns with the higher layer — but the resulting instruction must be the higher layer's instruction, not a synthesis.
+
+When layers contradict ("L2 says verify pending-test items each cycle" / "L4 appends verifier handles all verification — PM does not"):
+
+- **Higher L wins.** L4 > L3 > L2 > L1. The link stage already places higher-layer content later in the linked body via `(slot_index, ordinal)` sort.
+- Replace the lower-layer prose with the higher-layer position. Do not silently delete; the conflict is reported separately by the conflict-detection pass.
+
+## Output Format
+
+Emit ONLY the rewritten slot body. No preamble, no commentary, no markdown code fence around the whole output. The output is concatenated under the slot's `## <Heading>` directly in the assembled CLAUDE.md, so anything you write that isn't part of the slot body becomes runtime noise the agent reads each cycle.

--- a/references/scripts/assemble_pass.py
+++ b/references/scripts/assemble_pass.py
@@ -24,6 +24,14 @@ from pathlib import Path
 
 VERBATIM_SLOTS = frozenset({"project-context", "vault"})
 
+# Per-call tempfiles live UNDER the repo root (``.squidsquad/tmp/assemble/``)
+# so they satisfy ``model_router._is_path_in_sandbox``. The router refuses
+# to read input paths resolved outside REPO_ROOT — using the system temp
+# dir (``%TEMP%`` / ``/tmp``) made the linked body invisible to the LLM
+# (#10444 QA route-back).
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_ASSEMBLE_TMP_ROOT = _REPO_ROOT / ".squidsquad" / "tmp" / "assemble"
+
 
 def assemble_slot(slot_name, linked_body, *, task_id=None, model_router=None):
     """Run the assemble pass on one slot. Returns the assembled body as a string.
@@ -54,9 +62,14 @@ def assemble_slot(slot_name, linked_body, *, task_id=None, model_router=None):
         task_id = f"assemble-{slot_name}"
 
     # Router uses file-based I/O; write linked body to a temp input file
-    # and ask it to produce its response in a temp output file. The router
-    # then deletes nothing — we clean both up after read.
-    with tempfile.TemporaryDirectory(prefix=f"assemble-{slot_name}-") as td:
+    # and ask it to produce its response in a temp output file. The temp
+    # directory lives UNDER the repo root so the router's sandbox check
+    # (`_is_path_in_sandbox`) accepts the input path. Using the system
+    # tempdir would resolve outside REPO_ROOT and the router would skip
+    # the input with "Path outside repository boundary" (#10444 QA finding).
+    _ASSEMBLE_TMP_ROOT.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=f"assemble-{slot_name}-",
+                                     dir=str(_ASSEMBLE_TMP_ROOT)) as td:
         td_path = Path(td)
         input_path = td_path / f"linked-{slot_name}.md"
         output_path = td_path / f"assembled-{slot_name}.md"

--- a/references/scripts/assemble_pass.py
+++ b/references/scripts/assemble_pass.py
@@ -1,0 +1,108 @@
+"""Assemble pass scaffolding — per-slot LLM rewrite (#10444, PRD-B Story B1).
+
+Per [[compose-assemble-stage]] §4.6, after the link stage produces a
+per-slot linked composite, each non-skipped slot's linked body passes
+through an agent-driven rewrite that collapses the layered prose into a
+single coherent voice. B1 wires the per-slot dispatch:
+
+- ``project-context`` and ``vault`` slots are NOT rewritten — they pass
+  through verbatim. Project-context is L4-authored as-is and vault is
+  framework-owned; both are read by the agent as the human intended.
+- Every other slot is dispatched to ``model_router`` with the new
+  ``"assemble"`` task type (template at ``references/prompts/assemble.md.j2``).
+
+B1 does NOT enforce preservation (B2 #10441 does), conflict detection
+(B4 #10445), cache (B6), or atomic write (B7 #10447). It is the
+plumbing PR — the LLM is called, the body comes back, callers (B7 + B2)
+own the rest.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+
+VERBATIM_SLOTS = frozenset({"project-context", "vault"})
+
+
+def assemble_slot(slot_name, linked_body, *, task_id=None, model_router=None):
+    """Run the assemble pass on one slot. Returns the assembled body as a string.
+
+    ``project-context`` and ``vault`` are returned verbatim per the AC.
+
+    For other slots, ``model_router.route`` is invoked with task_type
+    ``"assemble"``, the linked body written to a tempfile (the router's
+    file-based input convention), and the response read back from the
+    router's output file.
+
+    ``model_router`` — an optional injected reference to the
+    ``model_router`` module. Tests pass a stub here so the unit tests
+    don't depend on a live LLM. When omitted, the real module is
+    imported lazily.
+
+    ``task_id`` — optional id used in router diagnostics. Defaults to
+    ``f"assemble-{slot_name}"``.
+    """
+    if slot_name in VERBATIM_SLOTS:
+        return linked_body
+
+    if model_router is None:
+        import model_router as _real_router  # noqa: WPS433
+        model_router = _real_router
+
+    if task_id is None:
+        task_id = f"assemble-{slot_name}"
+
+    # Router uses file-based I/O; write linked body to a temp input file
+    # and ask it to produce its response in a temp output file. The router
+    # then deletes nothing — we clean both up after read.
+    with tempfile.TemporaryDirectory(prefix=f"assemble-{slot_name}-") as td:
+        td_path = Path(td)
+        input_path = td_path / f"linked-{slot_name}.md"
+        output_path = td_path / f"assembled-{slot_name}.md"
+        input_path.write_text(linked_body, encoding="utf-8")
+
+        context = (
+            f"Rewrite the LINKED body for the `{slot_name}` slot into a "
+            f"single coherent voice while preserving every sub-skill and "
+            f"step:cycle/<id> reference verbatim. Higher-layer prose wins "
+            f"on contradiction (L4 > L3 > L2 > L1)."
+        )
+
+        exit_code = model_router.route(
+            task_type="assemble",
+            task_id=task_id,
+            input_files=str(input_path),
+            output_file=str(output_path),
+            context=context,
+        )
+
+        if exit_code != 0:
+            # Per route()'s contract: non-zero = fallback path (Claude
+            # via Agent tool / config error / timeout). B1's caller (B7)
+            # will own the abort-on-LLM-error path; here we surface a
+            # clear error and let the caller decide.
+            raise AssembleSlotError(
+                f"model_router.route returned exit code {exit_code} for "
+                f"assemble task_id={task_id} slot={slot_name}. See router "
+                f"diagnostics in .squidsquad/diagnostics/model-routing.log."
+            )
+
+        if not output_path.exists():
+            raise AssembleSlotError(
+                f"model_router.route produced no output file for "
+                f"task_id={task_id} slot={slot_name}. Expected at "
+                f"{output_path}."
+            )
+
+        body = output_path.read_text(encoding="utf-8")
+
+    return body
+
+
+class AssembleSlotError(RuntimeError):
+    """Raised when ``assemble_slot`` cannot obtain an assembled body.
+
+    B7 (#10447) catches this and routes to the abort path per the
+    §4.6 atomic-write contract; B1's contract is to raise.
+    """

--- a/references/scripts/model_router.py
+++ b/references/scripts/model_router.py
@@ -541,6 +541,7 @@ def _load_prompt_template(task_type):
         "test-plan": "test-plan.md.j2",
         "improvement-scan": "improvement-scan.md.j2",
         "code-review": "code-review.md.j2",  # #5932
+        "assemble": "assemble.md.j2",  # #10444 PRD-B/B1
     }
     filename = template_map.get(task_type)
     if not filename:

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -124,6 +124,7 @@ STATIC_TEST_MODULES = [
     "test_v2_link_stage",
     "test_link_stage_validator",
     "test_compose_a2f_10492",
+    "test_assemble_pass_b1",
 ]
 
 

--- a/tests/test_assemble_pass_b1.py
+++ b/tests/test_assemble_pass_b1.py
@@ -1,0 +1,179 @@
+"""Tests for references/scripts/assemble_pass.py (#10444, PRD-B Story B1)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import assemble_pass  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# A simple stub router that records calls and produces a canned response.
+# ---------------------------------------------------------------------------
+
+class _StubRouter:
+    """Minimal stand-in for the real model_router module.
+
+    Records each ``route()`` invocation and writes a canned response to
+    the output file so the caller's ``read_text`` succeeds.
+    """
+
+    def __init__(self, response="ASSEMBLED BODY\n", exit_code=0):
+        self.response = response
+        self.exit_code = exit_code
+        self.calls = []
+
+    def route(self, task_type, task_id, input_files, output_file, context):
+        self.calls.append({
+            "task_type": task_type,
+            "task_id": task_id,
+            "input_files": input_files,
+            "output_file": output_file,
+            "context": context,
+        })
+        if self.exit_code == 0:
+            Path(output_file).write_text(self.response, encoding="utf-8")
+        return self.exit_code
+
+
+# ---------------------------------------------------------------------------
+# AC: verbatim pass-through for project-context + vault
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("verbatim_slot", ["project-context", "vault"])
+def test_assemble_slot_returns_verbatim_for_special_slots(verbatim_slot):
+    """project-context and vault skip the LLM call entirely — returned verbatim."""
+    linked = "Some L4-authored project-context body.\n"
+    router = _StubRouter()
+    out = assemble_pass.assemble_slot(verbatim_slot, linked, model_router=router)
+    assert out == linked
+    # AC: 'no live LLM calls' — verbatim slots must not invoke the router.
+    assert router.calls == []
+
+
+def test_assemble_slot_verbatim_pass_through_with_empty_body():
+    """Empty body for a verbatim slot is still legal — pass through."""
+    out = assemble_pass.assemble_slot("vault", "", model_router=_StubRouter())
+    assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# AC: assemble_slot calls model_router with task_type="assemble"
+# ---------------------------------------------------------------------------
+
+def test_assemble_slot_dispatches_to_router_for_normal_slots():
+    router = _StubRouter(response="rewritten identity\n")
+    out = assemble_pass.assemble_slot("identity", "Layered identity prose.\n",
+                                      model_router=router)
+    assert out == "rewritten identity\n"
+    assert len(router.calls) == 1
+    assert router.calls[0]["task_type"] == "assemble"
+
+
+def test_assemble_slot_uses_default_task_id_for_slot():
+    router = _StubRouter()
+    assemble_pass.assemble_slot("instructions", "body", model_router=router)
+    assert router.calls[0]["task_id"] == "assemble-instructions"
+
+
+def test_assemble_slot_honors_custom_task_id():
+    router = _StubRouter()
+    assemble_pass.assemble_slot(
+        "soul", "body", task_id="custom-soul-task", model_router=router,
+    )
+    assert router.calls[0]["task_id"] == "custom-soul-task"
+
+
+def test_assemble_slot_writes_linked_body_to_input_file_for_router():
+    """The router gets a file path. Verify the file contains the linked body."""
+    linked = "MUST APPEAR IN INPUT FILE\n"
+    captured_input = {}
+
+    def route(task_type, task_id, input_files, output_file, context):
+        # Capture file contents at call time (before TemporaryDirectory unlinks).
+        captured_input["contents"] = Path(input_files).read_text(encoding="utf-8")
+        Path(output_file).write_text("ok", encoding="utf-8")
+        return 0
+
+    router = type("R", (), {"route": staticmethod(route)})()
+    assemble_pass.assemble_slot("instructions", linked, model_router=router)
+    assert captured_input["contents"] == linked
+
+
+def test_assemble_slot_passes_slot_name_into_router_context():
+    router = _StubRouter()
+    assemble_pass.assemble_slot("instructions", "body", model_router=router)
+    assert "instructions" in router.calls[0]["context"]
+
+
+def test_assemble_slot_returns_router_output_verbatim():
+    """The assembled body comes from what the router wrote to output_file."""
+    expected = "THE ROUTER'S RESPONSE\nLINE TWO\n"
+    router = _StubRouter(response=expected)
+    out = assemble_pass.assemble_slot("identity", "linked", model_router=router)
+    assert out == expected
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+def test_assemble_slot_raises_when_router_returns_nonzero():
+    router = _StubRouter(exit_code=1)
+    with pytest.raises(assemble_pass.AssembleSlotError) as exc:
+        assemble_pass.assemble_slot("identity", "linked", model_router=router)
+    assert "exit code 1" in str(exc.value)
+    assert "identity" in str(exc.value)
+
+
+def test_assemble_slot_raises_when_router_writes_no_output():
+    """A 'success' return with no output file is still a failure — protect downstream."""
+    class NoOutputRouter:
+        def route(self, task_type, task_id, input_files, output_file, context):
+            # Intentionally do not write output_file.
+            return 0
+
+    with pytest.raises(assemble_pass.AssembleSlotError) as exc:
+        assemble_pass.assemble_slot("identity", "linked",
+                                    model_router=NoOutputRouter())
+    assert "no output file" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Template + task_type registration in model_router (AC: 'new model_router task type')
+# ---------------------------------------------------------------------------
+
+def test_model_router_recognizes_assemble_task_type():
+    """The 'assemble' task type must be registered in _load_prompt_template."""
+    import model_router
+    template = model_router._load_prompt_template("assemble")
+    assert template is not None
+    assert "sub-skill" in template  # the preservation guidance
+
+
+def test_assemble_template_exists_at_canonical_path():
+    """AC: 'prompt template at references/prompts/assemble.md.j2'."""
+    repo_root = Path(__file__).resolve().parent.parent
+    template_path = repo_root / "references" / "prompts" / "assemble.md.j2"
+    assert template_path.exists()
+
+
+def test_assemble_template_includes_required_preservation_directives():
+    """The template MUST direct the LLM to preserve sub-skill refs and step IDs.
+
+    B2's preservation pass relies on these being preserved; if the
+    prompt doesn't say so, B2 will routinely fail and trigger aborts.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    template_path = repo_root / "references" / "prompts" / "assemble.md.j2"
+    text = template_path.read_text(encoding="utf-8")
+    # Sub-skill references (verbatim in the template — escaped vs plain
+    # doesn't matter, the string is what gets sent to the LLM).
+    assert "sub-skill" in text.lower()
+    assert "step:cycle" in text
+    # Conflict resolution direction.
+    assert "L4 > L3 > L2 > L1" in text or "higher" in text.lower()

--- a/tests/test_assemble_pass_b1.py
+++ b/tests/test_assemble_pass_b1.py
@@ -1,7 +1,9 @@
 """Tests for references/scripts/assemble_pass.py (#10444, PRD-B Story B1)."""
 
+import os
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -9,6 +11,29 @@ SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 import assemble_pass  # noqa: E402
+import model_router  # noqa: E402
+
+
+# Realistic fixture: a slot body with the preservation tokens B2/B3 verify.
+# Used by the smoke tests to prove the dispatch carries them end-to-end.
+_FIXTURE_LINKED_INSTRUCTIONS = """\
+### step:cycle/boot
+
+→ run sub-skill: boot-bootstrap
+
+Verify tracker access and read config. Run `python references/scripts/tracker.py check-gh`.
+
+### step:cycle/pickup
+
+→ run sub-skill: task-pickup
+
+Query the tracker for approved tasks assigned to this role. Pick the highest-priority
+item per the deterministic queue ordering. Record the choice in working-state.md.
+
+### step:cycle/work
+
+Do the unit of work for the current cycle. Implementation varies by role.
+"""
 
 
 # ---------------------------------------------------------------------------
@@ -177,3 +202,107 @@ def test_assemble_template_includes_required_preservation_directives():
     assert "step:cycle" in text
     # Conflict resolution direction.
     assert "L4 > L3 > L2 > L1" in text or "higher" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# AC5: smoke tests against a real fixture
+# ---------------------------------------------------------------------------
+#
+# AC5 reads: "Smoke test against a real fixture confirms LLM is invoked +
+# body returned." Two smokes implement this:
+#
+#   1. test_smoke_assemble_slot_dispatches_through_real_model_router
+#      -- always runs. Exercises the FULL assemble_slot -> model_router.route
+#      pipeline with a mocked provider adapter. Proves the dispatch reaches
+#      the routing layer, the assemble.md.j2 template is loaded, the linked
+#      fixture body lands in the adapter call, and the response is returned
+#      back through assemble_slot.
+#
+#   2. test_smoke_assemble_slot_live_llm_round_trip
+#      -- gated by SQUIDSQUAD_LIVE_LLM=1. When opted in (e.g., by a verifier
+#      with API keys), this runs a real round-trip against the configured
+#      provider. Skipped by default so CI doesn't burn API tokens.
+
+def test_smoke_assemble_slot_dispatches_through_real_model_router(tmp_path):
+    """Smoke: real model_router.route called with task_type='assemble'.
+
+    Uses the real `model_router.route` (not the stub class). Provider
+    config + adapter are mocked the same way the existing
+    test_model_router.py smokes mock them (see #5932 patterns).
+
+    Asserts:
+    - The adapter's `call()` was invoked.
+    - The user prompt sent to the adapter contains the FIXTURE linked body
+      (proves the template substitution carried the file contents
+      through).
+    - The user prompt is the assemble.md.j2 template's content
+      (proves task_type='assemble' picked up the right template).
+    - assemble_slot returned the adapter's response.
+    """
+    # Build a response above the MIN_OUTPUT_LENGTH=200 quality gate.
+    canned_response = (
+        "### step:cycle/boot\n\n"
+        "→ run sub-skill: boot-bootstrap\n\n"
+        "Verify tracker access and read config. " * 6
+    )
+    fake_adapter = MagicMock()
+    fake_adapter.call.return_value = canned_response
+
+    config_text = "## Model Routing\n- **Assemble Model**: gpt-5.2\n"
+    with patch.object(model_router, "_read_config", return_value=config_text), \
+         patch.object(model_router, "_load_provider_manifest",
+                      return_value=("openai", {
+                          "name": "openai",
+                          "auth": {"env_var": "OPENAI_API_KEY"},
+                          "api_base": "",
+                          "deps": [],
+                      })), \
+         patch.object(model_router, "_ensure_deps"), \
+         patch.object(model_router, "_load_adapter", return_value=fake_adapter), \
+         patch.dict(os.environ, {"OPENAI_API_KEY": "smoke-fixture-key"}):
+        out = assemble_pass.assemble_slot(
+            "instructions",
+            _FIXTURE_LINKED_INSTRUCTIONS,
+            model_router=model_router,
+        )
+
+    # Adapter was actually invoked.
+    fake_adapter.call.assert_called_once()
+    call_kwargs = fake_adapter.call.call_args.kwargs
+
+    # The user prompt is built from the assemble.md.j2 template. The
+    # template contains the literal phrase "→ run sub-skill:" in its
+    # preservation rules; assert it survived the substitution.
+    user_prompt = call_kwargs.get("user_prompt", "")
+    assert "→ run sub-skill:" in user_prompt, (
+        "user_prompt should contain the assemble.md.j2 preservation directive"
+    )
+    # And the FIXTURE body must be embedded in the prompt (via the
+    # {{ file_contents }} placeholder in the template).
+    assert "step:cycle/boot" in user_prompt
+    assert "boot-bootstrap" in user_prompt
+
+    # The body returned to the caller is the adapter's response.
+    assert out == canned_response
+
+
+@pytest.mark.skipif(
+    os.environ.get("SQUIDSQUAD_LIVE_LLM") != "1",
+    reason="Live-LLM round-trip — opt in with SQUIDSQUAD_LIVE_LLM=1 + API keys",
+)
+def test_smoke_assemble_slot_live_llm_round_trip():
+    """Live-LLM smoke: assemble_slot returns a non-empty body from the configured provider.
+
+    Skipped by default. Verifiers with API keys can enable by setting
+    `SQUIDSQUAD_LIVE_LLM=1` in their environment. The test does NOT
+    assert preservation (B2/B3 own that against the returned body) —
+    its scope is exactly AC5: 'LLM is invoked + body returned'.
+    """
+    out = assemble_pass.assemble_slot(
+        "instructions",
+        _FIXTURE_LINKED_INSTRUCTIONS,
+    )
+    assert out, "Live-LLM smoke: assemble_slot returned an empty body"
+    assert len(out.strip()) >= model_router.MIN_OUTPUT_LENGTH, (
+        f"Live-LLM smoke: body length {len(out)} below router's MIN_OUTPUT_LENGTH"
+    )


### PR DESCRIPTION
## Planning contract

Acceptance contract is the AC list in the issue body of #10444 (PRD-B Story B1). The §4.6 assemble-pass spec lives in COMPOSE-ARCHITECTURE; B1 is the plumbing PR (B2/B3/B4/B5/B6/B7 layer preservation, conflict detection, cache, and atomic write on top). No PM-side `CONTEXT-10444.md` exists. Verifier will produce `.squidsquad/qa/planning/TEST-PLAN-10444.md` during verification per the #9184 workflow. Cited per #8950 Gate #4 requirement.

## Summary

Adds the per-slot assemble-pass dispatch. `project-context` and `vault` slots pass through verbatim per §4.6; every other slot dispatches to `model_router` with the new `assemble` task type and a new prompt template at `references/prompts/assemble.md.j2`.

## What landed

- `references/prompts/assemble.md.j2` (new template). Directs the editor agent to rewrite the LINKED body into one coherent voice while preserving sub-skill refs and `step:cycle/<id>` refs verbatim and applying L4 > L3 > L2 > L1 conflict resolution. Output is the slot body only — no preamble, no commentary.
- `references/scripts/model_router.py`: registers `"assemble"` in the `_load_prompt_template` task-type → template-filename map.
- `references/scripts/assemble_pass.py` (new module):
  - `assemble_slot(slot_name, linked_body, *, task_id=None, model_router=None) -> str`
  - `VERBATIM_SLOTS = {"project-context", "vault"}` — these skip the LLM call entirely and return the linked body as-is.
  - Other slots: write linked_body to a tempfile, call `model_router.route(task_type="assemble", ...)` with file-based I/O, read the response back. The tempdir is cleaned up via `TemporaryDirectory` regardless of success/failure.
  - Optional injected `model_router` for tests; default lazy-imports the real module so importing `assemble_pass` doesn't pull in routing config or YAML deps.
  - `AssembleSlotError(RuntimeError)` raised on non-zero exit code or missing output file. B7 (#10447) will catch this and route to the §4.6 abort path.
- `tests/test_assemble_pass_b1.py` (14 stubbed unit tests).
- `tests/run_tests.py`: registered `test_assemble_pass_b1` in `STATIC_TEST_MODULES`.

## AC mapping

| AC | Where |
|---|---|
| New `model_router` task type `assemble` with prompt template at `references/prompts/assemble.md.j2` | `_load_prompt_template` map + `assemble.md.j2` + `test_model_router_recognizes_assemble_task_type` + `test_assemble_template_exists_at_canonical_path` |
| `assemble_slot(slot_name, linked_body)` calls model_router and returns assembled body | `assemble_pass.assemble_slot` + `test_assemble_slot_dispatches_to_router_for_normal_slots` + `test_assemble_slot_returns_router_output_verbatim` |
| Verbatim pass-through for project-context + vault slots | `VERBATIM_SLOTS` check + parametrized `test_assemble_slot_returns_verbatim_for_special_slots[project-context/vault]` + `test_assemble_slot_verbatim_pass_through_with_empty_body` |
| Unit tests with stubbed model_router (no live LLM calls in unit tests) | All 14 tests use `_StubRouter` or `monkeypatch`-style fakes; no real LLM keys required |
| Smoke test against a real fixture confirms LLM is invoked + body returned | Deferred — see Notes below. Live-LLM smoke tests run outside the static-analysis suite (require API keys); B1's contract is plumbing, and B7's atomic-emit tests will exercise the full path once that PR lands |

## Tests

`python -m pytest tests/test_assemble_pass_b1.py` — 14 passed in 0.11s.

## Notes

- The template includes the preservation directives that B2 (#10441) and B3 (#10442) verify. If those directives ever drift, the test `test_assemble_template_includes_required_preservation_directives` will fail at static time.
- B1 does NOT enforce preservation (B2 owns), conflict detection (B4), cache (B6), or atomic write (B7). The signature gives B7 a clean dispatch point: catch `AssembleSlotError`, route to the abort path, leave the prior triple untouched.
- Live-LLM smoke test is deferred. The unit tests cover every code path; what they can't cover is "does a real LLM actually preserve the references". That assertion belongs in B2's integration tests (which run preservation checks against real LLM output) or in B8's golden-file suite (#10448).

Closes #10444