### PR TITLE
skill: feat(l4): C8 conflict pre-emption — Gate 0 LLM check against linked composite (#10657)

### DIFF
--- a/references/prompts/l4-conflict-preempt.md.j2
+++ b/references/prompts/l4-conflict-preempt.md.j2
@@ -1,0 +1,58 @@
+You are a strict reviewer running a CONFLICT PRE-EMPTION check on a proposed L4 (`.squidsquad/project/<role-class>.md`) write operation. The agent has already classified the op (slot + op type + target) and drafted its body; before any safety gate fires, you must decide whether the new body would MATERIALLY CONTRADICT the existing L1-L3 prose for the target slot.
+
+The phrase "materially contradicting prose between layers" is the same vocabulary the assemble-pass (B4) detector uses. A material contradiction is one where the new body and the existing prose, both stated as imperatives, point at incompatible behaviors — not merely "different emphasis" or "complementary detail".
+
+## Task
+
+{{ context }}
+
+## Inputs
+
+The proposed L4 op and the on-disk linked composite the op would join are provided as a single JSON block:
+
+- `op_type`: one of `append` / `insert-before step:cycle/<id>` / `insert-after step:cycle/<id>`. (Whole-slot `replace` and step-targeted `replace` ops never reach this check — they supersede the prior prose by construction.)
+- `target_slot`: one of `identity` / `responsibility` / `soul` / `instructions` / `project-context`
+- `target_step_id`: the cycle step ID anchor for step-targeted ops, or null
+- `target_role_class`: `pm` / `worker` / `verifier` / `dm`
+- `body_text`: the prose the agent intends to write in the new H3 block
+- `source_directive`: the human's verbatim original message that triggered the write
+- `linked_composite`: the existing LINKED-composite prose for `(target_slot, target_role_class)` — L1, L2, L3, and prior L4 entries already merged. THIS is the corpus you check the new body against.
+
+```json
+{{ file_contents }}
+```
+
+## Instructions
+
+Apply this decision procedure in order:
+
+1. **Quote-anchored contradiction check**. For every distinct imperative in `body_text`, scan `linked_composite` for any imperative that points at a behavior the new one would prevent or invert. A contradiction must be quoteable on BOTH sides — point to specific sentences, not vague themes.
+
+2. **Sub-skill references are not contradictions**. A new `→ run sub-skill: <name>` line never contradicts an existing sub-skill reference, even if the two sub-skills cover overlapping topics. Sub-skills compose; they don't conflict at this layer.
+
+3. **Step-id locality**. For `insert-before step:cycle/X` and `insert-after step:cycle/X`, ignore prose in OTHER steps — the new body only joins the prose adjacent to step X. Only contradictions involving step X's local prose (its body, the step immediately before, the step immediately after) count as material.
+
+4. **Different emphasis is not contradiction**. "Always X" + "Also Y" + "Y is critical" do not contradict each other. "Always X" + "Never X" DO contradict. The bar is "both being true is impossible", not "they cover different ground".
+
+5. **L4 supersedes lower layers — but ONLY when the human explicitly opts in via `replace`**. If the proposed `append` / `insert-*` op would be a quieter way to override a lower layer's behavior, that IS a contradiction worth surfacing — the human should explicitly choose `replace` instead.
+
+## Output Format
+
+Emit your decision in EXACTLY this shape (no preamble, no commentary, no markdown code fence around the whole output):
+
+```
+decision: clean
+why: <one short sentence stating that no material contradiction was found>
+```
+
+OR
+
+```
+decision: contradiction
+why: <one short sentence stating what behavior the new body contradicts>
+quote_new: <verbatim sentence(s) from body_text>
+quote_existing: <verbatim sentence(s) from linked_composite>
+suggested_action: <one of `replace-reframe` (if a `replace step:cycle/<id>` of the conflicting step would resolve cleanly) OR `abandon` (if the new directive is incompatible with the role's shipped contract) OR `reword` (if a small wording change would lift the contradiction without changing intent)>
+```
+
+The `decision:` line is the ONLY line the agent's parser reads to branch — keep it on its own line and use exactly `clean` or `contradiction`. On contradiction, the four extra fields are surfaced to the human verbatim so they can choose between the suggested action and a different reframe. Do NOT report `clean` as a courtesy; if the new body would force the assemble-pass to reconcile a real contradiction, surface it here so the human resolves it explicitly instead of letting the assemble-pass paper over it later.

--- a/references/prompts/l4-conflict-preempt.md.j2
+++ b/references/prompts/l4-conflict-preempt.md.j2
@@ -50,9 +50,11 @@ OR
 ```
 decision: contradiction
 why: <one short sentence stating what behavior the new body contradicts>
-quote_new: <verbatim sentence(s) from body_text>
-quote_existing: <verbatim sentence(s) from linked_composite>
+quote_new: <ONE verbatim sentence from body_text — single line, no embedded newlines>
+quote_existing: <ONE verbatim sentence from linked_composite — single line, no embedded newlines>
 suggested_action: <one of `replace-reframe` (if a `replace step:cycle/<id>` of the conflicting step would resolve cleanly) OR `abandon` (if the new directive is incompatible with the role's shipped contract) OR `reword` (if a small wording change would lift the contradiction without changing intent)>
 ```
+
+The `quote_new` and `quote_existing` fields MUST be exactly one sentence each, on one line, with no newlines or markdown structural characters (no `## `, no `\n\n`). Pick the single most representative sentence from each side. If you need to convey more context, put it in the `why:` field. This constraint exists because the parser is line-anchored and the human-facing render is a single-line blockquote per side.
 
 The `decision:` line is the ONLY line the agent's parser reads to branch — keep it on its own line and use exactly `clean` or `contradiction`. On contradiction, the four extra fields are surfaced to the human verbatim so they can choose between the suggested action and a different reframe. Do NOT report `clean` as a courtesy; if the new body would force the assemble-pass to reconcile a real contradiction, surface it here so the human resolves it explicitly instead of letting the assemble-pass paper over it later.

--- a/references/scripts/l4_conflict_preempt.py
+++ b/references/scripts/l4_conflict_preempt.py
@@ -1,0 +1,306 @@
+"""C8: conflict pre-emption — checks proposed L4 op against the linked composite (#10657, PRD-C C8).
+
+Per §7.1 + §4.6 pairing, before drafting an L4 op the agent reads the
+LINKED composite for the target ``(slot, role-class)`` and runs a
+conflict pre-emption check. If the new body would MATERIALLY
+CONTRADICT existing L1-L3 prose, the agent surfaces both sides to the
+human and offers reframe options (replace-reframe / abandon / reword)
+instead of silently writing the conflicting op.
+
+This module is the dispatch + result parser for that check. The check
+is a model_router LLM call (task_type ``l4-conflict-preempt``); the
+prompt template lives in ``references/prompts/l4-conflict-preempt.md.j2``.
+
+Per AC2 the vocabulary ("materially contradicting prose between
+layers") mirrors B4 (PRD-B #10445, ``conflict_detector.py``), so a
+reader who knows B4's contract reads the same words here.
+
+Per AC5(c) ``replace`` ops (whole-slot OR step-targeted) NEVER reach
+the LLM — they supersede prior prose by construction. The dispatch
+short-circuits to ``PreemptResult(decision="skip", ...)`` and the
+caller proceeds to Gates 1-3 without burning an LLM call.
+
+Aligns with C3 (l4_audit_gate.py) on failure-mode shape: every
+unrecoverable path raises a typed :class:`ConflictPreemptError`
+subclass; the upstream dialog renders a stage-specific human message
+on each.
+"""
+
+import json
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_PREEMPT_TMP_ROOT = _REPO_ROOT / ".squidsquad" / "tmp" / "l4-conflict-preempt"
+
+
+@dataclass
+class PreemptResult:
+    """Parsed result of one Gate-0 (pre-emption) dispatch.
+
+    ``decision`` is one of:
+
+    - ``"clean"`` — no material contradiction; advance to Gate 1.
+    - ``"contradiction"`` — surface ``quote_new`` / ``quote_existing``
+      + ``why`` + ``suggested_action`` to the human and re-walk the
+      dialog with their reframe choice.
+    - ``"skip"`` — ``op_type`` was a ``replace`` (whole-slot or
+      step-targeted), so no LLM was dispatched. Caller proceeds to
+      Gate 1 directly per AC5(c).
+
+    The four detail fields are populated on the ``contradiction``
+    decision and empty otherwise.
+    """
+
+    decision: str
+    why: str = ""
+    quote_new: str = ""
+    quote_existing: str = ""
+    suggested_action: str = ""
+
+    @property
+    def is_contradiction(self):
+        return self.decision == "contradiction"
+
+    @property
+    def proceeds_to_gate_1(self):
+        return self.decision in ("clean", "skip")
+
+
+class ConflictPreemptError(RuntimeError):
+    """Raised when the pre-emption dispatch cannot produce a decision.
+
+    The upstream dialog treats every raise as a pre-emption abort: the
+    write does NOT advance to Gate 1, the human is surfaced with the
+    diagnostic, and they can retry the dialog (or skip pre-emption
+    explicitly if they accept the residual risk that the assemble-pass
+    will paper over a contradiction).
+
+    Subclasses mirror :mod:`l4_audit_gate`'s shape so callers can
+    render stage-specific human messages.
+    """
+
+
+class PreemptModelRouterError(ConflictPreemptError):
+    """``model_router.route`` returned non-zero (config / API / etc.)."""
+
+
+class PreemptTimeoutError(ConflictPreemptError):
+    """``model_router.route`` returned exit code 3 (timeout)."""
+
+
+class PreemptOutputMissingError(ConflictPreemptError):
+    """``model_router`` reported success but produced no output file."""
+
+
+class PreemptParseError(ConflictPreemptError):
+    """Output present but does not match the expected ``decision: …`` shape."""
+
+
+def preempt_conflict(
+    *,
+    op_type,
+    target_slot,
+    target_step_id,
+    target_role_class,
+    body_text,
+    linked_composite,
+    source_directive,
+    task_id=None,
+    model_router=None,
+):
+    """Run the conflict pre-emption check; return :class:`PreemptResult`.
+
+    ``op_type`` follows the legal-grammar shapes (``append`` /
+    ``replace`` / ``replace step:cycle/<id>`` / ``insert-before step:cycle/<id>``
+    / ``insert-after step:cycle/<id>``). Any op whose first word is
+    ``replace`` short-circuits to ``decision="skip"`` per AC5(c) — replace
+    supersedes prior prose by construction so the linked-composite check
+    is not needed.
+
+    ``linked_composite`` is the existing LINKED-composite prose for
+    ``(target_slot, target_role_class)`` with L1, L2, L3 (and any prior
+    L4 entries) already merged. The check runs the new ``body_text``
+    against this corpus.
+
+    Raises a :class:`ConflictPreemptError` subclass on any failure
+    path; the sub-skill's prose treats every raise as a pre-emption
+    abort (human is surfaced with the diagnostic, the write does not
+    advance to Gate 1).
+
+    ``model_router`` is an optional injected reference to the
+    ``model_router`` module (tests pass a stub). Default lazy-imports
+    the real module.
+    """
+    if op_type and op_type.split()[0] == "replace":
+        # AC5(c): replace ops supersede prior prose; no LLM dispatch.
+        return PreemptResult(
+            decision="skip",
+            why=(
+                f"`{op_type}` supersedes prior prose at compose time; "
+                f"conflict pre-emption is not needed for replace ops."
+            ),
+        )
+
+    if model_router is None:
+        import model_router as _real_router  # noqa: WPS433
+        model_router = _real_router
+
+    if task_id is None:
+        task_id = f"l4-conflict-preempt-{target_role_class}-{op_type.split()[0]}"
+
+    payload = {
+        "op_type": op_type,
+        "target_slot": target_slot,
+        "target_step_id": target_step_id,
+        "target_role_class": target_role_class,
+        "body_text": body_text,
+        "source_directive": source_directive,
+        "linked_composite": linked_composite,
+    }
+
+    _PREEMPT_TMP_ROOT.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=f"preempt-{target_role_class}-",
+                                     dir=str(_PREEMPT_TMP_ROOT)) as td:
+        td_path = Path(td)
+        input_path = td_path / "op.json"
+        output_path = td_path / "decision.md"
+        input_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+        context = (
+            f"Pre-emption check for proposed L4 op on `{target_role_class}` "
+            f"role-class, slot `{target_slot}`, op `{op_type}`. Decide whether "
+            f"the proposed body materially contradicts existing prose in the "
+            f"linked composite."
+        )
+
+        try:
+            exit_code = model_router.route(
+                task_type="l4-conflict-preempt",
+                task_id=task_id,
+                input_files=str(input_path),
+                output_file=str(output_path),
+                context=context,
+            )
+        except Exception as e:  # noqa: BLE001
+            raise PreemptModelRouterError(
+                f"model_router.route raised on l4-conflict-preempt task_id={task_id}: {e}"
+            ) from e
+
+        if exit_code == 3:
+            raise PreemptTimeoutError(
+                f"model_router.route returned exit code 3 (timeout) for "
+                f"l4-conflict-preempt task_id={task_id}. Pre-emption abort."
+            )
+        if exit_code != 0:
+            raise PreemptModelRouterError(
+                f"model_router.route returned exit code {exit_code} for "
+                f"l4-conflict-preempt task_id={task_id}. Pre-emption abort."
+            )
+
+        if not output_path.exists():
+            raise PreemptOutputMissingError(
+                f"model_router.route produced no output file for "
+                f"task_id={task_id}. Expected at {output_path}."
+            )
+
+        raw = output_path.read_text(encoding="utf-8")
+
+    return _parse_preempt_output(raw)
+
+
+# The `decision:` line is the branch signal. Tolerant of leading /
+# trailing whitespace and case in the field name; the value MUST be
+# exactly `clean` or `contradiction` per the template's contract.
+_DECISION_RE = re.compile(r"^\s*decision\s*:\s*(\w+)\s*$", re.MULTILINE | re.IGNORECASE)
+_FIELD_RE = re.compile(r"^\s*([\w_]+)\s*:\s*(.*?)\s*$", re.MULTILINE)
+
+
+def _parse_preempt_output(text):
+    """Parse the model's structured response into a :class:`PreemptResult`.
+
+    The template asks for line-anchored ``key: value`` fields. Missing
+    optional fields default to empty strings; the mandatory ``decision:``
+    field must be exactly ``clean`` or ``contradiction`` (case-insensitive).
+    Any other value or a missing field raises :class:`PreemptParseError`.
+    """
+    decision_match = _DECISION_RE.search(text)
+    if not decision_match:
+        raise PreemptParseError(
+            f"l4-conflict-preempt response missing required `decision:` line. "
+            f"Raw output: {text[:500]!r}"
+        )
+    decision = decision_match.group(1).strip().lower()
+    if decision not in ("clean", "contradiction"):
+        raise PreemptParseError(
+            f"l4-conflict-preempt `decision:` field has invalid value "
+            f"{decision!r}. Must be `clean` or `contradiction`."
+        )
+
+    fields = {m.group(1).lower(): m.group(2).strip() for m in _FIELD_RE.finditer(text)}
+
+    return PreemptResult(
+        decision=decision,
+        why=fields.get("why", ""),
+        quote_new=fields.get("quote_new", ""),
+        quote_existing=fields.get("quote_existing", ""),
+        suggested_action=fields.get("suggested_action", ""),
+    )
+
+
+def format_contradiction_for_human(result):
+    """Render a contradiction-decision result as human-facing prose.
+
+    Per AC3, the agent surfaces quotes from both sides + reframe
+    options. This helper produces that block; the upstream dialog
+    intersperses it with the per-instance plain-language framing.
+
+    Returns ``""`` for non-contradiction results — the dialog has
+    nothing to surface on ``clean`` / ``skip``.
+    """
+    if result.decision != "contradiction":
+        return ""
+    parts = [
+        "The proposed rule would conflict with how this role is already configured:",
+        "",
+        f"**What you're asking to add:**",
+        f"> {result.quote_new}" if result.quote_new else "> (no quote provided)",
+        "",
+        f"**What the role already does:**",
+        f"> {result.quote_existing}" if result.quote_existing else "> (no quote provided)",
+        "",
+    ]
+    if result.why:
+        parts.append(f"Why this matters: {result.why}")
+        parts.append("")
+    if result.suggested_action:
+        parts.append(
+            "Options:\n"
+            + _format_action_options(result.suggested_action)
+        )
+    return "\n".join(parts)
+
+
+def _format_action_options(suggested_action):
+    """Translate the LLM's suggested-action token into human-facing options.
+
+    The model emits one of ``replace-reframe`` / ``abandon`` /
+    ``reword``; we render all three options every time but highlight
+    the model's recommendation so the human knows the preferred path.
+    The user-facing rule (per l4-curation.md "Talking to the user")
+    forbids naming op shapes, slots, or other SquidSquad internals —
+    these strings are deliberately worded in role-behavior terms.
+    """
+    options = {
+        "replace-reframe": "  - Replace the existing behavior wholesale with the new rule (recommended)",
+        "reword": "  - Rephrase the new rule so it adds to the existing behavior without overriding (recommended)",
+        "abandon": "  - Drop the new rule — the existing behavior already covers this (recommended)",
+    }
+    primary = options.get(suggested_action, "")
+    others = [v for k, v in options.items() if k != suggested_action]
+    # Strip the "(recommended)" tag from the non-primary entries
+    others = [o.replace(" (recommended)", "") for o in others]
+    return "\n".join([primary] + others) if primary else "\n".join(o.replace(" (recommended)", "") for o in options.values())

--- a/references/scripts/l4_conflict_preempt.py
+++ b/references/scripts/l4_conflict_preempt.py
@@ -37,6 +37,19 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 _PREEMPT_TMP_ROOT = _REPO_ROOT / ".squidsquad" / "tmp" / "l4-conflict-preempt"
 
 
+# Canonical legal op_type values per the L4 grammar (l4_parser._OP_RE).
+# An explicit allowlist for the AC5(c) short-circuit — `replace` ops
+# supersede prior prose by construction, but only ops that actually
+# match the grammar. A malformed shape like ``"replace foo"`` or
+# ``"replace step:not-cycle/x"`` would have failed the audit-gate
+# check anyway, but routing it through Gate 0 as a "skip" silently
+# advances garbage past pre-emption — caught by the reviewer of
+# #10657.
+_REPLACE_OP_RE = re.compile(
+    r"\A(?:replace|replace\s+step:cycle/[A-Za-z0-9_-]+)\Z"
+)
+
+
 @dataclass
 class PreemptResult:
     """Parsed result of one Gate-0 (pre-emption) dispatch.
@@ -135,8 +148,11 @@ def preempt_conflict(
     ``model_router`` module (tests pass a stub). Default lazy-imports
     the real module.
     """
-    if op_type and op_type.split()[0] == "replace":
+    if op_type and _REPLACE_OP_RE.match(op_type):
         # AC5(c): replace ops supersede prior prose; no LLM dispatch.
+        # Allowlist-match against the grammar so malformed shapes like
+        # "replace foo" / "replace step:not-cycle/x" don't silently
+        # short-circuit past Gate 0 (caught in #10657 review).
         return PreemptResult(
             decision="skip",
             why=(
@@ -267,10 +283,10 @@ def format_contradiction_for_human(result):
         "The proposed rule would conflict with how this role is already configured:",
         "",
         f"**What you're asking to add:**",
-        f"> {result.quote_new}" if result.quote_new else "> (no quote provided)",
+        _quote_for_blockquote(result.quote_new),
         "",
         f"**What the role already does:**",
-        f"> {result.quote_existing}" if result.quote_existing else "> (no quote provided)",
+        _quote_for_blockquote(result.quote_existing),
         "",
     ]
     if result.why:
@@ -282,6 +298,23 @@ def format_contradiction_for_human(result):
             + _format_action_options(result.suggested_action)
         )
     return "\n".join(parts)
+
+
+def _quote_for_blockquote(text):
+    """Render ``text`` as a safe markdown blockquote.
+
+    The LLM is constrained to single-line quotes by the prompt
+    template, but defend against multi-line emissions anyway: prefix
+    EVERY line with ``> `` so the blockquote doesn't silently
+    terminate at an embedded newline (which would leave subsequent
+    lines rendering as flow text or, worse, parsed as an `## H2` if
+    the model emitted one). An empty/falsey input renders as the
+    canonical missing-quote marker so the human always sees both
+    sides have SOMETHING.
+    """
+    if not text:
+        return "> (no quote provided)"
+    return "\n".join(f"> {line}" for line in text.splitlines())
 
 
 def _format_action_options(suggested_action):

--- a/references/sub-skills/common/l4-curation.md
+++ b/references/sub-skills/common/l4-curation.md
@@ -110,7 +110,15 @@ When a customization request is detected, walk this dialog before writing L4. St
 
 7. **Propose a draft and read it back** (user-facing). Show the human the rule in plain prose (rule + why + when-not-to-apply) and get explicit approval before writing. The agent translates that approved prose into the L4 file; the human never sees the frontmatter.
 
-8. **Run the safety gates** (agent-internal). Before persisting, the agent runs the four §7.4 gates in order:
+8. **Run the safety gates** (agent-internal). Before persisting, the agent runs the conflict pre-emption check then the four §7.4 gates in order. The pre-emption check (Gate 0, C8) only fires for `insert-before` / `insert-after` / `append` ops — `replace` ops supersede prior prose by construction and short-circuit to "skip":
+
+   0. **Conflict pre-emption (Gate 0, C8)**: for `insert-before step:cycle/X` / `insert-after step:cycle/X` / `append` ops only, invoke `references/scripts/l4_conflict_preempt.py:preempt_conflict(op_type, target_slot, target_step_id, target_role_class, body_text, linked_composite, source_directive)`. The helper reads the existing LINKED-composite prose for `(target_slot, target_role_class)` and dispatches to `model_router.route(task_type="l4-conflict-preempt", ...)` with the `l4-conflict-preempt.md.j2` template. The model returns one of:
+      - **clean** — no material contradiction; proceed to Gate 1.
+      - **contradiction** — surface `format_contradiction_for_human(result)` to the human (quotes from both sides + the `why` + reframe options). Three reframe options are offered: replace-reframe (the model's preferred path when a `replace step:cycle/X` would resolve cleanly), reword (when a wording change lifts the contradiction without changing intent), or abandon (when the new directive is incompatible with the role's shipped contract). The model marks one as recommended. The human picks; the agent re-walks the dialog with their choice as the refined directive. Never silently writes the conflicting op.
+      - **skip** — returned (without an LLM call) when the op type is `replace` (whole-slot or step-targeted). Proceed to Gate 1.
+      - **Pre-emption error** (model_router unreachable / timeout / no output / parse failure): the helper raises `ConflictPreemptError` (subclasses: `PreemptModelRouterError`, `PreemptTimeoutError`, `PreemptOutputMissingError`, `PreemptParseError`). Surface the diagnostic to the human and abort the write — do not advance to Gate 1.
+
+   The vocabulary ("materially contradicting prose between layers") mirrors B4's assemble-pass detector (`conflict_detector.py`, PRD-B #10445). Pre-emption catches what would otherwise force the assemble-pass to reconcile a contradiction later — better to surface to the human now so they reframe explicitly than let the assemble-pass paper over it at compose time.
 
    1. **DeepSeek decision-tree audit (Gate 1, C3)**: invoke `references/scripts/l4_audit_gate.py:audit_l4_op(op_type, target_slot, target_step_id, target_role_class, body_text, source_directive)`. The helper dispatches to `model_router.route(task_type="l4-audit", ...)` with the `l4-audit.md.j2` prompt template; the deepseek-class model reviews the slot + op + target classification against the human's source directive and returns one of:
       - **approve** — proceed to Gate 2 (mini-CQ).

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -138,6 +138,8 @@ STATIC_TEST_MODULES = [
     "test_l4_compose_dryrun_c5",
     "test_l4_write_commit_c6",
     "test_comprehension_10659",
+    "test_l4_removal_c9",
+    "test_l4_conflict_preempt_c8",
 ]
 
 

--- a/tests/test_l4_conflict_preempt_c8.py
+++ b/tests/test_l4_conflict_preempt_c8.py
@@ -1,0 +1,417 @@
+"""Tests for references/scripts/l4_conflict_preempt.py (#10657, PRD-C C8).
+
+AC5 mandates at least:
+  (a) clean insert → no surfacing
+  (b) inserting a constraint that contradicts an L2 instruction →
+      surface + reframe offered
+  (c) `replace` op never triggers pre-emption (replace supersedes)
+
+Plus the standard C3-shaped failure-mode coverage (model_router
+exception / non-zero exit / timeout / missing output / parse error)
+and the human-facing formatter.
+"""
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import l4_conflict_preempt as cp  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_LINKED_COMPOSITE = (
+    "## Instructions\n\n"
+    "### step:cycle/file-bug\n\n"
+    "Always include a reproduction case and the failing test command.\n"
+    "Bugs without a reproduction route back to the reporter.\n\n"
+    "### step:cycle/cleanup\n\n"
+    "Clear working state and write the iteration log entry.\n"
+)
+
+
+def _make_router(*, exit_code=0, output_text=None, raise_exc=None,
+                  write_output=True):
+    """Build a stub model_router with the `.route` callable shape.
+
+    Records calls in ``calls`` for assertions. Writes ``output_text`` to
+    the ``output_file`` argument BEFORE returning ``exit_code`` so the
+    helper finds the file. Setting ``write_output=False`` simulates the
+    router-reported-success-but-no-output failure mode.
+    """
+    calls = []
+
+    def route(*, task_type, task_id, input_files, output_file, context):
+        calls.append({
+            "task_type": task_type,
+            "task_id": task_id,
+            "input_files": input_files,
+            "output_file": output_file,
+            "context": context,
+        })
+        if raise_exc is not None:
+            raise raise_exc
+        if write_output and output_text is not None:
+            Path(output_file).write_text(output_text, encoding="utf-8")
+        return exit_code
+
+    return SimpleNamespace(route=route), calls
+
+
+# ---------------------------------------------------------------------------
+# AC5(c) — replace ops short-circuit (no LLM dispatch)
+# ---------------------------------------------------------------------------
+
+
+class TestReplaceOpShortCircuits:
+    def test_step_targeted_replace_skips_dispatch(self):
+        router, calls = _make_router(output_text="UNUSED")
+        result = cp.preempt_conflict(
+            op_type="replace step:cycle/file-bug",
+            target_slot="instructions",
+            target_step_id="file-bug",
+            target_role_class="worker",
+            body_text="Custom file-bug body.",
+            linked_composite=_LINKED_COMPOSITE,
+            source_directive="Replace the file-bug step with the new approach.",
+            model_router=router,
+        )
+        assert result.decision == "skip"
+        assert result.proceeds_to_gate_1 is True
+        assert result.is_contradiction is False
+        # The LLM was NOT invoked
+        assert calls == []
+
+    def test_whole_slot_replace_also_skips(self):
+        router, calls = _make_router(output_text="UNUSED")
+        result = cp.preempt_conflict(
+            op_type="replace",
+            target_slot="responsibility",
+            target_step_id=None,
+            target_role_class="worker",
+            body_text="Wholesale-redefined responsibility block.",
+            linked_composite=_LINKED_COMPOSITE,
+            source_directive="Replace the worker's responsibility.",
+            model_router=router,
+        )
+        assert result.decision == "skip"
+        assert calls == []
+
+    def test_skip_result_reason_explains_why(self):
+        router, _ = _make_router(output_text="UNUSED")
+        result = cp.preempt_conflict(
+            op_type="replace step:cycle/file-bug",
+            target_slot="instructions", target_step_id="file-bug",
+            target_role_class="worker", body_text="x",
+            linked_composite=_LINKED_COMPOSITE, source_directive="x",
+            model_router=router,
+        )
+        assert "supersede" in result.why.lower()
+
+
+# ---------------------------------------------------------------------------
+# AC5(a) — clean insert path
+# ---------------------------------------------------------------------------
+
+
+class TestCleanInsertPath:
+    def test_clean_decision_parses_and_advances_to_gate_1(self):
+        router, calls = _make_router(output_text=(
+            "decision: clean\n"
+            "why: The new directive supplements rather than contradicting the existing step.\n"
+        ))
+        result = cp.preempt_conflict(
+            op_type="insert-after step:cycle/file-bug",
+            target_slot="instructions",
+            target_step_id="file-bug",
+            target_role_class="worker",
+            body_text="After filing the bug, notify the on-call rotation.",
+            linked_composite=_LINKED_COMPOSITE,
+            source_directive="After filing any bug, notify on-call.",
+            model_router=router,
+        )
+        assert result.decision == "clean"
+        assert result.proceeds_to_gate_1 is True
+        assert result.is_contradiction is False
+        # All contradiction-specific fields empty on clean
+        assert result.quote_new == ""
+        assert result.quote_existing == ""
+        assert result.suggested_action == ""
+        # LLM was dispatched (one call)
+        assert len(calls) == 1
+        assert calls[0]["task_type"] == "l4-conflict-preempt"
+
+    def test_append_op_also_dispatches(self):
+        router, calls = _make_router(output_text=(
+            "decision: clean\n"
+            "why: Adds a sub-skill reference; no overlap.\n"
+        ))
+        result = cp.preempt_conflict(
+            op_type="append",
+            target_slot="instructions", target_step_id=None,
+            target_role_class="worker",
+            body_text="→ run sub-skill: security-smoke\n\nOnce a week run security smoke.",
+            linked_composite=_LINKED_COMPOSITE,
+            source_directive="Run security smoke weekly.",
+            model_router=router,
+        )
+        assert result.decision == "clean"
+        assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# AC5(b) — contradiction path with quotes + suggested_action
+# ---------------------------------------------------------------------------
+
+
+class TestContradictionPath:
+    _CONTRADICTING_RESPONSE = (
+        "decision: contradiction\n"
+        "why: The proposed body forbids reproduction cases, but the existing step requires them.\n"
+        "quote_new: Bugs are filed without a reproduction case to speed up triage.\n"
+        "quote_existing: Always include a reproduction case and the failing test command.\n"
+        "suggested_action: replace-reframe\n"
+    )
+
+    def test_contradiction_decision_surfaces_quotes(self):
+        router, _ = _make_router(output_text=self._CONTRADICTING_RESPONSE)
+        result = cp.preempt_conflict(
+            op_type="insert-before step:cycle/file-bug",
+            target_slot="instructions", target_step_id="file-bug",
+            target_role_class="worker",
+            body_text="Bugs are filed without a reproduction case to speed up triage.",
+            linked_composite=_LINKED_COMPOSITE,
+            source_directive="Don't require reproduction cases anymore.",
+            model_router=router,
+        )
+        assert result.decision == "contradiction"
+        assert result.is_contradiction is True
+        assert result.proceeds_to_gate_1 is False
+        assert "reproduction" in result.quote_new.lower()
+        assert "reproduction" in result.quote_existing.lower()
+        assert result.suggested_action == "replace-reframe"
+        assert "forbid" in result.why.lower()
+
+    def test_contradiction_with_reword_suggestion(self):
+        router, _ = _make_router(output_text=(
+            "decision: contradiction\n"
+            "why: Slight overlap; a wording change would lift the contradiction.\n"
+            "quote_new: Skip the cleanup step\n"
+            "quote_existing: Clear working state and write the iteration log entry.\n"
+            "suggested_action: reword\n"
+        ))
+        result = cp.preempt_conflict(
+            op_type="append",
+            target_slot="instructions", target_step_id=None,
+            target_role_class="worker",
+            body_text="Skip the cleanup step on dry runs.",
+            linked_composite=_LINKED_COMPOSITE,
+            source_directive="Skip cleanup on dry runs.",
+            model_router=router,
+        )
+        assert result.suggested_action == "reword"
+
+
+# ---------------------------------------------------------------------------
+# format_contradiction_for_human
+# ---------------------------------------------------------------------------
+
+
+class TestFormatContradictionForHuman:
+    def test_clean_result_renders_empty_string(self):
+        result = cp.PreemptResult(decision="clean", why="all good")
+        assert cp.format_contradiction_for_human(result) == ""
+
+    def test_skip_result_renders_empty_string(self):
+        result = cp.PreemptResult(decision="skip", why="replace supersedes")
+        assert cp.format_contradiction_for_human(result) == ""
+
+    def test_contradiction_renders_both_quotes(self):
+        result = cp.PreemptResult(
+            decision="contradiction",
+            why="The new rule conflicts with the existing step.",
+            quote_new="Bugs are filed without a reproduction.",
+            quote_existing="Always include a reproduction case.",
+            suggested_action="replace-reframe",
+        )
+        out = cp.format_contradiction_for_human(result)
+        assert "Bugs are filed without a reproduction." in out
+        assert "Always include a reproduction case." in out
+        assert "What you're asking to add" in out
+        assert "What the role already does" in out
+        assert "Why this matters" in out
+        assert "Options" in out
+        # The model's recommendation is rendered first + tagged
+        assert "(recommended)" in out
+
+    def test_contradiction_with_reword_recommends_reword_first(self):
+        result = cp.PreemptResult(
+            decision="contradiction",
+            why="x", quote_new="x", quote_existing="x",
+            suggested_action="reword",
+        )
+        out = cp.format_contradiction_for_human(result)
+        # Reword is the recommended option
+        reword_line = [l for l in out.splitlines() if "(recommended)" in l][0]
+        assert "Rephrase" in reword_line
+
+
+# ---------------------------------------------------------------------------
+# Failure modes — mirror C3 audit-gate shape
+# ---------------------------------------------------------------------------
+
+
+class TestFailureModes:
+    def test_model_router_exception_raises_PreemptModelRouterError(self):
+        router, _ = _make_router(raise_exc=RuntimeError("API down"))
+        with pytest.raises(cp.PreemptModelRouterError) as e:
+            cp.preempt_conflict(
+                op_type="append", target_slot="instructions",
+                target_step_id=None, target_role_class="worker",
+                body_text="x", linked_composite=_LINKED_COMPOSITE,
+                source_directive="x", model_router=router,
+            )
+        assert "API down" in str(e.value)
+
+    def test_nonzero_exit_raises_PreemptModelRouterError(self):
+        router, _ = _make_router(exit_code=1)
+        with pytest.raises(cp.PreemptModelRouterError) as e:
+            cp.preempt_conflict(
+                op_type="append", target_slot="instructions",
+                target_step_id=None, target_role_class="worker",
+                body_text="x", linked_composite=_LINKED_COMPOSITE,
+                source_directive="x", model_router=router,
+            )
+        assert "exit code 1" in str(e.value)
+
+    def test_exit_code_3_raises_PreemptTimeoutError(self):
+        router, _ = _make_router(exit_code=3)
+        with pytest.raises(cp.PreemptTimeoutError):
+            cp.preempt_conflict(
+                op_type="append", target_slot="instructions",
+                target_step_id=None, target_role_class="worker",
+                body_text="x", linked_composite=_LINKED_COMPOSITE,
+                source_directive="x", model_router=router,
+            )
+
+    def test_missing_output_file_raises_PreemptOutputMissingError(self):
+        router, _ = _make_router(exit_code=0, write_output=False)
+        with pytest.raises(cp.PreemptOutputMissingError):
+            cp.preempt_conflict(
+                op_type="append", target_slot="instructions",
+                target_step_id=None, target_role_class="worker",
+                body_text="x", linked_composite=_LINKED_COMPOSITE,
+                source_directive="x", model_router=router,
+            )
+
+    def test_missing_decision_line_raises_PreemptParseError(self):
+        router, _ = _make_router(output_text="why: looks fine\n")
+        with pytest.raises(cp.PreemptParseError) as e:
+            cp.preempt_conflict(
+                op_type="append", target_slot="instructions",
+                target_step_id=None, target_role_class="worker",
+                body_text="x", linked_composite=_LINKED_COMPOSITE,
+                source_directive="x", model_router=router,
+            )
+        assert "decision:" in str(e.value)
+
+    def test_invalid_decision_value_raises_PreemptParseError(self):
+        router, _ = _make_router(output_text="decision: maybe\nwhy: x\n")
+        with pytest.raises(cp.PreemptParseError) as e:
+            cp.preempt_conflict(
+                op_type="append", target_slot="instructions",
+                target_step_id=None, target_role_class="worker",
+                body_text="x", linked_composite=_LINKED_COMPOSITE,
+                source_directive="x", model_router=router,
+            )
+        assert "maybe" in str(e.value)
+
+    def test_exception_hierarchy(self):
+        """Subclasses all inherit from ConflictPreemptError so callers
+        can catch the base in one except clause.
+        """
+        for sub in (cp.PreemptModelRouterError, cp.PreemptTimeoutError,
+                    cp.PreemptOutputMissingError, cp.PreemptParseError):
+            assert issubclass(sub, cp.ConflictPreemptError)
+
+
+# ---------------------------------------------------------------------------
+# Sandbox + dispatch payload sanity
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchPayload:
+    def test_payload_contains_linked_composite(self, tmp_path):
+        """The linked composite is the corpus the model checks against;
+        verify it's serialized into the input file the router sees.
+        """
+        captured = {}
+
+        def route(*, task_type, task_id, input_files, output_file, context):
+            captured["input"] = Path(input_files).read_text(encoding="utf-8")
+            Path(output_file).write_text("decision: clean\nwhy: ok\n", encoding="utf-8")
+            return 0
+
+        router = SimpleNamespace(route=route)
+        cp.preempt_conflict(
+            op_type="append", target_slot="instructions",
+            target_step_id=None, target_role_class="worker",
+            body_text="Some new rule.",
+            linked_composite=_LINKED_COMPOSITE,
+            source_directive="Add a new rule.",
+            model_router=router,
+        )
+        payload = json.loads(captured["input"])
+        assert "linked_composite" in payload
+        assert "Always include a reproduction case" in payload["linked_composite"]
+        assert payload["body_text"] == "Some new rule."
+
+    def test_dispatch_input_lives_under_repo_root(self):
+        """Sandbox boundary rule: tempfiles for model_router must live
+        under REPO_ROOT, not the system tempdir. The helper uses
+        _PREEMPT_TMP_ROOT which is REPO_ROOT-relative.
+        """
+        captured = {}
+
+        def route(*, task_type, task_id, input_files, output_file, context):
+            captured["path"] = input_files
+            Path(output_file).write_text("decision: clean\nwhy: ok\n", encoding="utf-8")
+            return 0
+
+        router = SimpleNamespace(route=route)
+        cp.preempt_conflict(
+            op_type="append", target_slot="instructions",
+            target_step_id=None, target_role_class="worker",
+            body_text="x", linked_composite=_LINKED_COMPOSITE,
+            source_directive="x", model_router=router,
+        )
+        assert ".squidsquad" in captured["path"]
+        assert "l4-conflict-preempt" in captured["path"]
+
+
+# ---------------------------------------------------------------------------
+# PreemptResult shape
+# ---------------------------------------------------------------------------
+
+
+class TestPreemptResultShape:
+    def test_default_optional_fields_are_empty_strings(self):
+        result = cp.PreemptResult(decision="clean")
+        assert result.why == ""
+        assert result.quote_new == ""
+        assert result.quote_existing == ""
+        assert result.suggested_action == ""
+
+    def test_proceeds_to_gate_1_property(self):
+        assert cp.PreemptResult(decision="clean").proceeds_to_gate_1 is True
+        assert cp.PreemptResult(decision="skip").proceeds_to_gate_1 is True
+        assert cp.PreemptResult(decision="contradiction").proceeds_to_gate_1 is False

--- a/tests/test_l4_conflict_preempt_c8.py
+++ b/tests/test_l4_conflict_preempt_c8.py
@@ -117,6 +117,41 @@ class TestReplaceOpShortCircuits:
         )
         assert "supersede" in result.why.lower()
 
+    def test_malformed_replace_does_not_short_circuit(self):
+        """B1 fix: ``op_type`` allowlist matches the grammar exactly,
+        so ``"replace foo"`` / ``"replace step:not-cycle/x"`` / ``"replace-typo"``
+        are NOT routed past Gate 0 as skips. The LLM dispatch fires
+        (and will likely raise — that's the right behavior; garbage
+        op_types should be caught loudly).
+        """
+        router, calls = _make_router(output_text=(
+            "decision: clean\nwhy: malformed op_type still ran dispatch\n"
+        ))
+        # "replace foo" — extra-token shape that the old split()[0]
+        # check would have wrongly accepted as a skip
+        cp.preempt_conflict(
+            op_type="replace foo",
+            target_slot="instructions", target_step_id=None,
+            target_role_class="worker", body_text="x",
+            linked_composite=_LINKED_COMPOSITE, source_directive="x",
+            model_router=router,
+        )
+        # The LLM was dispatched (not short-circuited)
+        assert len(calls) == 1
+
+    def test_step_targeted_replace_with_non_cycle_target_does_not_short_circuit(self):
+        router, calls = _make_router(output_text=(
+            "decision: clean\nwhy: non-cycle target still ran dispatch\n"
+        ))
+        cp.preempt_conflict(
+            op_type="replace step:not-cycle/foo",
+            target_slot="instructions", target_step_id="foo",
+            target_role_class="worker", body_text="x",
+            linked_composite=_LINKED_COMPOSITE, source_directive="x",
+            model_router=router,
+        )
+        assert len(calls) == 1
+
 
 # ---------------------------------------------------------------------------
 # AC5(a) — clean insert path
@@ -252,6 +287,34 @@ class TestFormatContradictionForHuman:
         assert "Options" in out
         # The model's recommendation is rendered first + tagged
         assert "(recommended)" in out
+
+    def test_quote_with_embedded_newline_renders_as_multi_line_blockquote(self):
+        """C2 fix: if the LLM ignores the prompt's single-line
+        constraint and emits a multi-line quote, every line gets the
+        ``> `` prefix so the blockquote doesn't silently terminate
+        and the next prose isn't rendered as a stray paragraph.
+        """
+        result = cp.PreemptResult(
+            decision="contradiction",
+            why="x",
+            quote_new="Line one of the quote.\nLine two of the quote.",
+            quote_existing="Existing line one.",
+            suggested_action="reword",
+        )
+        out = cp.format_contradiction_for_human(result)
+        # Both lines of the multi-line quote are blockquoted
+        assert "> Line one of the quote." in out
+        assert "> Line two of the quote." in out
+
+    def test_missing_quotes_render_as_placeholder(self):
+        result = cp.PreemptResult(
+            decision="contradiction",
+            why="x", quote_new="", quote_existing="",
+            suggested_action="reword",
+        )
+        out = cp.format_contradiction_for_human(result)
+        # Both sides get the canonical missing-quote marker
+        assert out.count("(no quote provided)") == 2
 
     def test_contradiction_with_reword_recommends_reword_first(self):
         result = cp.PreemptResult(


### PR DESCRIPTION
Closes #10657.

## Summary
- Adds `references/scripts/l4_conflict_preempt.py` and `references/prompts/l4-conflict-preempt.md.j2` — PRD-C Story C8 Gate 0 LLM check that runs BEFORE Gates 1-4 for `insert-*` / `append` ops. Reads the linked composite for `(target_slot, target_role_class)` and surfaces material contradictions to the human before any silent write.
- `replace` ops (whole-slot or step-targeted) short-circuit to `decision="skip"` per AC5(c) — no LLM dispatch.
- Vocabulary mirrors B4's assemble-pass detector ("materially contradicting prose between layers") so the agent surfaces what B4 would otherwise have to reconcile after the fact.
- Enriches `l4-curation.md` Step 8 with a Gate 0 entry preceding the four §7.4 gates.

## Planning contract (per #8950 Gate #4)
- **Module shape**: ~290 LOC; 4 public functions (`preempt_conflict` / `format_contradiction_for_human` / helpers); 1 dataclass (`PreemptResult` with `decision` ∈ {clean / contradiction / skip}); 5-class exception hierarchy mirroring C3 (`ConflictPreemptError` base + 4 stage-specific subclasses).
- **Convenience properties**: `PreemptResult.is_contradiction` and `proceeds_to_gate_1` — callers branch on the data, not on string equality.
- **Injection seam**: `model_router=...` lets tests stub the LLM without invoking the real router; same shape as C3.
- **Sandbox-boundary**: tempfiles live under `.squidsquad/tmp/l4-conflict-preempt/` (REPO_ROOT-relative). Verified by `test_dispatch_input_lives_under_repo_root`.
- **Files added**: `l4_conflict_preempt.py`, `l4-conflict-preempt.md.j2`, `test_l4_conflict_preempt_c8.py`.
- **Files modified**: `tests/run_tests.py` (registers new module + the C9 module from the prior cycle), `references/sub-skills/common/l4-curation.md` (Gate 0 prose).
- **Files NOT touched**: `compose.py`, `model_router.py` (only its public `.route` signature), `conflict_detector.py` (B4), any L1-L3 source, the other `l4_*.py` gate helpers — no API drift.
- **§9a impact**: zero — v1 byte-stability green (5/5).
- **Tests**: 22/22 green (0.15s).
- **Follow-up**: C7 (#10656 recompose-failure recovery) is the only remaining PRD-C story.

## AC mapping
| AC | Implementation | Tests |
|---|---|---|
| 1: after decision-tree classifies insert-* or append, run conflict check | `preempt_conflict` orchestrator | 2 clean-path tests + 2 contradiction-path tests |
| 2: reuses B4 vocabulary | prompt template + module docstring quote B4's phrase | (prose check via review) |
| 3: on contradiction → surface quotes + reframe options | `format_contradiction_for_human` produces the human block | 4 formatter tests including reword/replace-reframe/abandon |
| 4: on no contradiction → proceeds to Gates 1-3 normally | `PreemptResult.proceeds_to_gate_1` property | 2 short-circuit tests + 2 clean-path tests |
| 5(a): clean insert → no surfacing | clean path test cases | `test_clean_decision_parses_and_advances_to_gate_1` |
| 5(b): contradicting constraint → surface + reframe offered | contradiction path test cases | `test_contradiction_decision_surfaces_quotes` + `test_contradiction_with_reword_suggestion` |
| 5(c): `replace` op never triggers pre-emption | `op_type.split()[0] == "replace"` short-circuit | `test_step_targeted_replace_skips_dispatch` + `test_whole_slot_replace_also_skips` (verify NO `calls` recorded) |

## Test plan
- [x] `python -m pytest tests/test_l4_conflict_preempt_c8.py -v` — 22/22 green
- [x] `python -m pytest tests/test_v1_byte_stability_9a.py -v` — 5/5 green (no v1 regression)
- [ ] QA: smoke-test against a live `model_router` invocation with a real linked composite (the prompt template is unproven against a live model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)