### PR TITLE
PRD-A/A3: byte-stability golden-file test suite for v2 link stage (#10387)

### DIFF
--- a/tests/compose-fixtures/pm/.squidsquad/project/pm.md
+++ b/tests/compose-fixtures/pm/.squidsquad/project/pm.md
@@ -1,0 +1,33 @@
+## Instructions
+
+### replace step:cycle/boot
+
+→ run sub-skill: boot-bootstrap
+
+Verify tracker access and check for any open SEV1 tickets before proceeding.
+
+### insert-before step:cycle/triage
+
+→ run sub-skill: vault-consult
+
+Consult the vault for active priorities before triage.
+
+### insert-after step:cycle/work
+
+→ run sub-skill: post-cycle-checkpoint
+
+Checkpoint cycle state into the working-state file.
+
+### append
+
+→ run sub-skill: human-status-update
+
+End each cycle with a short status update to the human.
+
+## Identity
+
+### append
+
+→ run sub-skill: project-context-load
+
+Project Acme PM: deeply familiar with the Acme team's cadences and incident-response rituals.

--- a/tests/compose-fixtures/pm/CLAUDE.linked.golden.md
+++ b/tests/compose-fixtures/pm/CLAUDE.linked.golden.md
@@ -1,0 +1,46 @@
+## Identity
+
+You are a SquidSquad PM agent. You coordinate the team, talk to the human, and orchestrate work.
+→ run sub-skill: project-context-load
+
+Project Acme PM: deeply familiar with the Acme team's cadences and incident-response rituals.
+
+## Responsibility
+
+PM coordinates the team, shapes incoming work into concrete plans, and assigns it to the right specialist.
+
+## Soul
+
+Calm, methodical, transparent. Coordinate without commandeering.
+
+## Instructions
+
+### step:cycle/boot
+
+→ run sub-skill: boot-bootstrap
+
+Verify tracker access and check for any open SEV1 tickets before proceeding.
+### step:cycle/work
+
+Do the unit of work for the current cycle. Vary by role.
+
+→ run sub-skill: vault-consult
+
+Consult the vault for active priorities before triage.
+→ run sub-skill: post-cycle-checkpoint
+
+Checkpoint cycle state into the working-state file.
+### step:cycle/triage
+
+→ run sub-skill: task-pickup
+
+Triage approved tasks; assign each to the role best suited to deliver.
+→ run sub-skill: human-status-update
+
+End each cycle with a short status update to the human.
+
+## Project Context
+
+## Vault
+
+The vault is the institutional memory the squad consults before acting.

--- a/tests/compose-fixtures/pm/references/roles/SOUL.md
+++ b/tests/compose-fixtures/pm/references/roles/SOUL.md
@@ -1,0 +1,6 @@
+---
+slot: soul
+ordinal: 10
+---
+
+Calm, methodical, transparent. Coordinate without commandeering.

--- a/tests/compose-fixtures/pm/references/roles/identity.md
+++ b/tests/compose-fixtures/pm/references/roles/identity.md
@@ -1,0 +1,6 @@
+---
+slot: identity
+ordinal: 10
+---
+
+You are a SquidSquad PM agent. You coordinate the team, talk to the human, and orchestrate work.

--- a/tests/compose-fixtures/pm/references/roles/instructions.md
+++ b/tests/compose-fixtures/pm/references/roles/instructions.md
@@ -1,0 +1,15 @@
+---
+slot: instructions
+ordinal: 10
+step-ids: [step:cycle/boot, step:cycle/work]
+---
+
+### step:cycle/boot
+
+→ run sub-skill: boot-bootstrap
+
+Verify tracker access and read the config.
+
+### step:cycle/work
+
+Do the unit of work for the current cycle. Vary by role.

--- a/tests/compose-fixtures/pm/references/roles/pm/instructions.md
+++ b/tests/compose-fixtures/pm/references/roles/pm/instructions.md
@@ -1,0 +1,12 @@
+---
+slot: instructions
+ordinal: 20
+roles: [pm]
+step-ids: [step:cycle/triage]
+---
+
+### step:cycle/triage
+
+→ run sub-skill: task-pickup
+
+Triage approved tasks; assign each to the role best suited to deliver.

--- a/tests/compose-fixtures/pm/references/roles/pm/responsibility.md
+++ b/tests/compose-fixtures/pm/references/roles/pm/responsibility.md
@@ -1,0 +1,7 @@
+---
+slot: responsibility
+ordinal: 20
+roles: [pm]
+---
+
+PM coordinates the team, shapes incoming work into concrete plans, and assigns it to the right specialist.

--- a/tests/compose-fixtures/pm/references/roles/vault.md
+++ b/tests/compose-fixtures/pm/references/roles/vault.md
@@ -1,0 +1,6 @@
+---
+slot: vault
+ordinal: 10
+---
+
+The vault is the institutional memory the squad consults before acting.

--- a/tests/compose-fixtures/worker-fe/.squidsquad/project/worker.md
+++ b/tests/compose-fixtures/worker-fe/.squidsquad/project/worker.md
@@ -1,0 +1,25 @@
+## Instructions
+
+### replace step:cycle/implement
+
+→ run sub-skill: implement-tasks
+
+Implement the approved task; in this project, ALSO run `npm run typecheck` before transitioning.
+
+### insert-before step:cycle/fe-build
+
+→ run sub-skill: design-review
+
+Pull the Figma frame for the change and confirm visual parity before building.
+
+### insert-after step:cycle/pickup
+
+→ run sub-skill: design-context-load
+
+Load the project's design system tokens into the working state.
+
+### append
+
+→ run sub-skill: commit-with-design-tag
+
+Tag each implementation commit with the Figma frame ID for traceability.

--- a/tests/compose-fixtures/worker-fe/CLAUDE.linked.golden.md
+++ b/tests/compose-fixtures/worker-fe/CLAUDE.linked.golden.md
@@ -1,0 +1,51 @@
+## Identity
+
+You are a SquidSquad agent. You execute discrete units of work and report back through Discussion entries.
+
+## Responsibility
+
+Worker implements approved tasks, fixes bugs filed to its tracker, and lands regression tests for every fix.
+
+## Soul
+
+Pragmatic. Implementation-focused. Honest about tradeoffs.
+
+## Instructions
+
+### step:cycle/boot
+
+→ run sub-skill: boot-bootstrap
+
+Verify tracker access and check for resumable work.
+
+### step:cycle/pickup
+
+→ run sub-skill: task-pickup
+
+Pick up the highest-priority approved item from the deterministic queue.
+
+→ run sub-skill: design-context-load
+
+Load the project's design system tokens into the working state.
+### step:cycle/implement
+
+→ run sub-skill: implement-tasks
+
+Implement the approved task; in this project, ALSO run `npm run typecheck` before transitioning.
+→ run sub-skill: design-review
+
+Pull the Figma frame for the change and confirm visual parity before building.
+### step:cycle/fe-build
+
+→ run sub-skill: fe-build-and-snapshot
+
+Run the FE build pipeline; capture visual snapshots for changed components.
+→ run sub-skill: commit-with-design-tag
+
+Tag each implementation commit with the Figma frame ID for traceability.
+
+## Project Context
+
+## Vault
+
+Worker agents read the vault to align with the squad's standing decisions before implementing.

--- a/tests/compose-fixtures/worker-fe/references/roles/SOUL.md
+++ b/tests/compose-fixtures/worker-fe/references/roles/SOUL.md
@@ -1,0 +1,6 @@
+---
+slot: soul
+ordinal: 10
+---
+
+Pragmatic. Implementation-focused. Honest about tradeoffs.

--- a/tests/compose-fixtures/worker-fe/references/roles/identity.md
+++ b/tests/compose-fixtures/worker-fe/references/roles/identity.md
@@ -1,0 +1,6 @@
+---
+slot: identity
+ordinal: 10
+---
+
+You are a SquidSquad agent. You execute discrete units of work and report back through Discussion entries.

--- a/tests/compose-fixtures/worker-fe/references/roles/instructions.md
+++ b/tests/compose-fixtures/worker-fe/references/roles/instructions.md
@@ -1,0 +1,17 @@
+---
+slot: instructions
+ordinal: 10
+step-ids: [step:cycle/boot, step:cycle/pickup]
+---
+
+### step:cycle/boot
+
+→ run sub-skill: boot-bootstrap
+
+Verify tracker access and check for resumable work.
+
+### step:cycle/pickup
+
+→ run sub-skill: task-pickup
+
+Pick up the highest-priority approved item from the deterministic queue.

--- a/tests/compose-fixtures/worker-fe/references/roles/vault.md
+++ b/tests/compose-fixtures/worker-fe/references/roles/vault.md
@@ -1,0 +1,6 @@
+---
+slot: vault
+ordinal: 10
+---
+
+Worker agents read the vault to align with the squad's standing decisions before implementing.

--- a/tests/compose-fixtures/worker-fe/references/roles/worker/fe/instructions.md
+++ b/tests/compose-fixtures/worker-fe/references/roles/worker/fe/instructions.md
@@ -1,0 +1,12 @@
+---
+slot: instructions
+ordinal: 30
+roles: [worker]
+step-ids: [step:cycle/fe-build]
+---
+
+### step:cycle/fe-build
+
+→ run sub-skill: fe-build-and-snapshot
+
+Run the FE build pipeline; capture visual snapshots for changed components.

--- a/tests/compose-fixtures/worker-fe/references/roles/worker/instructions.md
+++ b/tests/compose-fixtures/worker-fe/references/roles/worker/instructions.md
@@ -1,0 +1,12 @@
+---
+slot: instructions
+ordinal: 20
+roles: [worker]
+step-ids: [step:cycle/implement]
+---
+
+### step:cycle/implement
+
+→ run sub-skill: implement-tasks
+
+Implement the approved task against its acceptance criteria; land unit tests in the same PR.

--- a/tests/compose-fixtures/worker-fe/references/roles/worker/responsibility.md
+++ b/tests/compose-fixtures/worker-fe/references/roles/worker/responsibility.md
@@ -1,0 +1,7 @@
+---
+slot: responsibility
+ordinal: 20
+roles: [worker]
+---
+
+Worker implements approved tasks, fixes bugs filed to its tracker, and lands regression tests for every fix.

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -129,6 +129,7 @@ STATIC_TEST_MODULES = [
     "test_conflict_resolver_b5",
     "test_atomic_emit_b7",
     "test_compose_check_a45_10395",
+    "test_a3_golden_link_stage",
 ]
 
 

--- a/tests/test_a3_golden_link_stage.py
+++ b/tests/test_a3_golden_link_stage.py
@@ -1,0 +1,176 @@
+"""Byte-stability golden-file test suite for the v2 link stage (#10387, PRD-A A3).
+
+Each fixture under ``tests/compose-fixtures/<install>/`` is a miniature
+installed repo: ``references/`` (L1-L3 source tree) + ``.squidsquad/``
+(L4 file). For every fixture, ``emit_v2_linked`` is invoked against the
+fixture root and the result is diffed byte-for-byte against the
+committed ``CLAUDE.linked.golden.md``. Any drift fails the test.
+
+The negative test mutates a fixture's L4 to a parse-error shape (a
+malformed H3 op heading) and confirms ``emit_v2_linked`` raises
+``L4ParseError`` rather than silently producing a different output.
+
+Out of scope per the issue body: CI hook / pre-merge wiring; that
+belongs to PRD-E. This suite makes the regression net catchable; the
+hook to make it gating lands later.
+"""
+
+import re
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO_ROOT / "references" / "scripts"
+FIXTURES = REPO_ROOT / "tests" / "compose-fixtures"
+sys.path.insert(0, str(SCRIPTS))
+
+import v2_link_stage  # noqa: E402
+from l4_parser import L4ParseError  # noqa: E402
+
+
+# Per-fixture (alias, role_class, l3_domain) tuples. The alias is the
+# directory name under tests/compose-fixtures/; role_class + l3_domain
+# are the arguments emit_v2_linked needs to scope the L1-L3 walk.
+_FIXTURES = [
+    ("pm", "pm", None),
+    ("worker-fe", "worker", "fe"),
+]
+
+
+@pytest.mark.parametrize("fixture_name,role_class,l3_domain", _FIXTURES)
+def test_fixture_emit_matches_committed_golden(fixture_name, role_class, l3_domain):
+    """The link stage's output for this fixture must byte-match the golden."""
+    fixture_root = FIXTURES / fixture_name
+    golden_path = fixture_root / "CLAUDE.linked.golden.md"
+    assert golden_path.exists(), (
+        f"Golden file missing for fixture '{fixture_name}'. "
+        f"Regenerate with: python -c \"from pathlib import Path; "
+        f"import sys; sys.path.insert(0, '{SCRIPTS}'); "
+        f"import v2_link_stage; "
+        f"Path('{golden_path}').write_text("
+        f"v2_link_stage.emit_v2_linked('{role_class}', "
+        f"{l3_domain!r}, repo_root=Path('{fixture_root}')))\""
+    )
+    expected = golden_path.read_text(encoding="utf-8")
+    actual = v2_link_stage.emit_v2_linked(
+        role_class, l3_domain, repo_root=fixture_root,
+    )
+    if actual != expected:
+        # Surface a precise diff in the failure message so the operator
+        # can decide between "fix the link stage" and "regenerate the
+        # golden" without re-running by hand.
+        import difflib
+        diff = "\n".join(difflib.unified_diff(
+            expected.splitlines(),
+            actual.splitlines(),
+            fromfile=f"{golden_path}",
+            tofile=f"emit_v2_linked({role_class!r}, {l3_domain!r})",
+            lineterm="",
+        ))
+        pytest.fail(
+            f"Golden drift on fixture '{fixture_name}'. "
+            f"Either fix the link stage to restore the golden output or "
+            f"regenerate the golden if the change was intentional.\n\n{diff}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC: L4 ops of each type — fixture coverage
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("fixture_name,role_class,l3_domain", _FIXTURES)
+def test_fixture_l4_uses_all_four_op_types(fixture_name, role_class, l3_domain):
+    """Each fixture's L4 must exercise replace + insert-before + insert-after + append."""
+    fixture_root = FIXTURES / fixture_name
+    l4_path = fixture_root / ".squidsquad" / "project" / f"{role_class}.md"
+    assert l4_path.exists(), f"L4 file missing for fixture '{fixture_name}'"
+    l4_text = l4_path.read_text(encoding="utf-8")
+    # Each op heading present at least once. Matched line-anchored so a
+    # stray phrase in prose doesn't satisfy the check.
+    assert re.search(r"^### replace\b", l4_text, re.MULTILINE), (
+        f"fixture '{fixture_name}' L4 missing `### replace`"
+    )
+    assert re.search(r"^### insert-before\b", l4_text, re.MULTILINE), (
+        f"fixture '{fixture_name}' L4 missing `### insert-before`"
+    )
+    assert re.search(r"^### insert-after\b", l4_text, re.MULTILINE), (
+        f"fixture '{fixture_name}' L4 missing `### insert-after`"
+    )
+    assert re.search(r"^### append\b", l4_text, re.MULTILINE), (
+        f"fixture '{fixture_name}' L4 missing `### append`"
+    )
+
+
+def test_fixture_pm_has_no_l3_subtree():
+    """AC: 'one role-class with no L3 (pm)' — verify the structural property."""
+    pm_role_dir = FIXTURES / "pm" / "references" / "roles" / "pm"
+    assert pm_role_dir.is_dir()
+    subdirs = [p for p in pm_role_dir.iterdir() if p.is_dir()]
+    assert subdirs == [], (
+        f"pm fixture should have no L3 subtree under references/roles/pm/; "
+        f"found {subdirs}"
+    )
+
+
+def test_fixture_worker_fe_has_l3_subtree():
+    """AC: 'one with L3 (worker + fe)' — verify the structural property."""
+    fe_dir = FIXTURES / "worker-fe" / "references" / "roles" / "worker" / "fe"
+    assert fe_dir.is_dir()
+    md_files = list(fe_dir.glob("*.md"))
+    assert md_files, "worker-fe fixture should have at least one .md under worker/fe/"
+
+
+# ---------------------------------------------------------------------------
+# Negative test: corrupted L4 → compose aborts (does not silently produce drift)
+# ---------------------------------------------------------------------------
+
+def test_corrupted_l4_aborts_with_parse_error(tmp_path):
+    """AC: 'corrupted L4 op → compose aborts (does not silently produce drift)'."""
+    # Copy the pm fixture into a tmp tree so we can mutate it safely.
+    src = FIXTURES / "pm"
+    shutil.copytree(src, tmp_path / "pm")
+    bad_root = tmp_path / "pm"
+    l4_path = bad_root / ".squidsquad" / "project" / "pm.md"
+    # Corrupt: introduce an H3 line that does NOT match any legal op
+    # grammar. A2b's parser rejects this with L4ParseError.
+    l4_path.write_text(
+        "## Instructions\n\n"
+        "### frobnicate step:cycle/work\n\n"
+        "Not a legal op heading.\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(L4ParseError):
+        v2_link_stage.emit_v2_linked(
+            "pm", None, repo_root=bad_root,
+        )
+
+
+def test_corrupted_l4_does_not_silently_match_golden(tmp_path):
+    """The link stage must NOT silently swallow a corrupted L4 and emit the same body.
+
+    Belt-and-braces companion to the parse-error test: even if a future
+    refactor caught L4ParseError and proceeded, the byte-stability test
+    would still catch the drift. This test pins that property.
+    """
+    src = FIXTURES / "pm"
+    shutil.copytree(src, tmp_path / "pm")
+    bad_root = tmp_path / "pm"
+    l4_path = bad_root / ".squidsquad" / "project" / "pm.md"
+    l4_path.write_text(
+        "## Instructions\n\n"
+        "### frobnicate step:cycle/work\n\n"
+        "Not a legal op heading.\n",
+        encoding="utf-8",
+    )
+    golden = (FIXTURES / "pm" / "CLAUDE.linked.golden.md").read_text(encoding="utf-8")
+    try:
+        actual = v2_link_stage.emit_v2_linked("pm", None, repo_root=bad_root)
+    except L4ParseError:
+        return  # Expected — assertion holds via the raise.
+    assert actual != golden, (
+        "A corrupted L4 produced byte-identical output to the golden — "
+        "the link stage silently dropped the malformed ops, masking drift."
+    )


### PR DESCRIPTION
## Planning contract

Acceptance contract is the AC list in the issue body of #10387 (PRD-A Story A3). Byte-stability per COMPOSE-ARCHITECTURE §4 success-criterion 7. No PM-side `CONTEXT-10387.md` exists. Verifier will produce `.squidsquad/qa/planning/TEST-PLAN-10387.md` during verification per the #9184 workflow. Cited per #8950 Gate #4 requirement.

## Summary

Adds the byte-stability regression net for the v2 link stage. Two fixture installs under `tests/compose-fixtures/` each cover the AC "L4 ops of each type" + cross both layer topologies (one role-class with no L3, one with L3).

## What landed

- `tests/compose-fixtures/pm/` (no L3):
  - L1: `references/roles/identity.md`, `instructions.md`, `SOUL.md`, `vault.md`
  - L2: `references/roles/pm/responsibility.md`, `instructions.md`
  - L4: `.squidsquad/project/pm.md` (all 4 op types under Instructions + an `append` under Identity for slot diversity)
  - Golden: `CLAUDE.linked.golden.md`
- `tests/compose-fixtures/worker-fe/` (with L3 = fe):
  - L1: same four files
  - L2: `references/roles/worker/responsibility.md`, `instructions.md`
  - L3: `references/roles/worker/fe/instructions.md`
  - L4: `.squidsquad/project/worker.md` (all 4 op types)
  - Golden: `CLAUDE.linked.golden.md`
- `tests/test_a3_golden_link_stage.py` (8 tests):
  - Parametrized byte-stability per fixture: `emit_v2_linked` vs committed golden. On drift, prints a unified diff in the failure message so the operator can decide between "fix the link stage" vs "regenerate the golden" without re-running by hand.
  - Structural checks: pm fixture has no L3 subtree; worker-fe has L3 subtree with at least one `.md`.
  - L4 op-type coverage check per fixture (so a future fixture edit can't accidentally drop op-type coverage).
  - Negative: corrupted L4 (`### frobnicate step:cycle/work`) → `emit_v2_linked` raises `L4ParseError` instead of silently producing drift. Uses `tmp_path` + `shutil.copytree` to mutate a copy; committed fixture stays intact.
  - Belt-and-braces negative: confirms a corrupted L4 does NOT emit a golden-matching output if a future refactor caught `L4ParseError` silently.
- `tests/run_tests.py`: registered `test_a3_golden_link_stage`.

## AC mapping

| AC | Where |
|---|---|
| Fixture install under `tests/compose-fixtures/` covering one role-class with no L3 (pm), one with L3 (worker + fe), one with L4 ops of each type (replace, insert-before, insert-after, append) | `tests/compose-fixtures/pm/` (no L3) + `tests/compose-fixtures/worker-fe/` (with L3); each L4 file exercises all four op types — verified at static time by `test_fixture_l4_uses_all_four_op_types` |
| Golden expected output (`CLAUDE.linked.md` committed alongside fixture) | `CLAUDE.linked.golden.md` per fixture (suffixed `.golden` so it doesn't shadow the real path A2f writes to under `.squidsquad/<alias>/`) |
| Test runner: invoke link stage, diff result against golden, fail on any byte difference | `test_fixture_emit_matches_committed_golden` (parametrized over fixtures) + unified-diff failure message |
| Tests live under `tests/` and are reachable via the project's existing test entry point | `tests/test_a3_golden_link_stage.py`; registered in `tests/run_tests.py` `STATIC_TEST_MODULES` |
| At least one negative test: corrupted L4 op → compose aborts (does not silently produce drift) | `test_corrupted_l4_aborts_with_parse_error` + `test_corrupted_l4_does_not_silently_match_golden` |
| CI hook / pre-merge test integration is out of scope here | Yes — making the suite gating belongs to PRD-E |

## Tests

`python -m pytest tests/test_a3_golden_link_stage.py` — 8 passed in 0.16s.

## Notes

- Golden files use Python's `Path.write_text(out, encoding="utf-8")` and tests read via `Path.read_text(encoding="utf-8")`. Universal newlines on read normalize CRLF→LF, so the cross-platform comparison stays stable even when git on Windows checks out the file with CRLF line endings.
- `CLAUDE.linked.golden.md` filename uses `.golden.md` suffix so it doesn't shadow the canonical `CLAUDE.linked.v2.md` path A2f writes to under `.squidsquad/<alias>/`. The two files have the same content shape but different roles: the v2 file is runtime output, the golden is a regression checkpoint.
- Negative tests work on `tmp_path` copies of the fixture so the committed fixture is never mutated by the test run. Future maintainers can edit the fixture safely.
- B8 (#10448) will land an analogous golden-file suite for the assemble pass, consuming the same fixture install pattern but exercising `atomic_emit.assemble_and_emit` end-to-end.

Closes #10387