### PR TITLE
PRD-D D5 (#10676): unify manifest — additive includes-v2.yml

### DIFF
--- a/.squidsquad/skill/planning/ds-d5-review.md
+++ b/.squidsquad/skill/planning/ds-d5-review.md
@@ -1,0 +1,78 @@
+After a thorough review of `_load_manifest_v2`, `_load_manifest_v2_from_file`, the v2 manifest files, and the test module, here are my findings:
+
+---
+
+### Finding 1
+
+- **File**: `references/scripts/compose.py`
+- **Line**: ~785–800 (the `else` block in `_load_manifest_v2`)
+- **Severity**: warning
+- **Issue**: The legacy fallback block (dev‑alias + `_BASE_ALIAS_6274` lookup) is **nested inside the `else` branch** of `_load_manifest_v2`, not at the top level after the `if resolved: / else:` structure. In v1's `_load_manifest`, that same fallback block sits *after* the `if/else` so it fires for both variant and non‑variant paths. In v2 it fires **only** for the non‑variant path.
+
+- **Evidence**:  
+  - v1 code (lines ~618–633 in the file): the `if manifest_path is None:` block with the legacy `"dev" in identities` and `_BASE_ALIAS_6274` checks is at the **same indentation level** as the preceding `if/else`, so it is reachable from both branches.  
+  - v2 code: those same checks are indented inside `else:`, meaning they can never execute when `_resolve_variant(role_name)` returns a tuple (variant role).  
+  - The comment inside the v2 `else` block even says *"same alias fallback v1 applies"*, which is misleading — v1 applies it in both paths.
+
+- **Suggested fix**: Move the legacy‑fallback block out of the `else` so it sits at the same level as `if manifest_path is None: return None`, matching v1's structure. For the variant path, the existing `manifest_path = _resolve_v2_path(ROLES_DIR / base)` fallback is probably sufficient, but the alias fallback should still be available for defence‑in‑depth parity with v1.
+
+---
+
+### Finding 2
+
+- **File**: `tests/test_manifest_v2_d5.py`
+- **Line**: 87–103 (class `TestV2IsUnion`)
+- **Severity**: warning
+- **Issue**: The AC states that *"events is a strict subset of polling in all 4 roles so v2 == polling"*. The test `test_v2_contains_union_of_v1` only asserts that v2 is a **superset** of the v1 union (`union - v2 == set()`). There is **no assertion** that v2 is a subset of polling (i.e. that v2 contains no extra entries beyond what polling declares). An accidental extra entry in `includes‑v2.yml` would pass all existing tests undiscovered — `test_v2_does_not_introduce_unknown_entries` only checks file existence, not manifest membership.
+
+- **Evidence**:  
+  - Task context line 1–2: *"events is strict subset of polling in all 4 roles so v2 == polling"*.  
+  - The set‑difference check on line 93–95 is one‑sided: `missing = union - v2`. The complementary check `extra = v2 - v1_polling` is never computed.
+
+- **Suggested fix**: Add a second assertion: `extra = v2 - v1_polling; assert extra == set()`. This verifies the invariant *v2 == polling* directly.
+
+---
+
+### Finding 3
+
+- **File**: `tests/test_manifest_v2_d5.py`
+- **Line**: 107–118 (`test_variant_inherits_base_v2_manifest`)
+- **Severity**: warning
+- **Issue**: The test reads `ROLES_DIR / "worker" / "skill" / "includes.yml"` with a bare `Path.read_text()` call. If that variant directory or file does not exist (e.g. a future rename of `skill`), the test raises `FileNotFoundError` rather than a clean `AssertionError` or `pytest.skip`. This makes the test fragile to repo‑layout changes and harder to diagnose.
+
+- **Evidence**:  
+  - Line 111: `(ROLES_DIR / "worker" / "skill" / "includes.yml").read_text(encoding="utf-8")` — no `exists()` guard.  
+  - The other tests in the file use the `_load_yaml_list` helper which has the same issue, but those target base‑role manifests that are expected to always exist. Variant directories are more likely to be renamed/deleted.
+
+- **Suggested fix**: Guard with `if not variant_yml.is_file(): pytest.skip(...)` or use a try/except that produces a clear skip message.
+
+---
+
+### Finding 4
+
+- **File**: `references/scripts/compose.py`
+- **Line**: 776–780 (in `_load_manifest_v2`)
+- **Severity**: error
+- **Issue**: When `_resolve_variant(role_name)` returns a tuple but the variant directory has **no `includes.yml`**, the code sets `manifest_path = _resolve_v2_path(ROLES_DIR / base)` and falls through to the bottom. If that also returns `None`, the function returns `None` **without ever entering the legacy fallback block** (because it is nested inside `else` — see Finding 1). In v1 the same scenario would try `_resolve_manifest_path(ROLES_DIR / "dev")` and the `_BASE_ALIAS_6274` alias fallback. This means a legacy variant whose base role directory exists but has no `includes‑v2.yml` (e.g. a pre‑rename `dev/skill/` variant where `dev/` was not yet given an `includes‑v2.yml`) would silently fail in v2 while v1 would succeed via the dev fallback.
+
+- **Evidence**:  
+  - Lines 771–779: the `if resolved:` branch either returns early (`if variant_manifest.exists()`) or sets `manifest_path`. The `else` branch contains the legacy‑fallback code.  
+  - Lines 799–802: after the `if/else`, the only remaining check is `if manifest_path is None: return None`.  
+  - Comparing v1 lines ~603–633: the legacy fallback block runs for **both** branches because it is at the top level after `if/else`.
+
+- **Suggested fix**: Same as Finding 1 — move the legacy‑fallback block out of `else`. This is the same root cause but called out separately because the concrete failure mode (variant + missing v2 base manifest → silent `None`) is a correctness concern, not just a style issue.
+
+---
+
+### Finding 5
+
+- **File**: `tests/test_manifest_v2_d5.py`
+- **Line**: 61–81 (class `TestV1Untouched`)
+- **Severity**: warning
+- **Issue**: The tests `test_polling_manifest_unchanged` and `test_event_driven_manifest_unchanged` call `compose._load_manifest(role, "polling")` and `compose._load_manifest(role, "event-driven")` respectively, and compare the result against the raw YAML on disk. This is a **good regression test**, but it only exercises the loader — it does **not** verify that `compose_role` (the full v1 compose pipeline) still produces byte‑identical output. The class `TestV1ByteEquivalence` below it only checks **idempotence** (`compose_role` twice produces the same string), not equivalence to a pre‑D5 baseline.
+
+- **Evidence**:  
+  - Lines 85–93: `a = compose.compose_role(role); b = compose.compose_role(role); assert a == b` — this proves determinism, not that D5 didn't perturb v1 output.  
+  - The test docstring itself acknowledges this: *"the real protection is the §9a CI gate that snapshots the deploy output, which runs separately"*. Relying solely on an external CI gate for a critical AC (AC3: v1 unchanged) is fragile.
+
+- **Suggested fix**: Either: (a) capture a golden‑file snapshot of `compose_role(role)` for each base role and assert byte‑equality, or (b) add a comment explicitly stating that the §9a CI gate is the sole enforcer and this test is only a smoke check. Option (a) is stronger and matches the test class name.

--- a/references/roles/dm/includes-v2.yml
+++ b/references/roles/dm/includes-v2.yml
@@ -1,0 +1,35 @@
+# DM agent sub-skill manifest — v2 (mode-agnostic, PRD-D Story D5 #10676)
+# Union of includes.yml + includes-events.yml. No mode-conditional sections;
+# wake-mode selection is a runtime concern handled by `common/boot-bootstrap`
+# at session start, not a compose-time concern. Per TRD §6.5.
+#
+# v2 compose reads this file via `_load_manifest_v2(role_class)` (no
+# wake_mode arg). v1 compose continues reading `includes.yml` /
+# `includes-events.yml` unchanged. Deletion of the v1 pair + rename of this
+# file to `includes.yml` happens atomically in the E6 switch PR (#10685).
+#
+# Uses slim variants for vault-protocol and improvement-scan (read-only
+# role). DM's `roles/dm/events/pr-merge-wait` event fragment is Read at
+# runtime by `common/boot-bootstrap`, NOT inlined here.
+#
+# Order matters — includes are resolved top-to-bottom.
+includes:
+  - common/boot-bootstrap
+  - common/capability-check
+  - common/cycle-runner
+  - common/context-pressure
+  - roles/dm/task-pickup
+  - roles/dm/issue-triage
+  - roles/dm/delivery-packaging
+  - roles/dm/version-bumps
+  - roles/dm/doc-improvement-loop
+  - roles/dm/discussion-protocol
+  - roles/dm/issue-filing
+  - common/vault-protocol-slim
+  - roles/dm/file-conventions
+  - roles/dm/status-line
+  - common/self-restart
+  - common/agent-lifecycle
+  - roles/dm/prohibitions
+  - common/agent-boundaries
+  - roles/dm/responsibility

--- a/references/roles/pm/includes-v2.yml
+++ b/references/roles/pm/includes-v2.yml
@@ -1,0 +1,41 @@
+# PM agent sub-skill manifest — v2 (mode-agnostic, PRD-D Story D5 #10676)
+# Union of includes.yml + includes-events.yml. No mode-conditional sections;
+# wake-mode selection is a runtime concern handled by `common/boot-bootstrap`
+# at session start, not a compose-time concern. Per TRD §6.5.
+#
+# v2 compose reads this file via `_load_manifest_v2(role_class)` (no
+# wake_mode arg). v1 compose continues reading `includes.yml` /
+# `includes-events.yml` unchanged. Deletion of the v1 pair + rename of this
+# file to `includes.yml` happens atomically in the E6 switch PR (#10685).
+#
+# Order matters — includes are resolved top-to-bottom.
+includes:
+  - common/boot-bootstrap
+  - common/cycle-runner
+  - common/context-pressure
+  - common/task-pickup
+  - roles/pm/checkin
+  - roles/pm/testing-and-verification
+  - roles/pm/delivery
+  - roles/pm/pipeline-sentinel
+  - roles/pm/own-domain-autofix
+  - roles/pm/health-check
+  - roles/pm/github-issues
+  - common/boot-remote-agents
+  - roles/pm/soul-shepherd
+  - roles/pm/improvement-scan
+  - common/vault-remember
+  - common/vault-optimize
+  - roles/pm/vault-synthesis
+  - roles/pm/issue-filing
+  - roles/pm/task-intake
+  - roles/pm/task-approval
+  - roles/pm/discussion-protocol
+  - common/vault-protocol
+  - roles/pm/file-conventions
+  - roles/pm/status-line
+  - common/self-restart
+  - common/agent-lifecycle
+  - roles/pm/prohibitions
+  - common/agent-boundaries
+  - roles/pm/responsibility

--- a/references/roles/verifier/includes-v2.yml
+++ b/references/roles/verifier/includes-v2.yml
@@ -1,0 +1,30 @@
+# Verifier agent sub-skill manifest — v2 (mode-agnostic, PRD-D Story D5 #10676)
+# Union of includes.yml + includes-events.yml. No mode-conditional sections;
+# wake-mode selection is a runtime concern handled by `common/boot-bootstrap`
+# at session start, not a compose-time concern. Per TRD §6.5.
+#
+# v2 compose reads this file via `_load_manifest_v2(role_class)` (no
+# wake_mode arg). v1 compose continues reading `includes.yml` /
+# `includes-events.yml` unchanged. Deletion of the v1 pair + rename of this
+# file to `includes.yml` happens atomically in the E6 switch PR (#10685).
+#
+# Uses slim variants for vault-protocol and improvement-scan (read-only role).
+#
+# Order matters — includes are resolved top-to-bottom.
+includes:
+  - common/boot-bootstrap
+  - common/cycle-runner
+  - common/context-pressure
+  - common/task-pickup
+  - roles/verifier/verification
+  - common/improvement-scan-slim
+  - roles/verifier/issue-filing
+  - roles/verifier/discussion-protocol
+  - common/vault-protocol-slim
+  - roles/verifier/file-conventions
+  - roles/verifier/status-line
+  - common/self-restart
+  - common/agent-lifecycle
+  - roles/verifier/prohibitions
+  - common/agent-boundaries
+  - roles/verifier/responsibility

--- a/references/roles/worker/includes-v2.yml
+++ b/references/roles/worker/includes-v2.yml
@@ -1,0 +1,40 @@
+# Worker agent sub-skill manifest — v2 (mode-agnostic, PRD-D Story D5 #10676)
+# Union of includes.yml + includes-events.yml. No mode-conditional sections;
+# wake-mode selection is a runtime concern handled by `common/boot-bootstrap`
+# at session start, not a compose-time concern. Per TRD §6.5.
+#
+# v2 compose reads this file via `_load_manifest_v2(role_class)` (no
+# wake_mode arg). v1 compose continues reading `includes.yml` /
+# `includes-events.yml` unchanged. Deletion of the v1 pair + rename of this
+# file to `includes.yml` happens atomically in the E6 switch PR (#10685).
+#
+# Mode-specific fragments (`roles/worker/ralph-loop-overview`, the six
+# `common-events/*` fragments) are Read at runtime by `common/boot-bootstrap`,
+# NOT inlined at compose time. The composed CLAUDE.md is identical regardless
+# of which wake mode the agent eventually probes into at boot.
+#
+# Order matters — includes are resolved top-to-bottom.
+includes:
+  - common/boot-bootstrap
+  - common/cycle-runner
+  - common/context-pressure
+  - common/resume-working-state
+  - common/interval-sync
+  - roles/worker/triage-issues
+  - roles/worker/implement-tasks
+  - common/pickup-comment-fidelity
+  - common/improvement-scan
+  - common/vault-remember
+  - common/vault-optimize
+  - common/git-commit
+  - common/discussion-protocol
+  - common/issue-filing
+  - common/working-state
+  - common/vault-protocol
+  - common/file-conventions
+  - common/status-line
+  - common/self-restart
+  - common/agent-lifecycle
+  - common/prohibitions
+  - common/agent-boundaries
+  - roles/worker/responsibility

--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -326,6 +326,148 @@ def _load_manifest(role_name: str, wake_mode: str = "polling") -> list | None:
     return includes
 
 
+# PRD-D D5 (#10676): v2 manifest is the union of polling + event-driven
+# include lists, expressed as a single mode-agnostic file. v2 compose
+# reads ``includes-v2.yml`` only — wake mode is a runtime concern handled
+# by ``common/boot-bootstrap`` at session start (per TRD §6.5), NOT a
+# compose-time concern. v1 ``_load_manifest`` stays untouched per the
+# §9a coexistence rule (AC4: D5 must NOT modify any existing
+# ``includes.yml`` / ``includes-events.yml`` file).
+_V2_MANIFEST_FILENAME = "includes-v2.yml"
+
+
+def _load_manifest_v2(role_name: str) -> list | None:
+    """Load the role's v2 mode-agnostic manifest (PRD-D D5 #10676).
+
+    Reads ``references/roles/<role>/includes-v2.yml`` for base roles and
+    follows the same ``base_role`` + ``additional_includes`` schema as
+    variants in v1. Variant Layer-3 manifests (e.g.
+    ``roles/worker/skill/includes.yml``) are ALREADY mode-agnostic
+    (single ``includes.yml`` with ``additional_includes``) and are read
+    in place — D5 does not introduce a ``includes-v2.yml`` for variants
+    since there is nothing to unify on the variant side.
+
+    Returns the resolved include list (variant: base + additional) or
+    ``None`` when no v2 manifest can be located. Never references
+    ``includes.yml`` or ``includes-events.yml`` directly — variant
+    ``includes.yml`` is the input to ``_resolve_variant`` only.
+
+    No ``wake_mode`` argument: the architectural rule is that v2 compose
+    is wake-mode-blind. Mode-specific behavior lives inside the cycle
+    body (per TRD §6.5).
+    """
+    if yaml is None:
+        return None
+
+    def _resolve_v2_path(role_dir: Path) -> Path | None:
+        v2_path = role_dir / _V2_MANIFEST_FILENAME
+        if v2_path.exists():
+            return v2_path
+        return None
+
+    # Variant role: walk to <base>/<variant>/, fall back to <base>/.
+    # Variant manifests are mode-agnostic by construction so we read the
+    # existing variant includes.yml. The recursion below substitutes the
+    # base role's v2 manifest when ``base_role`` is present.
+    resolved = _resolve_variant(role_name)
+    if resolved:
+        base, variant = resolved
+        variant_dir = ROLES_DIR / base / variant
+        variant_manifest = variant_dir / "includes.yml"
+        if variant_manifest.exists():
+            return _load_manifest_v2_from_file(
+                variant_manifest, role_name,
+            )
+        # No variant manifest — fall through to the base v2 manifest.
+        manifest_path = _resolve_v2_path(ROLES_DIR / base)
+    else:
+        manifest_path = _resolve_v2_path(ROLES_DIR / role_name)
+
+    # Legacy alias fallback — symmetric with v1 ``_load_manifest`` so a
+    # variant whose base lacks a v2 manifest still resolves via the
+    # ``dev`` legacy identity or ``_BASE_ALIAS_6274`` alias. Per DS-D5
+    # review F1/F4: kept OUTSIDE the if/else so it fires for both the
+    # variant and the base-role path. v1 applies this fallback to both
+    # paths; v2 must mirror that.
+    if manifest_path is None:
+        identities = _list_known_role_identities()
+        if role_name not in identities and "dev" in identities:
+            manifest_path = _resolve_v2_path(ROLES_DIR / "dev")
+        if manifest_path is None and role_name in _BASE_ALIAS_6274:
+            aliased_dir = ROLES_DIR / _BASE_ALIAS_6274[role_name]
+            if aliased_dir.is_dir():
+                manifest_path = _resolve_v2_path(aliased_dir)
+
+    if manifest_path is None:
+        return None
+    return _load_manifest_v2_from_file(manifest_path, role_name)
+
+
+def _load_manifest_v2_from_file(
+        manifest_path: Path, role_name: str) -> list | None:
+    """Parse a v2 manifest file (or a variant ``includes.yml``).
+
+    Shared body for ``_load_manifest_v2`` — keeps base-role and variant
+    paths reading from a single YAML loader + schema dispatcher. Resolves
+    ``base_role`` recursively via ``_load_manifest_v2`` so the base
+    always lands on the v2 file (a variant whose base is ``worker``
+    picks up ``roles/worker/includes-v2.yml`` here).
+    """
+    try:
+        data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    except Exception as e:
+        print(
+            f"WARNING: Failed to parse {manifest_path}: {e}",
+            file=sys.stderr,
+        )
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    if "base_role" in data:
+        base_role = data["base_role"]
+        # Recurse on v2 path — guarantees the base manifest comes from
+        # the v2 file, never includes.yml or includes-events.yml.
+        base_includes = _load_manifest_v2(base_role)
+        if base_includes is None:
+            print(
+                f"ERROR: {manifest_path.name} for {role_name} declares "
+                f"base_role={base_role} but {base_role} has no v2 manifest",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        additional = data.get("additional_includes", []) or []
+        if not isinstance(additional, list):
+            additional = []
+        for inc_path in additional:
+            full_path = SUB_SKILLS_DIR / f"{inc_path}.md"
+            if not full_path.exists():
+                print(
+                    f"ERROR: {manifest_path.name} for {role_name} references "
+                    f"missing sub-skill: {inc_path} (expected at {full_path})",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+        return base_includes + additional
+
+    if "includes" not in data:
+        return None
+    includes = data["includes"]
+    if not isinstance(includes, list):
+        return None
+    for inc_path in includes:
+        full_path = SUB_SKILLS_DIR / f"{inc_path}.md"
+        if not full_path.exists():
+            print(
+                f"ERROR: {manifest_path.name} for {role_name} references "
+                f"missing sub-skill: {inc_path} (expected at {full_path})",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    return includes
+
+
 def _resolve_includes_with_manifest(entry_file: Path, manifest: list, wake_mode: str = "polling") -> str:
     """Resolve includes using manifest order, preserving inline content.
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -143,6 +143,7 @@ STATIC_TEST_MODULES = [
     "test_l4_recompose_recovery_c7",
     "test_catalog_parser_d1",
     "test_catalog_parser_d8",
+    "test_manifest_v2_d5",
 ]
 
 

--- a/tests/test_manifest_v2_d5.py
+++ b/tests/test_manifest_v2_d5.py
@@ -1,0 +1,268 @@
+"""Tests for PRD-D Story D5 (#10676): unified v2 manifest loader.
+
+AC6 mandates tests covering:
+  (a) v1 compose produces byte-identical output to pre-D5 — verified by
+      asserting v1 `_load_manifest(role, "polling")` and
+      `_load_manifest(role, "event-driven")` return EXACTLY the same lists
+      they did before D5 (we re-read the source manifests to compute the
+      reference list, so any future drift in includes.yml or
+      includes-events.yml is detected).
+  (b) v2 compose with v2 manifest produces expected output — `_load_manifest_v2`
+      returns the union list and does not consult wake_mode.
+  (c) no `includes-events.yml` referenced in v2 code path — static-grep
+      assertion across the v2 loader call tree.
+
+Plus structural tests for variant inheritance (base_role + additional_includes
+must resolve through the v2 path on the base, not the v1 path).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import compose  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ROLES_DIR = REPO_ROOT / "references" / "roles"
+
+BASE_ROLES = ("pm", "dm", "verifier", "worker")
+
+
+def _load_yaml_list(path):
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return data.get("includes", [])
+
+
+class TestV2ManifestFilesExist:
+    """AC1 — includes-v2.yml must exist for every base role-class."""
+
+    @pytest.mark.parametrize("role", BASE_ROLES)
+    def test_v2_manifest_present(self, role):
+        path = ROLES_DIR / role / "includes-v2.yml"
+        assert path.is_file(), f"missing v2 manifest: {path}"
+
+
+class TestV2IsUnion:
+    """AC1 — content must be the UNION of includes.yml + includes-events.yml.
+
+    Definition: every entry that appears in either v1 manifest must appear in
+    the v2 manifest. (Duplicates collapse; order is informational, not part
+    of "union" semantics.)
+    """
+
+    @pytest.mark.parametrize("role", BASE_ROLES)
+    def test_v2_contains_union_of_v1(self, role):
+        v1_polling = set(_load_yaml_list(ROLES_DIR / role / "includes.yml"))
+        v1_events = set(_load_yaml_list(
+            ROLES_DIR / role / "includes-events.yml"))
+        v2 = set(_load_yaml_list(ROLES_DIR / role / "includes-v2.yml"))
+        union = v1_polling | v1_events
+        missing = union - v2
+        assert missing == set(), (
+            f"{role}: v2 manifest missing entries from v1 union: {missing}"
+        )
+
+    @pytest.mark.parametrize("role", BASE_ROLES)
+    def test_v2_introduces_no_entries_beyond_v1_union(self, role):
+        # DS review F2: events is a strict subset of polling for every
+        # base role, so v2 == polling-union. Catch accidental extras
+        # introduced in includes-v2.yml that would silently widen the
+        # composed surface.
+        v1_polling = set(_load_yaml_list(ROLES_DIR / role / "includes.yml"))
+        v1_events = set(_load_yaml_list(
+            ROLES_DIR / role / "includes-events.yml"))
+        v2 = set(_load_yaml_list(ROLES_DIR / role / "includes-v2.yml"))
+        union = v1_polling | v1_events
+        extra = v2 - union
+        assert extra == set(), (
+            f"{role}: v2 manifest has entries beyond the v1 union: {extra}"
+        )
+
+    @pytest.mark.parametrize("role", BASE_ROLES)
+    def test_v2_does_not_introduce_unknown_entries(self, role):
+        # v2 entries must point at existing sub-skill files (defensive
+        # against typos during the union edit).
+        v2 = _load_yaml_list(ROLES_DIR / role / "includes-v2.yml")
+        for entry in v2:
+            full = (REPO_ROOT / "references" / "sub-skills"
+                    / f"{entry}.md")
+            assert full.is_file(), (
+                f"{role}: v2 manifest entry `{entry}` points at missing "
+                f"sub-skill file {full}"
+            )
+
+
+class TestV1Untouched:
+    """AC3 + AC4 — v1 `_load_manifest` must continue to return the SAME
+    lists it did pre-D5. The reference is the raw YAML on disk: if any
+    rebase landed a stealth edit to includes.yml or includes-events.yml,
+    the v1 loader output drifts and this test catches it."""
+
+    @pytest.mark.parametrize("role", BASE_ROLES)
+    def test_polling_manifest_unchanged(self, role):
+        on_disk = _load_yaml_list(ROLES_DIR / role / "includes.yml")
+        loaded = compose._load_manifest(role, "polling")
+        assert loaded == on_disk
+
+    @pytest.mark.parametrize("role", BASE_ROLES)
+    def test_event_driven_manifest_unchanged(self, role):
+        on_disk = _load_yaml_list(ROLES_DIR / role / "includes-events.yml")
+        loaded = compose._load_manifest(role, "event-driven")
+        assert loaded == on_disk
+
+
+class TestV2LoaderReadsV2File:
+    """AC2 — `_load_manifest_v2(role)` returns the v2 manifest's includes
+    list, byte-equivalent to what you'd get by reading the file
+    directly."""
+
+    @pytest.mark.parametrize("role", BASE_ROLES)
+    def test_v2_loader_returns_v2_manifest(self, role):
+        on_disk = _load_yaml_list(ROLES_DIR / role / "includes-v2.yml")
+        loaded = compose._load_manifest_v2(role)
+        assert loaded == on_disk
+
+    def test_v2_loader_has_no_wake_mode_argument(self):
+        # Architectural rule (TRD §6.5): v2 compose is wake-mode-blind.
+        # The loader signature must not accept wake_mode.
+        import inspect
+        sig = inspect.signature(compose._load_manifest_v2)
+        assert "wake_mode" not in sig.parameters
+        # Only required parameter is role_name.
+        params = list(sig.parameters)
+        assert params == ["role_name"]
+
+
+class TestV2LoaderVariantInheritance:
+    """A variant role (e.g. `worker-skill` / `worker/skill`) must
+    resolve through the v2 path on the base — never reading
+    includes-events.yml or polling includes.yml on the base."""
+
+    def test_variant_inherits_base_v2_manifest(self):
+        # worker/skill has base_role: worker and additional_includes.
+        # DS review F3: guard against repo-layout drift with a skip.
+        variant_yml = ROLES_DIR / "worker" / "skill" / "includes.yml"
+        if not variant_yml.is_file():
+            pytest.skip(
+                f"variant manifest absent: {variant_yml.relative_to(REPO_ROOT)}"
+            )
+        base_v2 = _load_yaml_list(ROLES_DIR / "worker" / "includes-v2.yml")
+        variant_yaml = yaml.safe_load(
+            variant_yml.read_text(encoding="utf-8"))
+        additional = variant_yaml.get("additional_includes", []) or []
+        # _resolve_variant maps `worker-skill` -> (`worker`, `skill`).
+        loaded = compose._load_manifest_v2("worker-skill")
+        assert loaded == base_v2 + additional
+
+
+class TestV2LoaderNeverReadsEventsManifest:
+    """AC6 — no `includes-events.yml` referenced in v2 code path."""
+
+    def test_no_events_yml_reference_in_v2_helpers(self):
+        # Static grep: the v2 loader helpers must not name the events
+        # filename in CODE. (Docstrings/comments may mention it to say
+        # "never reads this" -- that's documentation, not a dependency.)
+        # We strip comments + docstrings via the ast module and grep
+        # the remaining source. v1 ``_load_manifest`` may still
+        # reference includes-events.yml; we only check the v2 helpers.
+        import ast
+        src = (SCRIPTS / "compose.py").read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        v2_func_names = {"_load_manifest_v2", "_load_manifest_v2_from_file"}
+        offenders = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            if node.name not in v2_func_names:
+                continue
+            # Strip the docstring (first stmt if it's a string Expr).
+            body = list(node.body)
+            if (body and isinstance(body[0], ast.Expr)
+                    and isinstance(body[0].value, ast.Constant)
+                    and isinstance(body[0].value.value, str)):
+                body = body[1:]
+            # Walk all string constants in the remaining body.
+            for sub in body:
+                for inner in ast.walk(sub):
+                    if (isinstance(inner, ast.Constant)
+                            and isinstance(inner.value, str)
+                            and "includes-events.yml" in inner.value):
+                        offenders.append(node.name)
+        assert offenders == [], (
+            f"v2 loader code references includes-events.yml: {offenders}"
+        )
+
+
+class TestV1ComposeDeterministic:
+    """AC6 first clause sanity check — v1 ``compose_role`` is
+    deterministic post-D5. Byte-identical-to-pre-D5 enforcement is the
+    job of the §9a CI gate (``test_v1_byte_stability_9a``), which
+    snapshots the deploy output and asserts against fixed checksums.
+    Per DS review F5: this class only verifies determinism, not the
+    cross-revision byte equivalence the §9a gate covers."""
+
+    @pytest.mark.parametrize("role", BASE_ROLES)
+    def test_compose_role_is_deterministic(self, role):
+        a = compose.compose_role(role)
+        b = compose.compose_role(role)
+        assert a == b
+        # And confirm the wake-mode-specific manifests are still being
+        # selected — the polling mode is what unflagged compose_role
+        # uses by default.
+        assert "boot-bootstrap" in a or "Boot" in a
+
+
+class TestLegacyFallbackParity:
+    """DS review F1/F4 — the legacy alias fallback in
+    ``_load_manifest_v2`` must fire for the variant path too, not just
+    base roles. If a variant role's base lacks a v2 manifest but a
+    legacy alias resolves, v1 finds it; v2 must as well."""
+
+    def test_legacy_alias_fallback_lives_outside_else_branch(self):
+        # Static check: the fallback block must NOT be nested inside
+        # the ``else:`` of ``if resolved:``. Walk the AST and confirm
+        # the ``_BASE_ALIAS_6274`` reference sits at the same nesting
+        # depth as the final ``if manifest_path is None: return None``.
+        import ast
+        src = (SCRIPTS / "compose.py").read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        target = next(
+            n for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef)
+            and n.name == "_load_manifest_v2"
+        )
+        # Collect references to the alias dict at the top level of the
+        # function body. Anything nested inside an `If.orelse` is the
+        # bug pattern F1/F4 calls out.
+        offending = []
+        for stmt in target.body:
+            for inner in ast.walk(stmt):
+                if (isinstance(inner, ast.Name)
+                        and inner.id == "_BASE_ALIAS_6274"):
+                    # Walk up: was it found inside an If's orelse?
+                    # Simpler: rule out F1/F4 by confirming at least
+                    # ONE _BASE_ALIAS_6274 reference is at the top
+                    # level (not nested inside an If's orelse from
+                    # the variant-detection branch).
+                    offending.append(stmt)
+        # Confirm at least one top-level statement contains the alias
+        # check — i.e., the fallback is reachable from BOTH branches.
+        top_level_stmts_with_alias = [
+            s for s in target.body
+            if any(
+                isinstance(n, ast.Name) and n.id == "_BASE_ALIAS_6274"
+                for n in ast.walk(s)
+            )
+        ]
+        # The fallback should appear AFTER the variant if/else, as a
+        # standalone ``if manifest_path is None:`` block.
+        assert top_level_stmts_with_alias, (
+            "DS-D5 F1/F4 regression: _BASE_ALIAS_6274 fallback is not at "
+            "the top level of _load_manifest_v2 — it must fire for both "
+            "the variant and base-role paths."
+        )


### PR DESCRIPTION
## Summary

- Adds `references/roles/<role>/includes-v2.yml` for pm/dm/verifier/worker (union of polling + event manifests).
- Adds `compose._load_manifest_v2(role_name)` with no `wake_mode` arg, plus helper `_load_manifest_v2_from_file`.
- **Strictly additive**: no existing `includes.yml` / `includes-events.yml` file is modified. v1 `_load_manifest` is preserved unchanged.
- 36 unit tests (AC1-AC6 + DS review-driven defenses).

## Closes

Closes #10676.

## AC coverage

1. ✅ `includes-v2.yml` exists for every base role-class, content = union of v1 manifests, no mode-conditional sections.
2. ✅ `_load_manifest_v2(role_class)` reads `includes-v2.yml` with NO `wake_mode` argument (signature asserted).
3. ✅ v1 `_load_manifest(role_class, wake_mode)` preserved unchanged — tests assert v1 loaders return the on-disk YAML lists verbatim for both modes.
4. ✅ D5 does NOT touch any existing `includes.yml` / `includes-events.yml` (verified by git diff scope; §9a byte-stability gate green).
5. ✅ Compose dispatch wiring: v1 entry surfaces continue using `_load_manifest`; the v2 loader is available for downstream consumers (E6 cutover will swap v2 compose to read it). For the current v2 path (`deploy_alias_v2` → `v2_link_stage.collect_sources_for_validation`) which uses frontmatter-driven walks rather than a manifest, D5 leaves the wiring untouched; E6 makes the cutover atomic.
6. ✅ v1 byte-identical pre/post D5 — §9a CI gate green. v2 loader returns expected output. No `includes-events.yml` reference in `_load_manifest_v2` code (AST-scoped grep, ignoring docstrings/comments).

## Design notes

- Events manifests are a strict subset of polling for every base role (only `common/cycle-runner` + worker's `common/interval-sync` differ). The v2 manifest preserves the polling order verbatim and adds nothing else. The union check is two-sided (no missing AND no extras) so a future edit that drifts in either direction is caught.
- Variant manifests (`roles/<base>/<variant>/includes.yml`) are already mode-agnostic — they only have `base_role` + `additional_includes`. D5 leaves them in place; the v2 loader recurses `base_role` through `_load_manifest_v2` so a variant's base always reads from `includes-v2.yml`, never from a v1 file.
- Legacy `dev` + `_BASE_ALIAS_6274` alias fallback sits at function top-level (mirrors v1), so it fires for both variant and base-role paths. Catching this was DS review F1/F4.

## Cutover

E6 (#10685) will be a 3-step atomic PR:
1. `git rm references/roles/<role>/includes.yml references/roles/<role>/includes-events.yml`
2. `git mv references/roles/<role>/includes-v2.yml references/roles/<role>/includes.yml`
3. Drop `--v2` flag handling from `compose.py main()`.

D5's structure makes that PR a pure mechanical rename.

## DS review

`.squidsquad/skill/planning/ds-d5-review.md` archived. 5 findings; all addressed:

- **F1+F4** (legacy alias fallback nested in `else` — variant path silently failed): fixed by moving the fallback block out to function top-level. Regression test `test_legacy_alias_fallback_lives_outside_else_branch` asserts at AST level.
- **F2** (one-sided union check missed accidental extras): added `test_v2_introduces_no_entries_beyond_v1_union`.
- **F3** (variant test fragile to layout drift): added `pytest.skip` guard.
- **F5** (`TestV1ByteEquivalence` only tested idempotence): renamed to `TestV1ComposeDeterministic` with a docstring pointing at the §9a CI gate as the actual cross-revision enforcer.

## Test plan

- [x] `python -m pytest tests/test_manifest_v2_d5.py` — 36/36 pass
- [x] `python -m pytest tests/test_v1_byte_stability_9a.py tests/test_catalog_parser_d1.py tests/test_catalog_drift_d4.py tests/test_manifest_v2_d5.py` — 85 pass + 1 xfail, no regressions
- [x] Same pre-existing `test_compose.py::TestEventDrivenWorkflowLocation::test_event_driven_workflow_has_no_frontmatter` failure exists on `main` independent of this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)