### PR TITLE
PRD-A/A4.5: deploy <alias> --check --staged-l4 staged-content validation (#10395)

### DIFF
--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -1239,6 +1239,60 @@ def check_role(role_name: str, target_root: Path = None,
     return "drift", _diff_compose_output(expected, on_disk)
 
 
+# A4.5 (#10395): staged-content check for `deploy <alias> --check --staged-l4 <path>`.
+# Runs in-memory v2 link-stage validation against a to-be-committed L4 file
+# WITHOUT writing anything to disk. Returns "clean" on success or raises the
+# original LinkStageValidationError so the CLI can render the rule name + path.
+
+
+def check_alias_staged_l4(alias, staged_l4_path, *, target_root=None,
+                          registry=None):
+    """Validate a staged L4 file as if it were ``.squidsquad/project/<role-class>.md``.
+
+    Resolves ``alias`` → ``(role_class, l3_domain)`` via the A5 registry,
+    walks L1-L3 sources via A2d's ``collect_sources_for_validation``,
+    parses the staged file via A2b, then runs A2e's seven R1-R7 rules
+    via ``validate_link_stage``. No disk writes.
+
+    Returns the resolved ``role_class`` on success. Raises:
+    - ``FileNotFoundError`` — ``staged_l4_path`` missing (setup error).
+    - ``KeyError`` — alias not in registry (setup error).
+    - ``LinkStageValidationError`` — R1-R7 violation; carries the rule
+      label and offending path/step-id for the CLI diagnostic.
+    - Other ``Exception`` — registry parse / l4 parse / source walk fault;
+      caller maps to setup-error exit code.
+    """
+    if target_root is None:
+        target_root = REPO_ROOT
+    target_root = Path(target_root)
+    staged_l4_path = Path(staged_l4_path)
+    if not staged_l4_path.is_file():
+        raise FileNotFoundError(
+            f"staged L4 file not found: {staged_l4_path}"
+        )
+    if registry is None:
+        registry = _config_module.parse_aliases_registry()
+    if alias not in registry:
+        raise KeyError(
+            f"alias '{alias}' not found in `## Aliases` registry. "
+            f"Known aliases: {sorted(registry)}"
+        )
+    role_class, l3_domain = registry[alias]
+
+    # Lazy imports — same pattern as deploy_alias_v2: keep v1 paths
+    # from loading these modules.
+    import v2_link_stage as _v2
+    from l4_parser import parse_l4_file as _parse_l4_file
+    from link_stage_validator import validate_link_stage as _validate_link_stage
+
+    sources = _v2.collect_sources_for_validation(
+        role_class, l3_domain, repo_root=target_root
+    )
+    l4_doc = _parse_l4_file(staged_l4_path)
+    _validate_link_stage(l4_doc, sources, l4_path=str(staged_l4_path))
+    return role_class
+
+
 def deploy_role(role_name: str, target_root: Path = None,
                 output_name: str = None,
                 output_filename: str = "CLAUDE.md",
@@ -1806,10 +1860,27 @@ def main():
 
     # #10388 PRD-A/A4: --check runs in-memory compose and diffs against
     # on-disk CLAUDE.md without writing. Recognized on `deploy` and
-    # `deploy-all` (mirrors --v2 placement). Mutually exclusive with --v2
-    # for now — A4.5 (#10395) layers v2 + staged-content semantics on top.
+    # `deploy-all` (mirrors --v2 placement).
     check_mode = "--check" in args
     args = [a for a in args if a != "--check"]
+
+    # #10395 PRD-A/A4.5: --staged-l4 <path> opts `deploy <alias> --check`
+    # into staged-content validation (R1-R7 vs a to-be-committed L4 file).
+    # Distinct from A4's drift-check: A4 compares in-memory compose to
+    # on-disk; A4.5 runs the v2 validator against the staged L4 + L1-L3
+    # sources without composing or writing anything. No --staged-l4 →
+    # `--check` falls through to A4's existing behavior.
+    staged_l4_path = None
+    while "--staged-l4" in args:
+        idx = args.index("--staged-l4")
+        if idx + 1 >= len(args):
+            print(
+                "ERROR: --staged-l4 requires a path argument.",
+                file=sys.stderr,
+            )
+            sys.exit(CHECK_EXIT_ERROR)
+        staged_l4_path = args[idx + 1]
+        args = args[:idx] + args[idx + 2:]
 
     cmd = args[0]
     if v2_mode and cmd not in ("deploy", "deploy-all"):
@@ -1845,6 +1916,34 @@ def main():
             sys.exit(1)
         role_name = args[1]
         if check_mode:
+            # A4.5 (#10395): --staged-l4 routes to staged-content validation.
+            if staged_l4_path is not None:
+                # Lazy import — only the staged-check path needs A2e here.
+                from link_stage_validator import LinkStageValidationError
+                try:
+                    check_alias_staged_l4(role_name, staged_l4_path)
+                except FileNotFoundError as e:
+                    print(f"ERROR: setup error for alias '{role_name}': {e}",
+                          file=sys.stderr)
+                    sys.exit(CHECK_EXIT_ERROR)
+                except KeyError as e:
+                    print(f"ERROR: setup error for alias '{role_name}': {e}",
+                          file=sys.stderr)
+                    sys.exit(CHECK_EXIT_ERROR)
+                except LinkStageValidationError as e:
+                    # AC: stderr names the rule that failed (R1-R7).
+                    print(
+                        f"  {role_name} (staged): VALIDATION FAIL — {e}",
+                        file=sys.stderr,
+                    )
+                    sys.exit(CHECK_EXIT_DRIFT)
+                except Exception as e:
+                    print(f"ERROR: setup error for alias '{role_name}': {e}",
+                          file=sys.stderr)
+                    sys.exit(CHECK_EXIT_ERROR)
+                print(f"  {role_name} (staged): clean")
+                sys.exit(CHECK_EXIT_CLEAN)
+            # A4 (#10388) per-alias drift-check fallback.
             try:
                 status, sections = check_role(role_name)
             except Exception as e:

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -128,6 +128,7 @@ STATIC_TEST_MODULES = [
     "test_conflict_detector_b4",
     "test_conflict_resolver_b5",
     "test_atomic_emit_b7",
+    "test_compose_check_a45_10395",
 ]
 
 

--- a/tests/test_compose_check_a45_10395.py
+++ b/tests/test_compose_check_a45_10395.py
@@ -1,0 +1,225 @@
+"""Tests for compose.py deploy <alias> --check --staged-l4 (#10395, PRD-A A4.5)."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO_ROOT / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import compose  # noqa: E402
+from link_stage_validator import LinkStageValidationError  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+def _frontmatter(slot, ordinal, roles=None):
+    lines = ["---", f"slot: {slot}", f"ordinal: {ordinal}"]
+    if roles is not None:
+        lines.append(f"roles: [{', '.join(roles)}]")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def _write_source(path, slot, ordinal, body, roles=None):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = _frontmatter(slot, ordinal, roles=roles) + "\n\n" + body
+    path.write_text(text, encoding="utf-8")
+
+
+def _stage_minimal_install(tmp_path, *, role="pm"):
+    """Stage a small fixture: L1 base + one L2 file for the role-class with a step ID."""
+    refs = tmp_path / "references"
+    _write_source(refs / "roles" / "identity.md", "identity", 10, "Base identity.")
+    _write_source(
+        refs / "roles" / "instructions.md", "instructions", 10,
+        "### step:cycle/boot\n→ run sub-skill: boot-bootstrap\nBoot body.\n",
+    )
+    _write_source(refs / "roles" / "vault.md", "vault", 10, "Vault base.")
+    _write_source(
+        refs / "roles" / role / "instructions.md", "instructions", 20,
+        "### step:cycle/work\n→ run sub-skill: triage-issues\nWork body.\n",
+        roles=[role],
+    )
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Function-level tests for check_alias_staged_l4
+# ---------------------------------------------------------------------------
+
+def test_check_alias_staged_l4_clean_returns_role_class(tmp_path):
+    _stage_minimal_install(tmp_path, role="pm")
+    staged = tmp_path / "staged.md"
+    staged.write_text(
+        "## Instructions\n\n"
+        "### insert-after step:cycle/boot\n\n"
+        "→ run sub-skill: pipeline-sentinel\n\n"
+        "Post-boot body.\n",
+        encoding="utf-8",
+    )
+    role_class = compose.check_alias_staged_l4(
+        "pm", staged, target_root=tmp_path,
+        registry={"pm": ("pm", None)},
+    )
+    assert role_class == "pm"
+
+
+def test_check_alias_staged_l4_missing_staged_file_raises_filenotfound(tmp_path):
+    _stage_minimal_install(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        compose.check_alias_staged_l4(
+            "pm", tmp_path / "nonexistent.md", target_root=tmp_path,
+            registry={"pm": ("pm", None)},
+        )
+
+
+def test_check_alias_staged_l4_unknown_alias_raises_keyerror(tmp_path):
+    _stage_minimal_install(tmp_path)
+    staged = tmp_path / "staged.md"
+    staged.write_text("## Instructions\n", encoding="utf-8")
+    with pytest.raises(KeyError):
+        compose.check_alias_staged_l4(
+            "ghost-alias", staged, target_root=tmp_path,
+            registry={"pm": ("pm", None)},
+        )
+
+
+def test_check_alias_staged_l4_r1_violation_raises(tmp_path):
+    """AC: 'staged R1 violation (vault H2)' — L4 file with `## Vault` aborts."""
+    _stage_minimal_install(tmp_path)
+    staged = tmp_path / "staged.md"
+    staged.write_text(
+        "## Vault\n\nProject-authored vault content (R1 violation).\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(LinkStageValidationError) as exc:
+        compose.check_alias_staged_l4(
+            "pm", staged, target_root=tmp_path,
+            registry={"pm": ("pm", None)},
+        )
+    assert exc.value.rule == "R1"
+
+
+def test_check_alias_staged_l4_r5_violation_raises(tmp_path):
+    """AC: 'staged R5 violation (orphan step ID)' — L4 op targets a non-existent step."""
+    _stage_minimal_install(tmp_path)
+    staged = tmp_path / "staged.md"
+    staged.write_text(
+        "## Instructions\n\n"
+        "### replace step:cycle/ghost-step\n\n"
+        "Body.\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(LinkStageValidationError) as exc:
+        compose.check_alias_staged_l4(
+            "pm", staged, target_root=tmp_path,
+            registry={"pm": ("pm", None)},
+        )
+    assert exc.value.rule == "R5"
+    assert exc.value.step_id == "ghost-step"
+
+
+def test_check_alias_staged_l4_r7_violation_raises(tmp_path):
+    """AC: 'staged R7 violation (duplicate replace target)' — two replaces hit same step."""
+    _stage_minimal_install(tmp_path)
+    staged = tmp_path / "staged.md"
+    staged.write_text(
+        "## Instructions\n\n"
+        "### replace step:cycle/work\n\n"
+        "First body.\n\n"
+        "### replace step:cycle/work\n\n"
+        "Second body.\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(LinkStageValidationError) as exc:
+        compose.check_alias_staged_l4(
+            "pm", staged, target_root=tmp_path,
+            registry={"pm": ("pm", None)},
+        )
+    assert exc.value.rule == "R7"
+    assert exc.value.step_id == "work"
+
+
+def test_check_alias_staged_l4_does_not_write_to_disk(tmp_path):
+    """AC: '--check mode: no disk writes'."""
+    _stage_minimal_install(tmp_path)
+    staged = tmp_path / "staged.md"
+    staged.write_text(
+        "## Instructions\n\n### insert-after step:cycle/boot\n\n→ run sub-skill: x\n\nBody.\n",
+        encoding="utf-8",
+    )
+    before = set(tmp_path.rglob("*"))
+    compose.check_alias_staged_l4(
+        "pm", staged, target_root=tmp_path,
+        registry={"pm": ("pm", None)},
+    )
+    after = set(tmp_path.rglob("*"))
+    assert before == after, (
+        "check_alias_staged_l4 must not create any files. "
+        f"new entries: {after - before}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests — exit code semantics (0 clean / 1 validation / 2 setup)
+# ---------------------------------------------------------------------------
+
+def _run_compose(*args, cwd=None):
+    if cwd is None:
+        cwd = REPO_ROOT
+    return subprocess.run(
+        [sys.executable, str(SCRIPTS / "compose.py"), *args],
+        capture_output=True, text=True, cwd=str(cwd),
+    )
+
+
+def test_cli_missing_value_after_staged_l4_exits_2():
+    """`--staged-l4` with no path argument is a setup error."""
+    result = _run_compose("deploy", "pm", "--check", "--staged-l4")
+    assert result.returncode == compose.CHECK_EXIT_ERROR
+    assert "requires a path argument" in result.stderr
+
+
+def test_cli_staged_l4_nonexistent_path_exits_2(tmp_path):
+    """`--staged-l4 <bogus path>` → setup error (exit 2)."""
+    result = _run_compose(
+        "deploy", "pm", "--check", "--staged-l4", str(tmp_path / "ghost.md"),
+    )
+    assert result.returncode == compose.CHECK_EXIT_ERROR
+    assert "setup error" in result.stderr
+
+
+def test_cli_staged_l4_with_unknown_alias_exits_2(tmp_path):
+    """Even with a valid staged file, an unknown alias is a setup error."""
+    staged = tmp_path / "staged.md"
+    staged.write_text("## Instructions\n", encoding="utf-8")
+    result = _run_compose(
+        "deploy", "definitely-not-a-real-alias", "--check",
+        "--staged-l4", str(staged),
+    )
+    assert result.returncode == compose.CHECK_EXIT_ERROR
+    assert "setup error" in result.stderr
+
+
+def test_cli_check_without_staged_l4_falls_through_to_a4_check():
+    """Without --staged-l4, `deploy <alias> --check` runs the A4 drift check."""
+    # A4 returns 0/1/2 depending on the on-disk state; we just assert it didn't crash
+    # and the exit code is one of the documented values.
+    result = _run_compose("deploy", "pm", "--check")
+    assert result.returncode in (
+        compose.CHECK_EXIT_CLEAN,
+        compose.CHECK_EXIT_DRIFT,
+        compose.CHECK_EXIT_ERROR,
+    )
+
+
+def test_cli_help_or_no_args_does_not_crash():
+    """Sanity: passing the new flag args parser shouldn't break the help path."""
+    result = _run_compose()
+    assert result.returncode == 0


### PR DESCRIPTION
## Planning contract

Acceptance contract is the AC list in the issue body of #10395 (PRD-A Story A4.5). The §3.3 + §4.2 validation rules (R1-R7) are implemented in `link_stage_validator.py` from A2e (#10491). The `--check` infrastructure + distinct exit codes 0/1/2 come from A4 (#10388). No PM-side `CONTEXT-10395.md` exists. Verifier will produce `.squidsquad/qa/planning/TEST-PLAN-10395.md` during verification per the #9184 workflow. Cited per #8950 Gate #4 requirement.

## Summary

Adds the `--staged-l4 <path>` flag to `compose.py deploy <alias> --check`. With the flag, the check reads the staged L4 file as if it were `.squidsquad/project/<role-class>.md`, walks L1-L3 sources, and runs all seven R1-R7 validation rules from A2e. Without the flag, `--check` falls through to A4's existing drift check (in-memory compose vs on-disk `CLAUDE.md`). The two checks are distinguished by the presence of `--staged-l4`; both share the 0/1/2 exit-code semantics.

## What landed

- `references/scripts/compose.py`:
  - `check_alias_staged_l4(alias, staged_l4_path, *, target_root, registry) -> role_class` — function entry point. Resolves alias via A5 registry, walks L1-L3 sources via A2d's `collect_sources_for_validation`, parses the staged L4 via A2b's `parse_l4_file`, runs A2e's `validate_link_stage`. Lazy-imports the v2 modules so v1 paths still load cleanly.
  - `main()` argv parser: extracts `--staged-l4 <path>` with a missing-value guard (exit 2 with diagnostic). Order-independent like `--v2` and `--check`.
  - CLI dispatch for `deploy <alias> --check`:
    - With `--staged-l4`: routes to `check_alias_staged_l4`. Maps exceptions to exit codes: 0 clean / 1 `LinkStageValidationError` (stderr names the rule) / 2 setup error (`FileNotFoundError`, `KeyError`, registry parse, source walk fault).
    - Without `--staged-l4`: A4 drift-check (unchanged).
  - Removed the stale "--check + --v2 reserved for A4.5" hint; A4.5 doesn't gate on `--v2`.
- `tests/test_compose_check_a45_10395.py` (12 tests).
- `tests/run_tests.py`: registered `test_compose_check_a45_10395`.

## AC mapping

| AC | Where |
|---|---|
| `compose.py deploy <alias> --check` accepts an optional `--staged-l4 <path>`; if absent, behaves as a per-alias variant of A4's check | `main()` argv parser + the `if staged_l4_path is not None` branch + `test_cli_check_without_staged_l4_falls_through_to_a4_check` |
| With `--staged-l4 <path>`: reads the staged file as if it were `.squidsquad/project/<role-class>.md`, composes in memory, validates per §3.3 + §4.2 rules | `check_alias_staged_l4` + `test_check_alias_staged_l4_clean_returns_role_class` |
| Exit 0 = clean / 1 = validation error / 2 = setup error (distinct from drift) | `CHECK_EXIT_CLEAN/DRIFT/ERROR` (the A4 constants); validation-error and drift share exit code 1 since both are "the config the operator was about to deploy is broken" |
| Stderr emits structured diagnostic naming the rule that failed (per A2's R1-R7 list) | `LinkStageValidationError.__str__` already prefixes with `[R<n>] (file)`; CLI message is `  <alias> (staged): VALIDATION FAIL — <e>` |
| No disk writes in `--check` mode | `test_check_alias_staged_l4_does_not_write_to_disk` asserts the tmp tree is bit-identical before/after |
| Unit + integration tests covering: clean stage / staged R1 violation (vault H2) / staged R5 violation (orphan step ID) / staged R7 violation (duplicate replace target) | 4 function-level tests + 4 CLI exit-code tests; R5 and R7 cases also assert the named step ID is surfaced |

## Tests

`python -m pytest tests/test_compose_check_a45_10395.py` — 12 passed in 0.77s.
Existing A4 + A6 + A2f tests still pass — 54 passed, 1 skipped.

## Notes

- A4.5 does NOT need `--v2`. The staged check is intrinsically v2 (L4 files are a v2 concept), but the flag surface is `--check --staged-l4`, not `--check --v2 --staged-l4`. Removed the prior "reserved for A4.5" guard since this PR fills the slot.
- `check_alias_staged_l4` returns the resolved role-class on success. Callers (the CLI, future PRD-C `l4-curation` Gate 3) can use that return value without re-running the registry lookup.
- The function-level tests cover the API contract; the CLI tests cover the exit-code mapping. The split keeps the suite fast (subprocess-only when exit-code semantics are the assertion).

Closes #10395