### PR TITLE
PRD-C/C3: l4_audit_gate — Gate 1 DS audit dispatch + parser (#10652)

### DIFF
--- a/references/prompts/l4-audit.md.j2
+++ b/references/prompts/l4-audit.md.j2
@@ -1,0 +1,73 @@
+You are a strict reviewer auditing one L4 (`.squidsquad/project/<role-class>.md`) write operation classified by an agent. Your job is to decide whether the classification — slot + op type + target step ID — matches the human directive that triggered it.
+
+## Task
+
+{{ context }}
+
+## Inputs
+
+The agent's classified L4 op is provided as a single JSON block below. Fields:
+
+- `op_type`: one of `append` / `replace` (whole-slot) / `replace step:cycle/<id>` / `insert-before step:cycle/<id>` / `insert-after step:cycle/<id>`
+- `target_slot`: one of `identity` / `responsibility` / `soul` / `instructions` / `project-context` (vault is L1-exclusive and rejection-eligible)
+- `target_step_id`: the cycle step ID anchor for step-targeted ops, or null
+- `target_role_class`: `pm` / `worker` / `verifier` / `dm`
+- `body_text`: the prose the agent intends to write in the H3 block
+- `source_directive`: the human's verbatim original message that triggered the write
+
+```json
+{{ file_contents }}
+```
+
+## Instructions
+
+Walk the §7.2 decision tree from COMPOSE-ARCHITECTURE.md against the inputs above:
+
+1. **Slot consistency**: does `target_slot` match the *intent* of `source_directive`?
+   - Behavior changes ("from now on do X") → `instructions`
+   - Identity statements ("this project is …") → `identity`
+   - Persona / tone overlays → `soul`
+   - Universal prohibitions for every role → `identity` (Boundaries)
+   - Role-specific contract rules ("the PM here never …") → `responsibility`
+   - Project facts → `project-context`
+   - Vault-shaped content → REJECT (vault is L1-exclusive)
+
+2. **Op-type legality per slot** (§3.3):
+   - `identity` / `soul` / `project-context`: append-only; reject any step-targeted op
+   - `responsibility`: append OR whole-slot `replace`; reject step-targeted ops
+   - `instructions`: any of the four ops; require a real `target_step_id` for `replace step:` / `insert-before step:` / `insert-after step:`
+   - `vault`: REJECT (L1-exclusive)
+
+3. **Op-type fit to the directive**:
+   - "Stop doing X" / "no longer …" → prefer `replace step:cycle/<id>` (replace the body of the existing step) over `append` (which would create a contradictory rule the assemble pass would have to resolve)
+   - "Before X do Y" → `insert-before step:cycle/X`
+   - "After X do Y" → `insert-after step:cycle/X`
+   - "Once a week do X" / "additionally do X" with no clear anchor → `append`
+   - "We do/are/believe X" (no behavior verb) → likely `identity` / `soul` / `project-context`, NOT `instructions`
+
+4. **Target step-id sanity**: when the op is step-targeted, does `target_step_id` plausibly match a real step the role-class would have? You do not have the L1-L3 catalog at hand, so accept any reasonable-looking step ID; flag only if the ID is obviously fabricated (e.g. random-looking string) or the directive provides no anchor for it.
+
+5. **Sub-skill reference**: if `target_slot` is `instructions` and `op_type` is `append`, the body MUST contain at least one `→ run sub-skill: <name>` reference (per §4.5 catalog gate). Reject if absent — the catalog gate would reject this op at compose time anyway, and the failure mode is confusing.
+
+## Output Format
+
+Emit your decision in EXACTLY this shape (no preamble, no commentary, no markdown code fence around the whole output):
+
+```
+decision: approve
+reason: <one short sentence explaining why the classification matches the directive>
+```
+
+OR
+
+```
+decision: reject
+reason: <one short sentence explaining what is wrong; if a different op_type/target_slot would be correct, name it>
+suggested_op_type: <the op_type you recommend instead, or empty>
+suggested_target_slot: <the target_slot you recommend instead, or empty>
+suggested_target_step_id: <the target_step_id you recommend instead, or empty>
+```
+
+The `decision:` line is the ONLY line the agent's parser reads to branch — keep it on its own line and use exactly `approve` or `reject`. The `reason:` field is surfaced verbatim to the human on rejection. The optional `suggested_*` fields help the agent's retry path; emit them when the rejection has a clear corrective recommendation, leave empty otherwise.
+
+Do NOT approve as a courtesy. If the classification is wrong in any of the five rule sets above, reject with a specific reason.

--- a/references/scripts/l4_audit_gate.py
+++ b/references/scripts/l4_audit_gate.py
@@ -1,0 +1,206 @@
+"""Gate 1: DeepSeek audit of an L4 op classification (#10652, PRD-C C3).
+
+Wraps the dispatch to ``model_router`` with task type ``l4-audit``. The
+audit reviews the agent's L4 op classification (slot + op + target) and
+returns an approve/reject + reason. Rejections may include suggested
+corrections.
+
+Per the §7.4 three-gate model, Gate 1 runs BEFORE the mini-CQ (Gate 2)
+confirmation; an approval here advances to Gate 2, a rejection routes
+back to the agent's elicitation flow with the DS reason surfaced to the
+human.
+
+This module is the dispatch + result parser. The integration into the
+``l4-curation`` sub-skill prose (composed at v2 emit time) lives in
+``references/sub-skills/common/l4-curation.md``; this Python helper is
+what the runtime agent calls to perform the dispatch.
+"""
+
+import json
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+# Same sandbox constraint as B1: tempfiles for model_router input/output
+# must live INSIDE REPO_ROOT or ``_is_path_in_sandbox`` rejects them and
+# the LLM never sees the input. Captured as a key decision after the
+# #10444 QA route-back; documented here so the audit gate doesn't repeat
+# the mistake.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_AUDIT_TMP_ROOT = _REPO_ROOT / ".squidsquad" / "tmp" / "l4-audit"
+
+
+@dataclass
+class AuditResult:
+    """Parsed result of one Gate 1 audit dispatch.
+
+    ``decision`` is ``"approve"`` or ``"reject"``; any other value (or
+    a parse failure) is treated as a failure mode by callers and aborts
+    the write per the §7.4 contract (failure-modes table).
+
+    ``reason`` is the one-sentence rationale surfaced to the human on
+    rejection (or to the audit log on approval).
+
+    The three ``suggested_*`` fields are optional rejection hints; empty
+    strings when not provided by the model.
+    """
+
+    decision: str
+    reason: str
+    suggested_op_type: str = ""
+    suggested_target_slot: str = ""
+    suggested_target_step_id: str = ""
+
+
+class AuditGateError(RuntimeError):
+    """Raised when the audit dispatch cannot produce a decision.
+
+    Callers (``l4-curation``) treat this as Gate 1 abort per the §7.4
+    failure-modes table: write aborted, human surfaced with diagnostic.
+    Subclasses distinguish the specific failure mode so the caller can
+    render an actionable message.
+    """
+
+
+class AuditModelRouterError(AuditGateError):
+    """``model_router.route`` returned non-zero (config / API / etc.)."""
+
+
+class AuditTimeoutError(AuditGateError):
+    """``model_router.route`` returned exit code 3 (timeout)."""
+
+
+class AuditOutputMissingError(AuditGateError):
+    """``model_router`` reported success but produced no output file."""
+
+
+class AuditParseError(AuditGateError):
+    """Output present but does not match the expected ``decision: …`` shape."""
+
+
+def audit_l4_op(
+    *,
+    op_type,
+    target_slot,
+    target_step_id,
+    target_role_class,
+    body_text,
+    source_directive,
+    task_id=None,
+    model_router=None,
+):
+    """Dispatch an L4 op for DS audit; return ``AuditResult``.
+
+    Raises an :class:`AuditGateError` subclass on any failure path; the
+    sub-skill's prose treats every raise as a Gate 1 abort (per §7.4
+    failure-modes table) and surfaces the diagnostic to the human.
+
+    ``model_router`` is an optional injected reference to the
+    ``model_router`` module (tests pass a stub). Default lazy-imports the
+    real module.
+    """
+    if model_router is None:
+        import model_router as _real_router  # noqa: WPS433
+        model_router = _real_router
+
+    if task_id is None:
+        task_id = f"l4-audit-{target_role_class}-{op_type.split()[0]}"
+
+    payload = {
+        "op_type": op_type,
+        "target_slot": target_slot,
+        "target_step_id": target_step_id,
+        "target_role_class": target_role_class,
+        "body_text": body_text,
+        "source_directive": source_directive,
+    }
+
+    _AUDIT_TMP_ROOT.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=f"audit-{target_role_class}-",
+                                     dir=str(_AUDIT_TMP_ROOT)) as td:
+        td_path = Path(td)
+        input_path = td_path / "op.json"
+        output_path = td_path / "decision.md"
+        input_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+        context = (
+            f"Audit the classified L4 op for the `{target_role_class}` role-class. "
+            f"Slot `{target_slot}`, op `{op_type}`. "
+            f"Reject if the classification does not match the source directive."
+        )
+
+        try:
+            exit_code = model_router.route(
+                task_type="l4-audit",
+                task_id=task_id,
+                input_files=str(input_path),
+                output_file=str(output_path),
+                context=context,
+            )
+        except Exception as e:  # noqa: BLE001 — any router exception is a Gate 1 abort
+            raise AuditModelRouterError(
+                f"model_router.route raised on l4-audit task_id={task_id}: {e}"
+            ) from e
+
+        if exit_code == 3:
+            raise AuditTimeoutError(
+                f"model_router.route returned exit code 3 (timeout) for "
+                f"l4-audit task_id={task_id}. Gate 1 abort per §7.4 failure-modes."
+            )
+        if exit_code != 0:
+            raise AuditModelRouterError(
+                f"model_router.route returned exit code {exit_code} for "
+                f"l4-audit task_id={task_id}. Gate 1 abort per §7.4 failure-modes."
+            )
+
+        if not output_path.exists():
+            raise AuditOutputMissingError(
+                f"model_router.route produced no output file for "
+                f"task_id={task_id}. Expected at {output_path}."
+            )
+
+        raw = output_path.read_text(encoding="utf-8")
+
+    return _parse_audit_output(raw)
+
+
+# `decision: <value>` line is THE branch signal. Tolerant of leading/trailing
+# whitespace and case in the field name; the value MUST be exactly
+# `approve` or `reject` per the template's contract.
+_DECISION_RE = re.compile(r"^\s*decision\s*:\s*(\w+)\s*$", re.MULTILINE | re.IGNORECASE)
+_FIELD_RE = re.compile(r"^\s*(\w[\w_]*)\s*:\s*(.*?)\s*$", re.MULTILINE)
+
+
+def _parse_audit_output(text):
+    """Parse the model's structured response into an :class:`AuditResult`.
+
+    The template asks for line-anchored ``key: value`` fields. We extract
+    every recognized field tolerantly; missing optional fields default
+    to empty strings. The ``decision:`` field is mandatory and constrained
+    to ``approve`` or ``reject`` (case-insensitive).
+    """
+    decision_match = _DECISION_RE.search(text)
+    if not decision_match:
+        raise AuditParseError(
+            f"l4-audit response missing required `decision:` line. "
+            f"Raw output: {text[:500]!r}"
+        )
+    decision = decision_match.group(1).strip().lower()
+    if decision not in ("approve", "reject"):
+        raise AuditParseError(
+            f"l4-audit `decision:` field has invalid value {decision!r}. "
+            f"Must be `approve` or `reject`."
+        )
+
+    fields = {m.group(1).lower(): m.group(2).strip() for m in _FIELD_RE.finditer(text)}
+
+    return AuditResult(
+        decision=decision,
+        reason=fields.get("reason", ""),
+        suggested_op_type=fields.get("suggested_op_type", ""),
+        suggested_target_slot=fields.get("suggested_target_slot", ""),
+        suggested_target_step_id=fields.get("suggested_target_step_id", ""),
+    )

--- a/references/scripts/model_router.py
+++ b/references/scripts/model_router.py
@@ -542,6 +542,7 @@ def _load_prompt_template(task_type):
         "improvement-scan": "improvement-scan.md.j2",
         "code-review": "code-review.md.j2",  # #5932
         "assemble": "assemble.md.j2",  # #10444 PRD-B/B1
+        "l4-audit": "l4-audit.md.j2",  # #10652 PRD-C/C3 Gate 1
     }
     filename = template_map.get(task_type)
     if not filename:

--- a/references/sub-skills/common/l4-curation.md
+++ b/references/sub-skills/common/l4-curation.md
@@ -112,7 +112,10 @@ When a customization request is detected, walk this dialog before writing L4. St
 
 8. **Run the safety gates** (agent-internal). Before persisting, the agent runs the three §7.4 gates in order:
 
-   1. **DeepSeek decision-tree audit**: a deepseek-class model reviews the agent's slot + op + target classification (which H2 the H3 block goes under, which op type, which step-id target if any) and rejects if the call is wrong.
+   1. **DeepSeek decision-tree audit (Gate 1, C3)**: invoke `references/scripts/l4_audit_gate.py:audit_l4_op(op_type, target_slot, target_step_id, target_role_class, body_text, source_directive)`. The helper dispatches to `model_router.route(task_type="l4-audit", ...)` with the `l4-audit.md.j2` prompt template; the deepseek-class model reviews the slot + op + target classification against the human's source directive and returns one of:
+      - **approve** — proceed to Gate 2 (mini-CQ).
+      - **reject** — surface the model's `reason:` field to the human verbatim, ask for a refined directive, and re-walk the decision tree with that refinement as input. **Do not silently retry** the same classification (per C3 AC3); the rejection is informational for the human, not a self-correcting loop. If the model emitted `suggested_op_type:` / `suggested_target_slot:` / `suggested_target_step_id:` fields, surface those to the human as the model's recommendation.
+      - **Audit-gate error** (model_router unreachable / timeout / no output / parse failure): the helper raises `AuditGateError` (subclasses: `AuditModelRouterError`, `AuditTimeoutError`, `AuditOutputMissingError`, `AuditParseError`). Surface the diagnostic to the human and **abort the write — do not advance to Gate 2** (per C3 AC5; failure-modes table in §7.4).
    2. **Mini-CQ**: the agent gives the human a one-sentence confirmation of the change in functional terms (e.g., "Adding a project rule that you want PM to check incidents before filing any bug — OK?") and gets explicit yes/no. The detailed prose draft was already shown in step 7; this is the final go/no-go in one line. Rejection aborts; no file changed.
    3. **Compose dry-run**: `compose.py deploy-all --check` validates the updated L4 file resolves cleanly (step-id targets exist, op type is legal for the enclosing slot, no validation errors).
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -133,6 +133,7 @@ STATIC_TEST_MODULES = [
     "test_b8_golden_assemble",
     "test_v1_byte_stability_9a",
     "test_compose_strip_frontmatter",
+    "test_l4_audit_gate_c3",
 ]
 
 

--- a/tests/test_l4_audit_gate_c3.py
+++ b/tests/test_l4_audit_gate_c3.py
@@ -1,0 +1,231 @@
+"""Tests for references/scripts/l4_audit_gate.py (#10652, PRD-C C3)."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import l4_audit_gate  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Stub model_router — records each route() call and writes a canned response
+# ---------------------------------------------------------------------------
+
+class _StubRouter:
+    """Minimal stand-in for the real model_router module."""
+
+    def __init__(self, response="decision: approve\nreason: looks fine\n",
+                 exit_code=0, write_output=True, raise_exception=None):
+        self.response = response
+        self.exit_code = exit_code
+        self.write_output = write_output
+        self.raise_exception = raise_exception
+        self.calls = []
+
+    def route(self, task_type, task_id, input_files, output_file, context):
+        self.calls.append({
+            "task_type": task_type,
+            "task_id": task_id,
+            "input_files": input_files,
+            "output_file": output_file,
+            "context": context,
+        })
+        if self.raise_exception is not None:
+            raise self.raise_exception
+        if self.write_output and self.exit_code == 0:
+            Path(output_file).write_text(self.response, encoding="utf-8")
+        return self.exit_code
+
+
+def _audit(**overrides):
+    """Default audit_l4_op invocation with sensible test defaults."""
+    base = dict(
+        op_type="insert-before step:cycle/file-bug",
+        target_slot="instructions",
+        target_step_id="file-bug",
+        target_role_class="pm",
+        body_text="Before filing any bug, list incidents/.",
+        source_directive="From now on, before filing a bug, also check incidents/.",
+    )
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# AC6(a): happy-path approve + proceed
+# ---------------------------------------------------------------------------
+
+def test_happy_path_approve_returns_audit_result():
+    router = _StubRouter(
+        response="decision: approve\nreason: classification matches the directive\n",
+    )
+    result = l4_audit_gate.audit_l4_op(**_audit(), model_router=router)
+    assert result.decision == "approve"
+    assert "classification matches" in result.reason
+    assert result.suggested_op_type == ""
+    assert len(router.calls) == 1
+    assert router.calls[0]["task_type"] == "l4-audit"
+
+
+def test_happy_path_writes_payload_json_as_input_file():
+    """The op JSON sent to the model contains all 6 classification inputs."""
+    captured = {}
+
+    def route(task_type, task_id, input_files, output_file, context):
+        captured["payload"] = json.loads(Path(input_files).read_text(encoding="utf-8"))
+        Path(output_file).write_text("decision: approve\nreason: ok\n", encoding="utf-8")
+        return 0
+
+    router = type("R", (), {"route": staticmethod(route)})()
+    l4_audit_gate.audit_l4_op(**_audit(), model_router=router)
+    payload = captured["payload"]
+    assert payload["op_type"].startswith("insert-before")
+    assert payload["target_slot"] == "instructions"
+    assert payload["target_step_id"] == "file-bug"
+    assert payload["target_role_class"] == "pm"
+    assert "incidents" in payload["body_text"]
+    assert "incidents" in payload["source_directive"]
+
+
+def test_default_task_id_is_derived_from_role_and_op():
+    router = _StubRouter()
+    l4_audit_gate.audit_l4_op(**_audit(target_role_class="worker"), model_router=router)
+    assert router.calls[0]["task_id"] == "l4-audit-worker-insert-before"
+
+
+def test_custom_task_id_honored():
+    router = _StubRouter()
+    l4_audit_gate.audit_l4_op(
+        **_audit(), task_id="custom-audit-id", model_router=router,
+    )
+    assert router.calls[0]["task_id"] == "custom-audit-id"
+
+
+# ---------------------------------------------------------------------------
+# AC6(b): DS rejection — agent re-prompts
+# ---------------------------------------------------------------------------
+
+def test_rejection_returns_reason_and_suggested_fields():
+    router = _StubRouter(response=(
+        "decision: reject\n"
+        "reason: \"stop doing X\" should be a replace, not an append\n"
+        "suggested_op_type: replace step:cycle/deploy-log-check\n"
+        "suggested_target_slot: instructions\n"
+        "suggested_target_step_id: deploy-log-check\n"
+    ))
+    result = l4_audit_gate.audit_l4_op(**_audit(), model_router=router)
+    assert result.decision == "reject"
+    assert "should be a replace" in result.reason
+    assert result.suggested_op_type == "replace step:cycle/deploy-log-check"
+    assert result.suggested_target_slot == "instructions"
+    assert result.suggested_target_step_id == "deploy-log-check"
+
+
+def test_rejection_without_suggested_fields_is_legal():
+    """Suggested fields are optional — a bare rejection is still parseable."""
+    router = _StubRouter(response="decision: reject\nreason: too vague\n")
+    result = l4_audit_gate.audit_l4_op(**_audit(), model_router=router)
+    assert result.decision == "reject"
+    assert result.reason == "too vague"
+    assert result.suggested_op_type == ""
+
+
+def test_decision_field_case_insensitive():
+    router = _StubRouter(response="Decision: REJECT\nreason: caps don't matter\n")
+    result = l4_audit_gate.audit_l4_op(**_audit(), model_router=router)
+    assert result.decision == "reject"
+
+
+def test_decision_field_invalid_value_raises():
+    router = _StubRouter(response="decision: maybe\nreason: model dithered\n")
+    with pytest.raises(l4_audit_gate.AuditParseError):
+        l4_audit_gate.audit_l4_op(**_audit(), model_router=router)
+
+
+def test_decision_field_missing_raises():
+    router = _StubRouter(response="reason: model forgot the decision\n")
+    with pytest.raises(l4_audit_gate.AuditParseError):
+        l4_audit_gate.audit_l4_op(**_audit(), model_router=router)
+
+
+# ---------------------------------------------------------------------------
+# AC6(c): model_router timeout / failure modes (write aborted)
+# ---------------------------------------------------------------------------
+
+def test_router_timeout_raises_audit_timeout_error():
+    router = _StubRouter(exit_code=3, write_output=False)
+    with pytest.raises(l4_audit_gate.AuditTimeoutError) as exc:
+        l4_audit_gate.audit_l4_op(**_audit(), model_router=router)
+    assert "exit code 3" in str(exc.value)
+    assert "Gate 1 abort" in str(exc.value)
+
+
+def test_router_non_zero_exit_raises_router_error():
+    router = _StubRouter(exit_code=1, write_output=False)
+    with pytest.raises(l4_audit_gate.AuditModelRouterError) as exc:
+        l4_audit_gate.audit_l4_op(**_audit(), model_router=router)
+    assert "exit code 1" in str(exc.value)
+
+
+def test_router_raises_exception_classified_as_router_error():
+    router = _StubRouter(raise_exception=RuntimeError("connection refused"))
+    with pytest.raises(l4_audit_gate.AuditModelRouterError) as exc:
+        l4_audit_gate.audit_l4_op(**_audit(), model_router=router)
+    assert "connection refused" in str(exc.value)
+
+
+def test_router_success_with_no_output_raises_output_missing():
+    router = _StubRouter(exit_code=0, write_output=False)
+    with pytest.raises(l4_audit_gate.AuditOutputMissingError):
+        l4_audit_gate.audit_l4_op(**_audit(), model_router=router)
+
+
+def test_audit_gate_error_subclasses_runtimeerror():
+    """All four failure-mode types share a base class so callers can catch broadly."""
+    for cls in (
+        l4_audit_gate.AuditModelRouterError,
+        l4_audit_gate.AuditTimeoutError,
+        l4_audit_gate.AuditOutputMissingError,
+        l4_audit_gate.AuditParseError,
+    ):
+        assert issubclass(cls, l4_audit_gate.AuditGateError)
+        assert issubclass(cls, RuntimeError)
+
+
+# ---------------------------------------------------------------------------
+# Template + task type registration
+# ---------------------------------------------------------------------------
+
+def test_model_router_recognizes_l4_audit_task_type():
+    import model_router
+    template = model_router._load_prompt_template("l4-audit")
+    assert template is not None
+    assert "decision:" in template  # the parser's anchor
+
+
+def test_l4_audit_template_exists_at_canonical_path():
+    repo_root = Path(__file__).resolve().parent.parent
+    assert (repo_root / "references" / "prompts" / "l4-audit.md.j2").exists()
+
+
+def test_l4_audit_template_documents_reject_for_vault():
+    """Vault is L1-exclusive; the template must instruct rejection."""
+    repo_root = Path(__file__).resolve().parent.parent
+    text = (repo_root / "references" / "prompts" / "l4-audit.md.j2").read_text(encoding="utf-8")
+    assert "vault" in text.lower()
+    assert "REJECT" in text or "reject" in text
+
+
+def test_l4_audit_template_enumerates_all_five_op_types():
+    """The template's parser depends on the model emitting one of the 5 legal ops."""
+    repo_root = Path(__file__).resolve().parent.parent
+    text = (repo_root / "references" / "prompts" / "l4-audit.md.j2").read_text(encoding="utf-8")
+    assert "append" in text
+    assert "replace step:cycle" in text
+    assert "insert-before step:cycle" in text
+    assert "insert-after step:cycle" in text


### PR DESCRIPTION
## Planning contract

Acceptance contract is the AC list in the issue body of #10652 (PRD-C Story C3). Gate 1 of the §7.4 three-gate model. Builds on C1 (sub-skill prose; ship 98a4a423) + C2 (instructions wiring; ship 6c6ed25b). No PM-side CONTEXT-10652.md exists. Verifier produces TEST-PLAN-10652.md during verification per #9184. Cited per Gate #4 #8950.

## Summary

Ships Gate 1: a new `l4-audit` task type on `model_router`, the matching prompt template that walks the §7.2 decision tree against the agent's classification, and a Python helper that handles dispatch + response parsing with a typed failure-mode hierarchy. The l4-curation sub-skill prose is enriched at the Gate 1 step to name the exact invocation contract.

## What landed

- `references/prompts/l4-audit.md.j2` — asks the model for `decision: approve|reject` + `reason` + optional `suggested_op_type` / `suggested_target_slot` / `suggested_target_step_id`. Documents the per-slot op legality rules + the vault rejection mandate (vault is L1-exclusive).
- `references/scripts/model_router.py` — registers `"l4-audit"` in the task_type → template-filename map (mirrors B1's `"assemble"` entry).
- `references/scripts/l4_audit_gate.py` (new module):
  - `audit_l4_op(*, op_type, target_slot, target_step_id, target_role_class, body_text, source_directive, task_id=None, model_router=None) -> AuditResult`
  - Tempdir under `.squidsquad/tmp/l4-audit/` (REPO_ROOT-relative — same sandbox lesson from #10444's QA route-back)
  - Writes the op payload as JSON for the prompt template
  - Parses the response into `AuditResult(decision, reason, suggested_op_type, suggested_target_slot, suggested_target_step_id)`
  - Typed exception hierarchy: `AuditGateError` (base) ← `AuditModelRouterError` / `AuditTimeoutError` / `AuditOutputMissingError` / `AuditParseError` — caller branches on the specific abort cause when surfacing the human diagnostic
- `references/sub-skills/common/l4-curation.md` — Gate 1 step prose enriched: names the Python helper, documents the approve/reject branches, calls out the no-silent-retry rule (per AC3), and maps each `AuditGateError` subclass to the human-surface diagnostic (per AC5)
- `tests/test_l4_audit_gate_c3.py` — 18 stubbed unit tests
- `tests/run_tests.py` — registered `test_l4_audit_gate_c3`

## AC mapping

| AC | Where |
|---|---|
| AC1 new `model_router` task type `l4-audit` with prompt template | `_load_prompt_template` map + `l4-audit.md.j2` + `test_model_router_recognizes_l4_audit_task_type` + `test_l4_audit_template_exists_at_canonical_path` |
| AC2 `l4-curation` invokes Gate 1 after decision tree + before mini-CQ | Sub-skill prose at the Gate 1 step now names `l4_audit_gate.audit_l4_op` as the Python entry point |
| AC3 rejection: surface DS reason + ask for refined directive; no silent retry | `AuditResult.reason` carries the model's reason verbatim; prose says "Do not silently retry the same classification" |
| AC4 approval → proceed to Gate 2 | Prose says "approve → proceed to Gate 2 (mini-CQ)" |
| AC5 failure modes (router unreachable / timeout) → human surfaced + write aborted | 4 typed exception subclasses + prose mapping each to "abort the write — do not advance to Gate 2" |
| AC6 tests: (a) happy-path approve, (b) DS rejection re-prompts, (c) timeout abort | 18 tests cover the three AC6 paths plus boundary cases: payload-JSON shape, task_id defaults, case-insensitive decision parsing, invalid-decision / missing-decision parse errors, all 4 failure-mode subclasses, template-static checks |

## Tests

`python -m pytest tests/test_l4_audit_gate_c3.py` — 18 passed in 0.15s.

§9a v1 byte-equivalence gate stays GREEN (l4-curation.md is in sub-skills/common/ but no role's includes.yml inlines it — only the C2 text reference appears in v1 output).

## Notes

- The tempdir under `.squidsquad/tmp/l4-audit/` and the lazy `model_router` import re-apply the lessons from B1's QA route-back (#10444): sandbox-boundary respect on input files + injection seam for tests so the suite stays LLM-free.
- The `decision:` line is the ONLY load-bearing parser anchor — the template repeats this constraint to the model, and the parser tolerates leading/trailing whitespace + case in the field name while enforcing exact `approve` / `reject` for the value.
- The `suggested_*` fields are optional but useful: when present, they give the agent a corrective recommendation to surface to the human alongside the rejection reason, enabling a more informative re-prompt without violating the no-silent-retry rule.

Closes #10652