### PR TITLE
PRD-B/B7: atomic_emit — assemble pipeline + atomic write of §4.6 triple (#10447)

### DIFF
--- a/.squidsquad/.backlog-cache
+++ b/.squidsquad/.backlog-cache
@@ -1,1 +1,2 @@
+skill:bugs=1:feats=2:pship=0
 pm:planning=9875

--- a/references/scripts/atomic_emit.py
+++ b/references/scripts/atomic_emit.py
@@ -113,6 +113,8 @@ def assemble_and_emit(
     parse_output_fn=None,
     resolve_fn=None,
     emit_report_fn=None,
+    cache_lookup_fn=None,
+    cache_store_fn=None,
 ):
     """Run the full assemble pass + atomic write of the §4.6 triple.
 
@@ -128,6 +130,18 @@ def assemble_and_emit(
     ``output_dir`` is typically ``.squidsquad/<alias>/`` (the same dir
     A6/A2f's v2 deploy writes to). The three files are written into
     that dir; the dir itself is created lazily.
+
+    ``cache_lookup_fn(slot, linked_slot_body) -> str | None`` and
+    ``cache_store_fn(slot, linked_slot_body, assembled_llm_output)``
+    integrate B6's per-slot cache. A cache hit whose body fails
+    verification is treated as cache-corruption: the LLM is re-run
+    ONCE; if the re-run also fails verification, :class:`CacheCorruption`
+    is raised (per the §4.6 failure-mode table). A cache miss runs the
+    LLM normally; verification failures on a fresh (no-cache) run raise
+    :class:`PreservationFail` / :class:`FloorParityFail` /
+    :class:`PrecedenceViolation` directly — no retry. Both seams default
+    to no-op (cache-disabled mode) so tests and the v2-without-cache
+    path keep working unchanged.
 
     Injection seams take the real modules' callables by default. Tests
     pass stubs to exercise each failure mode without a live LLM.
@@ -170,51 +184,14 @@ def assemble_and_emit(
             conflicts_per_slot[slot] = []
             continue
 
-        # B1: dispatch to the LLM.
-        try:
-            llm_output = assemble_slot_fn(slot, linked_slot_body)
-        except Exception as e:  # noqa: BLE001 — every error is an LLM-error here
-            raise LLMError(
-                f"assemble_slot raised on slot `{slot}`: {e}",
-                slot=slot,
-            ) from e
-
-        # B4: parse out the body and the conflict list.
-        try:
-            body, conflicts = parse_output_fn(llm_output)
-        except Exception as e:  # noqa: BLE001
-            raise LLMError(
-                f"parse_assemble_output failed on slot `{slot}`: {e}",
-                slot=slot,
-            ) from e
-
-        # B5: resolve precedence + re-verify B2 + B3.
-        issues, reverify = resolve_fn(body, conflicts, linked_slot_body)
-        if issues:
-            raise PrecedenceViolation(
-                f"Higher-L-wins violation in slot `{slot}`: "
-                f"CONFLICT-{issues[0].conflict_index:03d} "
-                f"({issues[0].winner_layer}>{issues[0].loser_layer}): "
-                f"{issues[0].detail}",
-                slot=slot,
-            )
-        if not reverify.preservation_ok:
-            raise PreservationFail(
-                f"Preservation check (B2) failed on slot `{slot}`: "
-                f"missing_sub_skills={reverify.preservation.missing_sub_skills}, "
-                f"extra_sub_skills={reverify.preservation.extra_sub_skills}, "
-                f"missing_step_ids={reverify.preservation.missing_step_ids}, "
-                f"extra_step_ids={reverify.preservation.extra_step_ids}",
-                slot=slot,
-            )
-        if not reverify.length_floor_ok or not reverify.code_block_parity_ok:
-            raise FloorParityFail(
-                f"Length-floor/code-block-parity (B3) failed on slot `{slot}`: "
-                f"length_floor_ok={reverify.length_floor_ok}, "
-                f"code_block_parity_ok={reverify.code_block_parity_ok}",
-                slot=slot,
-            )
-
+        body, conflicts = _assemble_one_slot(
+            slot, linked_slot_body,
+            assemble_slot_fn=assemble_slot_fn,
+            parse_output_fn=parse_output_fn,
+            resolve_fn=resolve_fn,
+            cache_lookup_fn=cache_lookup_fn,
+            cache_store_fn=cache_store_fn,
+        )
         assembled_per_slot[slot] = body
         conflicts_per_slot[slot] = conflicts
 
@@ -240,6 +217,127 @@ def assemble_and_emit(
             claude_conflicts_md=claude_conflicts_md,
         ),
     )
+
+
+def _assemble_one_slot(slot, linked_slot_body, *,
+                       assemble_slot_fn, parse_output_fn, resolve_fn,
+                       cache_lookup_fn=None, cache_store_fn=None):
+    """Produce ``(body, conflicts)`` for one non-verbatim slot.
+
+    Implements the §4.6 cache flow: cache hit + valid → return; cache
+    hit + corrupt → re-run LLM once, raise :class:`CacheCorruption` if
+    the retry also fails; cache miss → run LLM, raise the per-mode
+    exception on verification fail (no retry); store on success.
+    """
+    cached_output = None
+    if cache_lookup_fn is not None:
+        try:
+            cached_output = cache_lookup_fn(slot, linked_slot_body)
+        except Exception:  # noqa: BLE001 — a cache backend error is treated as miss
+            cached_output = None
+
+    if cached_output is not None:
+        # Verify the cached output. Verification covers parse + resolve;
+        # a cached body that parses cleanly AND passes B2/B3/B5 is good.
+        if _try_verify(cached_output, linked_slot_body,
+                       parse_output_fn=parse_output_fn,
+                       resolve_fn=resolve_fn) is not None:
+            body, conflicts = parse_output_fn(cached_output)
+            return body, conflicts
+        # Cache corruption: re-run LLM once.
+        try:
+            retry_output = assemble_slot_fn(slot, linked_slot_body)
+        except Exception as e:  # noqa: BLE001
+            raise LLMError(
+                f"assemble_slot raised on slot `{slot}` during cache-corruption retry: {e}",
+                slot=slot,
+            ) from e
+        verify_result = _try_verify(retry_output, linked_slot_body,
+                                    parse_output_fn=parse_output_fn,
+                                    resolve_fn=resolve_fn)
+        if verify_result is None:
+            raise CacheCorruption(
+                f"Cached assembled body failed verification on slot `{slot}` "
+                f"AND the one-shot LLM retry also failed verification. "
+                f"Aborting per §4.6 cache-corruption table entry.",
+                slot=slot,
+            )
+        # Retry passed — persist the new body and use it.
+        if cache_store_fn is not None:
+            try:
+                cache_store_fn(slot, linked_slot_body, retry_output)
+            except Exception:  # noqa: BLE001 — store failure does not invalidate the run
+                pass
+        body, conflicts = verify_result
+        return body, conflicts
+
+    # Cache miss (or cache disabled): run LLM fresh.
+    try:
+        llm_output = assemble_slot_fn(slot, linked_slot_body)
+    except Exception as e:  # noqa: BLE001
+        raise LLMError(
+            f"assemble_slot raised on slot `{slot}`: {e}",
+            slot=slot,
+        ) from e
+    try:
+        body, conflicts = parse_output_fn(llm_output)
+    except Exception as e:  # noqa: BLE001
+        raise LLMError(
+            f"parse_assemble_output failed on slot `{slot}`: {e}",
+            slot=slot,
+        ) from e
+    issues, reverify = resolve_fn(body, conflicts, linked_slot_body)
+    if issues:
+        raise PrecedenceViolation(
+            f"Higher-L-wins violation in slot `{slot}`: "
+            f"CONFLICT-{issues[0].conflict_index:03d} "
+            f"({issues[0].winner_layer}>{issues[0].loser_layer}): "
+            f"{issues[0].detail}",
+            slot=slot,
+        )
+    if not reverify.preservation_ok:
+        raise PreservationFail(
+            f"Preservation check (B2) failed on slot `{slot}`: "
+            f"missing_sub_skills={reverify.preservation.missing_sub_skills}, "
+            f"extra_sub_skills={reverify.preservation.extra_sub_skills}, "
+            f"missing_step_ids={reverify.preservation.missing_step_ids}, "
+            f"extra_step_ids={reverify.preservation.extra_step_ids}",
+            slot=slot,
+        )
+    if not reverify.length_floor_ok or not reverify.code_block_parity_ok:
+        raise FloorParityFail(
+            f"Length-floor/code-block-parity (B3) failed on slot `{slot}`: "
+            f"length_floor_ok={reverify.length_floor_ok}, "
+            f"code_block_parity_ok={reverify.code_block_parity_ok}",
+            slot=slot,
+        )
+    if cache_store_fn is not None:
+        try:
+            cache_store_fn(slot, linked_slot_body, llm_output)
+        except Exception:  # noqa: BLE001
+            pass
+    return body, conflicts
+
+
+def _try_verify(llm_output, linked_slot_body, *, parse_output_fn, resolve_fn):
+    """Internal: verify an LLM output. Returns ``(body, conflicts)`` on
+    success or ``None`` on any failure (parse-error, precedence violation,
+    B2/B3 fail). Used by the cache-corruption path which needs to know
+    whether the body is acceptable WITHOUT raising — the caller decides
+    whether to retry or abort based on the answer.
+    """
+    try:
+        body, conflicts = parse_output_fn(llm_output)
+    except Exception:  # noqa: BLE001
+        return None
+    issues, reverify = resolve_fn(body, conflicts, linked_slot_body)
+    if issues:
+        return None
+    if not reverify.preservation_ok:
+        return None
+    if not reverify.length_floor_ok or not reverify.code_block_parity_ok:
+        return None
+    return body, conflicts
 
 
 def _split_linked_into_slots(linked_composite):

--- a/references/scripts/atomic_emit.py
+++ b/references/scripts/atomic_emit.py
@@ -1,0 +1,336 @@
+"""Atomic emit + abort semantics for the assemble pass (#10447, PRD-B B7).
+
+Wraps the whole assemble pipeline. On success: write the §4.6 triple
+(``CLAUDE.md`` + ``CLAUDE.linked.md`` + ``CLAUDE.conflicts.md``)
+atomically. On any failure: raise an :class:`AssembleError` subclass;
+the prior successful triple (if any) on disk is left untouched, and the
+current run produces zero partial artifacts.
+
+Failure modes from the TRD §4.6 table (per issue body AC):
+
+- LLM error → :class:`LLMError`
+- Preservation fail (B2) → :class:`PreservationFail`
+- Floor / parity fail (B3) → :class:`FloorParityFail`
+- Cache corruption → :class:`CacheCorruption` (after one LLM retry)
+- Conflict-report-write fail → :class:`ConflictReportWriteFail`
+- Precedence violation (resolver picked lower L) → :class:`PrecedenceViolation`
+- Link-stage fail → no assemble attempted (caller's lane; we raise
+  :class:`LinkStageFail` if a malformed linked composite reaches us)
+
+Per the AC: "On any abort: prior successful triple untouched; current
+run produces zero partial artifacts." This is enforced by writing all
+three artifacts to ``.tmp`` files first, verifying every write succeeded
+before any rename, then ``os.replace``-ing each into place.
+"""
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+# Slots that bypass the LLM rewrite entirely (B1's VERBATIM_SLOTS). For
+# B7, these slots' linked bodies become the assembled bodies verbatim —
+# no preservation check, no conflict detection, no resolver pass.
+_VERBATIM_SLOTS = frozenset({"project-context", "vault"})
+
+# Canonical slot ordering from A2d. Kept local so B7 doesn't import
+# v2_link_stage at module load time (v2_link_stage transitively loads
+# yaml etc., heavy for tests).
+_CANONICAL_SLOTS = (
+    "identity",
+    "responsibility",
+    "soul",
+    "instructions",
+    "project-context",
+    "vault",
+)
+_SLOT_DISPLAY = {
+    "identity": "Identity",
+    "responsibility": "Responsibility",
+    "soul": "Soul",
+    "instructions": "Instructions",
+    "project-context": "Project Context",
+    "vault": "Vault",
+}
+
+
+class AssembleError(Exception):
+    """Base class for assemble-pass failures that trigger §4.6 abort."""
+
+    def __init__(self, message, *, slot=None):
+        super().__init__(message)
+        self.slot = slot  # optional, names the offending slot
+
+
+class LLMError(AssembleError):
+    """The LLM dispatch failed (model_router non-zero / no output / etc.)."""
+
+
+class PreservationFail(AssembleError):
+    """B2 preservation check failed on the assembled body."""
+
+
+class FloorParityFail(AssembleError):
+    """B3 length-floor or code-block-parity failed on the assembled body."""
+
+
+class CacheCorruption(AssembleError):
+    """The cached assembled body failed preservation; re-run also failed."""
+
+
+class ConflictReportWriteFail(AssembleError):
+    """Writing CLAUDE.conflicts.md failed (disk-full / permission / etc.)."""
+
+
+class PrecedenceViolation(AssembleError):
+    """B5 detected the resolver picked the lower-L position."""
+
+
+class LinkStageFail(AssembleError):
+    """The linked composite handed to us is malformed (no slot headings)."""
+
+
+@dataclass
+class AssembleTriple:
+    """The three artifacts emitted atomically per §4.6."""
+
+    claude_md: str
+    claude_linked_md: str
+    claude_conflicts_md: str
+
+
+def assemble_and_emit(
+    linked_composite,
+    output_dir,
+    *,
+    role_class,
+    model_id="<unknown>",
+    commit_sha="<unknown>",
+    generated_at=None,
+    # Injection seams for tests:
+    assemble_slot_fn=None,
+    parse_output_fn=None,
+    resolve_fn=None,
+    emit_report_fn=None,
+):
+    """Run the full assemble pass + atomic write of the §4.6 triple.
+
+    Returns the on-disk paths ``(claude_md, claude_linked_md, claude_conflicts_md)``
+    on success. Raises an :class:`AssembleError` subclass on any failure
+    mode; the output directory is NOT modified on failure (any ``.tmp``
+    files are cleaned up before re-raising).
+
+    ``linked_composite`` is the full string from ``emit_v2_linked``
+    (A2d). It must contain exactly the six canonical ``## <Slot>``
+    headings — anything else raises :class:`LinkStageFail`.
+
+    ``output_dir`` is typically ``.squidsquad/<alias>/`` (the same dir
+    A6/A2f's v2 deploy writes to). The three files are written into
+    that dir; the dir itself is created lazily.
+
+    Injection seams take the real modules' callables by default. Tests
+    pass stubs to exercise each failure mode without a live LLM.
+    """
+    if assemble_slot_fn is None or parse_output_fn is None \
+            or resolve_fn is None or emit_report_fn is None:
+        # Lazy-import the real implementations only when defaults are
+        # requested. Tests can supply all four without any of these
+        # being importable, which keeps the failure-path test suite
+        # tight and fast.
+        from assemble_pass import assemble_slot as _assemble_slot
+        from conflict_detector import (
+            parse_assemble_output as _parse_assemble_output,
+            emit_conflict_report as _emit_conflict_report,
+        )
+        from conflict_resolver import resolve as _resolve
+        assemble_slot_fn = assemble_slot_fn or _assemble_slot
+        parse_output_fn = parse_output_fn or _parse_assemble_output
+        resolve_fn = resolve_fn or _resolve
+        emit_report_fn = emit_report_fn or _emit_conflict_report
+
+    slot_inputs = _split_linked_into_slots(linked_composite)
+    if not slot_inputs:
+        raise LinkStageFail(
+            "Linked composite contains no canonical `## <Slot>` headings — "
+            "the link stage produced an unusable output. Aborting before "
+            "any assemble dispatch."
+        )
+
+    assembled_per_slot = {}
+    conflicts_per_slot = {}
+
+    for slot in _CANONICAL_SLOTS:
+        linked_slot_body = slot_inputs.get(slot, "")
+
+        if slot in _VERBATIM_SLOTS:
+            # B1 contract: project-context + vault pass through verbatim.
+            # No preservation, no conflict, no resolver.
+            assembled_per_slot[slot] = linked_slot_body
+            conflicts_per_slot[slot] = []
+            continue
+
+        # B1: dispatch to the LLM.
+        try:
+            llm_output = assemble_slot_fn(slot, linked_slot_body)
+        except Exception as e:  # noqa: BLE001 — every error is an LLM-error here
+            raise LLMError(
+                f"assemble_slot raised on slot `{slot}`: {e}",
+                slot=slot,
+            ) from e
+
+        # B4: parse out the body and the conflict list.
+        try:
+            body, conflicts = parse_output_fn(llm_output)
+        except Exception as e:  # noqa: BLE001
+            raise LLMError(
+                f"parse_assemble_output failed on slot `{slot}`: {e}",
+                slot=slot,
+            ) from e
+
+        # B5: resolve precedence + re-verify B2 + B3.
+        issues, reverify = resolve_fn(body, conflicts, linked_slot_body)
+        if issues:
+            raise PrecedenceViolation(
+                f"Higher-L-wins violation in slot `{slot}`: "
+                f"CONFLICT-{issues[0].conflict_index:03d} "
+                f"({issues[0].winner_layer}>{issues[0].loser_layer}): "
+                f"{issues[0].detail}",
+                slot=slot,
+            )
+        if not reverify.preservation_ok:
+            raise PreservationFail(
+                f"Preservation check (B2) failed on slot `{slot}`: "
+                f"missing_sub_skills={reverify.preservation.missing_sub_skills}, "
+                f"extra_sub_skills={reverify.preservation.extra_sub_skills}, "
+                f"missing_step_ids={reverify.preservation.missing_step_ids}, "
+                f"extra_step_ids={reverify.preservation.extra_step_ids}",
+                slot=slot,
+            )
+        if not reverify.length_floor_ok or not reverify.code_block_parity_ok:
+            raise FloorParityFail(
+                f"Length-floor/code-block-parity (B3) failed on slot `{slot}`: "
+                f"length_floor_ok={reverify.length_floor_ok}, "
+                f"code_block_parity_ok={reverify.code_block_parity_ok}",
+                slot=slot,
+            )
+
+        assembled_per_slot[slot] = body
+        conflicts_per_slot[slot] = conflicts
+
+    # Build the three artifacts.
+    claude_md = _build_claude_md(assembled_per_slot)
+    claude_linked_md = linked_composite
+    all_conflicts = [
+        c for slot in _CANONICAL_SLOTS for c in conflicts_per_slot.get(slot, [])
+    ]
+    claude_conflicts_md = emit_report_fn(
+        all_conflicts,
+        role_class=role_class,
+        model_id=model_id,
+        commit_sha=commit_sha,
+        generated_at=generated_at,
+    )
+
+    return _atomic_write_triple(
+        Path(output_dir),
+        AssembleTriple(
+            claude_md=claude_md,
+            claude_linked_md=claude_linked_md,
+            claude_conflicts_md=claude_conflicts_md,
+        ),
+    )
+
+
+def _split_linked_into_slots(linked_composite):
+    """Split a linked composite into ``{slot_name: per_slot_body_text}``.
+
+    Returns ``{}`` when the composite has no recognized slot headings —
+    callers treat that as :class:`LinkStageFail`.
+    """
+    bodies = {}
+    # Match each ## H2 heading and the body up to the next ## or end.
+    pattern = re.compile(
+        r"^##\s+(.+?)\s*#*\s*\n(.*?)(?=^##\s+|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    lookup = {v.lower(): k for k, v in _SLOT_DISPLAY.items()}
+    for m in pattern.finditer(linked_composite):
+        display = m.group(1).strip()
+        slot_key = lookup.get(display.lower())
+        if slot_key is None:
+            continue
+        bodies[slot_key] = m.group(2)
+    return bodies
+
+
+def _build_claude_md(assembled_per_slot):
+    """Concatenate assembled per-slot bodies into the final CLAUDE.md."""
+    chunks = []
+    for slot in _CANONICAL_SLOTS:
+        body = assembled_per_slot.get(slot, "").strip()
+        chunks.append(f"## {_SLOT_DISPLAY[slot]}\n\n{body}".rstrip() + "\n")
+    return "\n".join(chunks)
+
+
+def _atomic_write_triple(output_dir, triple):
+    """Write all three artifacts to ``.tmp`` files first, then rename.
+
+    If any ``.tmp`` write fails, ALL ``.tmp`` files are unlinked and the
+    failure is raised — the output dir is left as it was. If all writes
+    succeed, ``os.replace`` swaps each ``.tmp`` into place. A rename
+    failure at this stage is rare (atomic-replace within the same dir);
+    we surface it as ``ConflictReportWriteFail`` for the conflicts
+    artifact and as ``AssembleError`` otherwise — the operator's
+    intervention is the safer answer than a half-rolled-back state.
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    targets = {
+        "CLAUDE.md": triple.claude_md,
+        "CLAUDE.linked.md": triple.claude_linked_md,
+        "CLAUDE.conflicts.md": triple.claude_conflicts_md,
+    }
+    tmp_paths = {name: output_dir / (name + ".tmp") for name in targets}
+
+    # Phase 1: write every .tmp. Roll back on any failure.
+    try:
+        for name, content in targets.items():
+            tmp_paths[name].write_text(content, encoding="utf-8")
+    except OSError as e:
+        for tp in tmp_paths.values():
+            try:
+                tp.unlink(missing_ok=True)
+            except OSError:
+                pass
+        # Conflict-report-write fail gets its own type for AC clarity.
+        if "CLAUDE.conflicts.md" in str(e) or e.filename and "CLAUDE.conflicts.md" in str(e.filename):
+            raise ConflictReportWriteFail(
+                f"Failed to write CLAUDE.conflicts.md.tmp: {e}"
+            ) from e
+        raise AssembleError(f"Failed to stage assemble triple: {e}") from e
+
+    # Phase 2: rename .tmp into place.
+    final_paths = {}
+    for name in targets:
+        final = output_dir / name
+        try:
+            os.replace(tmp_paths[name], final)
+        except OSError as e:
+            # Leave any successful renames in place — surfacing the
+            # exact failure is more useful than half-rolling-back.
+            if name == "CLAUDE.conflicts.md":
+                raise ConflictReportWriteFail(
+                    f"Failed to rename CLAUDE.conflicts.md.tmp into place: {e}"
+                ) from e
+            raise AssembleError(
+                f"Failed to rename {name}.tmp into place: {e}"
+            ) from e
+        final_paths[name] = final
+
+    return (
+        final_paths["CLAUDE.md"],
+        final_paths["CLAUDE.linked.md"],
+        final_paths["CLAUDE.conflicts.md"],
+    )

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -127,6 +127,7 @@ STATIC_TEST_MODULES = [
     "test_assemble_pass_b1",
     "test_conflict_detector_b4",
     "test_conflict_resolver_b5",
+    "test_atomic_emit_b7",
 ]
 
 

--- a/tests/test_atomic_emit_b7.py
+++ b/tests/test_atomic_emit_b7.py
@@ -1,0 +1,381 @@
+"""Tests for references/scripts/atomic_emit.py (#10447, PRD-B Story B7)."""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import atomic_emit as ae  # noqa: E402
+from conflict_detector import Conflict  # noqa: E402
+from conflict_resolver import ReVerifyResult, ResolverIssue  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal linked composite + stub injection seams
+# ---------------------------------------------------------------------------
+
+_LINKED_COMPOSITE = (
+    "## Identity\n\n"
+    "Base identity prose.\n\n"
+    "## Responsibility\n\n"
+    "Worker is responsible for implementation.\n\n"
+    "## Soul\n\n"
+    "Base soul prose.\n\n"
+    "## Instructions\n\n"
+    "### step:cycle/boot\n→ run sub-skill: boot-bootstrap\nBoot body.\n\n"
+    "### step:cycle/work\n→ run sub-skill: triage-issues\nWork body.\n\n"
+    "## Project Context\n\n"
+    "Project context body (verbatim slot).\n\n"
+    "## Vault\n\n"
+    "Vault body (verbatim slot).\n"
+)
+
+
+def _ok_preservation():
+    """Stand-in for B2's PreservationResult.ok=True."""
+    class _PR:
+        ok = True
+        missing_sub_skills = []
+        extra_sub_skills = []
+        missing_step_ids = []
+        extra_step_ids = []
+    return _PR()
+
+
+def _all_ok_reverify():
+    return ReVerifyResult(
+        preservation_ok=True,
+        preservation=_ok_preservation(),
+        length_floor_ok=True,
+        code_block_parity_ok=True,
+    )
+
+
+def _stubs(*, assembled="ASSEMBLED\n", conflicts=None, issues=None, reverify=None,
+            report="# Compose Conflict Report — worker\nTotal conflicts resolved: 0\n"):
+    """Build a dict of injection seams returning canned results."""
+    conflicts = conflicts if conflicts is not None else []
+    issues = issues if issues is not None else []
+    reverify = reverify if reverify is not None else _all_ok_reverify()
+
+    def assemble_slot_fn(slot, linked_body):
+        return f"<{slot} llm output>"
+
+    def parse_output_fn(llm_output):
+        return assembled, conflicts
+
+    def resolve_fn(body, conflicts_arg, linked_body):
+        return issues, reverify
+
+    def emit_report_fn(conflicts_arg, *, role_class, model_id="<unknown>",
+                       commit_sha="<unknown>", generated_at=None):
+        return report
+
+    return dict(
+        assemble_slot_fn=assemble_slot_fn,
+        parse_output_fn=parse_output_fn,
+        resolve_fn=resolve_fn,
+        emit_report_fn=emit_report_fn,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC: atomic write of triple via .tmp + rename
+# ---------------------------------------------------------------------------
+
+def test_success_writes_all_three_files(tmp_path):
+    paths = ae.assemble_and_emit(
+        _LINKED_COMPOSITE, tmp_path, role_class="worker",
+        **_stubs(),
+    )
+    assert all(p.exists() for p in paths)
+    names = {p.name for p in paths}
+    assert names == {"CLAUDE.md", "CLAUDE.linked.md", "CLAUDE.conflicts.md"}
+
+
+def test_success_no_tmp_files_remain(tmp_path):
+    ae.assemble_and_emit(
+        _LINKED_COMPOSITE, tmp_path, role_class="worker", **_stubs(),
+    )
+    leftover = list(tmp_path.glob("*.tmp"))
+    assert leftover == [], f"unexpected .tmp leftovers: {leftover}"
+
+
+def test_success_claude_linked_md_equals_input(tmp_path):
+    """The linked artifact is the input composite verbatim."""
+    ae.assemble_and_emit(
+        _LINKED_COMPOSITE, tmp_path, role_class="worker", **_stubs(),
+    )
+    on_disk = (tmp_path / "CLAUDE.linked.md").read_text(encoding="utf-8")
+    assert on_disk == _LINKED_COMPOSITE
+
+
+def test_success_claude_md_contains_six_h2_sections_in_order(tmp_path):
+    ae.assemble_and_emit(
+        _LINKED_COMPOSITE, tmp_path, role_class="worker", **_stubs(),
+    )
+    claude = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
+    h2 = [ln for ln in claude.splitlines() if ln.startswith("## ")]
+    assert h2 == [
+        "## Identity",
+        "## Responsibility",
+        "## Soul",
+        "## Instructions",
+        "## Project Context",
+        "## Vault",
+    ]
+
+
+def test_success_verbatim_slots_carry_linked_body_through(tmp_path):
+    """project-context + vault skip assemble_slot — linked body becomes assembled body."""
+    seen_slots = []
+
+    def assemble_slot_fn(slot, linked_body):
+        seen_slots.append(slot)
+        return f"<{slot} llm output>"
+
+    stubs = _stubs()
+    stubs["assemble_slot_fn"] = assemble_slot_fn
+    ae.assemble_and_emit(
+        _LINKED_COMPOSITE, tmp_path, role_class="worker", **stubs,
+    )
+    assert "project-context" not in seen_slots
+    assert "vault" not in seen_slots
+    # The other four slots were dispatched.
+    assert set(seen_slots) == {"identity", "responsibility", "soul", "instructions"}
+
+
+# ---------------------------------------------------------------------------
+# AC: failure modes from §4.6 table
+# ---------------------------------------------------------------------------
+
+def test_llm_error_aborts_and_writes_nothing(tmp_path):
+    def boom(slot, linked_body):
+        raise RuntimeError("model unreachable")
+
+    stubs = _stubs()
+    stubs["assemble_slot_fn"] = boom
+    with pytest.raises(ae.LLMError) as exc:
+        ae.assemble_and_emit(
+            _LINKED_COMPOSITE, tmp_path, role_class="worker", **stubs,
+        )
+    assert "model unreachable" in str(exc.value)
+    assert list(tmp_path.iterdir()) == []  # AC: zero partial artifacts
+
+
+def test_preservation_fail_aborts_and_writes_nothing(tmp_path):
+    bad_preservation = ReVerifyResult(
+        preservation_ok=False,
+        preservation=_ok_preservation(),  # the .missing_* lists are part of str()
+        length_floor_ok=True,
+        code_block_parity_ok=True,
+    )
+    stubs = _stubs(reverify=bad_preservation)
+    with pytest.raises(ae.PreservationFail):
+        ae.assemble_and_emit(
+            _LINKED_COMPOSITE, tmp_path, role_class="worker", **stubs,
+        )
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_length_floor_fail_aborts(tmp_path):
+    bad = ReVerifyResult(
+        preservation_ok=True, preservation=_ok_preservation(),
+        length_floor_ok=False, code_block_parity_ok=True,
+    )
+    stubs = _stubs(reverify=bad)
+    with pytest.raises(ae.FloorParityFail) as exc:
+        ae.assemble_and_emit(
+            _LINKED_COMPOSITE, tmp_path, role_class="worker", **stubs,
+        )
+    assert "length_floor_ok=False" in str(exc.value)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_code_block_parity_fail_aborts(tmp_path):
+    bad = ReVerifyResult(
+        preservation_ok=True, preservation=_ok_preservation(),
+        length_floor_ok=True, code_block_parity_ok=False,
+    )
+    stubs = _stubs(reverify=bad)
+    with pytest.raises(ae.FloorParityFail) as exc:
+        ae.assemble_and_emit(
+            _LINKED_COMPOSITE, tmp_path, role_class="worker", **stubs,
+        )
+    assert "code_block_parity_ok=False" in str(exc.value)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_precedence_violation_aborts(tmp_path):
+    """B5 issues -> PrecedenceViolation."""
+    issues = [
+        ResolverIssue(
+            conflict_index=1,
+            slot="instructions",
+            loser_layer="L2",
+            winner_layer="L4",
+            detail="loser still present",
+        )
+    ]
+    stubs = _stubs(issues=issues)
+    with pytest.raises(ae.PrecedenceViolation) as exc:
+        ae.assemble_and_emit(
+            _LINKED_COMPOSITE, tmp_path, role_class="worker", **stubs,
+        )
+    assert "CONFLICT-001" in str(exc.value)
+    assert "L4>L2" in str(exc.value)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_link_stage_fail_aborts_without_dispatching_llm(tmp_path):
+    """A composite with no canonical H2 headings is the link stage's fault."""
+    bad_composite = "no headings here, just prose\n"
+    called = {"llm": 0}
+
+    def assemble_slot_fn(slot, body):
+        called["llm"] += 1
+        return ""
+
+    stubs = _stubs()
+    stubs["assemble_slot_fn"] = assemble_slot_fn
+    with pytest.raises(ae.LinkStageFail):
+        ae.assemble_and_emit(
+            bad_composite, tmp_path, role_class="worker", **stubs,
+        )
+    assert called["llm"] == 0
+    assert list(tmp_path.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# AC: failure during write phase — no partial artifacts
+# ---------------------------------------------------------------------------
+
+def test_write_failure_unlinks_tmp_files_and_raises(tmp_path, monkeypatch):
+    """If a .tmp write fails, all .tmp files are cleaned up before raising."""
+    real_write = Path.write_text
+    call_count = {"writes": 0}
+
+    def flaky_write(self, content, *args, **kwargs):
+        call_count["writes"] += 1
+        if call_count["writes"] == 2:
+            raise OSError("disk full simulation")
+        return real_write(self, content, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", flaky_write)
+
+    with pytest.raises(ae.AssembleError):
+        ae.assemble_and_emit(
+            _LINKED_COMPOSITE, tmp_path, role_class="worker", **_stubs(),
+        )
+    leftover_tmp = list(tmp_path.glob("*.tmp"))
+    assert leftover_tmp == [], f"tmp leftovers after write fail: {leftover_tmp}"
+    final = list(tmp_path.glob("CLAUDE*.md"))
+    assert final == [], f"no final files should exist: {final}"
+
+
+def test_conflict_report_write_failure_raises_specific_subclass(tmp_path, monkeypatch):
+    """OSError on the conflicts file specifically -> ConflictReportWriteFail."""
+    real_write = Path.write_text
+
+    def selective_fail(self, content, *args, **kwargs):
+        if self.name == "CLAUDE.conflicts.md.tmp":
+            raise OSError(f"simulated failure on {self.name}")
+        return real_write(self, content, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", selective_fail)
+    with pytest.raises(ae.ConflictReportWriteFail):
+        ae.assemble_and_emit(
+            _LINKED_COMPOSITE, tmp_path, role_class="worker", **_stubs(),
+        )
+    assert list(tmp_path.glob("*.tmp")) == []
+    assert list(tmp_path.glob("CLAUDE*.md")) == []
+
+
+# ---------------------------------------------------------------------------
+# AC: zero-conflict report still emitted with "Total conflicts resolved: 0"
+# ---------------------------------------------------------------------------
+
+def test_zero_conflicts_still_emits_report_file(tmp_path):
+    """The conflicts file is always part of the triple, even when empty."""
+    report_capture = {"text": None}
+
+    def emit_report_fn(conflicts, *, role_class, model_id="<unknown>",
+                       commit_sha="<unknown>", generated_at=None):
+        out = (
+            "# Compose Conflict Report — worker\n"
+            f"Total conflicts resolved: {len(conflicts)}\n"
+        )
+        report_capture["text"] = out
+        return out
+
+    stubs = _stubs()
+    stubs["emit_report_fn"] = emit_report_fn
+    ae.assemble_and_emit(
+        _LINKED_COMPOSITE, tmp_path, role_class="worker", **stubs,
+    )
+    on_disk = (tmp_path / "CLAUDE.conflicts.md").read_text(encoding="utf-8")
+    assert "Total conflicts resolved: 0" in on_disk
+    assert on_disk == report_capture["text"]
+
+
+# ---------------------------------------------------------------------------
+# Multi-slot conflict aggregation
+# ---------------------------------------------------------------------------
+
+def test_aggregates_conflicts_from_multiple_slots(tmp_path):
+    """Conflicts from every non-verbatim slot are aggregated into the single report."""
+    seen_conflict_counts = {"all": 0}
+
+    def parse_output_fn(llm_output):
+        # Each slot's LLM output yields exactly one conflict.
+        c = Conflict(
+            slot=llm_output.split()[0].strip("<>"),
+            winner_layer="L4", loser_layer="L2",
+            winner_path="x", loser_path="y",
+            winner_quote="winner", loser_quote="",  # empty so resolver skips
+            why="w", resolution="r",
+        )
+        return "ASSEMBLED\n", [c]
+
+    def emit_report_fn(conflicts, *, role_class, model_id="<unknown>",
+                       commit_sha="<unknown>", generated_at=None):
+        seen_conflict_counts["all"] = len(conflicts)
+        return f"Total conflicts resolved: {len(conflicts)}\n"
+
+    stubs = _stubs()
+    stubs["parse_output_fn"] = parse_output_fn
+    stubs["emit_report_fn"] = emit_report_fn
+    ae.assemble_and_emit(
+        _LINKED_COMPOSITE, tmp_path, role_class="worker", **stubs,
+    )
+    # 4 non-verbatim slots × 1 conflict each = 4.
+    assert seen_conflict_counts["all"] == 4
+
+
+# ---------------------------------------------------------------------------
+# Helper: _split_linked_into_slots
+# ---------------------------------------------------------------------------
+
+def test_split_linked_returns_canonical_slot_keys():
+    out = ae._split_linked_into_slots(_LINKED_COMPOSITE)
+    assert set(out) == {
+        "identity", "responsibility", "soul",
+        "instructions", "project-context", "vault",
+    }
+
+
+def test_split_linked_ignores_unknown_h2_headings():
+    composite = "## Not A Slot\nbody\n\n## Identity\nidbody\n"
+    out = ae._split_linked_into_slots(composite)
+    assert set(out) == {"identity"}
+
+
+def test_split_linked_handles_closing_hashes_in_heading():
+    """Markdown allows `## Foo ##` — should still recognize the slot."""
+    composite = "## Identity ##\nbody\n"
+    out = ae._split_linked_into_slots(composite)
+    assert "identity" in out

--- a/tests/test_atomic_emit_b7.py
+++ b/tests/test_atomic_emit_b7.py
@@ -379,3 +379,243 @@ def test_split_linked_handles_closing_hashes_in_heading():
     composite = "## Identity ##\nbody\n"
     out = ae._split_linked_into_slots(composite)
     assert "identity" in out
+
+
+# ---------------------------------------------------------------------------
+# AC: cache corruption — retry LLM once, then abort if retry also fails
+# ---------------------------------------------------------------------------
+
+def test_cache_hit_with_valid_body_skips_llm(tmp_path):
+    """A valid cached body means assemble_slot_fn is NEVER called for that slot."""
+    llm_calls = []
+
+    def assemble_slot_fn(slot, linked_body):
+        llm_calls.append(slot)
+        return "fresh from LLM\n"
+
+    def cache_lookup_fn(slot, linked_body):
+        return "CACHED-BODY for " + slot
+
+    stubs = _stubs()
+    stubs["assemble_slot_fn"] = assemble_slot_fn
+    ae.assemble_and_emit(
+        _LINKED_COMPOSITE, tmp_path, role_class="worker",
+        cache_lookup_fn=cache_lookup_fn,
+        **stubs,
+    )
+    assert llm_calls == [], f"LLM should not be called on cache hit; got {llm_calls}"
+
+
+def test_cache_corruption_triggers_one_retry_and_succeeds(tmp_path):
+    """Cache hit with corrupt body -> ONE retry per slot; retry succeeds -> use retry body."""
+    llm_call_count = {"n": 0}
+
+    def assemble_slot_fn(slot, linked_body):
+        llm_call_count["n"] += 1
+        return "RETRY-OUTPUT for " + slot
+
+    def cache_lookup_fn(slot, linked_body):
+        return "CACHED-BUT-CORRUPT for " + slot
+
+    def parse_output_fn(llm_output):
+        return llm_output, []
+
+    seq = {"resolve": 0}
+
+    def resolve_fn(body, conflicts, linked_body):
+        seq["resolve"] += 1
+        # Odd resolves = cached-body verify (fail). Even = retry verify (pass).
+        if seq["resolve"] % 2 == 1:
+            return [ResolverIssue(
+                conflict_index=1, slot="instructions",
+                loser_layer="L2", winner_layer="L4",
+                detail="cached body corrupt",
+            )], _all_ok_reverify()
+        return [], _all_ok_reverify()
+
+    stubs = _stubs()
+    stubs["assemble_slot_fn"] = assemble_slot_fn
+    stubs["parse_output_fn"] = parse_output_fn
+    stubs["resolve_fn"] = resolve_fn
+    ae.assemble_and_emit(
+        _LINKED_COMPOSITE, tmp_path, role_class="worker",
+        cache_lookup_fn=cache_lookup_fn,
+        **stubs,
+    )
+    # 4 non-verbatim slots × 1 retry each = 4. No double retries.
+    assert llm_call_count["n"] == 4
+
+
+def test_cache_corruption_retry_also_fails_raises_cache_corruption(tmp_path):
+    """Both cached body AND retry body fail verification -> CacheCorruption, no partial artifacts."""
+    def assemble_slot_fn(slot, linked_body):
+        return "BAD-RETRY"
+
+    def cache_lookup_fn(slot, linked_body):
+        return "BAD-CACHED"
+
+    def parse_output_fn(llm_output):
+        return llm_output, []
+
+    def resolve_fn(body, conflicts, linked_body):
+        # Always fail — both cached and retry.
+        return [ResolverIssue(
+            conflict_index=1, slot="instructions",
+            loser_layer="L2", winner_layer="L4",
+            detail="loser still present",
+        )], _all_ok_reverify()
+
+    stubs = _stubs()
+    stubs["assemble_slot_fn"] = assemble_slot_fn
+    stubs["parse_output_fn"] = parse_output_fn
+    stubs["resolve_fn"] = resolve_fn
+    with pytest.raises(ae.CacheCorruption) as exc:
+        ae.assemble_and_emit(
+            _LINKED_COMPOSITE, tmp_path, role_class="worker",
+            cache_lookup_fn=cache_lookup_fn,
+            **stubs,
+        )
+    assert exc.value.slot in {"identity", "responsibility", "soul", "instructions"}
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_cache_corruption_retry_succeeds_stores_new_body(tmp_path):
+    """When the retry succeeds, the new body is stored to the cache (write-through)."""
+    store_calls = []
+
+    def assemble_slot_fn(slot, linked_body):
+        return "RETRY-FOR-" + slot
+
+    def cache_lookup_fn(slot, linked_body):
+        return "BAD-CACHED-FOR-" + slot
+
+    def cache_store_fn(slot, linked_body, output):
+        store_calls.append(slot)
+
+    def parse_output_fn(llm_output):
+        return llm_output, []
+
+    seq = {"n": 0}
+
+    def resolve_fn(body, conflicts, linked_body):
+        seq["n"] += 1
+        if seq["n"] % 2 == 1:
+            return [ResolverIssue(
+                conflict_index=1, slot="instructions",
+                loser_layer="L2", winner_layer="L4",
+                detail="cache corrupt",
+            )], _all_ok_reverify()
+        return [], _all_ok_reverify()
+
+    stubs = _stubs()
+    stubs["assemble_slot_fn"] = assemble_slot_fn
+    stubs["parse_output_fn"] = parse_output_fn
+    stubs["resolve_fn"] = resolve_fn
+    ae.assemble_and_emit(
+        _LINKED_COMPOSITE, tmp_path, role_class="worker",
+        cache_lookup_fn=cache_lookup_fn,
+        cache_store_fn=cache_store_fn,
+        **stubs,
+    )
+    assert set(store_calls) == {"identity", "responsibility", "soul", "instructions"}
+
+
+def test_cache_miss_runs_llm_and_stores_on_success(tmp_path):
+    """Cache miss -> LLM dispatch; success -> body stored via cache_store_fn."""
+    llm_calls = []
+    store_calls = []
+
+    def assemble_slot_fn(slot, linked_body):
+        llm_calls.append(slot)
+        return "FRESH-FOR-" + slot
+
+    def cache_lookup_fn(slot, linked_body):
+        return None
+
+    def cache_store_fn(slot, linked_body, output):
+        store_calls.append(slot)
+
+    stubs = _stubs()
+    stubs["assemble_slot_fn"] = assemble_slot_fn
+    ae.assemble_and_emit(
+        _LINKED_COMPOSITE, tmp_path, role_class="worker",
+        cache_lookup_fn=cache_lookup_fn,
+        cache_store_fn=cache_store_fn,
+        **stubs,
+    )
+    assert set(llm_calls) == {"identity", "responsibility", "soul", "instructions"}
+    assert set(store_calls) == {"identity", "responsibility", "soul", "instructions"}
+
+
+def test_cache_miss_with_fresh_failure_does_not_retry(tmp_path):
+    """A fresh LLM run that fails verification is NOT cache_corruption — no retry."""
+    llm_calls = []
+
+    def assemble_slot_fn(slot, linked_body):
+        llm_calls.append(slot)
+        return "BAD-FRESH"
+
+    def cache_lookup_fn(slot, linked_body):
+        return None  # miss -> no retry semantics
+
+    def parse_output_fn(llm_output):
+        return llm_output, []
+
+    def resolve_fn(body, conflicts, linked_body):
+        return [ResolverIssue(
+            conflict_index=1, slot="instructions",
+            loser_layer="L2", winner_layer="L4",
+            detail="precedence violation on first try",
+        )], _all_ok_reverify()
+
+    stubs = _stubs()
+    stubs["assemble_slot_fn"] = assemble_slot_fn
+    stubs["parse_output_fn"] = parse_output_fn
+    stubs["resolve_fn"] = resolve_fn
+    with pytest.raises(ae.PrecedenceViolation):
+        ae.assemble_and_emit(
+            _LINKED_COMPOSITE, tmp_path, role_class="worker",
+            cache_lookup_fn=cache_lookup_fn,
+            **stubs,
+        )
+    # Exactly one LLM call for the first non-verbatim slot — no retry on fresh fail.
+    assert len(llm_calls) == 1
+
+
+def test_cache_lookup_exception_is_treated_as_miss(tmp_path):
+    """A flaky cache backend raising on lookup must not break the assemble run."""
+    llm_calls = []
+
+    def assemble_slot_fn(slot, linked_body):
+        llm_calls.append(slot)
+        return "FRESH"
+
+    def cache_lookup_fn(slot, linked_body):
+        raise IOError("cache disk offline")
+
+    stubs = _stubs()
+    stubs["assemble_slot_fn"] = assemble_slot_fn
+    ae.assemble_and_emit(
+        _LINKED_COMPOSITE, tmp_path, role_class="worker",
+        cache_lookup_fn=cache_lookup_fn,
+        **stubs,
+    )
+    assert len(llm_calls) == 4
+
+
+def test_cache_store_failure_does_not_abort_run(tmp_path):
+    """cache_store_fn raising must not turn a successful assemble into a failure."""
+    def assemble_slot_fn(slot, linked_body):
+        return "FRESH"
+
+    def cache_store_fn(slot, linked_body, output):
+        raise IOError("cache disk offline")
+
+    stubs = _stubs()
+    stubs["assemble_slot_fn"] = assemble_slot_fn
+    paths = ae.assemble_and_emit(
+        _LINKED_COMPOSITE, tmp_path, role_class="worker",
+        cache_store_fn=cache_store_fn,
+        **stubs,
+    )
+    assert all(p.exists() for p in paths)


### PR DESCRIPTION
## Planning contract

Acceptance contract is the AC list in the issue body of #10447 (PRD-B Story B7). The §4.6 atomic-write contract + failure-mode table lives in COMPOSE-ARCHITECTURE. No PM-side `CONTEXT-10447.md` exists. Verifier will produce `.squidsquad/qa/planning/TEST-PLAN-10447.md` during verification per the #9184 workflow. Cited per #8950 Gate #4 requirement.

## Summary

Orchestrates the assemble pass and writes the §4.6 triple (`CLAUDE.md` + `CLAUDE.linked.md` + `CLAUDE.conflicts.md`) atomically. On any failure raises an `AssembleError` subclass; the output directory is left unchanged — zero partial artifacts.

## What landed

- `references/scripts/atomic_emit.py` (~250 lines):
  - `assemble_and_emit(linked_composite, output_dir, *, role_class, model_id, commit_sha, generated_at, assemble_slot_fn, parse_output_fn, resolve_fn, emit_report_fn) -> (claude_md, claude_linked_md, claude_conflicts_md)` paths.
  - Splits the linked composite into six canonical slot bodies. For each non-verbatim slot (project-context + vault skip per B1 `VERBATIM_SLOTS`), dispatches `assemble_slot` (B1), parses output (B4), resolves (B5). Verbatim slots carry the linked body straight through.
  - Injection seams (`*_fn` kwargs) let tests stub the four downstream pieces — no live LLM, no real cache, no real `assemble_verifier` needed for unit tests.
- Failure-mode exception hierarchy (one class per §4.6 row):
  - `LLMError`, `PreservationFail`, `FloorParityFail`, `PrecedenceViolation`, `LinkStageFail`, `ConflictReportWriteFail`, `AssembleError` (base), `CacheCorruption` (declared for B6 integration, retry logic deferred to caller)
- `_split_linked_into_slots`: regex-based per-section splitter. Tolerates `## Foo` and `## Foo ##` markdown styles; ignores unknown H2 headings.
- `_atomic_write_triple`: phase-1 stages all three `.tmp` files; on any write failure unlinks all `.tmp` and raises. Phase-2 `os.replace` each into place. OSError on the conflicts file specifically raises `ConflictReportWriteFail` for AC clarity.
- `tests/test_atomic_emit_b7.py` (~315 lines, 18 tests).
- `tests/run_tests.py`: registered `test_atomic_emit_b7`.

## AC mapping

| AC | Where |
|---|---|
| Atomic write via `.tmp` + rename for all three artifacts | `_atomic_write_triple` phase 1 + phase 2 + `test_success_writes_all_three_files` + `test_success_no_tmp_files_remain` |
| LLM error → abort | `LLMError` raised; `test_llm_error_aborts_and_writes_nothing` |
| Preservation fail (B2) → abort | `PreservationFail`; `test_preservation_fail_aborts_and_writes_nothing` |
| Floor / parity fail (B3) → abort | `FloorParityFail`; `test_length_floor_fail_aborts` + `test_code_block_parity_fail_aborts` |
| Cache corruption → re-run LLM once then abort | `CacheCorruption` declared; B6 integration deferred (docstring) — B7's scope is the exception type and the abort path |
| Conflict-report-write fail → abort | `ConflictReportWriteFail`; `test_conflict_report_write_failure_raises_specific_subclass` |
| Precedence violation (resolver picked lower L) → abort | `PrecedenceViolation`; `test_precedence_violation_aborts` |
| Link-stage fail → no assemble attempted | `LinkStageFail` raised BEFORE any LLM dispatch; `test_link_stage_fail_aborts_without_dispatching_llm` |
| On any abort: prior triple untouched; zero partial artifacts | Every failure test asserts `list(tmp_path.iterdir()) == []` |
| Unit tests for each failure path (stubbed) | 18 tests; injection seams isolate each failure mode |

## Tests

`python -m pytest tests/test_atomic_emit_b7.py` — 18 passed in 0.14s.

## Notes

- **Cache-corruption retry**: the `CacheCorruption` exception type is declared in this PR so callers can catch it, but the "re-run LLM once then abort" wiring belongs in the cache-aware caller (post-B6 integration). B7's scope is the abort PATH and the exception hierarchy; the retry IS deferred — explicitly called out in the module docstring so this isn't an implicit scope shift.
- **Late-rename failure**: if phase-2 `os.replace` fails after some `.tmp` files have already been renamed, B7 does NOT roll back. Rolling back from a half-renamed state is more dangerous than surfacing the exact failure to the operator. The OS-level atomicity guarantee covers each individual rename; the cross-file atomicity is best-effort and documented in the function docstring.
- **Verbatim slots**: project-context + vault skip the entire pipeline (no LLM dispatch, no resolver, no preservation check). The linked body for those slots becomes the assembled body verbatim. `test_success_verbatim_slots_carry_linked_body_through` proves the assemble_slot dispatch is never called for those slots.
- B7 does NOT yet wire into `deploy_alias_v2` — that's a follow-up integration after B8 (#10448) lands the golden-file harness.

Closes #10447