### PR TITLE
PRD-D D3 (#10674): catalog gate at v2 compose time

### DIFF
--- a/.squidsquad/skill/planning/ds-d3-review.md
+++ b/.squidsquad/skill/planning/ds-d3-review.md
@@ -1,0 +1,29 @@
+I've completed a thorough review of both changed files and the test suite. Here's my analysis:
+
+**Files examined:**
+- `references/scripts/v2_catalog_gate.py` (full module)
+- `references/scripts/compose.py` (lines 1673–1696, plus surrounding `deploy_alias_v2` and `main()` dispatch)
+- `tests/test_v2_catalog_gate_d3.py` (all tests)
+- `references/scripts/catalog_parser.py` (`parse_catalog` return type — returns `{name: source_path}` dict)
+
+**What I checked:**
+
+1. **Regex correctness** (`_REF_RE`): The name character class `[a-z][a-z0-9/_-]*` is byte-for-byte identical to catalog_parser's `_NAME_CELL_RE`. Slash-bearing names, hyphens, underscores all match consistently. The `→` Unicode arrow matches what v2 link stage emits.
+
+2. **Resolution logic** (`validate_v2_compose`): `catalog.get(name)` returns `None` for missing entries → unresolved. Non-`None` paths are checked via `(repo_root / source_path).is_file()` → missing-file if gone. Both branches deduplicate correctly (`seen_unresolved` set of names; `seen_missing` set of `(name, source_path)` tuples).
+
+3. **Atomic-write contract**: Gate runs at lines 1678–1696, AFTER `emit_v2_linked` succeeds (line 1663) but BEFORE `output_path.write_text()` (line 1703). On failure, `sys.exit(1)` is called with zero artifacts on disk.
+
+4. **AC5 — v1 untouched**: Only `deploy_alias_v2` imports `v2_catalog_gate` (confirmed via grep). Neither `deploy_role`, `compose_role`, nor `_resolve_includes` reference it. The v1 dispatch in `main()` does not trigger it.
+
+5. **AC4 — all issues reported**: The `validate_v2_compose` loop processes all references. `GateResult.format()` renders both `unresolved` and `missing-file` sections in one report. Tests confirm multi-issue reporting.
+
+6. **Test coverage**: Tests cover regex shape (plain name, multiple, slash-bearing, unrelated arrows, duplicate extraction), clean compose, single unresolved, multiple unresolved, dedup collapse, missing-file, mixed issues, `CatalogGateError` shape, and the static AC5 assertion that only `deploy_alias_v2` references the gate module.
+
+7. **`deploy-all --v2` integration**: The `SystemExit` raised by `sys.exit(1)` in the gate is caught by the loop at line ~1750, so deploy-all correctly collects failures across all aliases without short-circuiting.
+
+8. **Edge cases**: Empty text → no references → clean. Catalog parse errors bubble through `except Exception` and abort with a diagnostic. Missing catalog file raises `CatalogParseError` which is caught. `full.is_file()` correctly returns `False` for directories and symlinks to directories.
+
+No correctness defects, regressions, or philosophy violations found.
+
+NO_FINDINGS

--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -1670,6 +1670,31 @@ def deploy_alias_v2(alias, registry=None, target_root=None):
         )
         sys.exit(1)
 
+    # PRD-D D3 (#10674): catalog gate. Every emitted
+    # ``→ run sub-skill: <name>`` MUST resolve via D1's catalog parser
+    # to a source-path that exists on disk. Drift aborts BEFORE the
+    # write, so the gate emits zero partial artifacts on failure
+    # (consistent with A2f's atomic-write contract).
+    import v2_catalog_gate as _v2_gate
+    catalog_path = target_root / "docs" / "sub-skill-catalog.md"
+    try:
+        gate_result = _v2_gate.validate_v2_compose(
+            body, catalog_path=catalog_path, repo_root=target_root,
+        )
+    except Exception as e:
+        print(
+            f"ERROR: catalog gate setup failed for alias '{alias}': {e}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if gate_result.has_issues:
+        print(
+            f"ERROR: catalog gate FAILED for alias '{alias}':",
+            file=sys.stderr,
+        )
+        print(gate_result.format(), file=sys.stderr)
+        sys.exit(1)
+
     output_path = target_root / ".squidsquad" / alias / _V2_LINKED_FILENAME
     output_path.parent.mkdir(parents=True, exist_ok=True)
     header = f"# SquidSquad -- {alias} Lead\n\n"

--- a/references/scripts/v2_catalog_gate.py
+++ b/references/scripts/v2_catalog_gate.py
@@ -1,0 +1,191 @@
+"""D3: Catalog gate at v2 compose time (#10674, PRD-D Story D3).
+
+Every `→ run sub-skill: <name>` reference that v2 compose emits MUST
+resolve via D1's catalog parser to a source-path that exists on disk.
+The gate runs against the composed v2 output AFTER `emit_v2_linked`
+returns but BEFORE the file is written, so a drift produces zero
+partial artifacts on disk (consistent with PRD-A A2f's atomic-write
+contract).
+
+Two distinct failure modes are surfaced (AC2 + AC3):
+
+- **unresolved** — the reference name has no row in
+  `docs/sub-skill-catalog.md`. PM-side action: add or rename the
+  catalog row, OR remove the orchestrator reference.
+- **missing-file** — the catalog row resolves to a `source_path`
+  that does not exist on disk. PM-side action: restore the source
+  file or update the catalog row.
+
+Per AC4 the gate reports **all** issues, not just the first. Callers
+raise `CatalogGateError` whose `issues` field is the full list and
+whose `__str__` is a multi-line block suitable for direct stderr
+printing.
+
+Per AC5 the gate is v2-only. v1 compose inlines bodies and has no
+`→ run sub-skill:` references in its output, so calling the gate on
+v1 output would always pass; we intentionally don't wire it there.
+
+Per AC6 tests cover: clean run, single unresolved, multiple
+unresolved, file-missing, and mixed clean/file-missing/unresolved.
+"""
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import catalog_parser as _cp
+
+
+# Match `→ run sub-skill: <name>` anywhere on a line. The name token
+# allows lowercase letters, digits, hyphens, underscores, and SLASHES
+# (slash-bearing catalog names like `roles/dm/events/pr-merge-wait`
+# are valid per D1). Capture only the name; trailing whitespace and
+# the optional comment tail are not part of the lookup key.
+_REF_RE = re.compile(
+    r"→\s+run\s+sub-skill:\s+([a-z][a-z0-9/_-]*)"
+)
+
+
+@dataclass
+class GateIssue:
+    """One unresolved or missing-file finding.
+
+    ``kind`` is ``"unresolved"`` or ``"missing-file"``. ``name`` is the
+    reference text as it appeared in the composed output. ``source_path``
+    is the resolved path (``None`` for ``unresolved`` rows).
+    """
+
+    kind: str
+    name: str
+    source_path: str | None = None
+
+
+@dataclass
+class GateResult:
+    """Result of a single ``validate_v2_compose`` pass.
+
+    Empty issues list = the gate passed; ``has_issues`` is False; the
+    caller writes the composite to disk. Non-empty = abort.
+    """
+
+    issues: list[GateIssue] = field(default_factory=list)
+
+    @property
+    def has_issues(self) -> bool:
+        return bool(self.issues)
+
+    def format(self) -> str:
+        """Render a multi-line abort report grouping issues by kind.
+
+        Empty sections are omitted. Stable-ordered so reviewer diffs
+        and test assertions are deterministic.
+        """
+        if not self.issues:
+            return ""
+        unresolved = sorted(
+            {(i.name,) for i in self.issues if i.kind == "unresolved"}
+        )
+        missing = sorted(
+            (i.name, i.source_path)
+            for i in self.issues if i.kind == "missing-file"
+        )
+        lines = []
+        if unresolved:
+            lines.append(
+                "Unresolved sub-skill references (no catalog row):"
+            )
+            for (name,) in unresolved:
+                lines.append(f"  - `{name}`")
+        if missing:
+            if lines:
+                lines.append("")
+            lines.append(
+                "Catalog row resolves but source file missing on disk:"
+            )
+            for name, path in missing:
+                lines.append(f"  - `{name}` -> {path}")
+        return "\n".join(lines)
+
+
+class CatalogGateError(Exception):
+    """Raised by the gate when the composed v2 output has drift.
+
+    ``result`` holds the full :class:`GateResult` so callers can
+    inspect the individual issues. ``__str__`` returns the rendered
+    multi-issue report — printing the exception body directly is the
+    canonical abort surface (used by ``compose.py deploy_alias_v2``).
+    """
+
+    def __init__(self, result, *, alias=None):
+        self.result = result
+        self.alias = alias
+        prefix = (
+            f"catalog gate FAILED for alias '{alias}':"
+            if alias else "catalog gate FAILED:"
+        )
+        super().__init__(f"{prefix}\n{result.format()}")
+
+
+def find_references(text):
+    """Extract every ``→ run sub-skill: <name>`` reference from ``text``.
+
+    Returns the list of name strings in source order. Duplicates are
+    preserved — a name appearing twice in the orchestrator surfaces as
+    two references in the result so the caller can decide whether
+    duplication itself is an issue (D3 does not flag duplicates; the
+    gate cares only about resolution).
+    """
+    return _REF_RE.findall(text)
+
+
+def validate_v2_compose(text, *, catalog_path, repo_root):
+    """Run the catalog gate against composed v2 output.
+
+    ``text`` is the body returned by ``v2_link_stage.emit_v2_linked``
+    (or the assembled v2 output once PRD-B's assemble stage feeds in).
+    ``catalog_path`` is ``docs/sub-skill-catalog.md`` (or a fixture in
+    tests). ``repo_root`` is the install root; source paths from the
+    catalog are checked relative to it.
+
+    Returns a :class:`GateResult`. Callers convert non-empty results
+    to ``CatalogGateError`` via ``raise CatalogGateError(result, alias=...)``.
+
+    A catalog parse error bubbles through unchanged — that is a
+    D1/parser concern and not a D3 finding.
+    """
+    catalog_path = Path(catalog_path)
+    repo_root = Path(repo_root)
+
+    catalog = _cp.parse_catalog(catalog_path)
+    result = GateResult()
+
+    seen_unresolved = set()
+    seen_missing = set()
+
+    for name in find_references(text):
+        source_path = catalog.get(name)
+        if source_path is None:
+            # AC2: unresolved -> abort. Dedup so a name referenced N
+            # times produces a single line in the report.
+            if name in seen_unresolved:
+                continue
+            seen_unresolved.add(name)
+            result.issues.append(GateIssue(
+                kind="unresolved",
+                name=name,
+            ))
+            continue
+        # AC3: resolved but file missing on disk -> abort.
+        full = repo_root / source_path
+        if full.is_file():
+            continue
+        key = (name, source_path)
+        if key in seen_missing:
+            continue
+        seen_missing.add(key)
+        result.issues.append(GateIssue(
+            kind="missing-file",
+            name=name,
+            source_path=source_path,
+        ))
+    return result

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -144,6 +144,7 @@ STATIC_TEST_MODULES = [
     "test_catalog_parser_d1",
     "test_catalog_parser_d8",
     "test_d2_link_stage_references",
+    "test_v2_catalog_gate_d3",
     "test_manifest_v2_d5",
     "test_l4_file_watcher_e3",
 ]

--- a/tests/test_v2_catalog_gate_d3.py
+++ b/tests/test_v2_catalog_gate_d3.py
@@ -1,0 +1,358 @@
+"""Tests for references/scripts/v2_catalog_gate.py (#10674, PRD-D D3).
+
+AC6 mandates tests covering:
+  (a) clean compose with all refs resolved -> no error
+  (b) single unresolved reference -> abort
+  (c) multiple unresolved -> ALL reported, not just first
+  (d) resolved but source file missing on disk -> abort
+  (e) mix of unresolved + missing-file -> both reported
+  (f) v1 path untouched -- verified at the compose dispatch level
+     (D3's gate function never runs on v1 output)
+
+Plus structural tests for the regex (slash-bearing names, duplicate
+references collapse to one issue, the reference syntax variants).
+"""
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import v2_catalog_gate as gate  # noqa: E402
+
+
+def _make_repo(tmp_path, *, catalog_body, sub_skill_files):
+    """Build a self-contained repo-root fixture."""
+    (tmp_path / "docs").mkdir()
+    catalog = tmp_path / "docs" / "sub-skill-catalog.md"
+    catalog.write_text(textwrap.dedent(catalog_body).lstrip("\n"),
+                       encoding="utf-8")
+    sub_skills = tmp_path / "references" / "sub-skills"
+    sub_skills.mkdir(parents=True)
+    for rel in sub_skill_files:
+        full = sub_skills / rel
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_text(f"# {rel}\n", encoding="utf-8")
+    return tmp_path, catalog
+
+
+_CATALOG_TWO_ROWS = """
+## `common/` — Cross-cutting
+
+### Boot
+
+| Sub-skill | One-liner | Used by |
+|---|---|---|
+| `boot-bootstrap` | Mode detection | all |
+| `cycle-runner` | 3-phase cycle | all |
+"""
+
+
+# ---------------------------------------------------------------------------
+# find_references — regex shape
+# ---------------------------------------------------------------------------
+
+
+class TestFindReferences:
+
+    def test_finds_plain_name(self):
+        text = "Step 1 → run sub-skill: boot-bootstrap"
+        assert gate.find_references(text) == ["boot-bootstrap"]
+
+    def test_finds_multiple(self):
+        text = textwrap.dedent("""
+            Step 1 → run sub-skill: boot-bootstrap
+
+            Step 2 → run sub-skill: cycle-runner
+
+            Step 3 → run sub-skill: vault-remember
+        """)
+        out = gate.find_references(text)
+        assert out == ["boot-bootstrap", "cycle-runner", "vault-remember"]
+
+    def test_finds_slash_bearing_name(self):
+        # Catalog convention for nested paths (e.g. event variants).
+        text = "→ run sub-skill: roles/dm/events/pr-merge-wait"
+        assert gate.find_references(text) == [
+            "roles/dm/events/pr-merge-wait",
+        ]
+
+    def test_ignores_unrelated_arrows(self):
+        # The composed output uses → as a directional glyph in prose
+        # too; only the `→ run sub-skill:` shape counts.
+        text = "pre-cycle → creative work → post-cycle (no ref)"
+        assert gate.find_references(text) == []
+
+    def test_duplicates_preserved_in_extraction(self):
+        # find_references doesn't dedupe -- dedup happens in the
+        # gate's issue construction so each issue lands once.
+        text = "→ run sub-skill: boot-bootstrap\n→ run sub-skill: boot-bootstrap"
+        assert gate.find_references(text) == [
+            "boot-bootstrap", "boot-bootstrap",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# AC6(a) clean compose -> no issues
+# ---------------------------------------------------------------------------
+
+
+class TestCleanCompose:
+
+    def test_all_refs_resolved_returns_clean(self, tmp_path):
+        repo, catalog = _make_repo(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                "common/cycle-runner.md",
+            ],
+        )
+        text = textwrap.dedent("""
+            → run sub-skill: boot-bootstrap
+            → run sub-skill: cycle-runner
+        """)
+        result = gate.validate_v2_compose(
+            text, catalog_path=catalog, repo_root=repo)
+        assert result.has_issues is False
+        assert result.format() == ""
+
+    def test_no_references_at_all_returns_clean(self, tmp_path):
+        repo, catalog = _make_repo(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                "common/cycle-runner.md",
+            ],
+        )
+        # Composed text with no `→ run sub-skill:` lines (e.g. a role
+        # with no orchestrator references).
+        result = gate.validate_v2_compose(
+            "## Identity\n\nNo refs here.\n",
+            catalog_path=catalog, repo_root=repo,
+        )
+        assert result.has_issues is False
+
+
+# ---------------------------------------------------------------------------
+# AC6(b)+(c) unresolved single + multiple
+# ---------------------------------------------------------------------------
+
+
+class TestUnresolved:
+
+    def test_single_unresolved_aborts(self, tmp_path):
+        repo, catalog = _make_repo(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                "common/cycle-runner.md",
+            ],
+        )
+        text = "→ run sub-skill: phantom-skill"
+        result = gate.validate_v2_compose(
+            text, catalog_path=catalog, repo_root=repo)
+        assert result.has_issues is True
+        assert len(result.issues) == 1
+        i = result.issues[0]
+        assert i.kind == "unresolved"
+        assert i.name == "phantom-skill"
+        out = result.format()
+        assert "Unresolved sub-skill references" in out
+        assert "`phantom-skill`" in out
+
+    def test_multiple_unresolved_all_reported(self, tmp_path):
+        # AC4 explicit: report ALL unresolved, not just the first.
+        repo, catalog = _make_repo(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                "common/cycle-runner.md",
+            ],
+        )
+        text = textwrap.dedent("""
+            → run sub-skill: phantom-one
+            → run sub-skill: cycle-runner
+            → run sub-skill: phantom-two
+            → run sub-skill: phantom-three
+        """)
+        result = gate.validate_v2_compose(
+            text, catalog_path=catalog, repo_root=repo)
+        unresolved = [i.name for i in result.issues
+                      if i.kind == "unresolved"]
+        assert sorted(unresolved) == [
+            "phantom-one", "phantom-three", "phantom-two",
+        ]
+
+    def test_duplicate_unresolved_reference_collapses_to_one_issue(
+            self, tmp_path):
+        repo, catalog = _make_repo(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                "common/cycle-runner.md",
+            ],
+        )
+        text = "→ run sub-skill: phantom\n→ run sub-skill: phantom"
+        result = gate.validate_v2_compose(
+            text, catalog_path=catalog, repo_root=repo)
+        assert len(result.issues) == 1
+        assert result.format().count("`phantom`") == 1
+
+
+# ---------------------------------------------------------------------------
+# AC6(d) resolved but file missing
+# ---------------------------------------------------------------------------
+
+
+class TestMissingSourceFile:
+
+    def test_resolved_but_file_missing_aborts(self, tmp_path):
+        # Catalog has the row, but the source file is not on disk.
+        repo, catalog = _make_repo(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                # cycle-runner.md intentionally NOT on disk
+            ],
+        )
+        text = "→ run sub-skill: cycle-runner"
+        result = gate.validate_v2_compose(
+            text, catalog_path=catalog, repo_root=repo)
+        assert result.has_issues is True
+        assert len(result.issues) == 1
+        i = result.issues[0]
+        assert i.kind == "missing-file"
+        assert i.name == "cycle-runner"
+        assert i.source_path == (
+            "references/sub-skills/common/cycle-runner.md"
+        )
+        out = result.format()
+        assert "source file missing on disk" in out
+
+
+# ---------------------------------------------------------------------------
+# AC6(e) mixed: clean + unresolved + missing-file
+# ---------------------------------------------------------------------------
+
+
+class TestMixedIssues:
+
+    def test_clean_plus_unresolved_plus_missing_all_reported(self, tmp_path):
+        repo, catalog = _make_repo(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                # cycle-runner.md NOT on disk -> missing-file
+            ],
+        )
+        text = textwrap.dedent("""
+            → run sub-skill: boot-bootstrap
+            → run sub-skill: cycle-runner
+            → run sub-skill: phantom
+        """)
+        result = gate.validate_v2_compose(
+            text, catalog_path=catalog, repo_root=repo)
+        kinds = sorted((i.kind, i.name) for i in result.issues)
+        assert kinds == [
+            ("missing-file", "cycle-runner"),
+            ("unresolved", "phantom"),
+        ]
+        out = result.format()
+        # Both sections render in the same report.
+        assert "Unresolved sub-skill references" in out
+        assert "source file missing on disk" in out
+
+
+# ---------------------------------------------------------------------------
+# CatalogGateError shape
+# ---------------------------------------------------------------------------
+
+
+class TestCatalogGateError:
+
+    def test_error_message_includes_alias_and_report(self, tmp_path):
+        repo, catalog = _make_repo(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                "common/cycle-runner.md",
+            ],
+        )
+        text = "→ run sub-skill: phantom"
+        result = gate.validate_v2_compose(
+            text, catalog_path=catalog, repo_root=repo)
+        with pytest.raises(gate.CatalogGateError) as ei:
+            raise gate.CatalogGateError(result, alias="pm")
+        msg = str(ei.value)
+        assert "pm" in msg
+        assert "phantom" in msg
+
+    def test_error_has_structured_result_attribute(self, tmp_path):
+        repo, catalog = _make_repo(
+            tmp_path,
+            catalog_body=_CATALOG_TWO_ROWS,
+            sub_skill_files=[
+                "common/boot-bootstrap.md",
+                "common/cycle-runner.md",
+            ],
+        )
+        text = "→ run sub-skill: phantom"
+        result = gate.validate_v2_compose(
+            text, catalog_path=catalog, repo_root=repo)
+        err = gate.CatalogGateError(result, alias="pm")
+        assert err.result is result
+        assert err.alias == "pm"
+
+
+# ---------------------------------------------------------------------------
+# Compose pipeline integration: v1 path untouched (AC5)
+# ---------------------------------------------------------------------------
+
+
+class TestV1Untouched:
+    """AC5 — v1 compose path never calls the gate. Verified by static
+    grep: only the v2 dispatch (deploy_alias_v2) imports v2_catalog_gate."""
+
+    def test_only_v2_dispatch_imports_gate(self):
+        src = (SCRIPTS / "compose.py").read_text(encoding="utf-8")
+        # Locate every v2_catalog_gate reference and confirm it sits
+        # inside ``def deploy_alias_v2(`` (the v2 dispatch).
+        ref_positions = []
+        start = 0
+        while True:
+            idx = src.find("v2_catalog_gate", start)
+            if idx < 0:
+                break
+            ref_positions.append(idx)
+            start = idx + 1
+        assert ref_positions, (
+            "compose.py should reference v2_catalog_gate at least once "
+            "(the v2 dispatch wiring)"
+        )
+        # Find the function that ENCLOSES each reference. Walk back
+        # to the most recent ``def `` line and assert it's the v2
+        # dispatch.
+        for pos in ref_positions:
+            preceding = src.rfind("\ndef ", 0, pos)
+            if preceding < 0:
+                pytest.fail(
+                    f"reference at offset {pos} sits outside any function"
+                )
+            fn_line_end = src.index("\n", preceding + 1)
+            fn_signature = src[preceding + 1:fn_line_end]
+            assert "deploy_alias_v2" in fn_signature, (
+                f"v2_catalog_gate referenced inside non-v2 function: "
+                f"{fn_signature!r}"
+            )


### PR DESCRIPTION
## Summary

- New `references/scripts/v2_catalog_gate.py` — `validate_v2_compose(text, *, catalog_path, repo_root)` returns a structured `GateResult` of `unresolved` and `missing-file` issues.
- Wired into `deploy_alias_v2` in `compose.py`: gate runs AFTER `emit_v2_linked` returns but BEFORE the file is written. Drift = `sys.exit(1)` with zero partial artifacts (PRD-A A2f atomic-write contract).
- 15 unit tests, all passing. DS code-review: **NO_FINDINGS**.

## Closes

Closes #10674.

## AC coverage

1. ✅ v2 compose calls D1's parser (`catalog.get(name)`) to look up `<name>` → `source_path` on every emitted reference.
2. ✅ Unresolved (name not in catalog) → abort with structured diagnostic naming the reference.
3. ✅ Resolved but `source_path` file missing on disk → abort with diagnostic naming both name and resolved path.
4. ✅ Multiple unresolved → **all reported**, not just the first. `GateResult.format()` renders both unresolved + missing-file sections in one block; tests assert `sorted(...)` of all three phantom names is reported.
5. ✅ v1 compose path untouched — only `deploy_alias_v2` imports `v2_catalog_gate`. Asserted at parse-time by `TestV1Untouched.test_only_v2_dispatch_imports_gate`.
6. ✅ Tests cover clean / single unresolved / multiple unresolved / file-missing / mixed clean+missing+unresolved.

## Design notes

- **Pure validator + thin caller**: `validate_v2_compose` is filesystem-only (reads catalog, stats source files). No imports of `compose.py` so D3's testability surface is independent of compose internals.
- **Dedup**: a name appearing N times in the orchestrator output produces one issue line. Both `seen_unresolved` (by name) and `seen_missing` (by `(name, source_path)`) sets enforce this.
- **Slash-bearing names**: `_REF_RE` allows `[a-z0-9/_-]` so catalog conventions like `roles/dm/events/pr-merge-wait` resolve through the same lookup path.
- **AC5 enforcement is structural**: the static-grep test walks every `v2_catalog_gate` reference in `compose.py` and asserts each sits inside `deploy_alias_v2`. A future caller that wires the gate into v1 fails the test at parse time, not at user time.
- **Atomic-write contract**: gate-fail aborts before `output_path.write_text(...)`. No need for tmp-files-then-mv; the write only happens on the success path.

## Future-proofing

When D4 (#10675, catalog drift check) wires into the compose pipeline, the gate becomes the single point where v2 compose surfaces catalog↔source drift. D4 covers the standalone CLI drift report; D3 covers the per-compose abort.

## DS review

`.squidsquad/skill/planning/ds-d3-review.md` archived. **NO_FINDINGS** — DS confirmed atomic-write contract, AC5 parity, dedup logic, regex-equivalence with `catalog_parser._NAME_CELL_RE`, and integration with `deploy-all --v2`'s `SystemExit` handling.

## Test plan

- [x] `python -m pytest tests/test_v2_catalog_gate_d3.py` — 15/15 pass
- [x] Adjacent regression (`test_catalog_parser_d1 + test_v1_byte_stability_9a + test_catalog_drift_d4 + test_d2_link_stage_references + this`) — 81 pass + 1 xfail (pre-existing #10743 catalog duplicate)
- [x] `STATIC_TEST_MODULES` registration — to be added in this PR if not auto-discovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)