### PR TITLE
PRD-B/B5: conflict_resolver — higher-L-wins verifier + B2/B3 re-verify (#10446)

### DIFF
--- a/references/scripts/conflict_resolver.py
+++ b/references/scripts/conflict_resolver.py
@@ -1,0 +1,159 @@
+"""Higher-L-wins conflict resolver (#10446, PRD-B Story B5).
+
+Per COMPOSE-ARCHITECTURE §4.6 the assemble pass collapses layered prose
+into one coherent voice with **higher-L wins** precedence (L4 > L3 > L2
+> L1). The LLM does the rewrite; B5 verifies it did the job:
+
+- For every ``Conflict`` record from B4, the lower-layer ``loser_quote``
+  must NOT appear in the final assembled body (the lower-L prose was
+  dropped — recorded in ``CLAUDE.conflicts.md`` for audit, NOT carried
+  into runtime).
+- The assembled body should still satisfy B2's preservation pass and
+  B3's length-floor + code-block-parity checks against the linked input
+  AFTER the resolver runs.
+
+B5 is pure verification — no rewriting. When the LLM fails to honor the
+precedence rule, the resolver raises ``ResolverError`` so B7's atomic-
+write contract can route to the abort path (zero partial artifacts on
+preservation-fail per §4.6).
+"""
+
+from dataclasses import dataclass
+
+# Late-imported in re_verify_preservation so the resolver module stays
+# loadable even if the assemble_verifier surface changes shape later.
+# (B2 and B3 ship in the same module.)
+
+
+@dataclass
+class ResolverIssue:
+    """One unresolved conflict detected by ``verify_higher_l_wins``."""
+
+    conflict_index: int  # 1-based, matches CONFLICT-NNN in the report
+    slot: str
+    loser_layer: str
+    winner_layer: str
+    detail: str  # human-readable description of the violation
+
+
+class ResolverError(ValueError):
+    """Raised when the resolver detects a higher-L-wins violation.
+
+    Carries ``issues`` (list[ResolverIssue]) so B7's caller can render
+    a precise diagnostic before aborting. The first issue is included
+    in the str() message for the common single-violation case.
+    """
+
+    def __init__(self, issues):
+        self.issues = list(issues)
+        first = self.issues[0] if self.issues else None
+        if first is None:
+            super().__init__("higher-L-wins violation (no issue details)")
+        else:
+            super().__init__(
+                f"higher-L-wins violation: CONFLICT-{first.conflict_index:03d} "
+                f"(slot={first.slot}, precedence={first.winner_layer}>{first.loser_layer}): "
+                f"{first.detail}"
+            )
+
+
+def verify_higher_l_wins(assembled_body, conflicts, *, raise_on_issue=False):
+    """Verify each Conflict's loser_quote is absent from the assembled body.
+
+    Returns a list of :class:`ResolverIssue` records (empty when clean).
+    When ``raise_on_issue=True`` and the list is non-empty, raises
+    :class:`ResolverError`.
+
+    Empty / whitespace-only loser quotes are skipped — they convey no
+    actionable check (the LLM emitted a placeholder, B7's audit-gap
+    logic owns that). The match is whitespace-insensitive: each
+    whitespace run is normalized to a single space before substring
+    comparison, so cosmetic reformatting of long quotes doesn't cause
+    false negatives.
+    """
+    issues = []
+    normalized_body = _normalize_whitespace(assembled_body)
+    for idx, conflict in enumerate(conflicts, start=1):
+        loser = (conflict.loser_quote or "").strip()
+        if not loser:
+            continue
+        if _normalize_whitespace(loser) in normalized_body:
+            issues.append(ResolverIssue(
+                conflict_index=idx,
+                slot=conflict.slot,
+                loser_layer=conflict.loser_layer,
+                winner_layer=conflict.winner_layer,
+                detail=(
+                    f"lower-layer prose still present in assembled body: "
+                    f"{loser[:120]!r}"
+                ),
+            ))
+    if issues and raise_on_issue:
+        raise ResolverError(issues)
+    return issues
+
+
+def re_verify_preservation(assembled_body, linked_body):
+    """Re-run B2 + B3 against the assembled body. Returns a ``ReVerifyResult``.
+
+    Per #10446 AC: "Re-verification after resolver runs (the conflict
+    report still satisfies B2/B3 preservation checks against the linked
+    input)". Re-running here lets B7 short-circuit the atomic-write
+    contract if the LLM degraded the body during the rewrite.
+    """
+    # Imported lazily so this module loads in environments where
+    # assemble_verifier isn't on the path (e.g. early unit tests).
+    from assemble_verifier import (  # noqa: WPS433
+        verify_preservation,
+        check_length_floor,
+        check_code_block_parity,
+    )
+    preservation = verify_preservation(linked_body, assembled_body)
+    floor_ok = check_length_floor(linked_body, assembled_body)
+    parity_ok = check_code_block_parity(linked_body, assembled_body)
+    return ReVerifyResult(
+        preservation_ok=preservation.ok,
+        preservation=preservation,
+        length_floor_ok=floor_ok,
+        code_block_parity_ok=parity_ok,
+    )
+
+
+@dataclass
+class ReVerifyResult:
+    """Outcome of ``re_verify_preservation`` — one boolean per B2/B3 check."""
+
+    preservation_ok: bool
+    preservation: object  # PreservationResult from B2 (kept for diagnostics)
+    length_floor_ok: bool
+    code_block_parity_ok: bool
+
+    @property
+    def all_ok(self):
+        return (
+            self.preservation_ok
+            and self.length_floor_ok
+            and self.code_block_parity_ok
+        )
+
+
+def resolve(assembled_body, conflicts, linked_body):
+    """One-call resolver: verify higher-L-wins + re-verify B2/B3 preservation.
+
+    Returns ``(resolver_issues, reverify_result)``. The caller (B7) inspects
+    both — any non-empty ``resolver_issues`` OR any False boolean on
+    ``reverify_result`` is a preservation-fail per §4.6 and aborts the
+    write.
+    """
+    issues = verify_higher_l_wins(assembled_body, conflicts)
+    reverify = re_verify_preservation(assembled_body, linked_body)
+    return issues, reverify
+
+
+def _normalize_whitespace(text):
+    """Collapse all runs of whitespace to a single space.
+
+    Used to make substring checks robust against cosmetic reformatting
+    of long verbatim quotes between linked input and assembled output.
+    """
+    return " ".join(text.split())

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -126,6 +126,7 @@ STATIC_TEST_MODULES = [
     "test_compose_a2f_10492",
     "test_assemble_pass_b1",
     "test_conflict_detector_b4",
+    "test_conflict_resolver_b5",
 ]
 
 

--- a/tests/test_conflict_resolver_b5.py
+++ b/tests/test_conflict_resolver_b5.py
@@ -1,0 +1,213 @@
+"""Tests for references/scripts/conflict_resolver.py (#10446, PRD-B Story B5)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import conflict_resolver as cr  # noqa: E402
+from conflict_detector import Conflict  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers — stub Conflict records
+# ---------------------------------------------------------------------------
+
+def _conflict(slot="instructions", winner_layer="L4", loser_layer="L2",
+              loser_quote="verify pending-test items each cycle",
+              winner_quote="verifier handles all verification"):
+    return Conflict(
+        slot=slot,
+        winner_layer=winner_layer,
+        loser_layer=loser_layer,
+        winner_path=f"references/roles/worker/{slot}.md",
+        loser_path=f"references/roles/worker/{slot}.md",
+        winner_quote=winner_quote,
+        loser_quote=loser_quote,
+        why="L4 explicitly transfers responsibility",
+        resolution="Assembled body aligns with the higher layer",
+    )
+
+
+# ---------------------------------------------------------------------------
+# verify_higher_l_wins — loser quote must be absent
+# ---------------------------------------------------------------------------
+
+def test_verify_no_conflicts_returns_empty_issues():
+    issues = cr.verify_higher_l_wins("any body content", [])
+    assert issues == []
+
+
+def test_verify_loser_absent_passes():
+    body = "Verifier handles all verification; PM coordinates the team.\n"
+    conflicts = [_conflict()]  # loser_quote = "verify pending-test items each cycle"
+    issues = cr.verify_higher_l_wins(body, conflicts)
+    assert issues == []
+
+
+def test_verify_loser_present_returns_issue():
+    """AC: lower-L prose is dropped — finding it is a resolver violation."""
+    body = (
+        "Verifier handles all verification.\n"
+        "Each cycle, you also verify pending-test items each cycle.\n"
+    )
+    conflicts = [_conflict()]
+    issues = cr.verify_higher_l_wins(body, conflicts)
+    assert len(issues) == 1
+    assert issues[0].slot == "instructions"
+    assert issues[0].winner_layer == "L4"
+    assert issues[0].loser_layer == "L2"
+    assert "lower-layer prose still present" in issues[0].detail
+
+
+def test_verify_raise_on_issue_true_raises():
+    body = "verify pending-test items each cycle is the rule.\n"
+    with pytest.raises(cr.ResolverError) as exc:
+        cr.verify_higher_l_wins(body, [_conflict()], raise_on_issue=True)
+    assert exc.value.issues[0].slot == "instructions"
+    # The first-issue summary is in the str().
+    assert "CONFLICT-001" in str(exc.value)
+    assert "L4>L2" in str(exc.value)
+
+
+def test_verify_raise_on_issue_false_collects_without_raising():
+    body = "verify pending-test items each cycle is still here.\n"
+    issues = cr.verify_higher_l_wins(body, [_conflict()], raise_on_issue=False)
+    assert len(issues) == 1
+
+
+def test_verify_multiple_conflicts_collects_all_issues():
+    body = (
+        "verify pending-test items each cycle is still here.\n"
+        "PM does not coordinate teams is also still here.\n"
+    )
+    conflicts = [
+        _conflict(slot="instructions",
+                  loser_quote="verify pending-test items each cycle"),
+        _conflict(slot="responsibility", loser_layer="L1",
+                  loser_quote="PM does not coordinate teams"),
+    ]
+    issues = cr.verify_higher_l_wins(body, conflicts)
+    assert len(issues) == 2
+    assert {i.slot for i in issues} == {"instructions", "responsibility"}
+
+
+def test_verify_indexing_matches_conflict_record_order():
+    """conflict_index is 1-based and matches the source list order."""
+    conflicts = [
+        _conflict(slot="identity", loser_quote="ABSENT-FROM-BODY-1"),
+        _conflict(slot="instructions",
+                  loser_quote="PRESENT-IN-BODY-2"),
+    ]
+    body = "PRESENT-IN-BODY-2 lives here in the body.\n"
+    issues = cr.verify_higher_l_wins(body, conflicts)
+    assert len(issues) == 1
+    assert issues[0].conflict_index == 2  # second conflict triggered
+
+
+def test_verify_empty_loser_quote_is_skipped():
+    """A blank loser quote is not actionable — skip silently rather than match-anything."""
+    conflicts = [_conflict(loser_quote="")]
+    issues = cr.verify_higher_l_wins("any body", conflicts)
+    assert issues == []
+
+
+def test_verify_whitespace_only_loser_quote_is_skipped():
+    conflicts = [_conflict(loser_quote="   \n  ")]
+    issues = cr.verify_higher_l_wins("any body", conflicts)
+    assert issues == []
+
+
+def test_verify_match_is_whitespace_insensitive():
+    """Cosmetic reformatting (extra spaces, line wraps) should NOT mask a real violation."""
+    conflicts = [_conflict(loser_quote="verify pending-test items each cycle")]
+    # Same words, different whitespace.
+    body = "We verify pending-test\n   items each   cycle as a rule.\n"
+    issues = cr.verify_higher_l_wins(body, conflicts)
+    assert len(issues) == 1
+
+
+def test_resolver_error_with_no_issues_still_constructs():
+    """Defensive: instantiating ResolverError with [] doesn't crash."""
+    err = cr.ResolverError([])
+    assert "no issue details" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# re_verify_preservation — runs B2 + B3 against the assembled body
+# ---------------------------------------------------------------------------
+
+_LINKED = (
+    "### step:cycle/boot\n"
+    "→ run sub-skill: boot-bootstrap\n"
+    "Boot body.\n\n"
+    "### step:cycle/pickup\n"
+    "→ run sub-skill: task-pickup\n"
+    "Pickup body.\n"
+)
+
+
+def test_reverify_clean_body_passes_all_three_checks():
+    """A body identical to linked input passes B2 preservation + B3 floor + parity."""
+    result = cr.re_verify_preservation(_LINKED, _LINKED)
+    assert result.preservation_ok is True
+    assert result.length_floor_ok is True
+    assert result.code_block_parity_ok is True
+    assert result.all_ok is True
+
+
+def test_reverify_missing_sub_skill_fails_preservation():
+    """A body that drops a sub-skill reference must fail B2."""
+    assembled = _LINKED.replace("→ run sub-skill: boot-bootstrap\n", "")
+    result = cr.re_verify_preservation(assembled, _LINKED)
+    assert result.preservation_ok is False
+    assert result.all_ok is False
+
+
+def test_reverify_too_short_assembled_fails_length_floor():
+    """Below 80% of linked length → length-floor fail."""
+    assembled = "tiny\n"
+    result = cr.re_verify_preservation(assembled, _LINKED)
+    assert result.length_floor_ok is False
+    assert result.all_ok is False
+
+
+def test_reverify_truncated_body_fails_floor_but_can_still_satisfy_others():
+    """Confirms the three checks are independent (one failure does not poison the others)."""
+    # Truncate the body to ~70% length but keep all preservation tokens by repeating them
+    # below in a compressed form — we want length-floor to fail while keeping enough
+    # references to pass preservation.
+    assembled = (
+        "→ run sub-skill: boot-bootstrap\n"
+        "→ run sub-skill: task-pickup\n"
+        "step:cycle/boot\n"
+        "step:cycle/pickup\n"
+    )
+    result = cr.re_verify_preservation(assembled, _LINKED)
+    # Preservation may still pass (all tokens present), but length-floor fails.
+    assert result.length_floor_ok is False
+
+
+# ---------------------------------------------------------------------------
+# resolve() — one-call wrapper for B7
+# ---------------------------------------------------------------------------
+
+def test_resolve_returns_issues_and_reverify():
+    """resolve() bundles both checks so B7 can short-circuit on either failure."""
+    body = "Verifier owns it. " + _LINKED  # contains the linked tokens + extra prose
+    conflicts = [_conflict()]
+    issues, reverify = cr.resolve(body, conflicts, _LINKED)
+    assert issues == []  # loser quote not in this body
+    assert reverify.all_ok is True
+
+
+def test_resolve_surfaces_resolver_issues_without_raising():
+    """resolve() never raises — caller (B7) decides; this is the audit path."""
+    body = _LINKED + "\nverify pending-test items each cycle still here.\n"
+    conflicts = [_conflict()]
+    issues, reverify = cr.resolve(body, conflicts, _LINKED)
+    assert len(issues) == 1
+    assert reverify.all_ok is True  # preservation still satisfied


### PR DESCRIPTION
## Planning contract

Acceptance contract is the AC list in the issue body of #10446 (PRD-B Story B5). The §4.6 higher-L-wins precedence rule + the "couples tightly with B4 — ship together" coupling are anchored in COMPOSE-ARCHITECTURE. No PM-side `CONTEXT-10446.md` exists. Verifier will produce `.squidsquad/qa/planning/TEST-PLAN-10446.md` during verification per the #9184 workflow. Cited per #8950 Gate #4 requirement.

## Summary

B4 detects + reports conflicts. B5 **verifies** the LLM honored the §4.6 higher-L-wins precedence: for every `Conflict` from B4, the lower-layer `loser_quote` must be absent from the assembled body. Plus a re-verification pass that re-runs B2 (preservation) + B3 (length floor + code-block parity) against the post-resolver body. Pure verification — no rewriting.

## What landed

- `references/scripts/conflict_resolver.py` (~135 lines):
  - `ResolverIssue` dataclass — `conflict_index` (1-based, matches `CONFLICT-NNN` in the B4 report), `slot`, `loser_layer`, `winner_layer`, `detail`.
  - `ResolverError(issues)` — carries the full issue list; `str()` summarizes the first issue with `CONFLICT-NNN` + precedence + detail for the common single-violation case.
  - `verify_higher_l_wins(assembled_body, conflicts, *, raise_on_issue=False)` — main check. Whitespace-insensitive substring match against each loser quote (collapses runs of WS to a single space) so cosmetic reformatting of long quotes doesn't cause false negatives. Empty / whitespace-only loser quotes are skipped (audit-gap signal owned by B7).
  - `re_verify_preservation(assembled_body, linked_body) -> ReVerifyResult` — runs B2's `verify_preservation` + B3's `check_length_floor` + `check_code_block_parity` against the post-resolver body. Lazy-imports `assemble_verifier` so this module stays loadable even if B2/B3 surface shape changes later.
  - `ReVerifyResult(preservation_ok, length_floor_ok, code_block_parity_ok, .all_ok)` — one boolean per check + aggregate. The three checks are independent; one failure does not poison the others.
  - `resolve(assembled_body, conflicts, linked_body) -> (issues, reverify)` — one-call wrapper. Never raises; B7 decides on the abort path.
- `tests/test_conflict_resolver_b5.py` (17 tests, all stub `Conflict` records per AC).
- `tests/run_tests.py`: registered `test_conflict_resolver_b5`.

## AC mapping

| AC | Where |
|---|---|
| On conflict detected: assembled output aligned with higher-L source verbatim or paraphrased; lower-L prose is dropped from assembled output but recorded in CLAUDE.conflicts.md | `verify_higher_l_wins` enforces the drop-check; B4's emit owns the CLAUDE.conflicts.md audit surface |
| Re-verification after resolver runs (the conflict report still satisfies B2/B3 preservation checks against the linked input) | `re_verify_preservation` re-runs B2's `verify_preservation` + B3's `check_length_floor` + `check_code_block_parity` against the post-resolver body |
| Unit tests stub B4 conflict records to test resolution logic | 17 tests; `_conflict()` helper stubs `Conflict` records |

## Tests

`python -m pytest tests/test_conflict_resolver_b5.py` — 17 passed in 0.10s.

## Notes

- Whitespace-insensitive match is critical: the linked input may have a quote split across line wraps (e.g. "verify pending-test\n   items each   cycle") and the assembled body may unify the spacing. A strict substring would miss this. The normalizer collapses both sides to single-space, then checks substring.
- Empty / whitespace-only loser quotes are skipped intentionally — they're an audit-gap signal (the LLM emitted a placeholder), which B7 owns. The resolver's job is conflict resolution, not template compliance.
- `resolve()` never raises so that B7 can collect both the resolver issues AND the re-verify result before deciding to abort. Some preservation-fail conditions (e.g. dropped sub-skill) are independent of resolver-fail conditions (loser-still-present); B7 needs both diagnostics to render a useful error.

B7 (#10447) wires this into the atomic-emit pipeline: call `resolve()` after the assemble pass returns, abort the write if `issues` is non-empty OR if `reverify.all_ok` is False.

Closes #10446