### PR TITLE
skill: feat(d1): sub-skill catalog parser (#10672, PRD-D D1)

### DIFF
--- a/references/scripts/catalog_parser.py
+++ b/references/scripts/catalog_parser.py
@@ -77,15 +77,28 @@ _TABLE_DELIM_RE = re.compile(r"^\s*\|(\s*:?-+:?\s*\|)+\s*$")
 
 # A sub-skill name in the catalog rows: lowercase, hyphen-separated,
 # enclosed in backticks. e.g. `boot-bootstrap` or `vault-protocol-slim`.
-# Strikethrough/tilde-wrapped names (~~`removed-name`~~) are ignored
-# because those rows are retirement notes, not active entries.
-_NAME_CELL_RE = re.compile(r"^`([a-z][a-z0-9-]*)`$")
+# Slash-bearing names like ``roles/dm/events/pr-merge-wait`` ARE valid —
+# they encode the source path inline (the catalog name IS the
+# `→ run sub-skill: <name>` lookup key per compose.py:53 + the
+# matching `{{include: roles/dm/events/pr-merge-wait}}` reference in
+# the role's L2 instructions). Strikethrough/tilde-wrapped names
+# (`~~`removed-name`~~`) are ignored because those rows are
+# retirement notes, not active entries.
+_NAME_CELL_RE = re.compile(r"^`([a-z][a-z0-9/_-]*)`$")
 
-# Directories explicitly excluded from the parser output. The
-# ``project/`` directory holds L4 seed templates that are NOT
-# referenced via ``→ run sub-skill``; they're scaffolding the
-# installer copies to ``.squidsquad/project/``.
-_EXCLUDED_DIRS = frozenset({"project"})
+# A "row that looks like it MIGHT be a catalog entry" — first cell
+# starts with a backtick at any depth. Used to distinguish silent-skip
+# (retirement annotation like ``~~`x`~~``) from malformed-entry (e.g.
+# `` `Boot-bootstrap` `` with a capital letter, or HTML strikethrough
+# ``<s>`x`</s>``) which the reviewer asked us to raise on.
+_BACKTICK_ANYWHERE_RE = re.compile(r"`[^`]+`")
+
+# Allowlist of directories whose H2 entries the parser MUST emit. An
+# allowlist (vs. the previous denylist) keeps intent self-documenting:
+# the parser knows exactly which trees feed v2 compose, and a future
+# catalog edit adding ``## \`docs/\` —`` for non-sub-skill content
+# won't silently leak entries into the mapping.
+_INCLUDED_DIRS = frozenset({"common", "common-events", "roles"})
 
 
 def parse_catalog(catalog_path):
@@ -177,37 +190,67 @@ def parse_catalog_entries(catalog_path):
             name_cell = cols[0].strip()
             name_match = _NAME_CELL_RE.match(name_cell)
             if name_match is None:
-                # Could be a comment row, a strikethrough retirement row,
-                # or a non-row (e.g. a blockquote continuation rendered
-                # as a table cell). Ignore quietly.
-                continue
-            name = name_match.group(1)
-            source_dir = _resolve_source_dir(
-                h2_dir=current_h2_dir,
-                h3_dir=current_h3_dir,
-                lineno=lineno,
-                name=name,
-            )
-            if source_dir is None:
-                # Row appears under a section that isn't a source-bearing
-                # directory (e.g. ``project/`` which is excluded), OR
-                # outside any H2 — skip silently in the excluded case,
-                # raise in the dangling case.
-                if current_h2_dir is None:
+                # Two distinct cases here, per C7 review C1:
+                #   1. The first cell has NO backticks at all OR is
+                #      tilde-wrapped (~~`x`~~ retirement note). Silent
+                #      skip is correct — these are intentional non-rows.
+                #   2. The first cell contains a backtick-wrapped name
+                #      but doesn't match the strict regex (e.g.
+                #      `Boot-bootstrap` with capital, HTML-wrapped
+                #      `<s>`x`</s>`, or some future formatting we don't
+                #      handle yet). Silent skip would mask a PM typo OR
+                #      a real catalog entry that v2 compose will fail
+                #      to resolve. RAISE so the catalog defect surfaces
+                #      at parser-build time, not compose time.
+                if name_cell.startswith("~~"):
+                    continue
+                if "`" in name_cell and _BACKTICK_ANYWHERE_RE.search(name_cell):
                     raise CatalogParseError(
-                        f"catalog row at line {lineno} has name `{name}` "
-                        f"but no enclosing ## `<dir>/` H2 — cannot derive "
-                        f"source-path."
+                        f"catalog row at line {lineno} has first cell "
+                        f"`{name_cell}` that contains a backtick-wrapped "
+                        f"name but does not match the strict-name regex "
+                        f"(lowercase, hyphen/slash/underscore only). "
+                        f"Either fix the catalog entry or add a retirement "
+                        f"strikethrough (`~~`...`~~`) if the row is no "
+                        f"longer active."
                     )
                 continue
-            source_path = f"references/sub-skills/{source_dir}/{name}.md"
+            name = name_match.group(1)
+            # B1 fix: slash-bearing names override H2/H3 derivation.
+            # Catalog convention: `roles/dm/events/pr-merge-wait`
+            # encodes both the lookup key (the name as-is) and the
+            # relative source-path under references/sub-skills/.
+            if "/" in name:
+                source_path = f"references/sub-skills/{name}.md"
+            else:
+                source_dir = _resolve_source_dir(
+                    h2_dir=current_h2_dir,
+                    h3_dir=current_h3_dir,
+                    lineno=lineno,
+                    name=name,
+                )
+                if source_dir is None:
+                    # Row appears under a section the allowlist excludes
+                    # (e.g. ``project/``), OR outside any H2 — skip the
+                    # excluded case silently, raise in the dangling case.
+                    if current_h2_dir is None:
+                        raise CatalogParseError(
+                            f"catalog row at line {lineno} has name `{name}` "
+                            f"but no enclosing ## `<dir>/` H2 — cannot derive "
+                            f"source-path."
+                        )
+                    continue
+                source_path = f"references/sub-skills/{source_dir}/{name}.md"
             _validate_source_path(source_path, lineno, name)
             if name in seen_names:
+                prior_lineno, prior_source_path = seen_names[name]
                 raise CatalogParseError(
-                    f"duplicate catalog entry `{name}` at line {lineno}; "
-                    f"first seen at line {seen_names[name]}."
+                    f"duplicate catalog entry `{name}` at line {lineno} "
+                    f"(`{source_path}`); first seen at line {prior_lineno} "
+                    f"(`{prior_source_path}`). PM: disambiguate by renaming "
+                    f"one of the two variants."
                 )
-            seen_names[name] = lineno
+            seen_names[name] = (lineno, source_path)
             description = ""
             if description_col_index is not None \
                     and description_col_index < len(cols):
@@ -258,11 +301,18 @@ def _resolve_source_dir(*, h2_dir, h3_dir, lineno, name):
 
     Priority: H3-pinned directory (e.g. ``roles/pm/``) wins, falling
     back to the enclosing H2 directory. Returns ``None`` when the row
-    falls under an EXCLUDED directory (``project/``) — caller skips.
+    falls outside the allowlisted set (``_INCLUDED_DIRS``) — caller
+    skips. The allowlist (vs. an exclusion list) keeps intent self-
+    documenting: only ``common/`` / ``common-events/`` / ``roles/``
+    feed v2 compose.
     """
     if h2_dir is None:
         return None
-    if h2_dir in _EXCLUDED_DIRS:
+    # H2's first path segment must be on the allowlist. For
+    # ``roles/<role>/`` placeholder H2s, the first segment is
+    # ``roles`` which IS allowlisted.
+    h2_root = h2_dir.split("/", 1)[0]
+    if h2_root not in _INCLUDED_DIRS:
         return None
     # H2 is ``roles/<role>/`` (literal angle-bracketed placeholder) —
     # the H3 MUST pin a real directory like ``roles/pm/`` for rows
@@ -299,10 +349,13 @@ def _validate_source_path(source_path, lineno, name):
             f"`{source_path}` which does not end in `.md`."
         )
     # AC5: `.claude/skills/` paths are NEVER valid catalog entries.
-    # Defensive: even though _resolve_source_dir constructs paths
-    # only from H2/H3 directories that read ``common/`` etc, guard
-    # against a future catalog edit that names ``.claude/skills/``.
-    if ".claude/" in source_path or "claude/skills" in source_path:
+    # Defensive guard against a future catalog edit that adds an H2
+    # named `.claude/skills/` — the source-path derivation would
+    # produce a path starting with `.claude/` which fails the
+    # `references/sub-skills/` prefix check above. This belt-and-
+    # suspenders check is also defensive against a slash-bearing name
+    # that contains `.claude/`.
+    if ".claude/" in source_path:
         raise CatalogParseError(
             f"catalog row at line {lineno} for `{name}` resolves to "
             f"`{source_path}` — `.claude/skills/` paths are NEVER valid "

--- a/references/scripts/catalog_parser.py
+++ b/references/scripts/catalog_parser.py
@@ -1,0 +1,311 @@
+"""D1: Sub-skill catalog parser (#10672, PRD-D Story D1).
+
+Parses ``docs/sub-skill-catalog.md`` and returns a ``{name: source_path}``
+mapping that v2 compose uses to resolve every ``→ run sub-skill: <name>``
+reference (per COMPOSE-ARCHITECTURE.md §4.5).
+
+The catalog is authored as multiple Markdown tables grouped under H2
+section headings that name the source directory (e.g. ``## `common/` —``,
+``## `common-events/` —``, ``## `roles/<role>/` —``). For ``roles/``,
+each H3 sub-section pins a specific role-class (e.g.
+``### PM (`roles/pm/`)``), giving the per-role source path.
+
+Parser semantics:
+
+- For each H2 matching the directory pattern, every table row under it
+  produces ``{name: f"references/sub-skills/{dir}/{name}.md"}``.
+- The ``project/`` H2 is EXCLUDED — those rows are L4 seed templates,
+  not sub-skills resolved by compose (per §4.5 the catalog gate
+  operates only on referenced sub-skill names; L4 seed templates are
+  install-time scaffolding).
+- Optional table columns beyond ``name`` (e.g. one-liner, used-by)
+  are read for the ``description`` field but never required (forward-
+  compatible per AC2's "Optional columns ignored gracefully").
+- Source-path validation per AC4: must be relative under
+  ``references/sub-skills/``, no ``..`` traversal segments, ends in
+  ``.md``. The parser derives the path so the only invalid shape
+  would be a malformed directory token in the H2.
+
+NEVER raises silently — every malformed-row condition raises
+``CatalogParseError`` with a structured diagnostic naming the offending
+line + the violated rule (AC3). Callers (D3/D4/D8) catch these and
+surface them as compose-time aborts.
+"""
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class CatalogParseError(ValueError):
+    """Raised when the catalog file violates the row schema."""
+
+
+@dataclass
+class CatalogEntry:
+    """One catalog row resolved to ``(name, source_path, description)``.
+
+    ``source_path`` is the relative path rooted at the repo root
+    (e.g. ``references/sub-skills/common/boot-bootstrap.md``).
+    ``description`` is the one-liner from the table's second column;
+    empty when the catalog row omits it.
+    """
+
+    name: str
+    source_path: str
+    description: str = ""
+
+
+# H2 headings naming a directory: ``## \`<dir>/\` —`` (with literal
+# backticks around the directory token, em-dash separator). The catalog
+# uses this convention to declare which directory rows under the H2
+# resolve to.
+_H2_DIR_RE = re.compile(
+    r"^##\s+`([a-z][a-z0-9_-]*(?:/[a-z<>][a-z0-9_<>-]*)*?)/`\s*[—-]",
+)
+
+# H3 headings under ``## \`roles/<role>/\`` that pin a specific
+# role-class via a parenthesized directory: ``### NAME (\`roles/<role>/\`)``.
+# The directory inside the parens is the actual source-path prefix used
+# for rows under this H3.
+_H3_ROLE_DIR_RE = re.compile(
+    r"^###\s+\S+.*?\(\s*`([a-z][a-z0-9_-]*(?:/[a-z][a-z0-9_-]*)*?)/`\s*\)",
+)
+
+# Markdown table delimiter row — `| --- | --- | --- |` style.
+_TABLE_DELIM_RE = re.compile(r"^\s*\|(\s*:?-+:?\s*\|)+\s*$")
+
+# A sub-skill name in the catalog rows: lowercase, hyphen-separated,
+# enclosed in backticks. e.g. `boot-bootstrap` or `vault-protocol-slim`.
+# Strikethrough/tilde-wrapped names (~~`removed-name`~~) are ignored
+# because those rows are retirement notes, not active entries.
+_NAME_CELL_RE = re.compile(r"^`([a-z][a-z0-9-]*)`$")
+
+# Directories explicitly excluded from the parser output. The
+# ``project/`` directory holds L4 seed templates that are NOT
+# referenced via ``→ run sub-skill``; they're scaffolding the
+# installer copies to ``.squidsquad/project/``.
+_EXCLUDED_DIRS = frozenset({"project"})
+
+
+def parse_catalog(catalog_path):
+    """Parse ``catalog_path`` and return ``{name: source_path}``.
+
+    See module docstring for the schema and validation rules. Returns
+    a plain dict so callers can do quick ``in`` / ``get`` membership
+    checks; the richer ``CatalogEntry`` list is available via
+    :func:`parse_catalog_entries`.
+    """
+    return {e.name: e.source_path for e in parse_catalog_entries(catalog_path)}
+
+
+def parse_catalog_entries(catalog_path):
+    """Parse ``catalog_path`` and return a list of :class:`CatalogEntry`.
+
+    Per AC6 the parser aborts on:
+
+    - Malformed row that looks like a sub-skill entry but breaks the
+      table shape.
+    - Duplicate ``name`` across catalog rows.
+    - Source path containing ``..`` segments, missing ``.md`` suffix,
+      or not rooted under ``references/sub-skills/``.
+
+    Raises :class:`CatalogParseError` on any of the above.
+    """
+    catalog_path = Path(catalog_path)
+    if not catalog_path.is_file():
+        raise CatalogParseError(f"catalog file not found: {catalog_path}")
+
+    text = catalog_path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    entries = []
+    seen_names = {}
+
+    current_h2_dir = None
+    current_h3_dir = None
+    in_table = False
+    table_header_cols = None
+    description_col_index = None
+
+    for lineno, raw in enumerate(lines, start=1):
+        stripped = raw.rstrip()
+
+        # H2 boundary — reset H3 + table state, capture new directory
+        h2_match = _H2_DIR_RE.match(stripped)
+        if h2_match is not None:
+            current_h2_dir = h2_match.group(1)
+            current_h3_dir = None
+            in_table = False
+            table_header_cols = None
+            description_col_index = None
+            continue
+
+        # H3 boundary — may pin a role-specific directory; otherwise
+        # carry the H2 directory forward.
+        if stripped.startswith("### "):
+            h3_match = _H3_ROLE_DIR_RE.match(stripped)
+            current_h3_dir = h3_match.group(1) if h3_match else None
+            in_table = False
+            table_header_cols = None
+            description_col_index = None
+            continue
+
+        # Detect the start of a table by spotting the delimiter row;
+        # the preceding line is the header.
+        if _TABLE_DELIM_RE.match(stripped):
+            header_line = lines[lineno - 2] if lineno >= 2 else ""
+            header_cols = _split_row(header_line)
+            if header_cols and header_cols[0].lower() in (
+                    "sub-skill", "name", "subskill"):
+                in_table = True
+                table_header_cols = [c.lower() for c in header_cols]
+                description_col_index = _resolve_description_column(
+                    table_header_cols,
+                )
+                continue
+            in_table = False
+            table_header_cols = None
+            description_col_index = None
+            continue
+
+        # Inside a table: parse rows, derive source path, validate.
+        if in_table and stripped.startswith("|") and not _TABLE_DELIM_RE.match(stripped):
+            cols = _split_row(stripped)
+            if not cols:
+                continue
+            name_cell = cols[0].strip()
+            name_match = _NAME_CELL_RE.match(name_cell)
+            if name_match is None:
+                # Could be a comment row, a strikethrough retirement row,
+                # or a non-row (e.g. a blockquote continuation rendered
+                # as a table cell). Ignore quietly.
+                continue
+            name = name_match.group(1)
+            source_dir = _resolve_source_dir(
+                h2_dir=current_h2_dir,
+                h3_dir=current_h3_dir,
+                lineno=lineno,
+                name=name,
+            )
+            if source_dir is None:
+                # Row appears under a section that isn't a source-bearing
+                # directory (e.g. ``project/`` which is excluded), OR
+                # outside any H2 — skip silently in the excluded case,
+                # raise in the dangling case.
+                if current_h2_dir is None:
+                    raise CatalogParseError(
+                        f"catalog row at line {lineno} has name `{name}` "
+                        f"but no enclosing ## `<dir>/` H2 — cannot derive "
+                        f"source-path."
+                    )
+                continue
+            source_path = f"references/sub-skills/{source_dir}/{name}.md"
+            _validate_source_path(source_path, lineno, name)
+            if name in seen_names:
+                raise CatalogParseError(
+                    f"duplicate catalog entry `{name}` at line {lineno}; "
+                    f"first seen at line {seen_names[name]}."
+                )
+            seen_names[name] = lineno
+            description = ""
+            if description_col_index is not None \
+                    and description_col_index < len(cols):
+                description = cols[description_col_index].strip()
+            entries.append(CatalogEntry(
+                name=name,
+                source_path=source_path,
+                description=description,
+            ))
+
+    return entries
+
+
+def _split_row(row_line):
+    """Split a Markdown table row into cell strings.
+
+    Strips outer pipes + per-cell whitespace. Returns ``[]`` on rows
+    that don't look like Markdown tables.
+    """
+    line = row_line.strip()
+    if not line.startswith("|"):
+        return []
+    if line.endswith("|"):
+        line = line[:-1]
+    parts = line.split("|")[1:]  # drop leading empty
+    return [p.strip() for p in parts]
+
+
+def _resolve_description_column(header_cols):
+    """Return the index of the one-liner / description column, or None.
+
+    Tolerates several common header names so future catalog edits
+    don't break the parser.
+    """
+    candidates = ("one-liner", "description", "purpose", "summary")
+    for i, h in enumerate(header_cols):
+        if h in candidates:
+            return i
+    if len(header_cols) >= 2:
+        # Default: column index 1 (second column) is the description in
+        # the current catalog format.
+        return 1
+    return None
+
+
+def _resolve_source_dir(*, h2_dir, h3_dir, lineno, name):
+    """Pick the directory token to use for a row's source path.
+
+    Priority: H3-pinned directory (e.g. ``roles/pm/``) wins, falling
+    back to the enclosing H2 directory. Returns ``None`` when the row
+    falls under an EXCLUDED directory (``project/``) — caller skips.
+    """
+    if h2_dir is None:
+        return None
+    if h2_dir in _EXCLUDED_DIRS:
+        return None
+    # H2 is ``roles/<role>/`` (literal angle-bracketed placeholder) —
+    # the H3 MUST pin a real directory like ``roles/pm/`` for rows
+    # under it to be resolvable.
+    if "<" in h2_dir or ">" in h2_dir:
+        if h3_dir is None:
+            raise CatalogParseError(
+                f"catalog row at line {lineno} has name `{name}` under "
+                f"placeholder H2 `## \\`{h2_dir}/\\` —` but no H3 "
+                f"pinning a concrete `<role>` directory — cannot derive "
+                f"source-path."
+            )
+        return h3_dir
+    return h2_dir
+
+
+def _validate_source_path(source_path, lineno, name):
+    """Per AC4: rooted at ``references/sub-skills/``, no ``..``, ends ``.md``."""
+    if not source_path.startswith("references/sub-skills/"):
+        raise CatalogParseError(
+            f"catalog row at line {lineno} for `{name}` resolves to "
+            f"`{source_path}` which is not rooted at "
+            f"`references/sub-skills/`."
+        )
+    if ".." in Path(source_path).parts:
+        raise CatalogParseError(
+            f"catalog row at line {lineno} for `{name}` resolves to "
+            f"`{source_path}` which contains a `..` path-traversal "
+            f"segment."
+        )
+    if not source_path.endswith(".md"):
+        raise CatalogParseError(
+            f"catalog row at line {lineno} for `{name}` resolves to "
+            f"`{source_path}` which does not end in `.md`."
+        )
+    # AC5: `.claude/skills/` paths are NEVER valid catalog entries.
+    # Defensive: even though _resolve_source_dir constructs paths
+    # only from H2/H3 directories that read ``common/`` etc, guard
+    # against a future catalog edit that names ``.claude/skills/``.
+    if ".claude/" in source_path or "claude/skills" in source_path:
+        raise CatalogParseError(
+            f"catalog row at line {lineno} for `{name}` resolves to "
+            f"`{source_path}` — `.claude/skills/` paths are NEVER valid "
+            f"catalog entries (AC5; only the authored "
+            f"`references/sub-skills/` path is the catalog's source)."
+        )

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -141,6 +141,7 @@ STATIC_TEST_MODULES = [
     "test_l4_removal_c9",
     "test_l4_conflict_preempt_c8",
     "test_l4_recompose_recovery_c7",
+    "test_catalog_parser_d1",
 ]
 
 

--- a/tests/test_catalog_parser_d1.py
+++ b/tests/test_catalog_parser_d1.py
@@ -98,6 +98,52 @@ class TestCleanParse:
                 "references/sub-skills/roles/dev/implement-tasks.md",
         }
 
+    def test_slash_bearing_name_overrides_h2_directory(self, tmp_path):
+        """B1 fix: names containing slashes encode the relative source-path
+        directly (catalog convention used at lines 177 + 225 of the
+        live catalog for cross-directory sub-skills like
+        `roles/dm/events/pr-merge-wait`). The slash-bearing name IS
+        the lookup key, and source-path = `references/sub-skills/{name}.md`.
+        """
+        catalog = _write_catalog(tmp_path, """
+        ## `common-events/` — Event-shaped fragments
+
+        ### Role-specific event extras
+
+        | Sub-skill | One-liner | Used by |
+        |---|---|---|
+        | `roles/dm/events/pr-merge-wait` | DM's behavior while a PR is merging | DM (event mode) |
+        """)
+        out = cp.parse_catalog(catalog)
+        assert out == {
+            "roles/dm/events/pr-merge-wait":
+                "references/sub-skills/roles/dm/events/pr-merge-wait.md",
+        }
+
+    def test_slash_bearing_name_under_role_h3(self, tmp_path):
+        """Live-catalog row at line 225 — `skill/finding-categories`
+        under `### QA (\`roles/qa/\`)` — uses the slash-name override
+        even when the H3 has its own role directory.
+        """
+        catalog = _write_catalog(tmp_path, """
+        ## `roles/<role>/` — Role-specific sub-skills
+
+        ### QA (`roles/qa/`)
+
+        | Sub-skill | One-liner |
+        |---|---|
+        | `verification` | E2E tests | QA |
+        | `skill/finding-categories` | Skill-domain finding taxonomy | QA |
+        """)
+        out = cp.parse_catalog(catalog)
+        assert out == {
+            "verification": "references/sub-skills/roles/qa/verification.md",
+            # Slash-name overrides the H3 directory — it's an absolute
+            # path under references/sub-skills/
+            "skill/finding-categories":
+                "references/sub-skills/skill/finding-categories.md",
+        }
+
     def test_project_section_is_excluded(self, tmp_path):
         """L4 seed templates under `project/` are NOT sub-skills resolved
         by compose — they're install scaffolding. Parser excludes them.
@@ -184,6 +230,34 @@ class TestDuplicateAbort:
             cp.parse_catalog(catalog)
         assert "duplicate" in str(e.value).lower()
         assert "discussion" in str(e.value)
+
+    def test_duplicate_diagnostic_includes_both_source_paths(self, tmp_path):
+        """C3 fix: the duplicate diagnostic surfaces BOTH source-paths
+        so PM can disambiguate without manually re-reading the catalog.
+        """
+        catalog = _write_catalog(tmp_path, """
+        ## `common/` — Cross-cutting
+
+        | Sub-skill | One-liner | Used by |
+        |---|---|---|
+        | `improvement-scan` | The common variant | all |
+
+        ## `roles/<role>/` — Role-specific
+
+        ### PM (`roles/pm/`)
+
+        | Sub-skill | One-liner | Used by |
+        |---|---|---|
+        | `improvement-scan` | The PM variant | PM |
+        """)
+        with pytest.raises(cp.CatalogParseError) as e:
+            cp.parse_catalog(catalog)
+        msg = str(e.value)
+        # Both source-paths named in the diagnostic
+        assert "common/improvement-scan.md" in msg
+        assert "roles/pm/improvement-scan.md" in msg
+        # PM-facing guidance present
+        assert "disambiguate" in msg.lower() or "rename" in msg.lower()
 
     def test_duplicate_across_sections_aborts(self, tmp_path):
         catalog = _write_catalog(tmp_path, """
@@ -306,6 +380,61 @@ class TestIgnoredRows:
             "discussion": "references/sub-skills/common/discussion.md",
         }
 
+    def test_non_backtick_meta_rows_are_skipped(self, tmp_path):
+        """Rows whose first cell has NO backticks (like the catalog's
+        `| Domain context | Per-stack QA notes ... |` meta-row at
+        line 223) are silently skipped — they describe how the section
+        works, they're not catalog entries.
+        """
+        catalog = _write_catalog(tmp_path, """
+        ## `common/` — Cross-cutting
+
+        | Sub-skill | One-liner | Used by |
+        |---|---|---|
+        | `discussion` | Active row | all |
+        | Domain context | Per-stack notes | all |
+        """)
+        out = cp.parse_catalog(catalog)
+        assert out == {
+            "discussion": "references/sub-skills/common/discussion.md",
+        }
+
+
+class TestBacktickWrappedNonMatchingRaises:
+    """C1 fix: when first cell has a backtick-wrapped name that does NOT
+    match the strict name regex, silent-skip would mask either a PM typo
+    OR a real catalog entry. The parser RAISES so the defect surfaces
+    at parser-build time rather than at v2 compose time.
+    """
+
+    def test_capital_letter_in_name_raises(self, tmp_path):
+        catalog = _write_catalog(tmp_path, """
+        ## `common/` — Cross-cutting
+
+        | Sub-skill | One-liner | Used by |
+        |---|---|---|
+        | `Boot-bootstrap` | Capital B is wrong | all |
+        """)
+        with pytest.raises(cp.CatalogParseError) as e:
+            cp.parse_catalog(catalog)
+        assert "strict-name regex" in str(e.value).lower() \
+            or "lowercase" in str(e.value).lower()
+
+    def test_html_strikethrough_raises(self, tmp_path):
+        """If a PM uses HTML strikethrough instead of Markdown `~~`,
+        the parser RAISES rather than silently skipping. The right
+        retirement convention is `~~`name`~~`.
+        """
+        catalog = _write_catalog(tmp_path, """
+        ## `common/` — Cross-cutting
+
+        | Sub-skill | One-liner | Used by |
+        |---|---|---|
+        | <s>`old-name`</s> | HTML strike instead of Markdown | _retired_ |
+        """)
+        with pytest.raises(cp.CatalogParseError):
+            cp.parse_catalog(catalog)
+
 
 # ---------------------------------------------------------------------------
 # Live catalog integration check
@@ -318,29 +447,54 @@ class TestLiveCatalogIntegration:
     The real `docs/sub-skill-catalog.md` currently has a known defect —
     `improvement-scan` is listed under BOTH `common/` and `roles/pm/`
     sections, which the parser correctly catches per AC3. PM must
-    disambiguate (filed separately). Until that's fixed, these tests
-    pin the parser's diagnostic shape against the live file so a
-    regression in parser behavior would surface, while not blocking
-    D1 on PM's catalog-content fix.
+    disambiguate (filed as #10687). Until that's fixed, the
+    parser-catches-duplicate test is marked `xfail(strict=True)` so it
+    flips to XPASS (loud test failure) the moment PM disambiguates —
+    forcing whoever fixes #10687 to also update this test rather than
+    silently leaving stale expected-fail behavior.
     """
 
-    def test_real_catalog_surfaces_duplicate_diagnostic_with_line_numbers(self):
-        """The parser correctly detects the catalog's duplicate-name
-        defect with a precise diagnostic (line numbers + name). When
-        PM disambiguates the catalog, this test will start failing —
-        flip it to assert clean parse at that point.
+    @pytest.mark.xfail(
+        reason="Pinned to the #10687 catalog defect (duplicate "
+        "`improvement-scan`). Will XPASS (and fail the suite) once PM "
+        "disambiguates — at which point this test should be deleted and "
+        "the clean-parse path enabled below.",
+        strict=True,
+    )
+    def test_real_catalog_parses_cleanly(self):
+        """When PM disambiguates #10687, this test should pass cleanly.
+        Today the parser raises on the catalog's duplicate name (which
+        is correct behavior), so the test is xfail strict.
         """
         catalog = REPO_ROOT / "docs" / "sub-skill-catalog.md"
         if not catalog.is_file():
             pytest.skip("docs/sub-skill-catalog.md not present")
-        with pytest.raises(cp.CatalogParseError) as e:
-            cp.parse_catalog(catalog)
-        msg = str(e.value)
-        assert "duplicate" in msg.lower()
-        # Diagnostic includes both line numbers so PM can disambiguate
-        assert "line" in msg.lower()
+        out = cp.parse_catalog(catalog)
+        assert len(out) >= 10
 
-    def test_real_catalog_partial_entries_have_valid_path_shape(self):
+    def test_real_catalog_diagnostic_for_known_defect(self):
+        """Today's behavior: parser raises CatalogParseError naming
+        both conflicting source-paths. Survives PM's fix because the
+        moment the catalog is clean, this test's `xfail` doesn't apply
+        — the assertion-side flips out of scope. Keep this test as a
+        defect-pinning audit trail until #10687 ships."""
+        catalog = REPO_ROOT / "docs" / "sub-skill-catalog.md"
+        if not catalog.is_file():
+            pytest.skip("docs/sub-skill-catalog.md not present")
+        try:
+            cp.parse_catalog(catalog)
+            # Clean parse — #10687 was fixed; this defect-pinning test
+            # is obsolete. The xfail-strict test above will XPASS and
+            # tell the human to delete BOTH tests.
+            return
+        except cp.CatalogParseError as e:
+            msg = str(e)
+            assert "duplicate" in msg.lower()
+            # Both source-paths surfaced per C3
+            assert "common/improvement-scan.md" in msg
+            assert "roles/pm/improvement-scan.md" in msg
+
+    def test_real_catalog_partial_entries_have_valid_path_shape(self, tmp_path):
         """Up to the point the parser hits the duplicate, every emitted
         path satisfies AC4 (rooted, no traversal, .md suffix). This
         exercises the live catalog's first 100+ lines.
@@ -348,22 +502,19 @@ class TestLiveCatalogIntegration:
         catalog = REPO_ROOT / "docs" / "sub-skill-catalog.md"
         if not catalog.is_file():
             pytest.skip("docs/sub-skill-catalog.md not present")
-        # Read up to (but not past) the duplicate row to exercise the
-        # path-shape validator against the real catalog format.
         text = catalog.read_text(encoding="utf-8").splitlines()
         # Cut at the section containing the duplicate (line ~140)
         partial_text = "\n".join(text[:138])
-        partial_catalog = catalog.parent / ".partial-catalog-for-test.md"
+        # N3 fix: write under tmp_path, not docs/, so an interrupted
+        # test doesn't leave a dotfile in the docs tree.
+        partial_catalog = tmp_path / "partial-catalog.md"
         partial_catalog.write_text(partial_text, encoding="utf-8")
-        try:
-            out = cp.parse_catalog(partial_catalog)
-            assert len(out) >= 10  # non-trivial number of entries
-            for name, path in out.items():
-                assert path.startswith("references/sub-skills/"), name
-                assert ".." not in Path(path).parts, name
-                assert path.endswith(".md"), name
-        finally:
-            partial_catalog.unlink(missing_ok=True)
+        out = cp.parse_catalog(partial_catalog)
+        assert len(out) >= 10  # non-trivial number of entries
+        for name, path in out.items():
+            assert path.startswith("references/sub-skills/"), name
+            assert ".." not in Path(path).parts, name
+            assert path.endswith(".md"), name
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_catalog_parser_d1.py
+++ b/tests/test_catalog_parser_d1.py
@@ -1,0 +1,389 @@
+"""Tests for references/scripts/catalog_parser.py (#10672, PRD-D D1).
+
+AC6 mandates tests for:
+  (a) clean catalog parse → returns expected `{name: source_path}` mapping
+  (b) malformed row → abort with diagnostic
+  (c) duplicate name → abort
+  (d) path traversal → abort
+  (e) valid forward-compatible extra column → ignored cleanly
+
+Plus the live-catalog integration check: parse the real
+`docs/sub-skill-catalog.md` and confirm every emitted source-path
+points at a file that exists on disk (defensive — catches drift
+between catalog and source tree).
+"""
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import catalog_parser as cp  # noqa: E402
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _write_catalog(tmp_path, body):
+    """Write a catalog fixture to tmp_path/catalog.md and return the path."""
+    f = tmp_path / "catalog.md"
+    f.write_text(textwrap.dedent(body).lstrip("\n"), encoding="utf-8")
+    return f
+
+
+# ---------------------------------------------------------------------------
+# AC6(a) — clean parse
+# ---------------------------------------------------------------------------
+
+
+class TestCleanParse:
+    def test_common_section_resolves_to_common_dir(self, tmp_path):
+        catalog = _write_catalog(tmp_path, """
+        ## `common/` — Cross-cutting sub-skills
+
+        ### Boot
+
+        | Sub-skill | One-liner | Used by |
+        |---|---|---|
+        | `boot-bootstrap` | Mode detection | all |
+        | `cycle-runner` | 3-phase cycle | all |
+        """)
+        out = cp.parse_catalog(catalog)
+        assert out == {
+            "boot-bootstrap": "references/sub-skills/common/boot-bootstrap.md",
+            "cycle-runner": "references/sub-skills/common/cycle-runner.md",
+        }
+
+    def test_common_events_section_resolves_to_common_events_dir(self, tmp_path):
+        catalog = _write_catalog(tmp_path, """
+        ## `common-events/` — Event-shaped fragments
+
+        | Sub-skill | One-liner | Used by |
+        |---|---|---|
+        | `event-driven-workflow` | The event-mode l2 base | all |
+        """)
+        out = cp.parse_catalog(catalog)
+        assert out == {
+            "event-driven-workflow":
+                "references/sub-skills/common-events/event-driven-workflow.md",
+        }
+
+    def test_roles_h3_pins_role_specific_directory(self, tmp_path):
+        catalog = _write_catalog(tmp_path, """
+        ## `roles/<role>/` — Role-specific sub-skills
+
+        ### PM (`roles/pm/`)
+
+        | Sub-skill | One-liner | Used by |
+        |---|---|---|
+        | `pm-planning` | Phase 1/2 research | PM |
+        | `pm-orphan-cleanup` | Stale ticket sweep | PM |
+
+        ### Dev (`roles/dev/`)
+
+        | Sub-skill | One-liner | Used by |
+        |---|---|---|
+        | `implement-tasks` | Task implementation flow | dev |
+        """)
+        out = cp.parse_catalog(catalog)
+        assert out == {
+            "pm-planning": "references/sub-skills/roles/pm/pm-planning.md",
+            "pm-orphan-cleanup":
+                "references/sub-skills/roles/pm/pm-orphan-cleanup.md",
+            "implement-tasks":
+                "references/sub-skills/roles/dev/implement-tasks.md",
+        }
+
+    def test_project_section_is_excluded(self, tmp_path):
+        """L4 seed templates under `project/` are NOT sub-skills resolved
+        by compose — they're install scaffolding. Parser excludes them.
+        """
+        catalog = _write_catalog(tmp_path, """
+        ## `common/` — Cross-cutting
+
+        | Sub-skill | One-liner | Used by |
+        |---|---|---|
+        | `discussion` | Tracker comments | all |
+
+        ## `project/` — L4 seed templates
+
+        | Sub-skill | One-liner | Used by |
+        |---|---|---|
+        | `seed-pm-l4` | PM L4 starter | install |
+        """)
+        out = cp.parse_catalog(catalog)
+        assert out == {
+            "discussion": "references/sub-skills/common/discussion.md",
+        }
+        assert "seed-pm-l4" not in out
+
+
+# ---------------------------------------------------------------------------
+# AC6(e) — forward-compatible extra columns
+# ---------------------------------------------------------------------------
+
+
+class TestForwardCompatibleColumns:
+    def test_extra_trailing_column_ignored(self, tmp_path):
+        catalog = _write_catalog(tmp_path, """
+        ## `common/` — Cross-cutting
+
+        | Sub-skill | One-liner | Used by | Status | Ordinal |
+        |---|---|---|---|---|
+        | `discussion` | Tracker comments | all | active | 10 |
+        """)
+        out = cp.parse_catalog(catalog)
+        assert out == {
+            "discussion": "references/sub-skills/common/discussion.md",
+        }
+
+    def test_description_extracted_from_one_liner_column(self, tmp_path):
+        catalog = _write_catalog(tmp_path, """
+        ## `common/` — Cross-cutting
+
+        | Sub-skill | One-liner | Used by |
+        |---|---|---|
+        | `discussion` | Tracker comment append-only format | all |
+        """)
+        entries = cp.parse_catalog_entries(catalog)
+        assert entries[0].description == "Tracker comment append-only format"
+
+    def test_description_falls_back_to_second_column_when_header_differs(self, tmp_path):
+        catalog = _write_catalog(tmp_path, """
+        ## `common/` — Cross-cutting
+
+        | Sub-skill | Purpose | Used by |
+        |---|---|---|
+        | `discussion` | Tracker comments | all |
+        """)
+        entries = cp.parse_catalog_entries(catalog)
+        # `purpose` is in the description-alias list — extracted from col 1
+        assert entries[0].description == "Tracker comments"
+
+
+# ---------------------------------------------------------------------------
+# AC6(c) — duplicate name aborts
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateAbort:
+    def test_duplicate_in_same_section_aborts(self, tmp_path):
+        catalog = _write_catalog(tmp_path, """
+        ## `common/` — Cross-cutting
+
+        | Sub-skill | One-liner | Used by |
+        |---|---|---|
+        | `discussion` | First definition | all |
+        | `discussion` | Second definition | dev |
+        """)
+        with pytest.raises(cp.CatalogParseError) as e:
+            cp.parse_catalog(catalog)
+        assert "duplicate" in str(e.value).lower()
+        assert "discussion" in str(e.value)
+
+    def test_duplicate_across_sections_aborts(self, tmp_path):
+        catalog = _write_catalog(tmp_path, """
+        ## `common/` — Cross-cutting
+
+        | Sub-skill | One-liner | Used by |
+        |---|---|---|
+        | `vault-protocol` | Full protocol | all |
+
+        ## `common-events/` — Events
+
+        | Sub-skill | One-liner | Used by |
+        |---|---|---|
+        | `vault-protocol` | Re-defined here (bug) | all |
+        """)
+        with pytest.raises(cp.CatalogParseError) as e:
+            cp.parse_catalog(catalog)
+        assert "duplicate" in str(e.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# AC6(d) — path traversal / malformed source-path aborts
+# ---------------------------------------------------------------------------
+
+
+class TestPathValidationAbort:
+    def test_double_dot_in_directory_aborts(self, tmp_path):
+        """A malformed H2 directory token containing `..` MUST be caught
+        by the source-path validator before any consumer sees it.
+        """
+        # Hand-craft a catalog with a directory token that would resolve
+        # to a `..` segment. The H2_DIR regex is restrictive enough that
+        # `..` won't match a directory pattern — so this test exercises
+        # the defensive _validate_source_path path via a direct call.
+        with pytest.raises(cp.CatalogParseError) as e:
+            cp._validate_source_path(
+                "references/sub-skills/common/../escape.md",
+                lineno=42, name="escape",
+            )
+        assert "traversal" in str(e.value).lower() or ".." in str(e.value)
+
+    def test_dot_claude_path_aborts(self, tmp_path):
+        """AC5: `.claude/skills/` paths are NEVER valid catalog entries."""
+        with pytest.raises(cp.CatalogParseError) as e:
+            cp._validate_source_path(
+                "references/sub-skills/.claude/skills/foo.md",
+                lineno=42, name="foo",
+            )
+        assert ".claude" in str(e.value)
+
+    def test_non_md_suffix_aborts(self, tmp_path):
+        with pytest.raises(cp.CatalogParseError):
+            cp._validate_source_path(
+                "references/sub-skills/common/boot-bootstrap.txt",
+                lineno=42, name="boot-bootstrap",
+            )
+
+    def test_outside_references_sub_skills_aborts(self, tmp_path):
+        with pytest.raises(cp.CatalogParseError) as e:
+            cp._validate_source_path(
+                "docs/sub-skill-catalog.md",
+                lineno=42, name="catalog",
+            )
+        assert "rooted" in str(e.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# AC6(b) — malformed-row diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedRowAbort:
+    def test_row_under_placeholder_h2_without_h3_aborts(self, tmp_path):
+        """H2 `## \\`roles/<role>/\\` —` is a placeholder; rows under it
+        without an H3 pinning a concrete directory cannot resolve.
+        """
+        catalog = _write_catalog(tmp_path, """
+        ## `roles/<role>/` — Role-specific sub-skills
+
+        | Sub-skill | One-liner | Used by |
+        |---|---|---|
+        | `dangling-row` | This row has no role context | ? |
+        """)
+        with pytest.raises(cp.CatalogParseError) as e:
+            cp.parse_catalog(catalog)
+        assert "placeholder" in str(e.value).lower() \
+            or "role" in str(e.value).lower()
+
+    def test_row_outside_any_h2_aborts(self, tmp_path):
+        """A row appearing before any H2 has no source directory context."""
+        catalog = _write_catalog(tmp_path, """
+        Some intro prose, no H2 yet.
+
+        | Sub-skill | One-liner | Used by |
+        |---|---|---|
+        | `floating` | No H2 above this row | ? |
+        """)
+        with pytest.raises(cp.CatalogParseError) as e:
+            cp.parse_catalog(catalog)
+        assert "h2" in str(e.value).lower() \
+            or "enclosing" in str(e.value).lower()
+
+
+class TestIgnoredRows:
+    def test_strikethrough_retirement_rows_are_skipped(self, tmp_path):
+        """Rows like `~~discussion-protocol~~` are retirement annotations,
+        not active catalog entries. They MUST be skipped silently — not
+        treated as malformed rows.
+        """
+        catalog = _write_catalog(tmp_path, """
+        ## `common/` — Cross-cutting
+
+        | Sub-skill | One-liner | Used by |
+        |---|---|---|
+        | `discussion` | Active row | all |
+        | ~~`discussion-protocol`~~ | Retired; do not use | _retired_ |
+        """)
+        out = cp.parse_catalog(catalog)
+        assert out == {
+            "discussion": "references/sub-skills/common/discussion.md",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Live catalog integration check
+# ---------------------------------------------------------------------------
+
+
+class TestLiveCatalogIntegration:
+    """Live catalog integration check.
+
+    The real `docs/sub-skill-catalog.md` currently has a known defect —
+    `improvement-scan` is listed under BOTH `common/` and `roles/pm/`
+    sections, which the parser correctly catches per AC3. PM must
+    disambiguate (filed separately). Until that's fixed, these tests
+    pin the parser's diagnostic shape against the live file so a
+    regression in parser behavior would surface, while not blocking
+    D1 on PM's catalog-content fix.
+    """
+
+    def test_real_catalog_surfaces_duplicate_diagnostic_with_line_numbers(self):
+        """The parser correctly detects the catalog's duplicate-name
+        defect with a precise diagnostic (line numbers + name). When
+        PM disambiguates the catalog, this test will start failing —
+        flip it to assert clean parse at that point.
+        """
+        catalog = REPO_ROOT / "docs" / "sub-skill-catalog.md"
+        if not catalog.is_file():
+            pytest.skip("docs/sub-skill-catalog.md not present")
+        with pytest.raises(cp.CatalogParseError) as e:
+            cp.parse_catalog(catalog)
+        msg = str(e.value)
+        assert "duplicate" in msg.lower()
+        # Diagnostic includes both line numbers so PM can disambiguate
+        assert "line" in msg.lower()
+
+    def test_real_catalog_partial_entries_have_valid_path_shape(self):
+        """Up to the point the parser hits the duplicate, every emitted
+        path satisfies AC4 (rooted, no traversal, .md suffix). This
+        exercises the live catalog's first 100+ lines.
+        """
+        catalog = REPO_ROOT / "docs" / "sub-skill-catalog.md"
+        if not catalog.is_file():
+            pytest.skip("docs/sub-skill-catalog.md not present")
+        # Read up to (but not past) the duplicate row to exercise the
+        # path-shape validator against the real catalog format.
+        text = catalog.read_text(encoding="utf-8").splitlines()
+        # Cut at the section containing the duplicate (line ~140)
+        partial_text = "\n".join(text[:138])
+        partial_catalog = catalog.parent / ".partial-catalog-for-test.md"
+        partial_catalog.write_text(partial_text, encoding="utf-8")
+        try:
+            out = cp.parse_catalog(partial_catalog)
+            assert len(out) >= 10  # non-trivial number of entries
+            for name, path in out.items():
+                assert path.startswith("references/sub-skills/"), name
+                assert ".." not in Path(path).parts, name
+                assert path.endswith(".md"), name
+        finally:
+            partial_catalog.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# CatalogEntry dataclass surface
+# ---------------------------------------------------------------------------
+
+
+class TestCatalogEntryShape:
+    def test_default_description_is_empty(self):
+        e = cp.CatalogEntry(name="foo", source_path="references/sub-skills/common/foo.md")
+        assert e.description == ""
+
+    def test_parse_catalog_returns_dict(self, tmp_path):
+        catalog = _write_catalog(tmp_path, """
+        ## `common/` — Cross-cutting
+
+        | Sub-skill | One-liner | Used by |
+        |---|---|---|
+        | `discussion` | Tracker comments | all |
+        """)
+        out = cp.parse_catalog(catalog)
+        assert isinstance(out, dict)
+        assert isinstance(list(out.keys())[0], str)


### PR DESCRIPTION
Closes #10672. **PRD-D Story D1 — foundational parser for v2 compose's sub-skill reference resolution.**

## Summary
- Adds `references/scripts/catalog_parser.py` — reads `docs/sub-skill-catalog.md` and returns `{name: source_path}` mapping per COMPOSE-ARCHITECTURE.md §4.5.
- 20 unit tests covering all 6 AC6 paths + 2 live-catalog integration tests + dataclass shape coverage.

## Planning contract (per #8950 Gate #4)
- **Module shape**: ~250 LOC; 2 public functions (`parse_catalog` returns dict for fast lookup, `parse_catalog_entries` returns list of records with descriptions); 4 private helpers; 1 dataclass; 1 exception class.
- **Files added**: `references/scripts/catalog_parser.py`, `tests/test_catalog_parser_d1.py`.
- **Files modified**: `tests/run_tests.py` (registers new module).
- **Files NOT touched**: `compose.py`, `model_router.py`, any L1-L3 source, any other `l4_*.py` module. Pure-read module per D1's "v1 coexistence" note.
- **§9a impact**: zero — v1 byte-stability green (5/5).
- **Tests**: 20/20 green (0.14s).
- **Dependencies**: NONE — foundational for D3, D4, D8.

## AC mapping
| AC | Implementation | Tests |
|---|---|---|
| 1: `parse_catalog(catalog_path) -> dict[str, str]` | `parse_catalog` returns `{name: source_path}` dict | `test_parse_catalog_returns_dict` + 3 clean-parse tests |
| 2: row schema = name + source-path + description; optional cols ignored | source-path DERIVED from H2 directory + H3 role-pin; description from one-liner with header aliases | `test_extra_trailing_column_ignored`, `test_description_extracted_from_one_liner_column`, `test_description_falls_back_to_second_column_when_header_differs` |
| 3: aborts on malformed row / duplicate / malformed source-path | `CatalogParseError(ValueError)` raised with structured diagnostic | 4 malformed-row tests + 2 duplicate tests + 4 path-validation tests |
| 4: source-path validation (rooted, no `..`, ends `.md`) | `_validate_source_path` helper | 4 path-validation tests |
| 5: `.claude/skills/` paths never valid | defensive check in `_validate_source_path` | `test_dot_claude_path_aborts` |
| 6: tests for clean / malformed / duplicate / path-traversal / extra-column | covered above | 20 unit tests |

## Catalog defect surfaced
The live `docs/sub-skill-catalog.md` has a duplicate `improvement-scan` entry at lines 140 (common/) and 209 (roles/pm/). The parser correctly catches it per AC3. Filed **#10687 to PM** for disambiguation (rename one variant). The two live-catalog integration tests pin the diagnostic shape against the current defect — when PM fixes the catalog, flip them to assert clean parse.

## Test plan
- [x] `python -m pytest tests/test_catalog_parser_d1.py -v` — 20/20 green
- [x] `python -m pytest tests/test_v1_byte_stability_9a.py -v` — 5/5 green (no v1 regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)