### PR TITLE
PRD-B/B4: conflict_detector — parse + emit assemble conflict report (#10445)

### DIFF
--- a/references/prompts/assemble.md.j2
+++ b/references/prompts/assemble.md.j2
@@ -28,4 +28,39 @@ When layers contradict ("L2 says verify pending-test items each cycle" / "L4 app
 
 ## Output Format
 
-Emit ONLY the rewritten slot body. No preamble, no commentary, no markdown code fence around the whole output. The output is concatenated under the slot's `## <Heading>` directly in the assembled CLAUDE.md, so anything you write that isn't part of the slot body becomes runtime noise the agent reads each cycle.
+Emit your output in TWO parts, separated by the literal delimiter `<!-- ASSEMBLE_CONFLICTS -->` on its own line.
+
+### Part 1 — Rewritten slot body
+
+Above the delimiter: ONLY the rewritten slot body. No preamble, no commentary, no markdown code fence around the whole output. The body is concatenated under the slot's `## <Heading>` directly in the assembled CLAUDE.md, so anything that isn't part of the slot body becomes runtime noise the agent reads each cycle.
+
+### Part 2 — Conflicts reconciled (audit trail)
+
+Below the delimiter: a bullet list of every contradiction you reconciled during the rewrite. Each conflict is one bullet group with the following fields. Field names MUST be lowercase exactly as shown; values are free-form text. Quotes ≤200 chars (longer quotes are auto-truncated by the report emitter).
+
+```
+<!-- ASSEMBLE_CONFLICTS -->
+
+- slot: <slot name, e.g. instructions>
+  winner_layer: <L1 | L2 | L3 | L4>
+  winner_path: <source file path>
+  winner_quote: <verbatim quote from the higher layer>
+  loser_layer: <L1 | L2 | L3 | L4>
+  loser_path: <source file path>
+  loser_quote: <verbatim quote from the lower layer>
+  why: <one sentence explaining the contradiction>
+  resolution: <one sentence describing what the assembled body says>
+
+- slot: ...
+  ...
+```
+
+If you reconciled NO conflicts during this rewrite, emit the delimiter followed by the literal placeholder `(none)`:
+
+```
+<!-- ASSEMBLE_CONFLICTS -->
+
+(none)
+```
+
+The placeholder is mandatory — its presence confirms you considered conflict detection and found none. Skipping the delimiter entirely is reserved for the rare case where the LLM cannot complete the task; the operator-facing tooling treats it as an audit gap.

--- a/references/scripts/conflict_detector.py
+++ b/references/scripts/conflict_detector.py
@@ -1,0 +1,206 @@
+"""Assemble-pass conflict detection + report emit (#10445, PRD-B Story B4).
+
+Per [[compose-assemble-stage]] §4.6, the assemble pass collapses layered
+prose into a single coherent voice. When layers materially contradict,
+the higher layer's prose prevails (L4 > L3 > L2 > L1). The lower-layer
+prose is not silently erased — every reconciled contradiction is
+recorded in ``CLAUDE.conflicts.md`` as the operator's audit surface.
+
+B4 is the DETECTION + REPORT-EMIT half:
+
+- The LLM, in a single pass, produces the assembled body AND lists any
+  conflicts it reconciled in a delimited section at the end of its
+  output (template directive in ``assemble.md.j2``).
+- ``parse_assemble_output`` splits the LLM output on the delimiter and
+  parses the trailing conflicts block into structured ``Conflict``
+  records.
+- ``emit_conflict_report`` produces the §4.6 canonical-format report
+  markdown from a list of ``Conflict`` records.
+
+B5 (#10446) is the higher-L-wins RESOLVER. B7 (#10447) wires the report
+into the atomic-emit pipeline (CLAUDE.md + CLAUDE.linked.md +
+CLAUDE.conflicts.md triple).
+
+This module is pure — no I/O beyond what callers do with the returned
+strings.
+"""
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+
+# HTML-comment delimiter marking the start of the conflicts section in
+# LLM output. Kept stable across releases so older composes can parse
+# newer outputs.
+CONFLICTS_DELIMITER = "<!-- ASSEMBLE_CONFLICTS -->"
+
+# Maximum length the §4.6 spec allows for a verbatim quote in the
+# report. Longer quotes are truncated with an ellipsis. Applied at
+# report-emit time so detection can keep the full quote in memory.
+MAX_QUOTE_CHARS = 200
+
+
+@dataclass
+class Conflict:
+    """One reconciled contradiction from an assemble pass.
+
+    Field names mirror the §4.6 canonical report format. ``winner_*``
+    is the higher-L source whose position the assembled body aligns
+    with; ``loser_*`` is the lower-L source whose prose was overridden.
+    ``ordinal`` is optional — the LLM does not always know the source
+    file's frontmatter ordinal, and the report renders ``?`` when None.
+    """
+
+    slot: str
+    winner_layer: str  # "L1" | "L2" | "L3" | "L4"
+    loser_layer: str
+    winner_path: str
+    loser_path: str
+    winner_quote: str
+    loser_quote: str
+    why: str
+    resolution: str
+    winner_ordinal: int | None = None
+    loser_ordinal: int | None = None
+    winner_op: str | None = None  # e.g. "replace step:cycle/work"
+
+
+def parse_assemble_output(llm_output):
+    """Split LLM output into ``(assembled_body, conflicts)``.
+
+    The delimiter ``CONFLICTS_DELIMITER`` separates the rewritten slot
+    body (above) from the conflict records (below). Outputs without the
+    delimiter are treated as having zero conflicts.
+
+    Each conflict record is a bullet group keyed ``- slot: <name>`` with
+    indented continuation lines carrying the remaining fields. A literal
+    ``(none)`` placeholder under the delimiter is supported for the
+    common zero-conflict case.
+    """
+    parts = llm_output.split(CONFLICTS_DELIMITER, 1)
+    if len(parts) == 1:
+        return llm_output.rstrip() + "\n", []
+    body = parts[0].rstrip() + "\n"
+    conflicts_block = parts[1].strip()
+    if not conflicts_block or conflicts_block.lower().startswith("(none)"):
+        return body, []
+    return body, _parse_conflict_records(conflicts_block)
+
+
+def _parse_conflict_records(block):
+    """Parse the trailing conflict bullet list into ``Conflict`` records.
+
+    Permissive: unknown keys are ignored, the first ``- slot:`` line
+    starts a record, and a record ends at the next ``- slot:`` line or
+    end of block. Required fields default to ``""`` when the LLM omits
+    them so partial records still surface in the report (operators get
+    "Resolution: " rather than a parse error blocking the whole report).
+    """
+    records = []
+    current = None
+    field_re = re.compile(r"^[\s-]+([A-Za-z_]+):\s*(.*)$")
+    for line in block.splitlines():
+        # Strip BOM/zero-width chars that occasionally appear in LLM output.
+        line = line.replace("﻿", "").rstrip()
+        if not line.strip():
+            continue
+        m = field_re.match(line)
+        if not m:
+            # Continuation of the prior field's value (long quote wrapped).
+            if current is not None and current["_last_key"]:
+                current[current["_last_key"]] += " " + line.strip()
+            continue
+        key, value = m.group(1), m.group(2).strip().strip('"').strip()
+        if key == "slot" and (current is None or current.get("slot")):
+            if current is not None:
+                records.append(_finalize_record(current))
+            current = {"_last_key": "slot", "slot": value}
+            continue
+        if current is None:
+            current = {"_last_key": key, key: value}
+        else:
+            current[key] = value
+            current["_last_key"] = key
+    if current is not None:
+        records.append(_finalize_record(current))
+    return records
+
+
+def _finalize_record(d):
+    """Build a Conflict from a parsed record dict. Missing fields default to ""."""
+    def _opt_int(key):
+        raw = d.get(key)
+        if raw is None or raw == "":
+            return None
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return None
+    return Conflict(
+        slot=d.get("slot", "") or "",
+        winner_layer=d.get("winner_layer", "") or "",
+        loser_layer=d.get("loser_layer", "") or "",
+        winner_path=d.get("winner_path", "") or "",
+        loser_path=d.get("loser_path", "") or "",
+        winner_quote=d.get("winner_quote", "") or "",
+        loser_quote=d.get("loser_quote", "") or "",
+        why=d.get("why", "") or "",
+        resolution=d.get("resolution", "") or "",
+        winner_ordinal=_opt_int("winner_ordinal"),
+        loser_ordinal=_opt_int("loser_ordinal"),
+        winner_op=d.get("winner_op") or None,
+    )
+
+
+def _truncate(text, limit=MAX_QUOTE_CHARS):
+    """Truncate ``text`` to ``limit`` chars, adding ellipsis when shortened."""
+    if len(text) <= limit:
+        return text
+    # Keep limit-3 chars + "..." per §4.6 "max 200 chars + ellipsis".
+    return text[: limit - 3].rstrip() + "..."
+
+
+def _ordinal_str(ordinal):
+    return str(ordinal) if ordinal is not None else "?"
+
+
+def emit_conflict_report(conflicts, *, role_class, model_id="<unknown>",
+                          commit_sha="<unknown>", generated_at=None):
+    """Produce ``CLAUDE.conflicts.md`` per §4.6 canonical format.
+
+    Zero conflicts is a valid input — the report is still emitted with
+    ``Total conflicts resolved: 0`` and no CONFLICT sections (per the
+    spec; presence confirms the pass ran cleanly).
+
+    ``generated_at`` accepts an explicit ``datetime`` for deterministic
+    tests; defaults to ``datetime.now(timezone.utc)``.
+    """
+    if generated_at is None:
+        generated_at = datetime.now(timezone.utc)
+    iso = generated_at.isoformat(timespec="seconds")
+
+    lines = [
+        f"# Compose Conflict Report — {role_class}",
+        f"Generated: {iso}",
+        f"Compose run: {commit_sha}",
+        f"Assemble model: {model_id}",
+        f"Total conflicts resolved: {len(conflicts)}",
+        "",
+    ]
+    for idx, c in enumerate(conflicts, start=1):
+        winner_op_suffix = f" + op: {c.winner_op}" if c.winner_op else ""
+        lines.extend([
+            f"## CONFLICT-{idx:03d} — slot: {c.slot} — "
+            f"precedence: {c.winner_layer} > {c.loser_layer}",
+            f"- **{c.loser_layer} source**: `{c.loser_path}` "
+            f"(ordinal {_ordinal_str(c.loser_ordinal)})",
+            f"  > {_truncate(c.loser_quote)}",
+            f"- **{c.winner_layer} source**: `{c.winner_path}` "
+            f"(ordinal {_ordinal_str(c.winner_ordinal)}{winner_op_suffix})",
+            f"  > {_truncate(c.winner_quote)}",
+            f"- **Why this is a conflict**: {c.why}",
+            f"- **Resolution in assembled output**: {c.resolution}",
+            "",
+        ])
+    return "\n".join(lines).rstrip() + "\n"

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -125,6 +125,7 @@ STATIC_TEST_MODULES = [
     "test_link_stage_validator",
     "test_compose_a2f_10492",
     "test_assemble_pass_b1",
+    "test_conflict_detector_b4",
 ]
 
 

--- a/tests/test_conflict_detector_b4.py
+++ b/tests/test_conflict_detector_b4.py
@@ -1,0 +1,314 @@
+"""Tests for references/scripts/conflict_detector.py (#10445, PRD-B Story B4)."""
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import conflict_detector as cd  # noqa: E402
+from conflict_detector import Conflict  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# parse_assemble_output — splitting body from conflicts
+# ---------------------------------------------------------------------------
+
+def test_parse_no_delimiter_returns_body_and_empty_conflicts():
+    """LLM output without the delimiter is treated as zero conflicts."""
+    text = "just the body\n"
+    body, conflicts = cd.parse_assemble_output(text)
+    assert body == "just the body\n"
+    assert conflicts == []
+
+
+def test_parse_delimiter_with_none_placeholder_means_zero_conflicts():
+    text = "Body line one.\nBody line two.\n\n<!-- ASSEMBLE_CONFLICTS -->\n\n(none)\n"
+    body, conflicts = cd.parse_assemble_output(text)
+    assert body.startswith("Body line one.")
+    assert "ASSEMBLE_CONFLICTS" not in body
+    assert conflicts == []
+
+
+def test_parse_delimiter_with_empty_block_means_zero_conflicts():
+    text = "body\n\n<!-- ASSEMBLE_CONFLICTS -->\n\n"
+    body, conflicts = cd.parse_assemble_output(text)
+    assert body == "body\n"
+    assert conflicts == []
+
+
+def test_parse_one_well_formed_conflict():
+    text = (
+        "rewritten body\n\n"
+        "<!-- ASSEMBLE_CONFLICTS -->\n\n"
+        "- slot: instructions\n"
+        "  winner_layer: L4\n"
+        "  winner_path: .squidsquad/project/worker.md\n"
+        "  winner_quote: verifier handles all verification\n"
+        "  loser_layer: L2\n"
+        "  loser_path: references/roles/worker/instructions.md\n"
+        "  loser_quote: verify pending-test items each cycle\n"
+        "  why: L4 transfers verification responsibility\n"
+        "  resolution: Assembled body says verifier owns verification\n"
+    )
+    body, conflicts = cd.parse_assemble_output(text)
+    assert body == "rewritten body\n"
+    assert len(conflicts) == 1
+    c = conflicts[0]
+    assert c.slot == "instructions"
+    assert c.winner_layer == "L4"
+    assert c.loser_layer == "L2"
+    assert c.winner_path == ".squidsquad/project/worker.md"
+    assert "verifier handles all verification" in c.winner_quote
+    assert "verify pending-test items" in c.loser_quote
+    assert c.why.startswith("L4 transfers")
+    assert c.resolution.startswith("Assembled body")
+
+
+def test_parse_multiple_conflicts():
+    text = (
+        "body\n<!-- ASSEMBLE_CONFLICTS -->\n"
+        "- slot: instructions\n"
+        "  winner_layer: L4\n"
+        "  loser_layer: L2\n"
+        "  why: foo\n"
+        "- slot: identity\n"
+        "  winner_layer: L3\n"
+        "  loser_layer: L1\n"
+        "  why: bar\n"
+    )
+    _, conflicts = cd.parse_assemble_output(text)
+    assert [c.slot for c in conflicts] == ["instructions", "identity"]
+    assert [c.winner_layer for c in conflicts] == ["L4", "L3"]
+    assert [c.why for c in conflicts] == ["foo", "bar"]
+
+
+def test_parse_missing_fields_default_to_empty_string():
+    """A partial record still surfaces in the report (avoid blocking on parse errors)."""
+    text = (
+        "body\n<!-- ASSEMBLE_CONFLICTS -->\n"
+        "- slot: instructions\n"
+        "  winner_layer: L4\n"  # everything else missing
+    )
+    _, conflicts = cd.parse_assemble_output(text)
+    assert len(conflicts) == 1
+    assert conflicts[0].why == ""
+    assert conflicts[0].loser_path == ""
+
+
+def test_parse_handles_quoted_string_values():
+    """LLMs sometimes emit `key: "quoted value"`. Quotes are stripped."""
+    text = (
+        "body\n<!-- ASSEMBLE_CONFLICTS -->\n"
+        "- slot: instructions\n"
+        '  winner_quote: "verifier owns it"\n'
+    )
+    _, conflicts = cd.parse_assemble_output(text)
+    assert conflicts[0].winner_quote == "verifier owns it"
+
+
+def test_parse_handles_continuation_line_for_long_quote():
+    """A wrapped quote (continuation line without `key:`) joins to the prior field."""
+    text = (
+        "body\n<!-- ASSEMBLE_CONFLICTS -->\n"
+        "- slot: instructions\n"
+        "  winner_quote: first line of a long quote\n"
+        "    that wrapped to a second line\n"
+    )
+    _, conflicts = cd.parse_assemble_output(text)
+    assert "wrapped to a second line" in conflicts[0].winner_quote
+
+
+def test_parse_ordinal_parsed_as_int_when_present():
+    text = (
+        "body\n<!-- ASSEMBLE_CONFLICTS -->\n"
+        "- slot: instructions\n"
+        "  winner_ordinal: 30\n"
+        "  loser_ordinal: 10\n"
+    )
+    _, conflicts = cd.parse_assemble_output(text)
+    assert conflicts[0].winner_ordinal == 30
+    assert conflicts[0].loser_ordinal == 10
+
+
+def test_parse_unparseable_ordinal_becomes_none():
+    text = (
+        "body\n<!-- ASSEMBLE_CONFLICTS -->\n"
+        "- slot: instructions\n"
+        "  winner_ordinal: not-a-number\n"
+    )
+    _, conflicts = cd.parse_assemble_output(text)
+    assert conflicts[0].winner_ordinal is None
+
+
+# ---------------------------------------------------------------------------
+# emit_conflict_report — §4.6 canonical format
+# ---------------------------------------------------------------------------
+
+_DETERMINISTIC_TS = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _full_conflict(**overrides):
+    base = dict(
+        slot="instructions",
+        winner_layer="L4",
+        loser_layer="L2",
+        winner_path=".squidsquad/project/worker.md",
+        loser_path="references/roles/worker/instructions.md",
+        winner_quote="verifier handles all verification",
+        loser_quote="verify pending-test items each cycle",
+        why="L4 transfers verification responsibility to verifier role",
+        resolution="Assembled body says verifier owns verification",
+        winner_ordinal=30,
+        loser_ordinal=10,
+    )
+    base.update(overrides)
+    return Conflict(**base)
+
+
+def test_emit_zero_conflicts_still_writes_report_header():
+    """Spec: 'still emit the file with Total conflicts resolved: 0 and no CONFLICT sections'."""
+    report = cd.emit_conflict_report(
+        [], role_class="worker", model_id="gpt-5.2",
+        commit_sha="abc123", generated_at=_DETERMINISTIC_TS,
+    )
+    assert "Total conflicts resolved: 0" in report
+    assert "CONFLICT-" not in report
+    assert "worker" in report
+    assert "gpt-5.2" in report
+    assert "abc123" in report
+
+
+def test_emit_one_conflict_matches_spec_field_order():
+    """§4.6 ordering: title -> L<loser> source -> L<winner> source -> Why -> Resolution."""
+    report = cd.emit_conflict_report(
+        [_full_conflict()], role_class="worker",
+        generated_at=_DETERMINISTIC_TS,
+    )
+    # Title line.
+    assert "## CONFLICT-001 — slot: instructions — precedence: L4 > L2" in report
+    # Loser source appears before winner source.
+    loser_idx = report.index("**L2 source**")
+    winner_idx = report.index("**L4 source**")
+    assert loser_idx < winner_idx
+    why_idx = report.index("**Why this is a conflict**")
+    resolution_idx = report.index("**Resolution in assembled output**")
+    assert winner_idx < why_idx < resolution_idx
+
+
+def test_emit_uses_iso8601_timestamp():
+    report = cd.emit_conflict_report(
+        [], role_class="worker", generated_at=_DETERMINISTIC_TS,
+    )
+    assert "Generated: 2026-06-01T12:00:00+00:00" in report
+
+
+def test_emit_quote_truncation_at_200_chars():
+    long_quote = "x" * 250
+    report = cd.emit_conflict_report(
+        [_full_conflict(winner_quote=long_quote)],
+        role_class="worker", generated_at=_DETERMINISTIC_TS,
+    )
+    # The quote in the report is truncated to MAX_QUOTE_CHARS with "..." appended.
+    assert "..." in report
+    assert "x" * 250 not in report
+
+
+def test_emit_short_quote_not_truncated():
+    report = cd.emit_conflict_report(
+        [_full_conflict(winner_quote="short")],
+        role_class="worker", generated_at=_DETERMINISTIC_TS,
+    )
+    assert "> short" in report
+
+
+def test_emit_ordinal_question_mark_when_missing():
+    report = cd.emit_conflict_report(
+        [_full_conflict(winner_ordinal=None, loser_ordinal=None)],
+        role_class="worker", generated_at=_DETERMINISTIC_TS,
+    )
+    assert "(ordinal ?)" in report
+
+
+def test_emit_ordinal_number_when_present():
+    report = cd.emit_conflict_report(
+        [_full_conflict(winner_ordinal=30, loser_ordinal=10)],
+        role_class="worker", generated_at=_DETERMINISTIC_TS,
+    )
+    assert "(ordinal 10)" in report
+    assert "(ordinal 30" in report
+
+
+def test_emit_winner_op_suffix_when_present():
+    """When the winner came in via an L4 op, the report includes it for audit."""
+    report = cd.emit_conflict_report(
+        [_full_conflict(winner_op="replace step:cycle/work")],
+        role_class="worker", generated_at=_DETERMINISTIC_TS,
+    )
+    assert "op: replace step:cycle/work" in report
+
+
+def test_emit_numbers_conflicts_with_three_digit_zero_padding():
+    """CONFLICT-001 / CONFLICT-002 / ... up to CONFLICT-999 in this scheme."""
+    report = cd.emit_conflict_report(
+        [_full_conflict(), _full_conflict(slot="identity")],
+        role_class="worker", generated_at=_DETERMINISTIC_TS,
+    )
+    assert "CONFLICT-001" in report
+    assert "CONFLICT-002" in report
+
+
+def test_emit_default_model_id_and_commit_sha_when_omitted():
+    """The emitter should not crash when caller doesn't know the model/SHA yet."""
+    report = cd.emit_conflict_report(
+        [], role_class="worker", generated_at=_DETERMINISTIC_TS,
+    )
+    assert "Assemble model: <unknown>" in report
+    assert "Compose run: <unknown>" in report
+
+
+# ---------------------------------------------------------------------------
+# Round trip: parse output -> emit report
+# ---------------------------------------------------------------------------
+
+def test_round_trip_parse_then_emit_produces_valid_report():
+    llm_output = (
+        "rewritten body\n\n"
+        "<!-- ASSEMBLE_CONFLICTS -->\n\n"
+        "- slot: instructions\n"
+        "  winner_layer: L4\n"
+        "  winner_path: .squidsquad/project/worker.md\n"
+        "  winner_quote: verifier owns verification\n"
+        "  loser_layer: L2\n"
+        "  loser_path: references/roles/worker/instructions.md\n"
+        "  loser_quote: verify pending-test items\n"
+        "  why: L4 transfers verification responsibility\n"
+        "  resolution: Assembled body aligns with L4\n"
+    )
+    body, conflicts = cd.parse_assemble_output(llm_output)
+    report = cd.emit_conflict_report(
+        conflicts, role_class="worker",
+        generated_at=_DETERMINISTIC_TS,
+    )
+    assert body == "rewritten body\n"
+    assert "Total conflicts resolved: 1" in report
+    assert "verifier owns verification" in report
+    assert "verify pending-test items" in report
+
+
+# ---------------------------------------------------------------------------
+# Template-side: assemble.md.j2 instructs the LLM to emit the delimiter
+# ---------------------------------------------------------------------------
+
+def test_assemble_template_includes_conflicts_delimiter_directive():
+    repo_root = Path(__file__).resolve().parent.parent
+    template = (repo_root / "references" / "prompts" / "assemble.md.j2").read_text(encoding="utf-8")
+    assert cd.CONFLICTS_DELIMITER in template
+    assert "(none)" in template  # zero-conflicts placeholder mandate
+    # The template must enumerate the field names the parser expects.
+    for field in ("winner_layer", "loser_layer", "winner_quote",
+                  "loser_quote", "why", "resolution"):
+        assert field in template, f"template missing field directive: {field}"


### PR DESCRIPTION
## Planning contract

Acceptance contract is the AC list in the issue body of #10445 (PRD-B Story B4). The §4.6 canonical report format lives in COMPOSE-ARCHITECTURE; B4 implements the detection + emit half of the §4.6 contract. No PM-side `CONTEXT-10445.md` exists. Verifier will produce `.squidsquad/qa/planning/TEST-PLAN-10445.md` during verification per the #9184 workflow. Cited per #8950 Gate #4 requirement.

## Summary

Adds single-pass conflict detection alongside the assemble pass. The LLM, in one call, produces the rewritten slot body AND a delimited audit list of every contradiction it reconciled. B4 parses that list into structured `Conflict` records and emits the `CLAUDE.conflicts.md` markdown per the §4.6 canonical format.

## What landed

- `references/scripts/conflict_detector.py` (~145 lines):
  - `CONFLICTS_DELIMITER = "<!-- ASSEMBLE_CONFLICTS -->"` — stable across releases so older composes can parse newer outputs.
  - `Conflict` dataclass — `slot`, `winner_layer`/`loser_layer`, `winner_path`/`loser_path`, `winner_quote`/`loser_quote`, `why`, `resolution`, plus optional `winner_ordinal`/`loser_ordinal`/`winner_op`.
  - `parse_assemble_output(llm_output) -> (assembled_body, [Conflict])` — splits on the delimiter; supports the literal `(none)` placeholder for zero conflicts and silent "no delimiter at all". Permissive parser: missing fields default to `""`, quoted-string values get stripped, continuation lines after a field key join to the prior value (handles wrapped long quotes).
  - `emit_conflict_report(conflicts, *, role_class, model_id, commit_sha, generated_at) -> str` — produces the markdown matching §4.6 line by line. Quote truncation at 200 chars + ellipsis; ordinals render `?` when None; optional `winner_op` suffix renders `(ordinal N + op: <op>)`.
  - Zero conflicts is a valid input — report still emits with `Total conflicts resolved: 0` and no CONFLICT sections (per spec; presence confirms the pass ran cleanly).
- `references/prompts/assemble.md.j2` updated with a new "Part 2 — Conflicts reconciled (audit trail)" section directing the LLM to emit the delimiter then a bullet list of conflicts using the field names the parser expects. Mandatory `(none)` placeholder for zero-conflict runs so a skipped delimiter is unambiguously an audit gap (not silent success).
- `tests/test_conflict_detector_b4.py` (22 tests).
- `tests/run_tests.py`: registered `test_conflict_detector_b4`.

## AC mapping

| AC | Where |
|---|---|
| Single-pass LLM with explicit "list any contradictions you reconciled" output section | `assemble.md.j2` Part 2 directives + `test_assemble_template_includes_conflicts_delimiter_directive` |
| Parser converts LLM's conflict list into structured Conflict records (slot / L-source-files / verbatim quotes ≤200 chars / why / proposed resolution) | `parse_assemble_output` + `Conflict` dataclass + `_truncate(MAX_QUOTE_CHARS=200)` applied at report-emit time per the §4.6 wording |
| Emit `CLAUDE.conflicts.md` (v2 path) per the §4.6 canonical format | `emit_conflict_report` + the spec-field-order test (`test_emit_one_conflict_matches_spec_field_order` asserts Loser-source first per §4.6) |
| Zero conflicts detected → still emit file with `Total conflicts resolved: 0` and no CONFLICT sections | `test_emit_zero_conflicts_still_writes_report_header` |
| Unit tests stub LLM responses to test detection + report-emit paths | 22 tests (12 parse-side / 10 emit-side / 1 round-trip / 1 template-static) |

## Tests

`python -m pytest tests/test_conflict_detector_b4.py` — 22 passed in 0.09s.

## Notes

- The `Conflict` dataclass keeps the FULL quote in memory at detection time; truncation to 200 chars happens at report-emit (`_truncate` in `emit_conflict_report`). This matches the §4.6 wording "max 200 chars + ellipsis" applying to the rendered report, not the in-memory record.
- The "(none)" placeholder requirement makes "the LLM forgot the delimiter" distinguishable from "the LLM ran cleanly with zero conflicts". B7 (#10447) can use this signal to flag audit gaps.
- B5 (#10446) is the higher-L-wins resolver. B7 (#10447) wires the report into the atomic emit (CLAUDE.md + CLAUDE.linked.md + CLAUDE.conflicts.md triple). B4's scope ends at "detection + report markdown".

Closes #10445