### PR TITLE
fix #10751: PRD-A audit ERROR + W1/W2/W4 (W3 deferred to PM)

### DIFF
--- a/.squidsquad/skill/planning/ds-10751-review.md
+++ b/.squidsquad/skill/planning/ds-10751-review.md
@@ -1,0 +1,37 @@
+Now I have all the information I need. Let me trace through the key logic one final time to confirm my finding.
+
+---
+
+After thorough review of all five changed files, I found one genuine issue:
+
+### Finding 1
+
+- **File**: `references/scripts/config.py`
+- **Line**: 379–383
+- **Severity**: warning
+- **Issue**: The `else` branch in `_parse_aliases_bullet_form` uses `continue` to skip unrecognized bullet values, **silently dropping them** when mixed with recognized bullets. Both the docstring (lines 352–354) and the inline comment (lines 379–382) claim the function returns `{}` / "falls through to the needs table format diagnostic" so the operator can fix the offending bullet — but that only happens when *all* bullets are unrecognized. A single recognized bullet makes `registry` truthy, and any unrecognized siblings are silently discarded with no diagnostic whatsoever.
+- **Evidence**:
+  - **Docstring** (lines 352–354): *"Any other `<value>` -> bullet form does not recognize it; `_parse_aliases_bullet_form` returns `{}` so the caller raises its normal 'needs table format' diagnostic."*
+  - **Inline comment** (lines 379–382): *"Unrecognized value -> caller falls through to the 'needs table format' diagnostic so the operator can fix the offending bullet **rather than silently dropping it**."* (emphasis mine)
+  - **Actual code** (line 383): `continue` — which advances to the next iteration. If any prior bullet was recognized, `registry` is non-empty, the function returns it, and the unrecognized entry vanishes without a trace.
+
+  Concrete example — this input:
+  ```
+  - **pm**: pm
+  - **skill**: skil
+  ```
+  …produces `{"pm": ("pm", None)}`. The `skill` alias is silently absent from the registry. No error, no warning. The operator has no signal that `skil` (a typo for `skill`) was ignored.
+
+  The existing test `test_unrecognized_value_falls_through_to_table_diagnostic` only covers the case where the **only** bullet is unrecognized — it doesn't exercise the mixed recognized+unrecognized path.
+
+- **Suggested fix**: Either (a) make the code match the documented intent — raise `AliasesRegistryError` on any unrecognized bullet value (not just when all are unrecognized), or (b) update the docstring and comment to accurately describe the permissive "skip unrecognized, keep recognized" behavior. Option (a) is safer because it prevents silent data loss from typos; it also matches what the docstring and comment already claim.
+
+---
+
+NO_FINDINGS for the remaining scope:
+- The **#6274 shim** (`_BULLET_LEGACY_ROLE_CLASS_SHIM`) is correctly mirrored from `compose._BASE_ALIAS_6274` (mapping `qa→verifier`, `dev→worker`) and correctly applied in both the bullet-form fallback (line 374) and the table-form path (line 502).
+- The **bullet-form fallback** in `parse_aliases_registry` (lines 444–459) correctly delegates to `_parse_aliases_bullet_form` when no table rows are detected, preventing v2 deploys from aborting on live config.md.
+- The **W1 column-header fix** — `_ALIASES_HEADER_COLUMNS = ("alias", "role-class", "L3 domain")` uses the canonical lowercase-hyphen form; the comparison at line 462–463 uses `.lower()` on both sides; the test fixture at line 80 of `test_compose_a2f_10492.py` now writes the matching header.
+- The **W4 R3 guard** at line 126 of `link_stage_validator.py` explicitly checks `src.layer in ("L1", "L2", "L3")`, symmetric with R2's `src.layer in ("L2", "L3")`, and the test `test_r3_l4_source_with_project_context_slot_does_not_trigger` confirms L4 sources pass through.
+- The **catalog fixture** (`_stage_minimal_catalog` in `test_compose_a6_v2.py` and inline in `_stage_minimal_install` in `test_compose_a2f_10492.py`) is correctly wired into the 4 previously-broken A6 tests plus the new A2f tests.
+- All other test coverage is correct and comprehensive for the stated acceptance criteria.

--- a/references/scripts/config.py
+++ b/references/scripts/config.py
@@ -296,6 +296,25 @@ def set_field(field, value):
 
 ALIASES_ROLE_CLASSES = frozenset({"pm", "worker", "verifier", "dm"})
 
+# #6274 dual-aware shim mirror — bullet-form fallback and table-form
+# normalization both pre-map legacy aliases (`qa` → `verifier`,
+# `dev` → `worker`) before validation, so a real install that still
+# declares `- **qa**: qa` resolves to `(verifier, None)` instead of
+# raising "unknown role-class `qa`". Symmetric with
+# `compose._BASE_ALIAS_6274` — avoids importing compose into config
+# (would create a cycle).
+_BULLET_LEGACY_ROLE_CLASS_SHIM = {"qa": "verifier", "dev": "worker"}
+
+# Worker-variant L3 domains carry the "skill" / "ios" / "web" /
+# "android" / "fullstack" shorthand in the legacy bullet form
+# (`- **skill**: skill` means alias=skill / role_class=worker /
+# l3_domain=skill — the dev-agent L3 fan-out). Used only by the
+# bullet-form fallback; table-form callers pass the explicit
+# (role-class, L3 domain) cells.
+_BULLET_LEGACY_WORKER_L3_DOMAINS = frozenset({
+    "skill", "ios", "web", "android", "fullstack",
+})
+
 # U+2014 EM DASH only. Hyphen-minus and en-dash are rejected by the strict
 # cell comparison below, giving the operator a crisper diagnostic than
 # silent acceptance of three lookalike characters.
@@ -312,6 +331,75 @@ class AliasesRegistryError(ValueError):
     config-parsing errors keep working; tests assert against the more
     specific type when they care about the diagnostic source.
     """
+
+
+def _parse_aliases_bullet_form(section_text):
+    """Parse the legacy bullet-form `## Aliases` block.
+
+    Recognizes lines of shape ``- **<alias>**: <value>`` and returns
+    ``{alias: (role_class, l3_domain)}`` using these rules:
+
+    - ``<value>`` in ``ALIASES_ROLE_CLASSES`` -> ``role_class=value``,
+      ``l3_domain=None``.
+    - ``<value>`` in ``_BULLET_LEGACY_ROLE_CLASS_SHIM`` (e.g. ``qa`` /
+      ``dev``) -> ``role_class=<shim-target>`` (``verifier`` /
+      ``worker``), ``l3_domain=None``.
+    - ``<value>`` in ``_BULLET_LEGACY_WORKER_L3_DOMAINS`` (e.g.
+      ``skill`` / ``ios`` / ``web`` / ``android`` / ``fullstack``)
+      -> ``role_class="worker"``, ``l3_domain=<value>``. This is the
+      legacy convention that ``- **skill**: skill`` declares a
+      worker-skill variant.
+    - Any other ``<value>`` -> bullet form does not recognize it;
+      ``_parse_aliases_bullet_form`` returns ``{}`` so the caller
+      raises its normal "needs table format" diagnostic.
+
+    Returns ``{}`` (NOT ``None``) when the section has NO bullet rows
+    at all so the caller's "needs table format" diagnostic stays the
+    canonical on-empty path. When at least one bullet row IS present,
+    every row must resolve via the rules above — an unrecognized value
+    raises :class:`AliasesRegistryError` rather than being silently
+    dropped. Per DS-10751 review: silent skip + ``return registry``
+    (when other rows were recognized) would make a single-character
+    typo like ``- **skill**: skil`` invisible to the operator; matches
+    the docstring's "rather than silently dropping it" guarantee.
+    """
+    bullet_re = re.compile(
+        r"^\s*-\s+\*\*([^*]+)\*\*\s*:\s*(\S+)\s*$",
+    )
+    registry = {}
+    for raw_line in section_text.splitlines():
+        m = bullet_re.match(raw_line)
+        if m is None:
+            continue
+        alias, value = m.group(1).strip(), m.group(2).strip()
+        if not alias or not value:
+            continue
+        if value in ALIASES_ROLE_CLASSES:
+            role_class, l3_domain = value, None
+        elif value in _BULLET_LEGACY_ROLE_CLASS_SHIM:
+            role_class = _BULLET_LEGACY_ROLE_CLASS_SHIM[value]
+            l3_domain = None
+        elif value in _BULLET_LEGACY_WORKER_L3_DOMAINS:
+            role_class, l3_domain = "worker", value
+        else:
+            # Unrecognized value — raise so a typo can't slip past
+            # the operator. Names the bullet that failed AND the
+            # accepted value set so the fix is obvious from the
+            # diagnostic alone.
+            raise AliasesRegistryError(
+                f"`## Aliases` bullet form has unrecognized value "
+                f"`{value}` for alias `{alias}`. Accepted values are "
+                f"role-classes ({sorted(ALIASES_ROLE_CLASSES)}), legacy "
+                f"shim aliases ({sorted(_BULLET_LEGACY_ROLE_CLASS_SHIM)}), "
+                f"or worker L3 domains "
+                f"({sorted(_BULLET_LEGACY_WORKER_L3_DOMAINS)})."
+            )
+        if alias in registry:
+            raise AliasesRegistryError(
+                f"`## Aliases` bullet form has duplicate alias `{alias}`."
+            )
+        registry[alias] = (role_class, l3_domain)
+    return registry
 
 
 def _split_table_row(line):
@@ -367,10 +455,20 @@ def parse_aliases_registry(text=None):
         rows.append(cells)
 
     if not rows:
+        # #10751 ERROR: bullet-form fallback. Real installs still ship
+        # the legacy `- **alias**: value` form (e.g. this repo's
+        # config.md). Without the fallback every v2 deploy aborts here
+        # before any link-stage work. Symmetric in semantics with the
+        # canonical 3-column table — see `_parse_aliases_bullet_form`
+        # for the per-row interpretation.
+        bullet_registry = _parse_aliases_bullet_form(section_text)
+        if bullet_registry:
+            return bullet_registry
         raise AliasesRegistryError(
             "`## Aliases` section is present but contains no table — expected "
             "a 3-column markdown table with header `| alias | role-class | "
-            "L3 domain |` (see COMPOSE-ARCHITECTURE §3.0)."
+            "L3 domain |` (see COMPOSE-ARCHITECTURE §3.0), OR the legacy "
+            "`- **alias**: value` bullet form."
         )
 
     header = rows[0]
@@ -409,11 +507,19 @@ def parse_aliases_registry(text=None):
                 f"`## Aliases` data row {data_row_index} (`{alias}`) has an "
                 f"empty `role-class` cell."
             )
+        # #10751 W2: pre-normalize via the #6274 shim so a real
+        # install with `qa` / `dev` in the role-class column resolves
+        # to `verifier` / `worker` instead of raising. Symmetric with
+        # `_parse_aliases_bullet_form` above and with
+        # `compose._BASE_ALIAS_6274` elsewhere.
+        if role_class in _BULLET_LEGACY_ROLE_CLASS_SHIM:
+            role_class = _BULLET_LEGACY_ROLE_CLASS_SHIM[role_class]
         if role_class not in ALIASES_ROLE_CLASSES:
             raise AliasesRegistryError(
                 f"`## Aliases` data row {data_row_index} (`{alias}`) has "
                 f"unknown role-class `{role_class}` — must be one of "
-                f"{sorted(ALIASES_ROLE_CLASSES)}."
+                f"{sorted(ALIASES_ROLE_CLASSES)} (with legacy `qa`/`dev` "
+                f"auto-mapped to `verifier`/`worker`)."
             )
         if alias in registry:
             raise AliasesRegistryError(

--- a/references/scripts/link_stage_validator.py
+++ b/references/scripts/link_stage_validator.py
@@ -116,8 +116,14 @@ def _check_r2_l2_l3_no_vault_slot(sources):
 
 
 def _check_r3_l1_l3_no_project_context_slot(sources):
+    # #10751 W4: explicit layer guard for self-documenting symmetry
+    # with `_check_r2_l2_l3_no_vault_slot` above. Today the source
+    # collector pre-filters to L1-L3 so the guard is functionally
+    # equivalent, but pinning the layer set inline means R3 stays
+    # correct if the collector ever yields L4 (or any new layer) —
+    # the maintenance hazard the audit called out.
     for src in sources:
-        if src.slot == "project-context":
+        if src.slot == "project-context" and src.layer in ("L1", "L2", "L3"):
             raise LinkStageValidationError(
                 "R3",
                 "L1-L3 source declares `slot: project-context` in its "

--- a/tests/test_compose_a2f_10492.py
+++ b/tests/test_compose_a2f_10492.py
@@ -52,12 +52,32 @@ def _stage_minimal_install(tmp_path, alias="pm", role="pm"):
         roles=[role],
     )
 
+    # PRD-D D3 (#10674) catalog gate: deploy_alias_v2 now consults
+    # docs/sub-skill-catalog.md after emit_v2_linked. The fixture's
+    # instructions slot doesn't emit any `→ run sub-skill:` references
+    # (just `### step:` markers and prose), so a minimal one-section
+    # catalog with at least one valid row is enough to pass the gate.
+    catalog = tmp_path / "docs" / "sub-skill-catalog.md"
+    catalog.parent.mkdir(parents=True, exist_ok=True)
+    catalog.write_text(
+        "## `common/` — Cross-cutting\n\n"
+        "| Sub-skill | One-liner | Used by |\n"
+        "|---|---|---|\n"
+        "| `boot-bootstrap` | Mode detection | all |\n",
+        encoding="utf-8",
+    )
+
     # Aliases registry: alias -> role (no L3 domain).
+    # #10751 W1: canonical column header is `| alias | role-class |
+    # L3 domain |` (lowercase, hyphen). The previous "Role class" with
+    # space silently fell through `parse_aliases_registry`'s strict
+    # comparison and only passed in this test because the test bypasses
+    # the parser via a pre-built registry dict elsewhere.
     config_md = tmp_path / ".squidsquad" / "config.md"
     config_md.parent.mkdir(parents=True, exist_ok=True)
     config_md.write_text(
         "## Aliases\n\n"
-        "| Alias | Role class | L3 domain |\n"
+        "| alias | role-class | L3 domain |\n"
         "|---|---|---|\n"
         f"| {alias} | {role} | |\n",
         encoding="utf-8",

--- a/tests/test_compose_a6_v2.py
+++ b/tests/test_compose_a6_v2.py
@@ -13,6 +13,27 @@ sys.path.insert(0, str(SCRIPTS))
 import compose  # noqa: E402
 
 
+def _stage_minimal_catalog(target_root):
+    """PRD-D D3 (#10674) added a catalog gate inside ``deploy_alias_v2``
+    that reads ``<target_root>/docs/sub-skill-catalog.md`` after
+    ``emit_v2_linked`` returns. Tests that mock the emit stage but
+    still drive the full ``deploy_alias_v2`` body must provide a
+    minimal catalog so the gate's parser can succeed. A single
+    ``common/`` row is enough — the emitted body in these tests
+    contains no ``→ run sub-skill:`` references for the gate to look
+    up, so the catalog only needs to be parseable.
+    """
+    catalog = Path(target_root) / "docs" / "sub-skill-catalog.md"
+    catalog.parent.mkdir(parents=True, exist_ok=True)
+    catalog.write_text(
+        "## `common/` — Cross-cutting\n\n"
+        "| Sub-skill | One-liner | Used by |\n"
+        "|---|---|---|\n"
+        "| `boot-bootstrap` | Mode detection | all |\n",
+        encoding="utf-8",
+    )
+
+
 # ---------------------------------------------------------------------------
 # deploy_role: backward compatibility for v1 (output_filename default)
 # ---------------------------------------------------------------------------
@@ -79,6 +100,7 @@ def test_deploy_alias_v2_resolves_via_parser_and_writes_v2_path(tmp_path, monkey
     monkeypatch.setattr(v2_link_stage, "collect_sources_for_validation",
                         lambda role_class, l3_domain, repo_root=None: [])
     monkeypatch.setattr(v2_link_stage, "emit_v2_linked", fake_emit)
+    _stage_minimal_catalog(tmp_path)
 
     out = compose.deploy_alias_v2("pm", target_root=tmp_path)
 
@@ -109,6 +131,7 @@ def test_deploy_alias_v2_uses_role_class_not_alias_for_compose_source(tmp_path, 
     monkeypatch.setattr(v2_link_stage, "collect_sources_for_validation", fake_collect)
     monkeypatch.setattr(v2_link_stage, "emit_v2_linked",
                         lambda role_class, l3_domain, *, repo_root=None, l4_path=None: "x")
+    _stage_minimal_catalog(tmp_path)
 
     out = compose.deploy_alias_v2("frontend-1", target_root=tmp_path)
 
@@ -169,6 +192,7 @@ def test_deploy_alias_v2_passes_registry_through(tmp_path, monkeypatch):
                         lambda role_class, l3_domain, repo_root=None: [])
     monkeypatch.setattr(v2_link_stage, "emit_v2_linked",
                         lambda role_class, l3_domain, *, repo_root=None, l4_path=None: "body")
+    _stage_minimal_catalog(tmp_path)
     compose.deploy_alias_v2("pm", registry={"pm": ("pm", None)}, target_root=tmp_path)
     assert calls["parse"] == 0
 
@@ -189,6 +213,7 @@ def test_deploy_alias_v2_v2_regenerate_cmd_in_output_header(tmp_path, monkeypatc
                         lambda role_class, l3_domain, repo_root=None: [])
     monkeypatch.setattr(v2_link_stage, "emit_v2_linked",
                         lambda role_class, l3_domain, *, repo_root=None, l4_path=None: "body")
+    _stage_minimal_catalog(tmp_path)
 
     out = compose.deploy_alias_v2("frontend-1", target_root=tmp_path)
     header = out.read_text(encoding="utf-8")

--- a/tests/test_config_aliases_registry_10385.py
+++ b/tests/test_config_aliases_registry_10385.py
@@ -242,3 +242,123 @@ class TestExportedConstants:
     def test_error_is_value_error_subclass(self):
         """Callers that already catch ValueError keep working."""
         assert issubclass(config.AliasesRegistryError, ValueError)
+
+
+# ---------------------------------------------------------------------------
+# #10751 ERROR — legacy bullet-form fallback. Real installs still ship
+# the `- **alias**: value` form. The parser must NOT abort on the bullet
+# form; it should produce a registry equivalent to what an explicit
+# 3-column table would have produced.
+# ---------------------------------------------------------------------------
+
+
+class TestBulletFormFallback:
+
+    def test_canonical_pm_and_dm_bullets(self):
+        body = (
+            "- **pm**: pm\n"
+            "- **dm**: dm\n"
+        )
+        result = config.parse_aliases_registry(_wrap_with_aliases(body))
+        assert result == {
+            "pm": ("pm", None),
+            "dm": ("dm", None),
+        }
+
+    def test_qa_bullet_maps_to_verifier_via_shim(self):
+        # #10751 W2: `- **qa**: qa` on a real install must produce
+        # role_class=verifier, NOT raise "unknown role-class qa".
+        body = "- **qa**: qa\n"
+        result = config.parse_aliases_registry(_wrap_with_aliases(body))
+        assert result == {"qa": ("verifier", None)}
+
+    def test_dev_bullet_maps_to_worker_via_shim(self):
+        body = "- **dev**: dev\n"
+        result = config.parse_aliases_registry(_wrap_with_aliases(body))
+        assert result == {"dev": ("worker", None)}
+
+    def test_skill_bullet_maps_to_worker_skill_variant(self):
+        # `- **skill**: skill` is the legacy convention for a
+        # worker-skill variant: role_class=worker, l3_domain=skill.
+        body = "- **skill**: skill\n"
+        result = config.parse_aliases_registry(_wrap_with_aliases(body))
+        assert result == {"skill": ("worker", "skill")}
+
+    def test_full_live_repo_install_bullets(self):
+        # Matches the live config.md on this repo exactly.
+        body = (
+            "- **skill**: skill\n"
+            "- **pm**: pm\n"
+            "- **dm**: dm\n"
+            "- **qa**: qa\n"
+        )
+        result = config.parse_aliases_registry(_wrap_with_aliases(body))
+        assert result == {
+            "skill": ("worker", "skill"),
+            "pm": ("pm", None),
+            "dm": ("dm", None),
+            "qa": ("verifier", None),
+        }
+
+    def test_unrecognized_value_raises_with_diagnostic(self):
+        # Per DS-10751 review: an unrecognized bullet value raises so
+        # a typo cannot slip past the operator. The diagnostic names
+        # the offending alias + value AND the accepted value set so
+        # the fix is obvious from the error alone.
+        body = "- **bogus**: not-a-thing\n"
+        with pytest.raises(
+            config.AliasesRegistryError,
+            match="unrecognized value",
+        ):
+            config.parse_aliases_registry(_wrap_with_aliases(body))
+
+    def test_mixed_recognized_and_typo_raises_not_silently_drops(self):
+        # DS-10751 regression: a typo in ONE bullet must raise even
+        # when other bullets are well-formed. Before the fix this
+        # returned {"pm": ("pm", None)} and silently dropped the
+        # `skill` alias because the typo'd `skil` value was just
+        # `continue`d past.
+        body = (
+            "- **pm**: pm\n"
+            "- **skill**: skil\n"  # typo: should be `skill`
+        )
+        with pytest.raises(
+            config.AliasesRegistryError,
+            match="unrecognized value `skil`",
+        ):
+            config.parse_aliases_registry(_wrap_with_aliases(body))
+
+    def test_duplicate_alias_in_bullet_form_raises(self):
+        body = (
+            "- **pm**: pm\n"
+            "- **pm**: dm\n"
+        )
+        with pytest.raises(
+            config.AliasesRegistryError,
+            match="duplicate alias",
+        ):
+            config.parse_aliases_registry(_wrap_with_aliases(body))
+
+
+class TestTableFormShim:
+    """#10751 W2 — table form must also auto-map `qa`/`dev` so an
+    install that migrates to table form without first manually
+    rewriting role-class cells works the same as the bullet form."""
+
+    def test_qa_role_class_in_table_maps_to_verifier(self):
+        body = (
+            "| alias | role-class | L3 domain |\n"
+            "|---|---|---|\n"
+            "| qa | qa | — |\n"
+        )
+        result = config.parse_aliases_registry(_wrap_with_aliases(body))
+        assert result == {"qa": ("verifier", None)}
+
+    def test_dev_role_class_in_table_maps_to_worker(self):
+        body = (
+            "| alias | role-class | L3 domain |\n"
+            "|---|---|---|\n"
+            "| dev | dev | skill |\n"
+        )
+        result = config.parse_aliases_registry(_wrap_with_aliases(body))
+        assert result == {"dev": ("worker", "skill")}

--- a/tests/test_link_stage_validator.py
+++ b/tests/test_link_stage_validator.py
@@ -93,6 +93,18 @@ def test_r3_any_l1_l3_source_with_project_context_slot_aborts(layer):
     assert exc.value.rule == "R3"
 
 
+def test_r3_l4_source_with_project_context_slot_does_not_trigger():
+    # #10751 W4 regression: R3 must only fire on L1-L3 sources. If the
+    # source collector ever yields L4 entries (today it pre-filters,
+    # but the asymmetry with R2 was a maintenance hazard), R3's
+    # explicit layer guard must keep L4's project-context content
+    # flowing — that's the slot L4 is supposed to own.
+    sources = [_src("L4", "project/pm.md", "project-context")]
+    # No raise = guard works. R4/R5/R6/R7 don't apply to this minimal
+    # input either, so the validator completes cleanly.
+    v.validate_link_stage(L4Document.empty(), sources)
+
+
 # ---------------------------------------------------------------------------
 # R4: L4 ### append under ## Instructions without sub-skill ref → abort
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes 4 of 5 DS audit findings in PRD-A (link stage). W3 (`--check --v2` promised at A4.5 but A4.5 shipped `--check --staged-l4` instead) is a spec/impl alignment question routed to PM as #10756 — implementing it unilaterally would mean filing a new PRD-A story.

## Closes

Closes #10751.

## Fixes

### ERROR — bullet-form fallback in `parse_aliases_registry`

Real installs (this repo's `config.md` included) still use the legacy bullet form. The parser was rejecting it at config-parse time, aborting every `compose.py deploy <alias> --v2` and `deploy-all --v2` invocation before any link-stage work.

`_parse_aliases_bullet_form` recognises:
- value in `ALIASES_ROLE_CLASSES` → `role_class=value, l3_domain=None`
- value in legacy shim `{qa, dev}` → maps to `{verifier, worker}`
- value in legacy worker L3 shorthand `{skill, ios, web, android, fullstack}` → `role_class=worker, l3_domain=value`

Unrecognized values **raise** (per DS review — silent skip would lose typos like `- **skill**: skil` when mixed with well-formed bullets).

### W1 — A2f fixture column header

Test fixture was writing `| Alias | Role class | L3 domain |`; parser does strict lowercase comparison against `"role-class"` (hyphen). The fixture passed only because the surrounding test bypassed the parser via a pre-built dict. Now writes the canonical lowercase-hyphen form.

### W2 — `qa`/`dev` shim mirrored into table-form path

Already worked in the bullet fallback. Mirrored the shim into the table-form validation step so an operator migrating to table form without renaming the role-class column gets the same `qa → verifier` mapping instead of "unknown role-class qa".

### W4 — R3 layer guard

`_check_r3_l1_l3_no_project_context_slot` accepted any layer because the source collector pre-filters L1-L3 upstream. Symmetric maintenance hazard with R2 which already had an explicit layer guard. Added `src.layer in ("L1", "L2", "L3")` to R3.

## W3 — deferred to PM (#10756)

A4.5 was supposed to deliver `--check --v2` per `docs/prd/compose-link-stage.md` §9a, but A4.5 shipped `--check --staged-l4` instead. The audit's recommended fix is *"implement OR explicitly defer to PRD-E with a tracking issue and correct the §9a wording"* — both options are PM-scope decisions. Filed as #10756; this PR ships everything else.

## Collateral — test-infrastructure fix

PRD-D D3 catalog gate (#10747) shipped and silently broke 4 tests in `tests/test_compose_a6_v2.py` — `deploy_alias_v2` now reads `docs/sub-skill-catalog.md` between emit and write, and those test fixtures didn't stage a catalog. Added `_stage_minimal_catalog` helper and wired it into the 4 broken sites; same fix landed inline in `test_compose_a2f_10492.py`. Matches `feedback-audit-pattern-shipped-unwired`'s "verify all callers' tests have the infrastructure the new gate needs" rule.

## DS review

`.squidsquad/skill/planning/ds-10751-review.md` archived. **One finding (warning)** — bullet-form fallback originally `continue`d past unrecognized values, silently dropping them when MIXED with recognized ones. Fixed to raise; added regression `test_mixed_recognized_and_typo_raises_not_silently_drops`. NO_FINDINGS on the remaining scope.

## Test plan

- [x] `pytest tests/test_config_aliases_registry_10385.py tests/test_link_stage_validator.py tests/test_compose_a2f_10492.py tests/test_compose_a6_v2.py` — 95/95 pass
- [x] Wide regression (catalog + drift + gate + §9a + D2 + D5 + E3) — 239 pass + 1 xfail (pre-existing #10743 pin awaiting PR #10749 merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)