### PR TITLE
PRD-B/B8: byte-stability golden suite for the assemble pass (#10448)

### DIFF
--- a/tests/compose-fixtures/assemble-contradiction/.squidsquad/project/pm.md
+++ b/tests/compose-fixtures/assemble-contradiction/.squidsquad/project/pm.md
@@ -1,0 +1,5 @@
+## Responsibility
+
+### append
+
+Project override: in this project, PM does NOT coordinate the team; verifier coordinates instead.

--- a/tests/compose-fixtures/assemble-contradiction/CLAUDE.conflicts.md.golden
+++ b/tests/compose-fixtures/assemble-contradiction/CLAUDE.conflicts.md.golden
@@ -1,0 +1,13 @@
+# Compose Conflict Report — pm
+Generated: 2026-06-01T12:00:00+00:00
+Compose run: fixture-sha
+Assemble model: stub-llm
+Total conflicts resolved: 1
+
+## CONFLICT-001 — slot: responsibility — precedence: L4 > L2
+- **L2 source**: `references/roles/pm/responsibility.md` (ordinal ?)
+  > PM coordinates the team
+- **L4 source**: `.squidsquad/project/pm.md` (ordinal ?)
+  > Project override: in this project, PM does NOT coordinate the team; verifier coordinates instead.
+- **Why this is a conflict**: L4 transfers team coordination from PM to verifier for this project.
+- **Resolution in assembled output**: Assembled body says verifier coordinates the team; PM still shapes work but does not coordinate.

--- a/tests/compose-fixtures/assemble-contradiction/CLAUDE.linked.md.golden
+++ b/tests/compose-fixtures/assemble-contradiction/CLAUDE.linked.md.golden
@@ -1,0 +1,26 @@
+## Identity
+
+You are a SquidSquad PM agent. You coordinate the team and orchestrate work for the human.
+
+## Responsibility
+
+PM coordinates the team, shapes incoming work, and assigns it to the right specialist.
+Project override: in this project, PM does NOT coordinate the team; verifier coordinates instead.
+
+## Soul
+
+Calm, methodical, and transparent in every team interaction.
+
+## Instructions
+
+### step:cycle/boot
+
+→ run sub-skill: boot-bootstrap
+
+Verify tracker access; resume any in-flight task before starting fresh work.
+
+## Project Context
+
+## Vault
+
+The vault is the institutional memory the squad consults before acting.

--- a/tests/compose-fixtures/assemble-contradiction/CLAUDE.md.golden
+++ b/tests/compose-fixtures/assemble-contradiction/CLAUDE.md.golden
@@ -1,0 +1,25 @@
+## Identity
+
+You are a SquidSquad PM agent. You coordinate the team and orchestrate work for the human.
+
+## Responsibility
+
+In this project, verifier coordinates the team; PM does not coordinate. The PM still shapes incoming work and assigns it to the right specialist for delivery, but team-level coordination is the verifier's job.
+
+## Soul
+
+Calm, methodical, and transparent in every team interaction.
+
+## Instructions
+
+### step:cycle/boot
+
+→ run sub-skill: boot-bootstrap
+
+Verify tracker access; resume any in-flight task before starting fresh work.
+
+## Project Context
+
+## Vault
+
+The vault is the institutional memory the squad consults before acting.

--- a/tests/compose-fixtures/assemble-contradiction/references/roles/SOUL.md
+++ b/tests/compose-fixtures/assemble-contradiction/references/roles/SOUL.md
@@ -1,0 +1,6 @@
+---
+slot: soul
+ordinal: 10
+---
+
+Calm, methodical, and transparent in every team interaction.

--- a/tests/compose-fixtures/assemble-contradiction/references/roles/identity.md
+++ b/tests/compose-fixtures/assemble-contradiction/references/roles/identity.md
@@ -1,0 +1,6 @@
+---
+slot: identity
+ordinal: 10
+---
+
+You are a SquidSquad PM agent. You coordinate the team and orchestrate work for the human.

--- a/tests/compose-fixtures/assemble-contradiction/references/roles/instructions.md
+++ b/tests/compose-fixtures/assemble-contradiction/references/roles/instructions.md
@@ -1,0 +1,11 @@
+---
+slot: instructions
+ordinal: 10
+step-ids: [step:cycle/boot]
+---
+
+### step:cycle/boot
+
+→ run sub-skill: boot-bootstrap
+
+Verify tracker access; resume any in-flight task before starting fresh work.

--- a/tests/compose-fixtures/assemble-contradiction/references/roles/pm/responsibility.md
+++ b/tests/compose-fixtures/assemble-contradiction/references/roles/pm/responsibility.md
@@ -1,0 +1,7 @@
+---
+slot: responsibility
+ordinal: 20
+roles: [pm]
+---
+
+PM coordinates the team, shapes incoming work, and assigns it to the right specialist.

--- a/tests/compose-fixtures/assemble-contradiction/references/roles/vault.md
+++ b/tests/compose-fixtures/assemble-contradiction/references/roles/vault.md
@@ -1,0 +1,6 @@
+---
+slot: vault
+ordinal: 10
+---
+
+The vault is the institutional memory the squad consults before acting.

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -130,6 +130,7 @@ STATIC_TEST_MODULES = [
     "test_atomic_emit_b7",
     "test_compose_check_a45_10395",
     "test_a3_golden_link_stage",
+    "test_b8_golden_assemble",
 ]
 
 

--- a/tests/test_b8_golden_assemble.py
+++ b/tests/test_b8_golden_assemble.py
@@ -1,0 +1,281 @@
+"""Golden-file regression tests for the assemble pass (#10448, PRD-B B8).
+
+Validates ``atomic_emit.assemble_and_emit`` against committed
+``CLAUDE.md.golden`` + ``CLAUDE.conflicts.md.golden`` artifacts. The
+LLM call is stubbed (no live model dispatch in this suite) — the stub
+is fully deterministic and exercises:
+
+- A slot that produces a §4.6 conflict (the L4 contradiction in the
+  ``assemble-contradiction`` fixture's Responsibility slot).
+- The cache flow: a second run with a populated cache returns cached
+  bodies and never calls the stub LLM.
+- A negative path: corrupt a copy of the fixture so a preservation
+  token disappears from the assembled output; ``assemble_and_emit``
+  raises ``PreservationFail`` instead of silently producing drift.
+
+Out of scope per the issue body: CI-gating wiring; live-LLM end-to-end
+(B1's smoke tests cover that surface).
+"""
+
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO_ROOT / "references" / "scripts"
+FIXTURES = REPO_ROOT / "tests" / "compose-fixtures"
+sys.path.insert(0, str(SCRIPTS))
+
+import atomic_emit  # noqa: E402
+import v2_link_stage  # noqa: E402
+
+
+_FIXTURE_NAME = "assemble-contradiction"
+_FIXTURE_ROOT = FIXTURES / _FIXTURE_NAME
+_GOLDEN_CLAUDE_PATH = _FIXTURE_ROOT / "CLAUDE.md.golden"
+_GOLDEN_CONFLICTS_PATH = _FIXTURE_ROOT / "CLAUDE.conflicts.md.golden"
+
+# Deterministic generated-at for the conflict report header so the
+# golden stays byte-stable across runs.
+_GENERATED_AT = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Deterministic stub LLM
+# ---------------------------------------------------------------------------
+
+# Stub assembled body for the contradiction slot. Crafted to:
+# - drop the L2 phrase "PM coordinates the team" (so B5 drop-check passes)
+# - paraphrase the L4 position so the higher layer is reflected
+# - satisfy B3's length floor (>= 0.8 × linked length) and code-block
+#   parity (0 fenced / 0 inline both sides)
+# - preserve B2 preservation tokens (responsibility slot has none)
+_STUB_RESPONSIBILITY_BODY = (
+    "In this project, verifier coordinates the team; PM does not coordinate. "
+    "The PM still shapes incoming work and assigns it to the right specialist "
+    "for delivery, but team-level coordination is the verifier's job.\n"
+)
+
+_STUB_RESPONSIBILITY_CONFLICTS = (
+    "<!-- ASSEMBLE_CONFLICTS -->\n\n"
+    "- slot: responsibility\n"
+    "  winner_layer: L4\n"
+    "  winner_path: .squidsquad/project/pm.md\n"
+    "  winner_quote: Project override: in this project, PM does NOT coordinate the team; "
+    "verifier coordinates instead.\n"
+    "  loser_layer: L2\n"
+    "  loser_path: references/roles/pm/responsibility.md\n"
+    "  loser_quote: PM coordinates the team\n"
+    "  why: L4 transfers team coordination from PM to verifier for this project.\n"
+    "  resolution: Assembled body says verifier coordinates the team; PM still shapes work "
+    "but does not coordinate.\n"
+)
+
+
+def stub_assemble_slot(slot, linked_body):
+    """Deterministic LLM stand-in.
+
+    Responsibility slot returns the hand-crafted assembled body + a
+    single-entry conflicts section. Other slots return the linked body
+    verbatim with an empty ``(none)`` conflicts section.
+    """
+    if slot == "responsibility":
+        return _STUB_RESPONSIBILITY_BODY + "\n" + _STUB_RESPONSIBILITY_CONFLICTS
+    return linked_body + "\n<!-- ASSEMBLE_CONFLICTS -->\n\n(none)\n"
+
+
+# ---------------------------------------------------------------------------
+# Helpers — emit_and_compare orchestration
+# ---------------------------------------------------------------------------
+
+def _run_assemble(fixture_root, tmp_output_dir, *, cache_lookup_fn=None,
+                  cache_store_fn=None, llm_call_recorder=None):
+    """Build linked composite for the fixture, run assemble_and_emit, return triple paths."""
+    linked = v2_link_stage.emit_v2_linked("pm", None, repo_root=fixture_root)
+
+    def recording_stub(slot, linked_body):
+        if llm_call_recorder is not None:
+            llm_call_recorder.append(slot)
+        return stub_assemble_slot(slot, linked_body)
+
+    return atomic_emit.assemble_and_emit(
+        linked,
+        tmp_output_dir,
+        role_class="pm",
+        model_id="stub-llm",
+        commit_sha="fixture-sha",
+        generated_at=_GENERATED_AT,
+        assemble_slot_fn=recording_stub,
+        cache_lookup_fn=cache_lookup_fn,
+        cache_store_fn=cache_store_fn,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC: assembled CLAUDE.md matches golden
+# ---------------------------------------------------------------------------
+
+def test_assembled_claude_md_matches_golden(tmp_path):
+    """End-to-end: emit_v2_linked + assemble_and_emit + diff vs committed CLAUDE.md.golden."""
+    assert _GOLDEN_CLAUDE_PATH.exists(), (
+        f"Golden CLAUDE.md missing for fixture '{_FIXTURE_NAME}'. "
+        f"Regenerate by running the assemble pass against the fixture."
+    )
+    paths = _run_assemble(_FIXTURE_ROOT, tmp_path)
+    claude_md = paths[0].read_text(encoding="utf-8")
+    expected = _GOLDEN_CLAUDE_PATH.read_text(encoding="utf-8")
+    if claude_md != expected:
+        import difflib
+        diff = "\n".join(difflib.unified_diff(
+            expected.splitlines(), claude_md.splitlines(),
+            fromfile=str(_GOLDEN_CLAUDE_PATH),
+            tofile="assemble_and_emit output",
+            lineterm="",
+        ))
+        pytest.fail(f"CLAUDE.md drift on '{_FIXTURE_NAME}':\n\n{diff}")
+
+
+def test_assembled_claude_conflicts_md_matches_golden(tmp_path):
+    """The §4.6 conflict report matches the committed golden (header + 1 conflict entry)."""
+    assert _GOLDEN_CONFLICTS_PATH.exists(), (
+        f"Golden CLAUDE.conflicts.md missing for fixture '{_FIXTURE_NAME}'."
+    )
+    paths = _run_assemble(_FIXTURE_ROOT, tmp_path)
+    conflicts_md = paths[2].read_text(encoding="utf-8")
+    expected = _GOLDEN_CONFLICTS_PATH.read_text(encoding="utf-8")
+    if conflicts_md != expected:
+        import difflib
+        diff = "\n".join(difflib.unified_diff(
+            expected.splitlines(), conflicts_md.splitlines(),
+            fromfile=str(_GOLDEN_CONFLICTS_PATH),
+            tofile="emit_conflict_report output",
+            lineterm="",
+        ))
+        pytest.fail(f"CLAUDE.conflicts.md drift on '{_FIXTURE_NAME}':\n\n{diff}")
+
+
+def test_conflict_report_names_the_l4_contradiction():
+    """AC: 'fixture covering at least one L4 contradiction with golden CLAUDE.conflicts.md'."""
+    text = _GOLDEN_CONFLICTS_PATH.read_text(encoding="utf-8")
+    # One CONFLICT-001 entry naming responsibility, L4 > L2.
+    assert "Total conflicts resolved: 1" in text
+    assert "CONFLICT-001" in text
+    assert "slot: responsibility" in text
+    assert "L4 > L2" in text
+
+
+# ---------------------------------------------------------------------------
+# AC: cache hit on second run (no LLM invocation)
+# ---------------------------------------------------------------------------
+
+def test_cache_hit_on_second_run_skips_llm(tmp_path):
+    """AC: 'suite asserts cache hit on second run (no LLM invocation)'."""
+    cache_store = {}
+
+    def cache_lookup_fn(slot, linked_body):
+        return cache_store.get((slot, linked_body))
+
+    def cache_store_fn(slot, linked_body, output):
+        cache_store[(slot, linked_body)] = output
+
+    first_calls = []
+    _run_assemble(
+        _FIXTURE_ROOT, tmp_path / "first",
+        cache_lookup_fn=cache_lookup_fn,
+        cache_store_fn=cache_store_fn,
+        llm_call_recorder=first_calls,
+    )
+    assert first_calls, "first run should have populated the LLM"
+
+    # Second run: same cache should yield zero LLM calls.
+    second_calls = []
+    _run_assemble(
+        _FIXTURE_ROOT, tmp_path / "second",
+        cache_lookup_fn=cache_lookup_fn,
+        cache_store_fn=cache_store_fn,
+        llm_call_recorder=second_calls,
+    )
+    assert second_calls == [], (
+        f"second run should not invoke the LLM; recorded calls: {second_calls}"
+    )
+
+
+def test_cache_hit_second_run_writes_byte_identical_artifacts(tmp_path):
+    """Two consecutive runs (cache miss then hit) emit byte-identical triples."""
+    cache_store = {}
+
+    def cache_lookup_fn(slot, linked_body):
+        return cache_store.get((slot, linked_body))
+
+    def cache_store_fn(slot, linked_body, output):
+        cache_store[(slot, linked_body)] = output
+
+    first_paths = _run_assemble(
+        _FIXTURE_ROOT, tmp_path / "first",
+        cache_lookup_fn=cache_lookup_fn,
+        cache_store_fn=cache_store_fn,
+    )
+    second_paths = _run_assemble(
+        _FIXTURE_ROOT, tmp_path / "second",
+        cache_lookup_fn=cache_lookup_fn,
+        cache_store_fn=cache_store_fn,
+    )
+    for f1, f2 in zip(first_paths, second_paths):
+        assert f1.read_text(encoding="utf-8") == f2.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# AC: negative — corrupt fixture mid-test → suite catches
+# ---------------------------------------------------------------------------
+
+def test_corrupt_fixture_triggers_preservation_fail(tmp_path):
+    """AC: 'corrupt a fixture mid-test → suite catches'.
+
+    Mutate a copy of the fixture so the L1 instructions file loses its
+    `→ run sub-skill: boot-bootstrap` reference. The stub returns the
+    linked body verbatim (unchanged for non-responsibility slots), so the
+    preservation multiset still matches — BUT a stub that DROPS the
+    token would trigger PreservationFail. Simulate that by injecting a
+    stub that returns a body with the token removed for instructions.
+    """
+    src = FIXTURES / _FIXTURE_NAME
+    bad_root = tmp_path / "bad"
+    shutil.copytree(src, bad_root)
+    linked = v2_link_stage.emit_v2_linked("pm", None, repo_root=bad_root)
+
+    def corrupting_stub(slot, linked_body):
+        if slot == "instructions":
+            # Drop the sub-skill reference -- B2 multiset must catch this.
+            corrupted = linked_body.replace(
+                "→ run sub-skill: boot-bootstrap", ""
+            )
+            return corrupted + "\n<!-- ASSEMBLE_CONFLICTS -->\n\n(none)\n"
+        return stub_assemble_slot(slot, linked_body)
+
+    out_dir = tmp_path / "out"
+    with pytest.raises(atomic_emit.PreservationFail):
+        atomic_emit.assemble_and_emit(
+            linked, out_dir,
+            role_class="pm",
+            generated_at=_GENERATED_AT,
+            assemble_slot_fn=corrupting_stub,
+        )
+    # AC: zero partial artifacts on abort.
+    assert not out_dir.exists() or list(out_dir.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# Structural sanity: fixture has the contradiction the goldens encode
+# ---------------------------------------------------------------------------
+
+def test_fixture_has_l4_contradiction_in_responsibility():
+    """The fixture's L4 file authors a position that contradicts L2 responsibility."""
+    l4 = (_FIXTURE_ROOT / ".squidsquad" / "project" / "pm.md").read_text(encoding="utf-8")
+    l2 = (_FIXTURE_ROOT / "references" / "roles" / "pm" / "responsibility.md").read_text(
+        encoding="utf-8"
+    )
+    assert "PM coordinates the team" in l2
+    assert "PM does NOT coordinate" in l4


### PR DESCRIPTION
## Planning contract

Acceptance contract is the AC list in the issue body of #10448 (PRD-B Story B8). The §4.6 assemble-pass contract + conflict-report canonical format live in COMPOSE-ARCHITECTURE. No PM-side `CONTEXT-10448.md` exists. Verifier will produce `.squidsquad/qa/planning/TEST-PLAN-10448.md` during verification per the #9184 workflow. Cited per #8950 Gate #4 requirement.

## Summary

Adds the §4.6 assemble-pass regression net. New fixture `assemble-contradiction/` carries an L4 contradiction in Responsibility (L2 says "PM coordinates the team"; L4 appends "PM does NOT coordinate the team; verifier coordinates instead"). Committed golden artifacts (`CLAUDE.md.golden` + `CLAUDE.linked.md.golden` + `CLAUDE.conflicts.md.golden`) capture the §4.6 triple. The test suite uses a deterministic stub LLM so the regression net runs in 0.17s without any API call.

## What landed

- `tests/compose-fixtures/assemble-contradiction/`:
  - L1: `references/roles/identity.md`, `instructions.md`, `SOUL.md`, `vault.md`
  - L2: `references/roles/pm/responsibility.md` ("PM coordinates the team…")
  - L4: `.squidsquad/project/pm.md` (`### append` under Responsibility with the contradicting position)
  - 3 goldens: `CLAUDE.md.golden`, `CLAUDE.linked.md.golden`, `CLAUDE.conflicts.md.golden`
- `tests/test_b8_golden_assemble.py` (7 tests):
  - Deterministic stub `stub_assemble_slot(slot, linked_body)`:
    - Responsibility: hand-crafted assembled body that drops the L2 phrase + single-entry conflicts section
    - Other slots: linked body verbatim + `(none)` conflicts
    - All outputs satisfy B2 (preservation), B3 (length floor + code-block parity), B5 (loser-quote absent)
  - Byte-stability of `CLAUDE.md` vs golden (unified diff on failure)
  - Byte-stability of `CLAUDE.conflicts.md` vs golden (unified diff on failure)
  - Structural check: conflict report names L4 > L2 on responsibility
  - Cache-hit test: second run hits the cache; LLM call recorder confirms zero calls
  - Cache-hit byte-equality: cache-miss + cache-hit runs produce byte-identical triples
  - Negative: mutate a copy of the fixture so the stub drops a sub-skill ref; `assemble_and_emit` raises `PreservationFail`; output dir untouched
  - Fixture invariant: pins the L4 contradiction the goldens depend on
- Deterministic `generated_at=2026-06-01T12:00:00Z` keeps the conflicts golden byte-stable across runs
- `tests/run_tests.py`: registered `test_b8_golden_assemble`

## AC mapping

| AC | Where |
|---|---|
| Fixture covering at least one L4 contradiction with golden `CLAUDE.conflicts.md` | `assemble-contradiction/` fixture + `CLAUDE.conflicts.md.golden` + `test_conflict_report_names_the_l4_contradiction` |
| Suite asserts assembled `CLAUDE.md` matches golden | `test_assembled_claude_md_matches_golden` + unified-diff failure message |
| Suite asserts cache hit on second run (no LLM invocation) | `test_cache_hit_on_second_run_skips_llm` + byte-equality follow-up `test_cache_hit_second_run_writes_byte_identical_artifacts` |
| Negative test: corrupt a fixture mid-test → suite catches | `test_corrupt_fixture_triggers_preservation_fail` — `shutil.copytree` to a tmp dir, mutate, expect `PreservationFail` with zero partial artifacts |

## Tests

`python -m pytest tests/test_b8_golden_assemble.py` — 7 passed in 0.17s.

## Notes

- The stub LLM is intentionally hand-crafted, not generated. Hand-crafting keeps the goldens reviewable in PR + the test deterministic across machines + the assembled bodies engineered to satisfy B2/B3/B5 simultaneously. A live-LLM round-trip belongs in B1's smoke tests, not here.
- Golden filenames use the `.md.golden` suffix (rather than `.golden.md`) so a glob like `*.md` doesn't accidentally match — same intent as A3's choice of `.golden.md`, different lexical realization. Both work; future refactors can converge.
- `_GENERATED_AT` constant pins the conflict-report timestamp. Without it, every run would mint a fresh ISO string and the golden would never match.
- Negative test uses `tmp_path + shutil.copytree` to mutate a copy; the committed fixture is never touched (same pattern as A3).

Closes #10448