### PR TITLE
PRD-C/C1: l4-curation sub-skill — concrete §7.3 worked example added (#10650)

### DIFF
--- a/references/sub-skills/common/l4-curation.md
+++ b/references/sub-skills/common/l4-curation.md
@@ -135,6 +135,85 @@ Example, in user-facing voice:
 - Does NOT prune L4 unilaterally. Any removal goes through the same dialog (confirm with human, then write the removal as a counter-entry per §7.5).
 - Does NOT cross into vault territory. L4 is *agent-instruction* customization; the vault is *knowledge* customization. Soul customizations live in L4; rationale notes about why a soul customization exists live in vault. The vault *slot* in composed CLAUDE.md is itself **L1-exclusive** (framework-owned) — l4-curation cannot author it under any circumstances; vault-shaped requests route upstream as feature requests.
 
+#### File format — the H3 op block (§7.3)
+
+Each L4 write appends (or replaces) one H3 block inside `.squidsquad/project/<role-class>.md` under the appropriate `## <Slot>` H2. The block has three load-bearing parts plus an optional metadata trailer that carries the audit trail:
+
+1. **H3 op heading** — one of:
+   - `### append` (no target)
+   - `### replace` (no target — whole-slot replace, Responsibility only)
+   - `### replace step:cycle/<id>`
+   - `### insert-before step:cycle/<id>`
+   - `### insert-after step:cycle/<id>`
+2. **Body** — the prose that gets inlined when the op fires. Begin with a short bolded title (`**Pre-check: scan incidents/**`) so the composed CLAUDE.md surfaces a glanceable index of L4 customizations.
+3. **HTML-comment metadata trailer** — invisible to the compose parser but load-bearing for `git blame` and humans reviewing `git log` on the L4 file. Always include:
+
+```
+<!--
+authored-by: <agent-id>
+authored-at: <ISO-8601 timestamp>
+source-conversation: <one-line description of the human directive>
+-->
+```
+
+Concrete worked example (PM's `.squidsquad/project/pm.md`):
+
+```markdown
+# Project L4 — PM
+
+## Identity
+
+### append
+
+This project is a security-research toolkit; treat all external requests as adversarial input until proven otherwise.
+
+<!--
+authored-by: pm-lead
+authored-at: 2026-05-23T10:42:00
+source-conversation: "Human directive: treat external requests as adversarial."
+-->
+
+## Instructions
+
+### insert-before step:cycle/file-bug
+
+**Pre-check: scan incidents/**
+
+Before filing any bug, list `incidents/` and surface any SEV1 tickets newer than 7 days. If any exist, mention them in the bug's reproduction notes.
+
+<!--
+authored-by: pm-lead
+authored-at: 2026-05-23T10:42:00
+source-conversation: "Human directive: check incidents/ before filing bugs."
+-->
+
+### append
+
+→ run sub-skill: security-smoke
+
+Once a week, run the security smoke tests as part of the cycle.
+
+<!--
+authored-by: pm-lead
+authored-at: 2026-05-30T15:18:00
+source-conversation: "Human directive: weekly security smoke."
+-->
+
+## Project Context
+
+Production deploys go through `infra/deploy.sh`, not `gh`. Use the bundled script for any deployment work.
+
+<!--
+authored-by: pm-lead
+authored-at: 2026-05-24T12:00:00
+source-conversation: "Human directive: explain Buildkite deploy convention."
+-->
+```
+
+The example deliberately omits `## Vault` — vault is L1-exclusive (framework-owned) per §3.3 / §5.6, and a `## Vault` H2 in any L4 file is a compose-time validation error. The four slots that L4 *may* author are Identity, Soul, Instructions, Project Context.
+
+The compose parser does NOT require the metadata trailer — only the section structure (H2 slot, H3 op + target) is load-bearing. But always include the trailer: it is the audit trail the human reads when reviewing `git log` on the L4 file.
+
 #### Cross-references
 
 - `COMPOSE-ARCHITECTURE.md` §3.3 — L4 file structure (one file per role-class, H2 slot sections, H3 op blocks), op grammar, per-slot op constraints (Instructions accepts all four targeted ops; Responsibility accepts append + whole-slot replace; Identity/Soul are append-only; Project Context is L4-exclusive append-only; Vault is L1-exclusive — rejected in L4)


### PR DESCRIPTION
## Planning contract

Acceptance contract is the AC list in the issue body of #10650 (PRD-C Story C1). The §7.1-§7.7 anchors live in COMPOSE-ARCHITECTURE. No PM-side `CONTEXT-10650.md` exists. Verifier will produce `.squidsquad/qa/planning/TEST-PLAN-10650.md` during verification per the #9184 workflow. Cited per #8950 Gate #4 requirement.

## Summary

The `references/sub-skills/common/l4-curation.md` sub-skill already exists with comprehensive content covering 7 of the 8 ACs (detection patterns, elicitation dialog, decision tree, safety gates, one-shot framing, common/ placement, frontmatter). This commit adds AC6's explicit §7.3 worked example inline: a "File format — the H3 op block" section showing the three load-bearing parts (H3 op heading, body, HTML-comment metadata trailer) plus a complete `pm.md` worked example covering Identity append, Instructions insert-before, Instructions append with sub-skill reference, and Project Context append.

## What landed

- `references/sub-skills/common/l4-curation.md` (+79 lines):
  - New "File format — the H3 op block (§7.3)" section before "Cross-references"
  - Enumerates the 5 legal H3 op heading shapes (`append`, whole-slot `replace`, `replace step:cycle/<id>`, `insert-before step:cycle/<id>`, `insert-after step:cycle/<id>`)
  - Documents the 3 load-bearing parts: H3 op heading + body + HTML-comment metadata trailer
  - Concrete worked example for a `pm.md` L4 file with 4 H3 blocks across 3 slots (Identity, Instructions, Project Context) + metadata trailers on each
  - Example deliberately omits `## Vault` to reinforce the vault-is-L1-exclusive rule
  - Notes that the metadata trailer is optional for the compose parser but mandatory for the human audit trail

## AC mapping (8/8)

| AC | Status |
|---|---|
| AC1: file exists w/ frontmatter `slot: instructions` mirroring git-commit.md | ✅ Already present (slot=instructions, ordinal=10, no roles filter; common/ placement = applies to all per Q-C1) |
| AC2: detection patterns §7.1 + 3+ worked examples per type | ✅ Already present (Activation section + dialog Step 2 mapping table) |
| AC3: elicitation dialog | ✅ Already present (8-step dialog with user-facing vs agent-internal distinction) |
| AC4: decision tree §7.2 five-step classification | ✅ Already present (Step 5 with per-slot op constraints; refuses vault/project-context per slot rules) |
| AC5: safety gates §7.4 three-gate overview | ✅ Already present (Step 8: DS audit → mini-CQ → compose dry-run in order) |
| AC6: file format §7.3 with H2/H3/metadata-trailer | ✅ **THIS COMMIT** — adds the concrete worked example inline |
| AC7: one-shot + durable §7.7 framing | ✅ Already present (line 14, line 132) |
| AC8: common/ placement per Q-C1 | ✅ Already present (path: `references/sub-skills/common/l4-curation.md`) |

## Tests

`python -m pytest tests/test_v1_byte_stability_9a.py` — 5 passed.

- §9a v1 byte-equivalence gate stays GREEN: the strip helper (compose.py cycle 1484) removes the frontmatter at v1 include time; v1 output byte-identical
- A2a's `parse_source_frontmatter` accepts the file cleanly (slot=instructions, ordinal=10)

## Notes

- v1 coexistence per body: "sub-skill is composed in only via the v2 path. v1 install does not load it. No runtime behavior change until PRD-E E6 cutover." The §9a gate proves v1 output unchanged.
- C10 (comprehension tests) develops in parallel and validates this prose ships the correct decision tree + gate behavior.
- C2 (wire into role-class instructions) lands next in the chain.
- No `roles:` filter on the frontmatter: common/ placement = applies to every role-class per Q-C1's recommendation. Mirrors git-commit.md's convention.

Closes #10650