### PR TITLE
PRD-C/C5: l4_compose_dryrun — Gate 3 staged --check + per-alias aggregation (#10654)

### DIFF
--- a/references/scripts/l4_compose_dryrun.py
+++ b/references/scripts/l4_compose_dryrun.py
@@ -1,0 +1,197 @@
+"""Gate 3: compose dry-run via A4.5 staged --check (#10654, PRD-C C5).
+
+After Gate 2 (mini-CQ) approves, ``l4-curation`` writes the proposed L4
+file to a temp path and invokes the per-alias staged-content check
+``compose.py deploy <alias> --check --staged-l4 <tmp>`` for EVERY alias
+of the affected role-class. Any failure aborts the write.
+
+This module wraps the per-alias dispatch + result aggregation. The
+underlying validation work was done by A4.5 (#10395) which exposes
+``compose.check_alias_staged_l4`` for in-process callers; this module
+calls THAT directly rather than subprocessing the CLI so the audit
+runs in the agent's process.
+
+The staged L4 file is written to ``.squidsquad/tmp/l4-dryrun/`` so it
+stays inside the model_router sandbox boundary (the lesson #10444 left
+us with: every Python helper that touches inputs the router will see
+must keep the path under REPO_ROOT). Even though Gate 3 does not
+itself call the router, keeping tempfiles under REPO_ROOT prevents the
+audit trail from referencing system paths.
+"""
+
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_DRYRUN_TMP_ROOT = _REPO_ROOT / ".squidsquad" / "tmp" / "l4-dryrun"
+
+
+@dataclass
+class DryrunFailure:
+    """One alias's failure during the staged-content dry-run.
+
+    ``rule`` is the R1-R7 label when A4.5 returns a
+    :class:`LinkStageValidationError`; otherwise ``"<setup>"`` for
+    setup errors (missing alias, missing staged file, parse failure)
+    or ``"<other>"`` for any unexpected exception.
+
+    ``detail`` is the diagnostic surfaced verbatim to the human per
+    AC2 ("Dry-run failed: <reason>").
+    """
+
+    alias: str
+    rule: str
+    detail: str
+
+
+@dataclass
+class DryrunResult:
+    """Outcome of dispatching the staged-content dry-run to every alias.
+
+    ``passed`` is ``True`` iff EVERY alias passes (per AC3). Even one
+    failure trips this to ``False`` and ``failures`` records each alias
+    that failed (so callers can render a list to the human when more
+    than one alias is broken — e.g. an L4 op that targets a step which
+    exists in one variant but not another).
+    """
+
+    passed: bool
+    failures: list = field(default_factory=list)
+
+
+def dryrun_l4(
+    staged_l4_text,
+    role_class,
+    *,
+    target_root=None,
+    registry=None,
+    check_alias_staged_l4_fn=None,
+):
+    """Stage ``staged_l4_text`` to a tempfile + run A4.5 check for every alias of ``role_class``.
+
+    Returns :class:`DryrunResult`. Never raises — every failure mode
+    (validation, setup, unexpected exception) is captured into the
+    result so the caller can branch cleanly per AC2/AC3.
+
+    Per AC4 the staged file is NOT written over the on-disk L4. The
+    function writes the staged content to a tempfile under
+    ``.squidsquad/tmp/l4-dryrun/`` and passes its path as the
+    ``--staged-l4`` argument; A4.5's helper uses this for the specified
+    alias while the on-disk L4 (the live file) is what the OTHER
+    aliases of the role-class still read at the same compose run. We
+    test the cross-alias-validation property by running the staged
+    check once per alias against the same tempfile (the OTHER aliases
+    of the role-class share the L4 file, but each alias still resolves
+    via A2d's walk against the same staged text — A4.5's call shape).
+
+    Injection seams:
+    - ``target_root``: where the staged file's parent directory lives
+      (defaults to ``REPO_ROOT``). Tests pass a tmp_path.
+    - ``registry``: pre-parsed alias registry. When omitted, the
+      A4.5 helper resolves it from ``.squidsquad/config.md`` via
+      ``parse_aliases_registry``.
+    - ``check_alias_staged_l4_fn``: stub for tests so the suite can
+      simulate per-alias pass/fail without running the full link
+      stage. Defaults to ``compose.check_alias_staged_l4``.
+    """
+    if check_alias_staged_l4_fn is None:
+        import compose as _compose
+        check_alias_staged_l4_fn = _compose.check_alias_staged_l4
+    if registry is None:
+        from config import parse_aliases_registry
+        registry = parse_aliases_registry()
+
+    aliases_for_role = [
+        alias for alias, (rc, _l3) in registry.items() if rc == role_class
+    ]
+    if not aliases_for_role:
+        return DryrunResult(
+            passed=False,
+            failures=[DryrunFailure(
+                alias="<none>",
+                rule="<setup>",
+                detail=(
+                    f"no aliases of role-class `{role_class}` in the install's "
+                    f"`## Aliases` registry; nothing to dry-run against. "
+                    f"Confirm the role-class is in `.squidsquad/config.md` "
+                    f"before retrying."
+                ),
+            )],
+        )
+
+    _DRYRUN_TMP_ROOT.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=f"dryrun-{role_class}-",
+                                     dir=str(_DRYRUN_TMP_ROOT)) as td:
+        staged_path = Path(td) / f"{role_class}.staged.md"
+        staged_path.write_text(staged_l4_text, encoding="utf-8")
+
+        failures = []
+        for alias in aliases_for_role:
+            failure = _dryrun_one_alias(
+                alias=alias,
+                staged_path=staged_path,
+                target_root=target_root,
+                registry=registry,
+                check_fn=check_alias_staged_l4_fn,
+            )
+            if failure is not None:
+                failures.append(failure)
+
+    if failures:
+        return DryrunResult(passed=False, failures=failures)
+    return DryrunResult(passed=True)
+
+
+def _dryrun_one_alias(*, alias, staged_path, target_root, registry, check_fn):
+    """Invoke A4.5's helper for one alias. Return ``DryrunFailure`` or ``None``."""
+    # Late import so test stubs don't have to install A4.5 dependencies
+    # to use the injection seam.
+    try:
+        from link_stage_validator import LinkStageValidationError
+    except ImportError:
+        LinkStageValidationError = ValueError  # noqa: N806 — fallback for test stubs
+
+    try:
+        check_fn(alias, staged_path, target_root=target_root, registry=registry)
+    except LinkStageValidationError as e:
+        return DryrunFailure(
+            alias=alias,
+            rule=getattr(e, "rule", "<validation>"),
+            detail=str(e),
+        )
+    except (FileNotFoundError, KeyError) as e:
+        # Setup-class errors per A4.5 contract: missing alias, missing
+        # staged file, registry resolution fault.
+        return DryrunFailure(
+            alias=alias,
+            rule="<setup>",
+            detail=str(e),
+        )
+    except Exception as e:  # noqa: BLE001 — anything else is a Gate 3 abort
+        return DryrunFailure(
+            alias=alias,
+            rule="<other>",
+            detail=f"{type(e).__name__}: {e}",
+        )
+    return None
+
+
+def format_failure_for_human(result):
+    """Render the failures in :class:`DryrunResult` as one human-facing string.
+
+    Matches the AC2 phrasing ("Dry-run failed: <reason>") and handles
+    the multi-alias case by enumerating each alias's failure on its
+    own line. Returns the empty string when the result passed (callers
+    branch on ``passed``; this helper exists for the surface step).
+    """
+    if result.passed:
+        return ""
+    if len(result.failures) == 1:
+        f = result.failures[0]
+        return f"Dry-run failed for alias `{f.alias}`: [{f.rule}] {f.detail}"
+    lines = [f"Dry-run failed for {len(result.failures)} alias(es):"]
+    for f in result.failures:
+        lines.append(f"  - `{f.alias}`: [{f.rule}] {f.detail}")
+    return "\n".join(lines)

--- a/references/sub-skills/common/l4-curation.md
+++ b/references/sub-skills/common/l4-curation.md
@@ -120,7 +120,10 @@ When a customization request is detected, walk this dialog before writing L4. St
       - **approve** — proceed to Gate 3 (compose dry-run).
       - **reject** — acknowledge in conversation, **cancel the write** (no file changed), and ask for a refined directive. The negative path is final on the first reject (no retry).
       - **ambiguous** — re-ask the same confirmation question ONCE. If the second reply is also ambiguous, **abandon the write** and surface to the human: "I can't tell whether you want to proceed; we can revisit the change later." (Per C4 AC4's 2-strike rule.) The classifier is intentionally conservative: mixed signals (e.g. "yes but no") are ambiguous, not approve — false approvals would commit an unintended L4 write.
-   3. **Compose dry-run**: `compose.py deploy-all --check` validates the updated L4 file resolves cleanly (step-id targets exist, op type is legal for the enclosing slot, no validation errors).
+   3. **Compose dry-run (Gate 3, C5)**: invoke `references/scripts/l4_compose_dryrun.py:dryrun_l4(staged_l4_text, role_class)`. The helper writes the proposed L4 file to a tempfile under `.squidsquad/tmp/l4-dryrun/` (REPO_ROOT-relative — same sandbox rule as the other gate helpers) and runs A4.5's `compose.check_alias_staged_l4(alias, staged_path)` for EVERY alias of the affected role-class. The result is `DryrunResult(passed, failures)`:
+      - `passed=True` — all aliases cleared all R1-R7 rules. Proceed to C6 atomic commit.
+      - `passed=False` — at least one alias failed. Surface via `format_failure_for_human(result)` ("Dry-run failed for alias `<a>`: [`R5`] orphan step-id `<id>`"). Abort the write and re-prompt for refinement.
+      - Per AC4 the on-disk L4 is NOT replaced by the staged file — A4.5's helper reads the staged path for the specified alias while OTHER aliases of the same role-class continue to see the on-disk file. The cross-alias validation is built in: the dispatch runs one check per alias, so a step ID that exists in one variant's L3 but not another's surfaces as a per-alias failure with the failing alias named in the diagnostic.
 
    Only after all three gates pass does the agent append the H3 block to the L4 file and commit. The gates are agent-side, not part of the compose pipeline itself — the file does not change until all three are green.
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -135,6 +135,7 @@ STATIC_TEST_MODULES = [
     "test_compose_strip_frontmatter",
     "test_l4_audit_gate_c3",
     "test_l4_mini_cq_c4",
+    "test_l4_compose_dryrun_c5",
 ]
 
 

--- a/tests/test_l4_compose_dryrun_c5.py
+++ b/tests/test_l4_compose_dryrun_c5.py
@@ -1,0 +1,279 @@
+"""Tests for references/scripts/l4_compose_dryrun.py (#10654, PRD-C C5)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import l4_compose_dryrun  # noqa: E402
+from link_stage_validator import LinkStageValidationError  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_CLEAN_L4 = (
+    "## Instructions\n\n"
+    "### append\n\n"
+    "→ run sub-skill: weekly-smoke\n\n"
+    "Once a week, run the security smoke tests as part of the cycle.\n"
+)
+
+
+def _registry(*alias_to_role_class):
+    """Build a registry dict shaped like ``parse_aliases_registry`` output."""
+    return {alias: (role_class, None) for alias, role_class in alias_to_role_class}
+
+
+def _stub_check(approve_aliases=(), reject_aliases=()):
+    """Build a check_alias_staged_l4 stub that approves / rejects per alias.
+
+    ``approve_aliases`` and ``reject_aliases`` are iterables of alias names.
+    Approval is a no-op; rejection raises ``LinkStageValidationError``
+    with a configurable rule label.
+    """
+    approve = set(approve_aliases)
+    reject = {alias: rule_or_message for alias, rule_or_message in reject_aliases}
+
+    def check(alias, staged_path, *, target_root=None, registry=None):
+        if alias in approve:
+            return
+        if alias in reject:
+            rule, message = reject[alias]
+            raise LinkStageValidationError(rule, message)
+        # Default: approve when neither list mentions the alias.
+        return
+
+    return check
+
+
+# ---------------------------------------------------------------------------
+# AC5(a): clean L4 → DryrunResult(passed=True)
+# ---------------------------------------------------------------------------
+
+def test_clean_l4_returns_passed_true(tmp_path):
+    check = _stub_check(approve_aliases=("pm-1", "pm-2"))
+    result = l4_compose_dryrun.dryrun_l4(
+        _CLEAN_L4,
+        role_class="pm",
+        registry=_registry(("pm-1", "pm"), ("pm-2", "pm"), ("worker-1", "worker")),
+        check_alias_staged_l4_fn=check,
+    )
+    assert result.passed is True
+    assert result.failures == []
+
+
+def test_clean_l4_runs_check_for_every_alias_of_role_class(tmp_path):
+    calls = []
+
+    def check(alias, staged_path, *, target_root=None, registry=None):
+        calls.append(alias)
+
+    l4_compose_dryrun.dryrun_l4(
+        _CLEAN_L4,
+        role_class="pm",
+        registry=_registry(("pm-1", "pm"), ("pm-2", "pm"), ("worker-1", "worker")),
+        check_alias_staged_l4_fn=check,
+    )
+    # Both pm-1 and pm-2 dispatched; worker-1 NOT included (different role-class)
+    assert set(calls) == {"pm-1", "pm-2"}
+
+
+def test_clean_l4_writes_staged_content_to_tempfile_under_repo_root(tmp_path):
+    """AC4 + sandbox lesson: staged path must live under .squidsquad/tmp/l4-dryrun/."""
+    captured = {}
+
+    def check(alias, staged_path, *, target_root=None, registry=None):
+        captured["path"] = Path(staged_path)
+        captured["text"] = Path(staged_path).read_text(encoding="utf-8")
+
+    l4_compose_dryrun.dryrun_l4(
+        _CLEAN_L4,
+        role_class="pm",
+        registry=_registry(("pm-1", "pm")),
+        check_alias_staged_l4_fn=check,
+    )
+    assert captured["text"] == _CLEAN_L4
+    # Path lives inside REPO_ROOT/.squidsquad/tmp/l4-dryrun/.
+    p = captured["path"].resolve()
+    assert "l4-dryrun" in p.parts
+    repo_root = Path(__file__).resolve().parent.parent
+    assert str(p).startswith(str(repo_root))
+
+
+# ---------------------------------------------------------------------------
+# AC5(b): orphan step-ID target → abort
+# AC5(c): per-slot constraint violation → abort
+# AC5(d): malformed H3 op → abort
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("rule_label,message", [
+    ("R5", "L4 op references non-existent step-id `ghost`"),
+    ("R1", "L4 file contains `## Vault` H2"),
+    ("R6", "whole-slot replace mixed with other ops"),
+])
+def test_validation_failure_returns_passed_false(rule_label, message):
+    """AC2: non-zero exit captures stderr; AC5: covers R1/R5/R6 paths."""
+    check = _stub_check(reject_aliases=[("pm-1", (rule_label, message))])
+    result = l4_compose_dryrun.dryrun_l4(
+        _CLEAN_L4,
+        role_class="pm",
+        registry=_registry(("pm-1", "pm")),
+        check_alias_staged_l4_fn=check,
+    )
+    assert result.passed is False
+    assert len(result.failures) == 1
+    f = result.failures[0]
+    assert f.alias == "pm-1"
+    assert f.rule == rule_label
+    assert message in f.detail
+
+
+def test_setup_error_classified_as_setup_rule_label(tmp_path):
+    """FileNotFoundError / KeyError from A4.5 surface as `<setup>`."""
+    def check(alias, staged_path, *, target_root=None, registry=None):
+        raise KeyError("alias 'pm-1' not found in registry")
+
+    result = l4_compose_dryrun.dryrun_l4(
+        _CLEAN_L4,
+        role_class="pm",
+        registry=_registry(("pm-1", "pm")),
+        check_alias_staged_l4_fn=check,
+    )
+    assert result.passed is False
+    assert result.failures[0].rule == "<setup>"
+
+
+def test_unexpected_exception_classified_as_other(tmp_path):
+    """Any non-validation, non-setup exception is `<other>` so callers can branch on it."""
+    def check(alias, staged_path, *, target_root=None, registry=None):
+        raise RuntimeError("compose pipeline broke in an unexpected way")
+
+    result = l4_compose_dryrun.dryrun_l4(
+        _CLEAN_L4,
+        role_class="pm",
+        registry=_registry(("pm-1", "pm")),
+        check_alias_staged_l4_fn=check,
+    )
+    assert result.failures[0].rule == "<other>"
+    assert "RuntimeError" in result.failures[0].detail
+
+
+# ---------------------------------------------------------------------------
+# AC5(e): one alias passes but another fails → abort with the failing alias named
+# ---------------------------------------------------------------------------
+
+def test_one_alias_fails_another_passes_returns_failed(tmp_path):
+    """The whole dry-run aborts when ANY alias fails (AC3)."""
+    check = _stub_check(
+        approve_aliases=("pm-1",),
+        reject_aliases=[("pm-2", ("R5", "orphan step in pm-2's variant"))],
+    )
+    result = l4_compose_dryrun.dryrun_l4(
+        _CLEAN_L4,
+        role_class="pm",
+        registry=_registry(("pm-1", "pm"), ("pm-2", "pm")),
+        check_alias_staged_l4_fn=check,
+    )
+    assert result.passed is False
+    assert len(result.failures) == 1
+    assert result.failures[0].alias == "pm-2"
+
+
+def test_multiple_alias_failures_all_recorded(tmp_path):
+    """When 2+ aliases fail, the result enumerates each."""
+    check = _stub_check(
+        reject_aliases=[
+            ("pm-1", ("R5", "orphan in pm-1")),
+            ("pm-2", ("R7", "duplicate replace in pm-2")),
+        ],
+    )
+    result = l4_compose_dryrun.dryrun_l4(
+        _CLEAN_L4,
+        role_class="pm",
+        registry=_registry(("pm-1", "pm"), ("pm-2", "pm")),
+        check_alias_staged_l4_fn=check,
+    )
+    assert result.passed is False
+    failures_by_alias = {f.alias: f.rule for f in result.failures}
+    assert failures_by_alias == {"pm-1": "R5", "pm-2": "R7"}
+
+
+# ---------------------------------------------------------------------------
+# Edge: no aliases of the role-class exist in the install
+# ---------------------------------------------------------------------------
+
+def test_role_class_with_no_aliases_returns_setup_failure():
+    """If the registry has no aliases for the requested role-class, there's
+    nothing to dry-run against. Surface as a setup failure so the caller
+    can guide the human to fix config.md."""
+    result = l4_compose_dryrun.dryrun_l4(
+        _CLEAN_L4,
+        role_class="pm",
+        registry=_registry(("worker-1", "worker")),
+        check_alias_staged_l4_fn=_stub_check(),
+    )
+    assert result.passed is False
+    assert len(result.failures) == 1
+    assert result.failures[0].rule == "<setup>"
+    assert "no aliases" in result.failures[0].detail
+
+
+# ---------------------------------------------------------------------------
+# format_failure_for_human helper
+# ---------------------------------------------------------------------------
+
+def test_format_failure_for_human_passed_returns_empty_string():
+    result = l4_compose_dryrun.DryrunResult(passed=True)
+    assert l4_compose_dryrun.format_failure_for_human(result) == ""
+
+
+def test_format_failure_for_human_single_alias_matches_ac2_phrasing():
+    result = l4_compose_dryrun.DryrunResult(
+        passed=False,
+        failures=[l4_compose_dryrun.DryrunFailure(
+            alias="pm-1", rule="R5", detail="orphan step-id `ghost`",
+        )],
+    )
+    out = l4_compose_dryrun.format_failure_for_human(result)
+    assert "Dry-run failed" in out  # AC2 phrasing
+    assert "pm-1" in out
+    assert "R5" in out
+    assert "ghost" in out
+
+
+def test_format_failure_for_human_multi_alias_enumerates_each():
+    result = l4_compose_dryrun.DryrunResult(
+        passed=False,
+        failures=[
+            l4_compose_dryrun.DryrunFailure(alias="pm-1", rule="R5", detail="orphan"),
+            l4_compose_dryrun.DryrunFailure(alias="pm-2", rule="R7", detail="dup"),
+        ],
+    )
+    out = l4_compose_dryrun.format_failure_for_human(result)
+    assert "2 alias(es)" in out
+    assert "pm-1" in out and "R5" in out
+    assert "pm-2" in out and "R7" in out
+
+
+# ---------------------------------------------------------------------------
+# DryrunResult / DryrunFailure dataclass surface
+# ---------------------------------------------------------------------------
+
+def test_dryrun_result_default_failures_is_independent_list():
+    """default_factory=list means each DryrunResult has its own list, not a shared one."""
+    a = l4_compose_dryrun.DryrunResult(passed=True)
+    b = l4_compose_dryrun.DryrunResult(passed=True)
+    a.failures.append("oops")
+    assert b.failures == []
+
+
+def test_dryrun_failure_has_all_three_fields():
+    f = l4_compose_dryrun.DryrunFailure(alias="pm-1", rule="R5", detail="orphan")
+    assert f.alias == "pm-1"
+    assert f.rule == "R5"
+    assert f.detail == "orphan"


### PR DESCRIPTION
## Planning contract

Acceptance contract is the AC list in the issue body of #10654 (PRD-C Story C5). Gate 3 of the §7.4 three-gate model. Wraps A4.5's `check_alias_staged_l4` (shipped #10395). C1 is the prose integration point. C3 (Gate 1, shipped 725c5c68) and C4 (Gate 2, shipped 3c897a63) are the upstream gates feeding approve into this dispatch. No PM-side `CONTEXT-10654.md`. Verifier produces `TEST-PLAN-10654.md` per #9184. Cited per Gate #4 #8950.

## Summary

Ships Gate 3: a small module that aggregates A4.5's per-alias staged-content check across every alias of the affected role-class. Cross-alias validation is built in (one check per alias). The staged content is written to a tempfile under `.squidsquad/tmp/l4-dryrun/` and the on-disk L4 is NOT replaced (per AC4). Never raises — every failure mode is captured into the result so the caller branches cleanly per AC2/AC3.

## What landed

- `references/scripts/l4_compose_dryrun.py` (new module):
  - `DryrunResult(passed, failures)` + `DryrunFailure(alias, rule, detail)` dataclasses with `default_factory=list` for the failure list (independence between instances)
  - `dryrun_l4(staged_l4_text, role_class, *, target_root=None, registry=None, check_alias_staged_l4_fn=None) -> DryrunResult` — main entry point
  - `format_failure_for_human(result) -> str` — renders the AC2 phrasing ("Dry-run failed: <reason>") + enumerates each alias in the multi-alias case
  - Calls `compose.check_alias_staged_l4` directly (in-process) instead of subprocessing the CLI, so the audit runs in the agent's process tree
  - Tempfiles under `.squidsquad/tmp/l4-dryrun/` (REPO_ROOT-relative — sandbox lesson from #10444 generalized to every Python helper that handles model_router-visible inputs, even when the helper doesn't call the router itself)
  - Failure-mode classification: `LinkStageValidationError` → carries the R1-R7 label; `FileNotFoundError` / `KeyError` → `<setup>`; any other exception → `<other>` (so callers can render specific guidance)
- `references/sub-skills/common/l4-curation.md` — Gate 3 prose enriched: names `dryrun_l4` + `format_failure_for_human` as the helpers; documents the on-disk-not-replaced rule (AC4); calls out the built-in cross-alias validation
- `tests/test_l4_compose_dryrun_c5.py` (16 tests)
- `tests/run_tests.py` — registered `test_l4_compose_dryrun_c5`

## AC mapping

| AC | Where |
|---|---|
| AC1 dispatch to A4.5's `compose.py deploy <alias> --check --staged-l4 <tmp>` for every alias of the role-class | `dryrun_l4` iterates `aliases_for_role` from registry, calls A4.5's helper for each |
| AC2 non-zero exit captures diagnostic + surfaces verbatim | `format_failure_for_human` matches AC2 phrasing; per-alias rule label included |
| AC3 exit 0 for all aliases proceeds to C6 | `DryrunResult(passed=True)` + sub-skill prose names the C6 hand-off |
| AC4 `--staged-l4` does NOT replace on-disk L4; cross-alias validation | Per-alias dispatch (one check per alias); `test_clean_l4_writes_staged_content_to_tempfile_under_repo_root` pins the staged-path-not-on-disk-L4 property |
| AC5 tests: clean / orphan step-ID / per-slot violation / malformed H3 / mixed pass/fail | 16 tests cover all five paths plus edge cases (setup error classification, role-class with no aliases, multi-alias enumeration, dataclass surface) |

## Tests

`python -m pytest tests/test_l4_compose_dryrun_c5.py tests/test_v1_byte_stability_9a.py` — 21 passed.

## Notes

- **In-process dispatch instead of subprocess**: A4.5 exposes `compose.check_alias_staged_l4` as the Python entry point. Calling it directly keeps the audit in the agent's process (faster, cleaner stack traces, no subprocess overhead). The injection seam (`check_alias_staged_l4_fn` kwarg) lets tests stub per-alias outcomes without running the full link stage
- **`<setup>` vs `<other>` rule labels**: the failure-mode classification distinguishes A4.5's documented setup errors (missing alias, missing staged file, registry resolution fault) from any other exception. The `<other>` bucket exists so an unknown failure mode surfaces to the human with the exception type name attached rather than being silently swallowed
- **Role-class with no aliases**: if the registry has no aliases for the requested role-class, there's nothing to dry-run. Surfaces as a `<setup>` failure with a "fix config.md" diagnostic so the caller can guide the human

Closes #10654