### PR TITLE
fix #10743: rename per-role catalog rows to slash-bearing form

### DIFF
--- a/docs/sub-skill-catalog.md
+++ b/docs/sub-skill-catalog.md
@@ -206,11 +206,11 @@ Role-specific event extras:
 | `health-check` | Step 7 — agent health sweep + log to `qa-log.md` |
 | `github-issues` | Step 7b — triage externally-filed issues; route to a role |
 | `soul-shepherd` | Detect character signals in new tasks; update SOUL adaptations |
-| `improvement-scan` | PM variant — process-focused, never code |
-| `issue-filing` | PM's bug-filing protocol (behavior-only, no RCA) |
-| `discussion-protocol` | PM's comment format (→ retires; common/`discussion` is the canonical) |
+| `roles/pm/improvement-scan` | PM variant — process-focused, never code (slash-bearing form per #10743; disambiguates from `common/improvement-scan`) |
+| `roles/pm/issue-filing` | PM's bug-filing protocol (behavior-only, no RCA) — slash-bearing per #10743 |
+| `roles/pm/discussion-protocol` | PM's comment format (→ retires; common/`discussion` is the canonical) — slash-bearing per #10743 |
 | `vault-synthesis` | Cross-agent pattern detection (PM-only) |
-| `ralph-loop-overview` | Runtime-loaded polling-mode cycle contract |
+| `roles/pm/ralph-loop-overview` | Runtime-loaded polling-mode cycle contract — slash-bearing per #10743 |
 | Domain context | Per-stack PM notes: `android/`, `ios/`, `web/`, `fullstack/`, `skill/` |
 
 ### QA (`roles/qa/`)
@@ -218,9 +218,9 @@ Role-specific event extras:
 | Sub-skill | One-liner |
 |---|---|
 | `verification` | Steps 2–6 — E2E tests, AC verification, health check |
-| `issue-filing` | QA's bug template (with reproduction + AC reference) |
-| `discussion-protocol` | QA's comment format (→ retires; common/`discussion` is the canonical) |
-| `ralph-loop-overview` | Runtime-loaded polling-mode cycle contract |
+| `roles/qa/issue-filing` | QA's bug template (with reproduction + AC reference) — slash-bearing per #10743 |
+| `roles/qa/discussion-protocol` | QA's comment format (→ retires; common/`discussion` is the canonical) — slash-bearing per #10743 |
+| `roles/qa/ralph-loop-overview` | Runtime-loaded polling-mode cycle contract — slash-bearing per #10743 |
 | Domain context | Per-stack QA notes: `android/`, `ios/`, `web/`, `fullstack/`, `skill/` |
 | `skill/finding-categories` | Skill-domain finding taxonomy for QA reports |
 
@@ -228,14 +228,14 @@ Role-specific event extras:
 
 | Sub-skill | One-liner |
 |---|---|
-| `task-pickup` | DM's queue: pending-ship items |
+| `roles/dm/task-pickup` | DM's queue: pending-ship items — slash-bearing per #10743 |
 | `issue-triage` | Triage DM-owned bug reports |
 | `delivery-packaging` | The packaging step: docs, CHANGELOG, release notes |
 | `version-bumps` | Bump rules (uses `shipped_since_bump` counter) |
 | `doc-improvement-loop` | DM's scan: drift between source docs and shipped state |
-| `issue-filing` | DM's bug template |
-| `discussion-protocol` | DM's comment format (→ retires; common/`discussion` is the canonical) |
-| `ralph-loop-overview` | Runtime-loaded polling-mode cycle contract |
+| `roles/dm/issue-filing` | DM's bug template — slash-bearing per #10743 |
+| `roles/dm/discussion-protocol` | DM's comment format (→ retires; common/`discussion` is the canonical) — slash-bearing per #10743 |
+| `roles/dm/ralph-loop-overview` | Runtime-loaded polling-mode cycle contract — slash-bearing per #10743 |
 | Domain context | Per-stack DM notes: `android/`, `ios/`, `web/`, `fullstack/`, `skill/` |
 
 ### Dev (`roles/dev/`)
@@ -244,7 +244,7 @@ Role-specific event extras:
 |---|---|
 | `triage-issues` | Step 2 — deterministic work-queue triage |
 | `implement-tasks` | Step 2b — pick up approved tasks; commit on feature branch; open PR |
-| `ralph-loop-overview` | Runtime-loaded polling-mode cycle contract |
+| `roles/dev/ralph-loop-overview` | Runtime-loaded polling-mode cycle contract — slash-bearing per #10743 |
 | Domain context | Per-stack dev notes: `android/`, `ios/`, `web/`, `fullstack/`, `skill/` |
 
 > Removed from all per-role tables: `responsibility`, `file-conventions`, `status-line`. These are no longer sub-skills (see the migration notes earlier in this section). Source files remain on disk under `references/sub-skills/roles/<role>/` until #10360 implements the migration; this catalog reflects target architecture, not v1 disk state.

--- a/tests/test_catalog_parser_d1.py
+++ b/tests/test_catalog_parser_d1.py
@@ -444,55 +444,29 @@ class TestBacktickWrappedNonMatchingRaises:
 class TestLiveCatalogIntegration:
     """Live catalog integration check.
 
-    The real `docs/sub-skill-catalog.md` currently has a known defect —
-    `improvement-scan` is listed under BOTH `common/` and `roles/pm/`
-    sections, which the parser correctly catches per AC3. PM must
-    disambiguate (filed as #10687). Until that's fixed, the
-    parser-catches-duplicate test is marked `xfail(strict=True)` so it
-    flips to XPASS (loud test failure) the moment PM disambiguates —
-    forcing whoever fixes #10687 to also update this test rather than
-    silently leaving stale expected-fail behavior.
+    The original #10687 (and re-filing as #10743) defect — duplicate
+    bare-name catalog rows for `improvement-scan`, `issue-filing`,
+    `task-pickup`, `discussion-protocol`, `ralph-loop-overview` — was
+    resolved by renaming the per-role variants to slash-bearing form
+    (e.g. `roles/pm/improvement-scan`). The xfail-strict regression
+    pin flipped to XPASS and is now removed; the live catalog parses
+    cleanly.
     """
 
-    @pytest.mark.xfail(
-        reason="Pinned to the #10687 catalog defect (duplicate "
-        "`improvement-scan`). Will XPASS (and fail the suite) once PM "
-        "disambiguates — at which point this test should be deleted and "
-        "the clean-parse path enabled below.",
-        strict=True,
-    )
     def test_real_catalog_parses_cleanly(self):
-        """When PM disambiguates #10687, this test should pass cleanly.
-        Today the parser raises on the catalog's duplicate name (which
-        is correct behavior), so the test is xfail strict.
-        """
+        """The live catalog must parse without raising. Replaces the
+        old xfail-strict pin from when #10743's duplicates blocked
+        parsing."""
         catalog = REPO_ROOT / "docs" / "sub-skill-catalog.md"
         if not catalog.is_file():
             pytest.skip("docs/sub-skill-catalog.md not present")
         out = cp.parse_catalog(catalog)
         assert len(out) >= 10
-
-    def test_real_catalog_diagnostic_for_known_defect(self):
-        """Today's behavior: parser raises CatalogParseError naming
-        both conflicting source-paths. Survives PM's fix because the
-        moment the catalog is clean, this test's `xfail` doesn't apply
-        — the assertion-side flips out of scope. Keep this test as a
-        defect-pinning audit trail until #10687 ships."""
-        catalog = REPO_ROOT / "docs" / "sub-skill-catalog.md"
-        if not catalog.is_file():
-            pytest.skip("docs/sub-skill-catalog.md not present")
-        try:
-            cp.parse_catalog(catalog)
-            # Clean parse — #10687 was fixed; this defect-pinning test
-            # is obsolete. The xfail-strict test above will XPASS and
-            # tell the human to delete BOTH tests.
-            return
-        except cp.CatalogParseError as e:
-            msg = str(e)
-            assert "duplicate" in msg.lower()
-            # Both source-paths surfaced per C3
-            assert "common/improvement-scan.md" in msg
-            assert "roles/pm/improvement-scan.md" in msg
+        # Spot-check: the previously-duplicated name now appears in
+        # both forms (common bare-name + roles/pm slash-bearing) so
+        # callers that look up either string find the right source.
+        assert "improvement-scan" in out
+        assert "roles/pm/improvement-scan" in out
 
     def test_real_catalog_partial_entries_have_valid_path_shape(self, tmp_path):
         """Up to the point the parser hits the duplicate, every emitted


### PR DESCRIPTION
## Summary

The live catalog had several bare-name rows that collided with `common/` rows (and across role sections), blocking the catalog parser on any clean parse attempt. Five names were duplicated: `improvement-scan` (2x), `issue-filing` (4x), `task-pickup` (2x), `discussion-protocol` (3x), `ralph-loop-overview` (4x).

**Fix**: rename every per-role variant in the PM/QA/DM/Dev sections to slash-bearing form (e.g. `roles/pm/improvement-scan`). This is already the precedent set by `roles/dm/events/pr-merge-wait` and matches what the `includes.yml` manifests reference verbatim — the rename is pure catalog hygiene with no behavioural change.

## Closes

Closes #10743.

## Why slash-bearing form

- The catalog_parser's slash-name branch already maps slash-bearing names to `references/sub-skills/<name>.md` (D1 #10672 `_NAME_CELL_RE` + the slash-handling in `parse_catalog_entries`).
- `includes.yml` for every role already lists `roles/<role>/<name>` form (verified by grep) — so the rename converges the catalog with the manifests.
- Source-path resolution is unchanged: `roles/pm/improvement-scan` resolves to the exact same file as the bare-name PM-section row did under the H3-derived prefix.

## Test impact

- `tests/test_catalog_parser_d1.py::TestLiveCatalogIntegration` had two defect-pinned tests (xfail-strict on the duplicate, plus a diagnostic-format defect-pinning audit). Both are now obsolete:
  - `test_real_catalog_parses_cleanly` — xfail marker removed; now a real pass. Added a positive assertion that BOTH `improvement-scan` and `roles/pm/improvement-scan` resolve, proving the rename preserves both lookup keys.
  - `test_real_catalog_diagnostic_for_known_defect` — deleted (the duplicate it pinned no longer exists).
- 26 D1 tests pass (down from 26 passed + 1 xfail).

## Drift surface

D4's drift-check now runs successfully on the live catalog and exits 1 with a full report. The report surfaces pre-existing orphans — `roles/dev/` references after the #6274 dev→worker rename, `common/discussion-protocol.md` source without a matching catalog row, several `<role>/<l3>/domain-context.md` files without rows, etc. **These are out of scope for #10743** (#10743's scope is "make the parser succeed"). I'll file a follow-up issue summarizing the orphan list so it can be triaged + cleaned up by PM/skill as a separate piece of work.

## Test plan

- [x] `python -m pytest tests/test_catalog_parser_d1.py` — 26 pass (xfail removed, replaced by real assertion)
- [x] `python -m pytest tests/test_catalog_parser_d1.py tests/test_catalog_drift_d4.py tests/test_v2_catalog_gate_d3.py tests/test_v1_byte_stability_9a.py tests/test_d2_link_stage_references.py tests/test_manifest_v2_d5.py tests/test_l4_file_watcher_e3.py` — 145 pass, no regressions
- [x] `python references/scripts/compose.py drift-check` exits 1 with structured orphan report (was exit 2 / parser error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)