### PR TITLE
PRD-D D4 (#10675): catalog drift check

### DIFF
--- a/.squidsquad/skill/planning/ds-d4-review.md
+++ b/.squidsquad/skill/planning/ds-d4-review.md
@@ -1,0 +1,65 @@
+After thorough review of the three changed files, I've identified several issues. Let me present them in priority order.
+
+---
+
+### Finding 1
+
+- **File**: `references/scripts/catalog_drift.py`
+- **Line**: `_collect_manifest_references` function, the `for role_dir in roles_dir.iterdir():` loop (approximately line 208-210)
+- **Severity**: warning
+- **Issue**: The dead-code scan only iterates top-level directories under `references/roles/` using `iterdir()`. Nested variant directories (e.g., `roles/worker/skill/`) are never visited, so any sub-skill referenced **only** by a variant's `additional_includes` (or a variant's own `includes`) will be falsely reported as a dead-code candidate. Additionally, even if nested directories were visited, the function only reads the `includes` key — it does not recognise the `base_role` + `additional_includes` variant schema that `compose.py._load_manifest` handles.
+- **Evidence**: `iterdir()` yields only immediate children; `roles/worker/skill/` is two levels deep and will not be yielded. Compose.py explicitly resolves variants via `_resolve_variant` → `ROLES_DIR / base / variant`, and those variant directories carry their own `includes.yml` files with the variant schema. The test helper `_make_fixture` only creates top-level manifests — no test covers nested variants.
+- **Suggested fix**: Either (a) walk the roles tree recursively (e.g., `roles_dir.rglob("*.yml")` filtered by `_MANIFEST_FILENAMES`) and extract referenced names from **both** `includes` and `additional_includes` keys, or (b) call `_load_manifest` / `_resolve_variant` for every known role identity to gather the resolved include list. Option (b) would guarantee the same reference set compose.py uses, but imports a heavier dependency. Option (a) is simpler: `rglob` + read both keys.
+
+---
+
+### Finding 2
+
+- **File**: `references/scripts/catalog_drift.py`
+- **Line**: `except _yaml.YAMLError: continue` in `_collect_manifest_references` (approximately line 228)
+- **Severity**: warning
+- **Issue**: YAML parse errors in individual manifest files are silently swallowed with no diagnostic. If a manifest file is corrupted, all of its includes are silently omitted from the reference set, which can cause false-positive dead-code warnings. The user has no indication that a manifest was skipped or why.
+- **Evidence**: The docstring says "YAML import failure is fatal" but parse errors are not. Compose.py's equivalent (`_load_manifest`) prints a `WARNING` to stderr on parse failure before returning `None`. The drift check should be at least as transparent.
+- **Suggested fix**: Print a warning to stderr before the `continue`, e.g.:
+  ```python
+  except _yaml.YAMLError:
+      print(f"WARNING: drift-check skipping unparseable manifest: {mpath}", file=sys.stderr)
+      continue
+  ```
+
+---
+
+### Finding 3
+
+- **File**: `tests/test_catalog_drift_d4.py`
+- **Line**: Function signature of `_make_fixture` — the `dead_code_extra` parameter (approximately line 23)
+- **Severity**: warning (minor)
+- **Issue**: The `dead_code_extra` parameter is accepted in the function signature but is never referenced anywhere in the function body. This is dead code in the test helper.
+- **Evidence**: A search of the function body confirms `dead_code_extra` is never read or used. No caller passes it either (all call-sites omit it, relying on the default `()`).
+- **Suggested fix**: Remove the parameter, or implement its intended purpose (if it was meant to add extra catalog rows that should be flagged as dead-code for testing).
+
+---
+
+### Finding 4
+
+- **File**: `references/scripts/catalog_drift.py`
+- **Line**: `if md_path.name in _NON_SUB_SKILL_BASENAMES: continue` inside `scan_drift` (approximately line 156)
+- **Severity**: warning (minor)
+- **Issue**: The check uses `md_path.name` (basename only) to exclude files, which means files named `manifest.md`, `README.md`, or `index.md` are excluded **anywhere** in the sub-skills tree, not only at the root. The docstring says "`manifest.md` at the top of `references/sub-skills/`" — the code excludes it in nested directories too, which could theoretically hide a real orphan source file.
+- **Evidence**: `md_path.name` returns just the filename; `md_path.parent` is not compared to `sub_skills_root`. A file at `references/sub-skills/common/manifest.md` would be silently excluded.
+- **Suggested fix**: Either restrict the exclusion to files directly in `sub_skills_root` (compare `md_path.parent == sub_skills_root`), or update the docstring to explicitly state the broader exclusion applies everywhere. The practical risk is negligible (nobody puts a real sub-skill in a file named `manifest.md`), so a doc fix may be sufficient.
+
+---
+
+### Finding 5
+
+- **File**: `references/scripts/catalog_drift.py`
+- **Line**: `_collect_manifest_references` basename logic (approximately line 235-237)
+- **Severity**: warning (minor)
+- **Issue**: The basename-based matching can produce **false negatives** in dead-code detection. If catalog entry `X` is genuinely unreferenced, but some **unrelated** manifest include like `some/other/X` happens to have the same basename, the catalog entry `X` will match the basename and won't be flagged. The inverse is also possible: a slash-bearing catalog entry like `deep/path/X` won't match a manifest include of just `X` (no slash → no basename extraction), yielding a **false positive**.
+- **Evidence**: For manifest include `some/other/X`, the code adds both `some/other/X` and `X`. Catalog entry `X` then matches. But `some/other/X` may be a completely different file unrelated to catalog entry `X`. Similarly, manifest include `X` (no slash) adds only `X`; catalog entry `deep/path/X` is the string `deep/path/X` and does not match `X`.
+- **Suggested fix**: A more precise approach: for each catalog name, check whether the **exact** name is in referenced, **or** (if the catalog name contains a slash) whether its basename is in referenced. This avoids the asymmetric false-positive case. The false-negative case (basename collision) is inherent to basename heuristics; consider logging when a basename match is the only reason a catalog entry escapes dead-code, so operators can audit.
+
+---
+
+**Overall assessment**: The core two-way orphan scan (directions 1 and 2) is correct and well-tested. The dead-code scan (direction 3) has genuine gaps — it doesn't walk nested variant directories and doesn't handle the `base_role` + `additional_includes` manifest schema, which can cause false-positive dead-code warnings. The other findings are lower severity (missing warnings, minor test dead code, and heuristic imprecision).

--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -8,31 +8,29 @@
 
 ## Completed Steps
 
-- Cycle 1512: PRD-D/D2 (#10673) — v2 link-stage stops inlining sub-skill bodies → references only. PR #10691 pending-test. Filter scoped to (slot=instructions AND path under references/sub-skills/). Both common/ and common-events/ subtrees covered. Measured size: avg 24.9% v2/v1 (target ≤30%).
-- Cycle 1511: PRD-D/D8 (#10679) row schema validation folded into catalog_parser. PR #10689 pending-test.
-- Cycle 1510: PRD-D/D1 (#10672) sub-skill catalog parser shipped to PR #10688 → MERGED.
-- Cycles 1502-1509: post-PRD-C wind-down + 5 quiet cycles.
+- Cycle 1513: PRD-E/E2 (#10681) — `last_compose_checksum` field plumbing in `.harness-state.json` shipped to pending-test on PR #10692. Foundational dep for E1 + E5. 11 tests + 2585 static passing.
+- Cycle 1512: PRD-D/D2 (#10673) — v2 link-stage filter for sub-skill bodies. PR #10691 pending-test. avg 24.9% v2/v1 size.
+- Cycle 1511: PRD-D/D8 (#10679) — row schema validation folded into catalog_parser. PR #10689 pending-test.
+- Cycle 1510: PRD-D/D1 (#10672) — sub-skill catalog parser. PR #10688 MERGED.
 
 ## Remaining Steps
 
-- Watch QA on PR #10691 (D2) and PR #10689 (D8).
-- PRD-D queue next: D3 (#10674 catalog gate, depends on D2/MERGED), D4 (#10675), D5 (#10676), D7 (#10678).
-- PRD-E queue: E1-E5 approved + actionable; E6+E7 cutover-gated.
+- Watch QA on PR #10691 (D2), PR #10689 (D8), PR #10692 (E2).
+- PRD-E queue next: E1 (#10680 boot-time freshness check — depends on E2 merged), E3 (#10682), E4 (#10683), E5 (#10684 — depends on E1).
+- PRD-D queue: D3 (#10674 catalog gate — depends on D2 merged), D4 (#10675), D5 (#10676), D7 (#10678).
 - Open follow-ups: #10670, #10671.
 
 ## Key Decisions (latest only)
 
-- **NEW: D2 source-migration vs code-transformation distinction.** Cycle 1512 lesson. AC1's "emit `→ run sub-skill: <name>` instead of inlining bodies" sounds like a code transformation but per TRD §3.0 it's a source-migration step + a filter — orchestrator files already author reference text verbatim; D2 only stops walking sub-skill BODIES into the instructions slot. Filter is one line of structural intent, not a parsing rewrite.
-- **NEW: Path-prefix filter scoped to slot, not path alone.** Filter is (slot=instructions AND path-under-sub-skills/). This locks the intent: sub-skill bodies are runtime-loaded by reference; only the instructions slot is reference-grammar; other slots under sub-skill paths (synthetic test pattern) still flow. Both common/ and common-events/ subtrees correctly suppressed — common-events are also runtime-loaded per boot Step 3.
-- **NEW: Parallel-reviewer pattern when DS is slow.** When model_router takes 10+ min, spawn a Claude subagent review IN PARALLEL with the still-running DS. Both come back; consolidate findings. Saves a cycle vs polling.
-- **NEW: DS findings on filter-broadness map directly to docstring updates, not code changes.** DS flagged the filter's coverage of common-events/ as "could be wrong if common-events ever gets slot:instructions" — but they ALREADY do (6 files), and the filter is correctly suppressing them. Disposition: document the breadth as intentional rather than narrow the predicate.
+- **NEW: PRD-E pickup order: foundation first.** Cycle 1513 lesson. Queue showed E5 first (medium) but E5 depends on E1 which depends on E2. The right pickup is the foundation (E2), not the queue-top. Reading issue bodies for "Dependencies:" before pickup keeps the gate chain from getting stuck. Recipe: when queue has multiple items at the same priority and you suspect dependencies, fetch issue bodies BEFORE picking up.
+- D2 source-migration vs code-transformation distinction (cycle 1512)
+- Path-prefix filter scoped to slot, not path alone (cycle 1512)
+- Parallel-reviewer pattern when DS is slow (cycle 1512)
 - Context-budget-driven story selection beats strict queue priority for small follow-on stories
-- Skip code-review for trivial fold-in stories where the diff is one new helper + tests mirroring existing pattern
-- 'Never raises' for multi-failure-mode orchestrators (C5/C6/C7/C9); raise-on-failure for LLM gates (C3/C8)
-- Sentinel-default dataclass fields beat None-defaults for never-raises orchestrators
+- Skip code-review for trivial fold-in stories where the diff mirrors an existing pattern
+- 'Never raises' for multi-failure-mode orchestrators; raise-on-failure for LLM gates
+- Sentinel-default dataclass fields beat None-defaults
 - pytest.mark.xfail(strict=True) for defect-dependency tests
-- Markdown catalog conventions can encode source-paths inside name columns
 - Allowlist over denylist for emit-or-skip decisions
-- DM DIRTY-PR workflow: git merge origin/main + force-transition past stale QA flag
 
 - **Vault Writes This Cycle**: 0

--- a/references/scripts/catalog_drift.py
+++ b/references/scripts/catalog_drift.py
@@ -1,0 +1,282 @@
+"""D4: Catalog drift check (#10675, PRD-D Story D4).
+
+Two-way orphan scan that confirms the catalog and the sub-skills source tree
+agree on what exists. Drift = abort; dead-code = warn.
+
+Scans run in three directions:
+
+1. **Orphan catalog rows** — every catalog entry's ``source_path`` must
+   exist on disk under ``references/sub-skills/``. A row that points at a
+   missing file is an "orphan catalog row".
+
+2. **Orphan source files** — every file under
+   ``references/sub-skills/**/*.md`` must have a matching catalog row. A
+   file with no catalog row is an "orphan source file".
+
+3. **Dead-code candidates** — a catalog row whose name does not appear as
+   an include in any role's ``includes.yml`` / ``includes-events.yml`` /
+   ``includes-v2.yml`` is a dead-code candidate. Per PRD §8 Q-D3 this is
+   warn-not-abort: the catalog row may be reserved for an in-flight role
+   or a sub-skill not yet referenced.
+
+The dead-code warning is **scoped to call-sites in role manifests** —
+inline ``→ run sub-skill:`` references inside other sub-skill bodies are
+not scanned (transitive references are surfaced by D3's compose-time
+gate; D4 stays at the manifest layer to keep the abort surface
+predictable, per AC5 independence).
+
+Per AC5, D4 is **independent of D2/D3**: it runs against the source tree
+only, never composes anything, and never reads the v2 link-stage output.
+"""
+
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import catalog_parser as _cp
+
+try:
+    import yaml as _yaml
+except ImportError:  # pragma: no cover — yaml is a hard dep in compose
+    _yaml = None
+
+
+SUB_SKILLS_REL = "references/sub-skills"
+# Files in the sub-skills tree that are not themselves sub-skills and so
+# must be excluded from the "orphan source file" scan. ``manifest.md`` at
+# the top of ``references/sub-skills/`` and any README-style index file
+# fall in this bucket.
+_NON_SUB_SKILL_BASENAMES = frozenset({"manifest.md", "README.md", "index.md"})
+# Subdirectories under ``references/sub-skills/`` that are excluded from
+# the orphan-source scan. ``project/`` holds L4 seed templates (the
+# catalog parser already excludes them on the catalog-emit side via the
+# ``_INCLUDED_DIRS`` allowlist — mirror that here so the two-way scan
+# stays symmetric). ``capabilities/`` holds the {{capability: id}} body
+# sources which compose.py resolves via a different path
+# (_resolve_capability) and are not catalog-tracked.
+_EXCLUDED_SUBDIRS = frozenset({"project", "capabilities"})
+
+# Manifest filenames scanned for dead-code detection. Tracks both the v1
+# split (polling vs event) and the post-D5 unified v2 file. Any subset
+# may be absent on a given role — we read whatever exists.
+_MANIFEST_FILENAMES = (
+    "includes.yml",
+    "includes-events.yml",
+    "includes-v2.yml",
+)
+
+
+@dataclass
+class DriftReport:
+    """Structured result of a drift scan.
+
+    Each field is a list so callers can render full reports (per AC3:
+    "list ALL orphans, not just first").
+    """
+
+    orphan_catalog_rows: list[tuple[str, str]] = field(default_factory=list)
+    """``(name, expected_source_path)`` per row whose file is missing."""
+
+    orphan_source_files: list[str] = field(default_factory=list)
+    """Repo-relative source paths with no matching catalog row."""
+
+    dead_code_candidates: list[str] = field(default_factory=list)
+    """Catalog names with no call-site in any role manifest. Warn only."""
+
+    @property
+    def has_drift(self) -> bool:
+        """True iff there is at least one orphan (either direction)."""
+        return bool(self.orphan_catalog_rows or self.orphan_source_files)
+
+    @property
+    def has_dead_code(self) -> bool:
+        return bool(self.dead_code_candidates)
+
+    def format(self) -> str:
+        """Render a human-readable multi-section report.
+
+        Empty sections are omitted. The output is stable-ordered so test
+        assertions and reviewer diffs are deterministic.
+        """
+        lines = []
+        if self.orphan_catalog_rows:
+            lines.append("Orphan catalog rows (source file missing):")
+            for name, path in sorted(self.orphan_catalog_rows):
+                lines.append(f"  - `{name}` -> {path}")
+        if self.orphan_source_files:
+            if lines:
+                lines.append("")
+            lines.append("Orphan source files (no catalog row):")
+            for path in sorted(self.orphan_source_files):
+                lines.append(f"  - {path}")
+        if self.dead_code_candidates:
+            if lines:
+                lines.append("")
+            lines.append("Dead-code candidates (catalog row, no call-site):")
+            for name in sorted(self.dead_code_candidates):
+                lines.append(f"  - `{name}`")
+        return "\n".join(lines)
+
+
+def scan_drift(
+    catalog_path,
+    repo_root,
+    *,
+    roles_dir=None,
+    manifest_filenames=_MANIFEST_FILENAMES,
+):
+    """Run the two-way drift scan + dead-code scan.
+
+    ``catalog_path`` — the catalog markdown file (``docs/sub-skill-catalog.md``).
+    ``repo_root`` — repository root; the sub-skills tree is read relative
+    to it (``<repo_root>/references/sub-skills/**/*.md``).
+    ``roles_dir`` — optional explicit roles directory (defaults to
+    ``<repo_root>/references/roles``). The dead-code scan reads
+    ``<roles_dir>/<role>/<manifest_filename>`` for each manifest filename.
+    ``manifest_filenames`` — tuple of include-manifest basenames to scan
+    for call-sites.
+
+    Returns a populated :class:`DriftReport`. A
+    :class:`catalog_parser.CatalogParseError` from the catalog raises
+    through to the caller — D4 does not silently swallow upstream
+    catalog defects.
+    """
+    catalog_path = Path(catalog_path)
+    repo_root = Path(repo_root)
+    sub_skills_root = repo_root / SUB_SKILLS_REL
+    roles_dir = Path(roles_dir) if roles_dir is not None else (
+        repo_root / "references" / "roles"
+    )
+
+    entries = _cp.parse_catalog_entries(catalog_path)
+    catalog_by_name = {e.name: e for e in entries}
+    catalog_source_paths = {e.source_path for e in entries}
+
+    report = DriftReport()
+
+    # Direction 1: catalog row -> file exists.
+    for entry in entries:
+        full_path = repo_root / entry.source_path
+        if not full_path.is_file():
+            report.orphan_catalog_rows.append(
+                (entry.name, entry.source_path),
+            )
+
+    # Direction 2: source file -> catalog row exists.
+    if sub_skills_root.is_dir():
+        for md_path in sub_skills_root.rglob("*.md"):
+            try:
+                rel = md_path.relative_to(sub_skills_root)
+            except ValueError:
+                continue
+            # Root-level non-sub-skill files (manifest.md, README.md,
+            # index.md). Per DS review F4 — restricted to root so a
+            # nested file with the same basename can't silently hide.
+            if md_path.parent == sub_skills_root \
+                    and md_path.name in _NON_SUB_SKILL_BASENAMES:
+                continue
+            # Excluded top-level subdir — symmetric with catalog
+            # parser's allowlist (project/, capabilities/).
+            if rel.parts and rel.parts[0] in _EXCLUDED_SUBDIRS:
+                continue
+            rel_to_repo = (
+                Path(SUB_SKILLS_REL) / rel
+            ).as_posix()
+            if rel_to_repo not in catalog_source_paths:
+                report.orphan_source_files.append(rel_to_repo)
+
+    # Direction 3: catalog row -> referenced in any role manifest.
+    referenced = _collect_manifest_references(roles_dir, manifest_filenames)
+    for name in catalog_by_name:
+        if _is_referenced(name, referenced):
+            continue
+        report.dead_code_candidates.append(name)
+
+    return report
+
+
+def _is_referenced(catalog_name, referenced):
+    """Decide if a catalog name has a call-site in any role manifest.
+
+    Match rules — symmetric with ``compose.py._resolve_includes`` which
+    resolves an include path like ``common/boot-bootstrap`` to the
+    catalog name ``boot-bootstrap`` via the source-path's last segment:
+
+    - **Exact path match**: the catalog name appears verbatim in some
+      manifest's ``includes:`` list (slash-bearing catalog names like
+      ``roles/dm/events/pr-merge-wait`` are referenced this way).
+    - **Basename match for plain names**: a non-slash catalog name like
+      ``boot-bootstrap`` matches a manifest entry whose **last** path
+      segment is the catalog name (e.g. ``common/boot-bootstrap``).
+      Per DS review F5: only invoked for plain catalog names; slash-
+      bearing catalog names must match exactly to avoid the asymmetric
+      false-negative (``deep/X`` vs ``X``).
+    """
+    if catalog_name in referenced:
+        return True
+    if "/" not in catalog_name:
+        # Plain catalog name; accept any manifest entry that ends in it.
+        return any(
+            inc.rsplit("/", 1)[-1] == catalog_name
+            for inc in referenced
+            if "/" in inc
+        )
+    return False
+
+
+# Keys inside a role manifest yaml whose values are include-path lists.
+# ``includes`` is the canonical key; ``additional_includes`` is the
+# variant schema used by ``roles/<base>/<variant>/includes.yml``
+# (compose.py:_load_manifest merges these with the base role's
+# ``includes:`` list).
+_MANIFEST_INCLUDE_KEYS = ("includes", "additional_includes")
+
+
+def _collect_manifest_references(roles_dir, manifest_filenames):
+    """Union of include-paths across every role manifest, recursively.
+
+    Returns the set of include-path strings observed across every
+    matching manifest file under ``roles_dir`` at any depth, reading
+    both ``includes:`` AND ``additional_includes:`` keys (per DS review
+    F1 — variant manifests at ``roles/<base>/<variant>/includes.yml``
+    use ``additional_includes`` to extend the base role's list, and
+    were silently skipped by the previous top-level-only scan).
+
+    YAML import failure is fatal. Per DS review F2: unparseable
+    manifest files emit a stderr warning before being skipped, so
+    operators can investigate the false-positive dead-code candidates
+    that result.
+    """
+    if _yaml is None:
+        raise RuntimeError(
+            "PyYAML is required for D4 catalog drift scan (manifest read).",
+        )
+
+    referenced = set()
+    roles_dir = Path(roles_dir)
+    if not roles_dir.is_dir():
+        return referenced
+
+    for fname in manifest_filenames:
+        for mpath in roles_dir.rglob(fname):
+            if not mpath.is_file():
+                continue
+            try:
+                data = _yaml.safe_load(mpath.read_text(encoding="utf-8"))
+            except _yaml.YAMLError as e:
+                print(
+                    f"WARNING: drift-check skipping unparseable manifest "
+                    f"{mpath}: {e}",
+                    file=sys.stderr,
+                )
+                continue
+            if not isinstance(data, dict):
+                continue
+            for key in _MANIFEST_INCLUDE_KEYS:
+                includes = data.get(key) or []
+                if not isinstance(includes, list):
+                    continue
+                for inc in includes:
+                    if isinstance(inc, str):
+                        referenced.add(inc)
+    return referenced

--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -2100,6 +2100,74 @@ def main():
         lines = soul_path.read_text(encoding="utf-8").count("\n")
         print(f"Upgraded {role_name} SOUL.md ({lines} lines) -> {soul_path.relative_to(REPO_ROOT)}")
 
+    elif cmd == "drift-check":
+        # PRD-D D4 (#10675). Two-way orphan scan: catalog row <-> source
+        # file. Dead-code candidates (catalog row not referenced in any
+        # role manifest) warn but do not abort. Exit 0 = clean (no
+        # drift; dead-code may have been warned), 1 = drift detected,
+        # 2 = catalog parse / setup error.
+        catalog_arg = None
+        repo_root_arg = None
+        sub_args = args[1:]
+        i = 0
+        while i < len(sub_args):
+            tok = sub_args[i]
+            if tok == "--catalog" and i + 1 < len(sub_args):
+                catalog_arg = sub_args[i + 1]
+                i += 2
+                continue
+            if tok == "--repo-root" and i + 1 < len(sub_args):
+                repo_root_arg = sub_args[i + 1]
+                i += 2
+                continue
+            print(
+                f"ERROR: unrecognized drift-check argument: {tok}",
+                file=sys.stderr,
+            )
+            print(
+                "Usage: compose.py drift-check "
+                "[--catalog <path>] [--repo-root <path>]",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        target_repo = Path(repo_root_arg) if repo_root_arg else REPO_ROOT
+        target_catalog = (
+            Path(catalog_arg) if catalog_arg
+            else target_repo / "docs" / "sub-skill-catalog.md"
+        )
+        # Lazy import — keep v1 deploy paths free of D4 module load
+        # cost until the explicit subcommand is invoked.
+        import catalog_drift as _cd
+        from catalog_parser import CatalogParseError as _CPE
+        try:
+            report = _cd.scan_drift(target_catalog, target_repo)
+        except _CPE as e:
+            print(
+                f"ERROR: catalog parse failed: {e}",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        except Exception as e:
+            print(
+                f"ERROR: drift-check setup failed: {e}",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        if report.has_drift:
+            print(report.format(), file=sys.stderr)
+            sys.exit(1)
+        if report.has_dead_code:
+            # Warn but exit 0 per Q-D3.
+            print(
+                "WARNING: dead-code candidates (catalog rows with no "
+                "call-site in any role manifest):",
+                file=sys.stderr,
+            )
+            print(report.format(), file=sys.stderr)
+            sys.exit(0)
+        print("Catalog drift check: clean")
+        sys.exit(0)
+
     else:
         # Treat as role entry file name
         content = compose_role(cmd)

--- a/tests/test_catalog_drift_d4.py
+++ b/tests/test_catalog_drift_d4.py
@@ -1,0 +1,556 @@
+"""Tests for references/scripts/catalog_drift.py (#10675, PRD-D D4).
+
+AC6 mandates tests for:
+  (a) clean run (no drift) -> exit 0 / has_drift=False
+  (b) orphan catalog row -> abort + report
+  (c) orphan source file -> abort + report
+  (d) both kinds -> both reported (not just first)
+  (e) dead-code candidate -> warn but exit 0
+
+Plus structural tests for the report format and manifest-reference
+collection (catalog rows whose names appear in any role's
+``includes.yml`` / ``includes-events.yml`` / ``includes-v2.yml`` are
+NOT flagged as dead-code).
+"""
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import catalog_drift as cd  # noqa: E402
+
+
+def _make_fixture(tmp_path, *, catalog_body, sub_skill_files, manifests=None):
+    """Build a self-contained repo-root fixture for drift testing.
+
+    Lays out:
+        tmp_path/docs/sub-skill-catalog.md
+        tmp_path/references/sub-skills/<files...>
+        tmp_path/references/roles/<role-path>/<manifest>
+
+    ``manifests`` keys are ``(role_path, filename)`` where ``role_path``
+    can contain slashes for variant manifests like ``worker/skill`` —
+    the helper creates the nested directory.
+    """
+    repo = tmp_path
+    (repo / "docs").mkdir()
+    catalog = repo / "docs" / "sub-skill-catalog.md"
+    catalog.write_text(textwrap.dedent(catalog_body).lstrip("\n"),
+                       encoding="utf-8")
+
+    sub_skills = repo / "references" / "sub-skills"
+    sub_skills.mkdir(parents=True)
+    for rel in sub_skill_files:
+        full = sub_skills / rel
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_text(f"# {rel}\n", encoding="utf-8")
+
+    roles_dir = repo / "references" / "roles"
+    roles_dir.mkdir(parents=True)
+    if manifests:
+        for (role, fname), payload in manifests.items():
+            role_dir = roles_dir / role
+            role_dir.mkdir(parents=True, exist_ok=True)
+            if isinstance(payload, str):
+                # Raw YAML body — used for malformed-manifest tests.
+                (role_dir / fname).write_text(payload, encoding="utf-8")
+                continue
+            if isinstance(payload, dict):
+                # Mapped form — e.g. {"includes": [...],
+                # "additional_includes": [...], "base_role": "worker"}.
+                body_parts = []
+                for k, v in payload.items():
+                    if isinstance(v, list):
+                        body_parts.append(
+                            f"{k}:\n" + "".join(f"  - {i}\n" for i in v)
+                        )
+                    else:
+                        body_parts.append(f"{k}: {v}\n")
+                (role_dir / fname).write_text(
+                    "".join(body_parts), encoding="utf-8")
+                continue
+            # Plain list form — shorthand for {"includes": [...]}.
+            body = "includes:\n" + "".join(f"  - {i}\n" for i in payload)
+            (role_dir / fname).write_text(body, encoding="utf-8")
+
+    return repo, catalog
+
+
+# Catalog body templates — share the H2/header structure tests need.
+
+_CATALOG_TWO_COMMON_ROWS = """
+## `common/` — Cross-cutting
+
+### Boot
+
+| Sub-skill | One-liner | Used by |
+|---|---|---|
+| `boot-bootstrap` | Mode detection | all |
+| `cycle-runner` | 3-phase cycle | all |
+"""
+
+
+class TestCleanRun:
+    """AC6(a) — no drift in either direction, exit 0."""
+
+    def test_all_rows_resolve_and_all_files_have_rows(self, tmp_path):
+        repo, catalog = _make_fixture(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_COMMON_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                "common/cycle-runner.md",
+            ],
+            manifests={
+                ("pm", "includes.yml"): [
+                    "common/boot-bootstrap",
+                    "common/cycle-runner",
+                ],
+            },
+        )
+        report = cd.scan_drift(catalog, repo)
+        assert report.has_drift is False
+        assert report.has_dead_code is False
+        assert report.orphan_catalog_rows == []
+        assert report.orphan_source_files == []
+        assert report.dead_code_candidates == []
+        assert report.format() == ""
+
+
+class TestOrphanCatalogRow:
+    """AC6(b) — catalog row points at a missing file."""
+
+    def test_missing_source_file_reported(self, tmp_path):
+        repo, catalog = _make_fixture(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_COMMON_ROWS,
+            sub_skill_files=["common/boot-bootstrap.md"],  # cycle-runner missing
+            manifests={
+                ("pm", "includes.yml"): [
+                    "common/boot-bootstrap",
+                    "common/cycle-runner",
+                ],
+            },
+        )
+        report = cd.scan_drift(catalog, repo)
+        assert report.has_drift is True
+        assert report.orphan_catalog_rows == [
+            ("cycle-runner", "references/sub-skills/common/cycle-runner.md"),
+        ]
+        # Other directions clean.
+        assert report.orphan_source_files == []
+        assert report.dead_code_candidates == []
+        # Report names the orphan.
+        out = report.format()
+        assert "Orphan catalog rows" in out
+        assert "`cycle-runner`" in out
+
+
+class TestOrphanSourceFile:
+    """AC6(c) — source file with no catalog row."""
+
+    def test_orphan_file_reported(self, tmp_path):
+        repo, catalog = _make_fixture(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_COMMON_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                "common/cycle-runner.md",
+                "common/uncatalogued-helper.md",  # not in catalog
+            ],
+            manifests={
+                ("pm", "includes.yml"): [
+                    "common/boot-bootstrap",
+                    "common/cycle-runner",
+                ],
+            },
+        )
+        report = cd.scan_drift(catalog, repo)
+        assert report.has_drift is True
+        assert report.orphan_catalog_rows == []
+        assert report.orphan_source_files == [
+            "references/sub-skills/common/uncatalogued-helper.md",
+        ]
+        out = report.format()
+        assert "Orphan source files" in out
+        assert "uncatalogued-helper" in out
+
+
+class TestBothDirections:
+    """AC6(d) — report ALL orphans, not just the first."""
+
+    def test_both_directions_listed(self, tmp_path):
+        repo, catalog = _make_fixture(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_COMMON_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                # cycle-runner is missing on disk (orphan catalog row)
+                "common/orphan-file.md",  # not in catalog (orphan source file)
+            ],
+            manifests={
+                ("pm", "includes.yml"): [
+                    "common/boot-bootstrap",
+                    "common/cycle-runner",
+                ],
+            },
+        )
+        report = cd.scan_drift(catalog, repo)
+        assert report.has_drift is True
+        # Both rendered in the report.
+        out = report.format()
+        assert "Orphan catalog rows" in out
+        assert "Orphan source files" in out
+        assert "cycle-runner" in out
+        assert "orphan-file" in out
+
+
+class TestDeadCodeCandidate:
+    """AC6(e) — catalog row not referenced in any manifest -> WARN, exit 0."""
+
+    def test_unreferenced_row_warns_but_does_not_abort(self, tmp_path):
+        repo, catalog = _make_fixture(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_COMMON_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                "common/cycle-runner.md",
+            ],
+            manifests={
+                # Only references boot-bootstrap. cycle-runner is dead-code.
+                ("pm", "includes.yml"): ["common/boot-bootstrap"],
+            },
+        )
+        report = cd.scan_drift(catalog, repo)
+        # NOT drift — exit code stays 0.
+        assert report.has_drift is False
+        assert report.has_dead_code is True
+        assert report.dead_code_candidates == ["cycle-runner"]
+        out = report.format()
+        assert "Dead-code candidates" in out
+        assert "cycle-runner" in out
+
+
+class TestManifestVariants:
+    """The dead-code scan must read includes.yml, includes-events.yml,
+    AND includes-v2.yml across every role."""
+
+    def test_v2_manifest_satisfies_reference(self, tmp_path):
+        repo, catalog = _make_fixture(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_COMMON_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                "common/cycle-runner.md",
+            ],
+            manifests={
+                # cycle-runner only appears in the v2 manifest.
+                ("pm", "includes.yml"): ["common/boot-bootstrap"],
+                ("pm", "includes-v2.yml"): [
+                    "common/boot-bootstrap",
+                    "common/cycle-runner",
+                ],
+            },
+        )
+        report = cd.scan_drift(catalog, repo)
+        assert report.dead_code_candidates == []
+
+    def test_events_manifest_satisfies_reference(self, tmp_path):
+        repo, catalog = _make_fixture(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_COMMON_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                "common/cycle-runner.md",
+            ],
+            manifests={
+                # cycle-runner appears in event-mode manifest only.
+                ("pm", "includes.yml"): ["common/boot-bootstrap"],
+                ("pm", "includes-events.yml"): [
+                    "common/boot-bootstrap",
+                    "common/cycle-runner",
+                ],
+            },
+        )
+        report = cd.scan_drift(catalog, repo)
+        assert report.dead_code_candidates == []
+
+
+class TestExclusions:
+    """Files outside the catalog's domain must NOT be flagged as orphans."""
+
+    def test_manifest_md_at_subskills_root_is_not_an_orphan(self, tmp_path):
+        repo, catalog = _make_fixture(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_COMMON_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                "common/cycle-runner.md",
+            ],
+            manifests={
+                ("pm", "includes.yml"): [
+                    "common/boot-bootstrap",
+                    "common/cycle-runner",
+                ],
+            },
+        )
+        # Drop a manifest.md sibling — should NOT be an orphan source file.
+        (repo / "references" / "sub-skills" / "manifest.md").write_text("# m\n")
+        report = cd.scan_drift(catalog, repo)
+        assert report.orphan_source_files == []
+
+    def test_project_subdir_excluded_from_source_scan(self, tmp_path):
+        repo, catalog = _make_fixture(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_COMMON_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                "common/cycle-runner.md",
+                "project/skill-template.md",  # L4 seed - excluded
+            ],
+            manifests={
+                ("pm", "includes.yml"): [
+                    "common/boot-bootstrap",
+                    "common/cycle-runner",
+                ],
+            },
+        )
+        report = cd.scan_drift(catalog, repo)
+        assert report.orphan_source_files == []
+
+    def test_capabilities_subdir_excluded_from_source_scan(self, tmp_path):
+        repo, catalog = _make_fixture(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_COMMON_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                "common/cycle-runner.md",
+                "capabilities/some-cap/sub-skill.md",
+            ],
+            manifests={
+                ("pm", "includes.yml"): [
+                    "common/boot-bootstrap",
+                    "common/cycle-runner",
+                ],
+            },
+        )
+        report = cd.scan_drift(catalog, repo)
+        assert report.orphan_source_files == []
+
+
+class TestSlashBearingName:
+    """Slash-bearing catalog names (e.g. `roles/dm/events/pr-merge-wait`)
+    must resolve to the literal source-path and match the manifest entry."""
+
+    def test_slash_bearing_name_resolves(self, tmp_path):
+        repo, catalog = _make_fixture(
+            tmp_path,
+            catalog_body="""
+            ## `roles/<role>/` — per-role
+
+            ### DM (`roles/dm/`)
+
+            | Sub-skill | One-liner | Used by |
+            |---|---|---|
+            | `roles/dm/events/pr-merge-wait` | wait for PR merge | dm |
+            """,
+            sub_skill_files=[
+                "roles/dm/events/pr-merge-wait.md",
+            ],
+            manifests={
+                ("dm", "includes.yml"): ["roles/dm/events/pr-merge-wait"],
+            },
+        )
+        report = cd.scan_drift(catalog, repo)
+        assert report.has_drift is False
+        assert report.dead_code_candidates == []
+
+
+class TestVariantManifests:
+    """DS review F1 — variant manifests at roles/<base>/<variant>/
+    must be walked recursively, and additional_includes must be read."""
+
+    def test_variant_additional_includes_satisfies_reference(self, tmp_path):
+        repo, catalog = _make_fixture(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_COMMON_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                "common/cycle-runner.md",
+            ],
+            manifests={
+                # Base worker role uses only boot-bootstrap.
+                ("worker", "includes.yml"): ["common/boot-bootstrap"],
+                # Variant at worker/skill extends with cycle-runner via
+                # additional_includes -- this is the schema compose.py
+                # _load_manifest reads.
+                ("worker/skill", "includes.yml"): {
+                    "base_role": "worker",
+                    "additional_includes": ["common/cycle-runner"],
+                },
+            },
+        )
+        report = cd.scan_drift(catalog, repo)
+        # cycle-runner is referenced via the variant -- NOT dead-code.
+        assert report.dead_code_candidates == []
+
+
+class TestMalformedManifest:
+    """DS review F2 — an unparseable manifest yields a stderr warning
+    but does not raise; other manifests still resolve correctly."""
+
+    def test_malformed_manifest_warns_to_stderr(self, tmp_path, capsys):
+        repo, catalog = _make_fixture(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_COMMON_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                "common/cycle-runner.md",
+            ],
+            manifests={
+                ("pm", "includes.yml"): [
+                    "common/boot-bootstrap",
+                    "common/cycle-runner",
+                ],
+                ("broken-role", "includes.yml"): "::: not valid yaml :::",
+            },
+        )
+        report = cd.scan_drift(catalog, repo)
+        # The good manifest covers everything -- no dead-code.
+        assert report.dead_code_candidates == []
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "broken-role" in captured.err
+
+
+class TestNestedManifestMdIsNotExcluded:
+    """DS review F4 — manifest.md is only excluded at the sub-skills
+    root, not nested under it. A nested file named manifest.md should
+    surface as an orphan source file (matching parser semantics)."""
+
+    def test_nested_manifest_md_treated_as_source_file(self, tmp_path):
+        repo, catalog = _make_fixture(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_COMMON_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                "common/cycle-runner.md",
+                "common/manifest.md",  # NESTED, should NOT be excluded
+            ],
+            manifests={
+                ("pm", "includes.yml"): [
+                    "common/boot-bootstrap",
+                    "common/cycle-runner",
+                ],
+            },
+        )
+        report = cd.scan_drift(catalog, repo)
+        assert report.orphan_source_files == [
+            "references/sub-skills/common/manifest.md",
+        ]
+
+
+class TestDeadCodeMatchTightening:
+    """DS review F5 — exact match wins; basename-only match applies
+    only to plain (no-slash) catalog names. Slash-bearing catalog
+    names must match exactly to avoid false negatives."""
+
+    def test_slash_bearing_catalog_name_requires_exact_match(self, tmp_path):
+        repo, catalog = _make_fixture(
+            tmp_path,
+            catalog_body="""
+            ## `roles/<role>/` — per-role
+
+            ### DM (`roles/dm/`)
+
+            | Sub-skill | One-liner | Used by |
+            |---|---|---|
+            | `roles/dm/events/pr-merge-wait` | wait for PR merge | dm |
+            """,
+            sub_skill_files=[
+                "roles/dm/events/pr-merge-wait.md",
+            ],
+            manifests={
+                # Manifest includes the basename only -- this should
+                # NOT count as a reference because the catalog name is
+                # slash-bearing and requires exact-path match.
+                ("dm", "includes.yml"): ["pr-merge-wait"],
+            },
+        )
+        report = cd.scan_drift(catalog, repo)
+        # Dead-code: the catalog row exists, files exists, but no
+        # exact-path reference.
+        assert report.dead_code_candidates == [
+            "roles/dm/events/pr-merge-wait",
+        ]
+
+
+class TestCLI:
+    """The compose.py drift-check subcommand exits 0 on clean, 1 on drift."""
+
+    def _run_drift_cli(self, repo, catalog_rel="docs/sub-skill-catalog.md"):
+        cli = SCRIPTS / "compose.py"
+        return subprocess.run(
+            [sys.executable, str(cli), "drift-check",
+             "--catalog", str(repo / catalog_rel),
+             "--repo-root", str(repo)],
+            capture_output=True, text=True,
+        )
+
+    def test_clean_returns_zero(self, tmp_path):
+        repo, _ = _make_fixture(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_COMMON_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                "common/cycle-runner.md",
+            ],
+            manifests={
+                ("pm", "includes.yml"): [
+                    "common/boot-bootstrap",
+                    "common/cycle-runner",
+                ],
+            },
+        )
+        result = self._run_drift_cli(repo)
+        assert result.returncode == 0, result.stderr
+
+    def test_drift_returns_nonzero_with_stderr_report(self, tmp_path):
+        repo, _ = _make_fixture(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_COMMON_ROWS,
+            sub_skill_files=["common/boot-bootstrap.md"],  # missing cycle-runner
+            manifests={
+                ("pm", "includes.yml"): [
+                    "common/boot-bootstrap",
+                    "common/cycle-runner",
+                ],
+            },
+        )
+        result = self._run_drift_cli(repo)
+        assert result.returncode != 0
+        assert "Orphan catalog rows" in result.stderr
+        assert "cycle-runner" in result.stderr
+
+    def test_dead_code_only_returns_zero_with_warning(self, tmp_path):
+        repo, _ = _make_fixture(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_COMMON_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                "common/cycle-runner.md",
+            ],
+            manifests={
+                ("pm", "includes.yml"): ["common/boot-bootstrap"],
+            },
+        )
+        result = self._run_drift_cli(repo)
+        assert result.returncode == 0, result.stderr
+        # The warning goes somewhere visible (stderr).
+        assert "Dead-code" in result.stderr or "Dead-code" in result.stdout


### PR DESCRIPTION
## Summary

- New `references/scripts/catalog_drift.py` — two-way orphan scan + dead-code warn against `docs/sub-skill-catalog.md` and `references/sub-skills/`.
- New `compose.py drift-check` CLI subcommand (`--catalog`, `--repo-root`). Exit 0 = clean, 1 = drift, 2 = parse/setup error.
- 18 unit tests in `tests/test_catalog_drift_d4.py`.

## Closes

Closes #10675.

## AC coverage

1. ✅ New compose-time check, standalone CLI subcommand + integrated.
2. ✅ Two-way scan: catalog row → file exists; file → catalog row exists.
3. ✅ Drift report lists ALL orphans, both directions, then aborts non-zero with stderr report.
4. ✅ Dead-code candidate (catalog row, no call-site in any role manifest) → WARN, exit 0 (per Q-D3).
5. ✅ Independent of D2/D3 — reads source tree only, never composes.
6. ✅ Tests cover clean, orphan-row, orphan-file, both, dead-code, plus extended cases.

## Design notes

- Manifest scan reads `includes.yml`, `includes-events.yml`, and `includes-v2.yml` across every role recursively.
- Reads BOTH `includes:` and `additional_includes:` keys so variant manifests at `roles/<base>/<variant>/includes.yml` (which use `additional_includes`) contribute to the reference union. Without this, every common sub-skill referenced only by a variant would be a false-positive dead-code candidate.
- Slash-bearing catalog names (like `roles/dm/events/pr-merge-wait`) require exact-path match in a manifest entry; plain catalog names match the last segment of any manifest path. This mirrors how compose.py resolves include paths and avoids the asymmetric basename false-negative.
- Excludes `references/sub-skills/manifest.md` (at root only — nested basename collisions still surface as orphans), plus `project/` and `capabilities/` subdirs (symmetric with catalog_parser's allowlist).

## Pre-existing drift

The live catalog has a duplicate `improvement-scan` row (common at line 140, roles/pm at line 209) — both source files exist and are wired, but catalog_parser rejects duplicates. Filed #10743 to disambiguate. Drift-check exits 2 against the live catalog until that's resolved; fixture-based tests confirm behaviour.

## DS review

`.squidsquad/skill/planning/ds-d4-review.md` archived in this PR. 5 findings; all fixed before commit (F1 variant manifests / additional_includes, F2 YAML warning, F3 unused param, F4 nested-manifest.md, F5 exact vs basename match).

## Test plan

- [x] `python -m pytest tests/test_catalog_drift_d4.py` — 18/18 pass
- [x] `python -m pytest tests/test_catalog_parser_d1.py` — 26 pass, 1 xfail (no regression)
- [x] `python references/scripts/compose.py drift-check` exits 2 with the expected duplicate-row diagnostic against the live catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)