### PR TITLE
PRD-E E1 (#10680): harness boot-time freshness check (Layer 1 primary gate)

### DIFF
--- a/.squidsquad/skill/planning/ds-10680-review.md
+++ b/.squidsquad/skill/planning/ds-10680-review.md
@@ -1,0 +1,109 @@
+Now I have a thorough understanding of all three files. Let me trace through each review area systematically.
+
+---
+
+### Finding 1
+
+- **File**: `references/scripts/harness.py`
+- **Line**: 1589–1616 (`start_all`), 1674–1710 (`start_agent`)
+- **Severity**: error
+- **Issue**: HTTP spawn endpoints do not check `state.compose_freshness_failed`, so they bypass the E1 spawn-refusal contract. When `compose_freshness_failed` is `True` (set at line 1388), the auto-start loop in `_deferred_init` correctly short-circuits (line 1397 `return`), but an operator can still spawn agents via `POST /agents/{role}/start` or `POST /agents/all/start` — directly violating AC4's mandate that "the caller MUST refuse to spawn agents until the operator resolves the source issue; no fall-back."
+- **Evidence**: 
+  - `compose_freshness.py` lines 68–70: AC4 states on `"failed"` "the caller MUST refuse to spawn agents." 
+  - `harness.py` line 1388: `state.compose_freshness_failed = True` is set on failure.
+  - `harness.py` lines 1674–1710: `start_agent` reads `state.get_agent(role)` for the "already running" check but never reads `state.compose_freshness_failed`. Same for `start_all` at lines 1589–1616.
+  - `tests/test_compose_freshness_e1.py` lines 253–255: the test `test_harness_state_carries_failure_flag` explicitly comments: *"The flag must live on HarnessState so spawn paths beyond _deferred_init's auto-start loop can also gate on it."* — yet those spawn paths never gate on it.
+- **Suggested fix**: Add a gate at the top of both `start_agent` and `start_all`:
+  ```python
+  if state.compose_freshness_failed:
+      raise HTTPException(
+          status_code=503,
+          detail="Compose freshness check failed — agents cannot be spawned. "
+                 "Fix the source issue and restart the harness."
+      )
+  ```
+  Also: the health-poller's auto-reboot path (lines 425–437) calls `boot_remote.boot_agent(role)` without checking the flag, so on a harness restart where `.harness-state.json` contains agents with `intent=running`, the poller will re-spawn them even after compose freshness failed. That path should also gate on `self.compose_freshness_failed`.
+
+---
+
+### Finding 2
+
+- **File**: `references/scripts/compose_freshness.py`
+- **Line**: 41–55 (specifically lines 48 and 54)
+- **Severity**: warning
+- **Issue**: `references/sub-skills/manifest.md` (line 54) is matched twice: once by the `references/sub-skills/**/*.md` glob on line 48, and once by the explicit literal glob on line 54. Python's `Path.glob('references/sub-skills/**/*.md')` matches zero or more intermediate directories, so `manifest.md` at the root of `sub-skills/` is included. The file is yielded twice by `_iter_compose_input_files` (line 94–110) and hashed twice in `compute_compose_checksum` (lines 113–152). The result is still deterministic, but:
+  1. The file's content contributes double weight — non-obvious to anyone reading the glob list.
+  2. If a future maintainer removes the explicit `manifest.md` glob (thinking it's redundant), the checksum changes because the file goes from being hashed 2× to 1× — a regression risk.
+- **Evidence**: Line 48 `"references/sub-skills/**/*.md"` — the `**` glob component matches zero directories per Python docs. Combined with line 54 `"references/sub-skills/manifest.md"`, the file `references/sub-skills/manifest.md` matches both patterns. `_iter_compose_input_files` (line 107–109) does not deduplicate; `compute_compose_checksum` (lines 135–141) also does not deduplicate.
+- **Suggested fix**: Either remove the explicit `"references/sub-skills/manifest.md"` from `COMPOSE_INPUT_GLOBS` (since it's already covered by `**/*.md`) or add deduplication in `_iter_compose_input_files`:
+  ```python
+  seen = set()
+  for path in _iter_compose_input_files(repo_root):
+      try:
+          rel = path.relative_to(repo_root).as_posix()
+      except ValueError:
+          continue
+      if rel not in seen:
+          seen.add(rel)
+          rel_paths.append((rel, path))
+  ```
+
+---
+
+### Finding 3
+
+- **File**: `references/scripts/harness.py`
+- **Line**: 1466 (thread launch) vs. 1374–1388 (the check itself)
+- **Severity**: warning
+- **Issue**: The E1 freshness check runs inside `_deferred_init`, which is launched as a daemon thread at line 1466. The lifespan then immediately starts the health poller (line 1467), starts the L4 watcher (line 1472), and `yield`s (line 1474) — making the HTTP server accept connections. This means `POST /agents/{role}/start` is callable **before** `_deferred_init` reaches the E1 check at line 1376 and potentially sets `compose_freshness_failed = True`. On the "drift → compose runs" path, the compose subprocess could take tens of seconds; during that entire window, HTTP spawn requests succeed unchallenged. 
+
+  Even with the fix from Finding 1 (flag check in endpoints), there's still a race: a spawn request arriving before `_deferred_init` sets the flag would not be blocked, because the flag defaults to `False` (line 221).
+- **Evidence**: The execution order in `lifespan`:
+  1. Line 1466: `threading.Thread(target=_deferred_init, daemon=True).start()` — the E1 check hasn't run yet.
+  2. Line 1467–1472: poller and L4 watcher start synchronously (fast).
+  3. Line 1474: `yield` — server begins accepting HTTP requests.
+  
+  Inside `_deferred_init`:
+  1. Lines 1344–1357: port file distribution (I/O, fast).
+  2. Lines 1361–1365: `load_state()`, `event_lifecycle.load()`, etc. (I/O, fast).
+  3. Lines 1374–1379: **E1 check** — if drift is detected, calls `compose.py deploy-all` via subprocess, which can take 10–60+ seconds.
+  4. Line 1388: `compose_freshness_failed = True` (only set after compose fails).
+  
+  Between steps 3 and 4 in lifespan and steps 1–3 in `_deferred_init`, any HTTP spawn request against the already-yielded server will see `compose_freshness_failed == False` and proceed.
+- **Suggested fix**: Move the E1 freshness check into the lifespan **synchronously, before the `yield`** — specifically after `load_state()` and before `threading.Thread(target=_deferred_init).start()`. That way the server doesn't accept connections until the gate has decided. The deferred thread would then only handle the auto-start loop (which is already gated). This also resolves the health-poller race because the poller starts after the check completes.
+
+  Concretely, restructure the lifespan as:
+  ```python
+  # --- E1 freshness gate (synchronous, before server accepts connections) ---
+  state.load_state()
+  # ... E1 check here ...
+  if result.status == "failed":
+      state.compose_freshness_failed = True
+      _log("ERROR: ...")
+      # Still yield so /status works, but flag blocks spawns
+  # --- deferred init (auto-start only) ---
+  threading.Thread(target=_deferred_init_auto_start, daemon=True).start()
+  state.start_poller()
+  state.start_l4_watcher()
+  yield
+  ```
+
+---
+
+### Finding 4
+
+- **File**: `references/scripts/harness.py`
+- **Line**: 425–437 (health poller auto-reboot)
+- **Severity**: warning
+- **Issue**: The health poller's auto-reboot loop (`update_health`, lines 425–437) calls `boot_remote.boot_agent(role)` without checking `self.compose_freshness_failed`. After a harness restart where `.harness-state.json` contains agents with `intent=running` and `status=running` (from the prior boot), `load_state()` (line 1362) restores those agents into `state.agents`. The poller (started at line 1467) will detect them as dead (stale PIDs), classify them as `status="stalled"` with `prev_status="running"`, and auto-reboot them — even if the E1 check subsequently fails. The same issue applies to agents that die naturally after the harness has been running with a failed compose check.
+- **Evidence**: 
+  - Lines 425–437: `boot_remote.boot_agent(role)` is called with no `compose_freshness_failed` guard.
+  - Line 1388: `state.compose_freshness_failed = True` is set, but `update_health` never reads this field.
+  - The `_NO_AUTO_REBOOT` escape hatch (line 99) provides a manual workaround, but the default path (`_NO_AUTO_REBOOT=False`) hits the gap.
+- **Suggested fix**: At the top of the reboot loop (line 426, inside the `for role in reboot_roles:` block), add:
+  ```python
+  if self.compose_freshness_failed:
+      _log(f"[compose-freshness-failed] {role} died; not respawning per E1 gate")
+      continue
+  ```
+  This is a defense-in-depth complement to Finding 1's HTTP-endpoint fix.

--- a/references/scripts/compose_freshness.py
+++ b/references/scripts/compose_freshness.py
@@ -1,0 +1,264 @@
+"""E1: Harness boot-time compose-freshness check (#10680, PRD-E E1).
+
+Layer 1 of the compose-freshness chain. The harness runs this check
+ONCE at boot, BEFORE spawning any agent — per PRD-E §8.1's "primary
+gate" rule. The check:
+
+1. Computes a deterministic SHA256 over the compose-input source tree
+   (``compute_compose_checksum``).
+2. Compares against the ``last_compose_checksum`` field that E2
+   (#10681) plumbed into ``.harness-state.json``.
+3. On drift OR first boot OR missing checksum: runs
+   ``compose.py deploy-all`` and stores the post-compose checksum.
+4. On compose failure: returns ``status="failed"`` per AC4. The caller
+   (the harness lifespan) MUST refuse to spawn agents — no fall-back
+   to last-known-good, no degraded boot.
+
+The module exposes pure functions so unit tests drive the logic
+directly without spinning up FastAPI or watchdog; the harness owns
+the wiring + the spawn-refusal flag (see ``harness._deferred_init``).
+
+Per AC5 the post-compose checksum is the NEW hash of the source tree
+AFTER ``compose.py deploy-all`` writes its outputs — those outputs
+land outside the checksumed input set (in ``.squidsquad/<alias>/``)
+so the post-compose source-tree checksum equals the pre-compose one
+unless the operator concurrently edited a source file. We re-checksum
+the inputs to capture that race correctly.
+"""
+
+import hashlib
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+# AC2: file sets that contribute to the checksum. Listed by repo-rooted
+# glob shape. Globs are evaluated against ``repo_root`` at check time.
+# The ordering is informational; ``compute_compose_checksum`` sorts the
+# resolved paths deterministically before hashing.
+#
+# Note: ``references/sub-skills/**/*.md`` already covers
+# ``references/sub-skills/manifest.md`` since the ``**`` segment matches
+# zero or more intermediate directories. No separate entry for
+# manifest.md — listing it twice would double-hash the file and create
+# a regression-risk surface if a later cleanup removes the duplicate
+# (per DS-10680 review F2).
+COMPOSE_INPUT_GLOBS = (
+    # Per-install config — affects which aliases compose deploys and
+    # which manifest each role-class reads (post-D5/D6 unification).
+    ".squidsquad/config.md",
+    # L4 project-local layer — every role-class's overlay file.
+    ".squidsquad/project/*.md",
+    # L1 sub-skill bodies — common + common-events + per-role —
+    # AND the top-level ``manifest.md`` (``**`` matches zero dirs).
+    "references/sub-skills/**/*.md",
+    # L1-L3 source files — base roles + per-role-class subdirs +
+    # variant subdirs (worker/skill etc.).
+    "references/roles/**/*",
+)
+
+
+@dataclass
+class FreshnessResult:
+    """Outcome of one ``check_and_repair`` invocation.
+
+    ``status`` is one of:
+
+    - ``"clean"`` — source-tree checksum matches the stored value; no
+      compose ran. Caller proceeds with normal boot.
+    - ``"repaired"`` — drift / first boot / missing checksum; compose
+      ran successfully and the stored checksum was updated.
+    - ``"failed"`` — compose itself failed. Per AC4 the caller MUST
+      refuse to spawn agents until the operator resolves the source
+      issue; no fall-back.
+
+    ``new_checksum`` carries the post-compose checksum when
+    ``status == "repaired"`` (the value the caller persists). On
+    ``"clean"`` it equals the input ``stored_checksum``. On
+    ``"failed"`` it is empty — nothing was persisted.
+
+    ``diagnostic`` is a one-line operator-readable message; safe to
+    print to stderr or log file. ``compose_stderr`` holds the
+    compose subprocess's stderr (capped) when ``status == "failed"``
+    so the operator can see what broke without re-running compose.
+    """
+
+    status: str
+    new_checksum: str = ""
+    diagnostic: str = ""
+    compose_stderr: str = ""
+
+
+# Cap compose stderr captured into ``FreshnessResult.compose_stderr``
+# so a 10 MB pyyaml traceback doesn't balloon the log line.
+_COMPOSE_STDERR_MAX = 4000
+
+
+def _iter_compose_input_files(repo_root):
+    """Yield every file path that contributes to the checksum.
+
+    Resolution: each glob in ``COMPOSE_INPUT_GLOBS`` is expanded
+    against ``repo_root``. Symlinks are followed only one level
+    (``glob`` semantics); directories produced by ``**/*`` are
+    filtered to files only. Paths are returned as ``Path`` objects
+    rooted at ``repo_root``.
+
+    Stable ordering is the caller's concern — this iterator yields
+    in glob-resolution order which is implementation-defined.
+    """
+    repo_root = Path(repo_root)
+    for pattern in COMPOSE_INPUT_GLOBS:
+        for path in repo_root.glob(pattern):
+            if path.is_file():
+                yield path
+
+
+def compute_compose_checksum(repo_root):
+    """Return a deterministic SHA256 over the compose-input set.
+
+    Algorithm (per AC2 "deterministic SHA256 over sorted file paths +
+    contents"):
+
+    1. Enumerate every file matching ``COMPOSE_INPUT_GLOBS`` under
+       ``repo_root``.
+    2. Sort by repo-relative POSIX path so the order is platform-
+       independent.
+    3. For each file, hash the path bytes + a separator + the file
+       contents into the running SHA256. Including the path in the
+       hash ensures a rename surfaces as drift even if the contents
+       moved verbatim.
+    4. Return the hex digest.
+
+    Files that disappear between enumeration and read are silently
+    skipped — racing the file-watch is not the gate's failure mode;
+    a missing source file shows up as a compose error a moment later.
+    """
+    repo_root = Path(repo_root)
+    h = hashlib.sha256()
+    rel_paths = []
+    seen = set()
+    for path in _iter_compose_input_files(repo_root):
+        try:
+            rel = path.relative_to(repo_root).as_posix()
+        except ValueError:
+            continue
+        # Per DS-10680 review F2: dedup so any future glob-overlap
+        # never double-hashes a file. The single-glob layout today
+        # makes this defensive — if a maintainer re-adds an explicit
+        # entry that overlaps ``**/*.md``, the hash stays stable.
+        if rel in seen:
+            continue
+        seen.add(rel)
+        rel_paths.append((rel, path))
+    rel_paths.sort(key=lambda t: t[0])
+    for rel, path in rel_paths:
+        try:
+            content = path.read_bytes()
+        except OSError:
+            continue
+        h.update(rel.encode("utf-8"))
+        h.update(b"\x00")
+        h.update(content)
+        h.update(b"\x00")
+    return h.hexdigest()
+
+
+def _default_compose_runner(repo_root):
+    """Shell out to ``compose.py deploy-all`` and return
+    ``(returncode, stdout, stderr)``.
+
+    Caller-injectable via ``check_and_repair(..., runner=...)`` so
+    unit tests drive without spawning a Python subprocess.
+    """
+    cmd = [
+        sys.executable,
+        str(Path(repo_root) / "references" / "scripts" / "compose.py"),
+        "deploy-all",
+    ]
+    proc = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root),
+        env={**os.environ},
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def check_and_repair(
+    *,
+    repo_root,
+    stored_checksum,
+    runner=None,
+    compute_checksum=None,
+):
+    """Run the E1 freshness check + repair sequence.
+
+    Returns a :class:`FreshnessResult`. Pure orchestration — does NOT
+    write the state file or set any harness flag. The caller (harness
+    lifespan) persists the ``new_checksum`` via
+    ``HarnessState.set_last_compose_checksum`` on ``"repaired"`` and
+    enforces the spawn-refusal contract on ``"failed"``.
+
+    ``stored_checksum`` is the value read from ``.harness-state.json``
+    via ``HarnessState.get_last_compose_checksum`` — ``None`` (or
+    empty string) indicates first boot or a legacy state file, both
+    of which trigger compose per AC3.
+
+    ``runner`` and ``compute_checksum`` are injection seams for tests.
+    """
+    if compute_checksum is None:
+        compute_checksum = compute_compose_checksum
+    if runner is None:
+        runner = _default_compose_runner
+
+    current = compute_checksum(repo_root)
+
+    if stored_checksum and current == stored_checksum:
+        return FreshnessResult(
+            status="clean",
+            new_checksum=current,
+            diagnostic="compose inputs unchanged since last boot",
+        )
+
+    # Drift / first boot / missing checksum — repair.
+    try:
+        returncode, _stdout, stderr = runner(repo_root)
+    except Exception as exc:  # noqa: BLE001 — defensive against runner bugs
+        return FreshnessResult(
+            status="failed",
+            new_checksum="",
+            diagnostic=(
+                f"compose runner raised: {exc!r}. Harness will NOT "
+                f"spawn agents until the operator resolves this."
+            ),
+            compose_stderr="",
+        )
+    if returncode != 0:
+        truncated = (stderr or "")[:_COMPOSE_STDERR_MAX]
+        return FreshnessResult(
+            status="failed",
+            new_checksum="",
+            diagnostic=(
+                f"compose.py deploy-all exited non-zero ({returncode}). "
+                f"Harness will NOT spawn agents until the source issue "
+                f"is fixed. See compose_stderr for details."
+            ),
+            compose_stderr=truncated,
+        )
+
+    # Re-checksum AFTER compose succeeded — see module docstring re:
+    # the operator-concurrent-edit race.
+    post_checksum = compute_checksum(repo_root)
+    diagnostic = (
+        "first boot — checksum stored"
+        if not stored_checksum
+        else "drift detected — compose ran cleanly"
+    )
+    return FreshnessResult(
+        status="repaired",
+        new_checksum=post_checksum,
+        diagnostic=diagnostic,
+    )

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -213,6 +213,12 @@ class HarnessState:
         self._l4_watcher_thread = None
         self._l4_observer = None
         self._l4_debouncer = None
+        # PRD-E E1 (#10680) — boot-time freshness gate. Set to True by
+        # ``_deferred_init`` when ``compose_freshness.check_and_repair``
+        # returns ``status="failed"``. The auto-start loop short-
+        # circuits when this is True; per AC4 the harness refuses to
+        # spawn agents until the operator fixes the source + restarts.
+        self.compose_freshness_failed = False
 
     def get_agent(self, role: str) -> AgentState | None:
         with self._lock:
@@ -418,6 +424,19 @@ class HarnessState:
 
         # Reboot outside the lock to avoid blocking health updates
         for role in reboot_roles:
+            # PRD-E E1 (#10680) / DS-10680 F4: respect the freshness
+            # gate. If the E1 check failed at boot, every spawn path
+            # (auto-start, HTTP endpoints, AND this auto-reboot loop)
+            # must refuse. The operator has to fix the source + restart
+            # the harness — re-spawning an agent against a broken
+            # compose set is exactly the "degraded boot" AC4 forbids.
+            if self.compose_freshness_failed:
+                _log(
+                    f"[compose-freshness-failed] {role} died but not "
+                    f"respawning — E1 gate is red, operator must fix "
+                    f"source + restart harness"
+                )
+                continue
             _log(f"Auto-rebooting {role} (was running, intent={self.agents[role].intent})")
             try:
                 result = boot_remote.boot_agent(role)
@@ -1352,12 +1371,22 @@ async def lifespan(app: FastAPI):
         except (SystemExit, Exception) as e:
             _log(f"WARNING: Could not distribute port to clones: {e}")
 
-        _log("Loading saved state...")
-        state.load_state()
         event_lifecycle.load()
         event_lifecycle.start_timeout_scanner()
         activity_detector.start()
         _log(f"Event state loaded: {len(event_stream)} events in stream")
+
+        # E1 check + state.load_state() ran SYNCHRONOUSLY in lifespan
+        # before yield (per DS-10680 review F3 — the TOCTOU race fix).
+        # Spawn paths beyond auto-start (HTTP /agents/*/start, the
+        # health poller's auto-reboot) read ``state.compose_freshness_failed``
+        # directly so they enforce the same refusal.
+        if state.compose_freshness_failed:
+            _log(
+                "Auto-start skipped — compose freshness check failed. "
+                "Operator: fix the source issue + restart the harness."
+            )
+            return
 
         # Skip initial update_health() — it's slow on Windows (tasklist per agent).
         # The health poller will pick up state within HEALTH_POLL_INTERVAL seconds.
@@ -1413,6 +1442,53 @@ async def lifespan(app: FastAPI):
             )
     except (SystemExit, Exception) as e:
         _log(f"WARNING: legacy-sentinel cleanup failed: {e}")
+
+    # PRD-E E1 (#10680): boot-time freshness check (Layer 1 — primary
+    # gate). Runs SYNCHRONOUSLY in lifespan BEFORE yield so the server
+    # never accepts spawn requests while the gate is still deciding
+    # (per DS-10680 review F3). On failure, ``state.compose_freshness_failed``
+    # blocks every spawn path: ``_deferred_init`` auto-start short-
+    # circuits, HTTP ``/agents/{role}/start`` returns 503, and the
+    # health poller's auto-reboot loop also gates on the flag.
+    _log("Loading saved state...")
+    state.load_state()
+    try:
+        import compose_freshness as _cf
+        _freshness = _cf.check_and_repair(
+            repo_root=REPO_ROOT,
+            stored_checksum=state.get_last_compose_checksum(),
+        )
+    except Exception as e:  # noqa: BLE001 — defensive against import bugs
+        _log(
+            f"WARNING: compose_freshness check raised {e!r}; proceeding "
+            f"without the E1 gate (degraded boot)"
+        )
+        _freshness = None
+    if _freshness is not None:
+        if _freshness.status == "failed":
+            state.compose_freshness_failed = True
+            _log(
+                "ERROR: compose freshness check FAILED — harness will NOT "
+                "spawn agents. Operator: fix the source issue + restart "
+                "the harness."
+            )
+            _log(f"  diagnostic: {_freshness.diagnostic}")
+            if _freshness.compose_stderr:
+                _log(
+                    f"  compose stderr (truncated): {_freshness.compose_stderr}"
+                )
+        elif _freshness.status == "repaired":
+            state.set_last_compose_checksum(_freshness.new_checksum)
+            state.save_state()
+            _log(
+                f"compose freshness: {_freshness.diagnostic} — checksum "
+                f"now {_freshness.new_checksum[:12]}..."
+            )
+        else:  # clean
+            _log(
+                f"compose freshness: clean (checksum "
+                f"{_freshness.new_checksum[:12]}...)"
+            )
 
     threading.Thread(target=_deferred_init, daemon=True, name="deferred-init").start()
     state.start_poller()
@@ -1539,6 +1615,18 @@ async def list_agents():
 @app.post("/agents/all/start")
 async def start_all():
     """Spawn all configured agents."""
+    # PRD-E E1 (#10680) / DS-10680 F1: the E1 spawn-refusal contract
+    # applies to every spawn path, not just _deferred_init's auto-
+    # start. Reject HTTP-driven spawns while the freshness gate is
+    # red so the operator can't bypass the gate with a manual POST.
+    if state.compose_freshness_failed:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Compose freshness check failed — agents cannot be "
+                "spawned. Fix the source issue and restart the harness."
+            ),
+        )
     roles = boot_remote._get_all_roles()
     _log(f"Starting all agents: {', '.join(roles)}")
 
@@ -1625,6 +1713,17 @@ async def get_agent(role: str):
 async def start_agent(role: str):
     """Spawn an agent in a visible terminal."""
     _validate_role(role)
+
+    # PRD-E E1 (#10680) / DS-10680 F1: per-role spawn endpoint must
+    # honor the E1 gate too. Same 503 + message as /agents/all/start.
+    if state.compose_freshness_failed:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Compose freshness check failed — agents cannot be "
+                "spawned. Fix the source issue and restart the harness."
+            ),
+        )
 
     # Check if already running
     agent = state.get_agent(role)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -149,6 +149,7 @@ STATIC_TEST_MODULES = [
     "test_feat_10681_compose_checksum",
     "test_manifest_v2_d5",
     "test_l4_file_watcher_e3",
+    "test_compose_freshness_e1",
 ]
 
 

--- a/tests/test_compose_freshness_e1.py
+++ b/tests/test_compose_freshness_e1.py
@@ -1,0 +1,342 @@
+"""Tests for references/scripts/compose_freshness.py (#10680, PRD-E E1).
+
+AC6 mandates tests for:
+  (a) clean install (no drift) → no compose run, status="clean"
+  (b) drifted install → compose runs, checksum updates, status="repaired"
+  (c) first boot (no checksum) → compose runs, status="repaired"
+  (d) compose failure → harness refuses to spawn, status="failed"
+
+Plus structural tests for the checksum algorithm (determinism, path
+sensitivity, content sensitivity) and the harness lifespan wiring
+(static-grep gate so the actor named in the AC is actually invoked
+from the production caller — per the audit-pattern memo).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import compose_freshness as cf  # noqa: E402
+
+
+def _stage_minimal_repo(tmp_path):
+    """Build a tiny repo-root with at least one file per
+    ``COMPOSE_INPUT_GLOBS`` shape so the checksum has something to
+    hash. Returns the repo_root path.
+    """
+    repo = tmp_path
+    (repo / ".squidsquad").mkdir()
+    (repo / ".squidsquad" / "config.md").write_text("- v: 1\n", encoding="utf-8")
+    (repo / ".squidsquad" / "project").mkdir()
+    (repo / ".squidsquad" / "project" / "pm.md").write_text(
+        "# pm L4\n", encoding="utf-8")
+    (repo / "references" / "sub-skills" / "common").mkdir(parents=True)
+    (repo / "references" / "sub-skills" / "common" / "boot.md").write_text(
+        "# boot\n", encoding="utf-8")
+    (repo / "references" / "sub-skills" / "manifest.md").write_text(
+        "# manifest\n", encoding="utf-8")
+    (repo / "references" / "roles").mkdir(parents=True)
+    (repo / "references" / "roles" / "identity.md").write_text(
+        "# identity\n", encoding="utf-8")
+    (repo / "references" / "roles" / "pm").mkdir()
+    (repo / "references" / "roles" / "pm" / "instructions.md").write_text(
+        "# pm instructions\n", encoding="utf-8")
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# compute_compose_checksum — determinism + sensitivity
+# ---------------------------------------------------------------------------
+
+
+class TestComputeChecksum:
+
+    def test_deterministic_across_runs(self, tmp_path):
+        repo = _stage_minimal_repo(tmp_path)
+        a = cf.compute_compose_checksum(repo)
+        b = cf.compute_compose_checksum(repo)
+        assert a == b
+        assert len(a) == 64  # SHA256 hex digest
+
+    def test_content_change_rolls_checksum(self, tmp_path):
+        repo = _stage_minimal_repo(tmp_path)
+        a = cf.compute_compose_checksum(repo)
+        # Mutate one input file.
+        (repo / "references" / "sub-skills" / "common" / "boot.md").write_text(
+            "# boot v2\n", encoding="utf-8")
+        b = cf.compute_compose_checksum(repo)
+        assert a != b
+
+    def test_rename_rolls_checksum(self, tmp_path):
+        repo = _stage_minimal_repo(tmp_path)
+        a = cf.compute_compose_checksum(repo)
+        # Rename a file — same content, different path.
+        old = repo / "references" / "sub-skills" / "common" / "boot.md"
+        new = repo / "references" / "sub-skills" / "common" / "boot-renamed.md"
+        old.rename(new)
+        b = cf.compute_compose_checksum(repo)
+        assert a != b, (
+            "rename must roll the checksum (path is part of the hash)"
+        )
+
+    def test_unrelated_file_does_not_affect_checksum(self, tmp_path):
+        repo = _stage_minimal_repo(tmp_path)
+        a = cf.compute_compose_checksum(repo)
+        # File outside the compose-input set.
+        (repo / "README.md").write_text("# unrelated\n", encoding="utf-8")
+        (repo / ".squidsquad" / "skill").mkdir()
+        (repo / ".squidsquad" / "skill" / "working-state.md").write_text(
+            "# state\n", encoding="utf-8")
+        b = cf.compute_compose_checksum(repo)
+        assert a == b, (
+            "files outside COMPOSE_INPUT_GLOBS must not change the hash"
+        )
+
+
+# ---------------------------------------------------------------------------
+# check_and_repair — the four AC6 scenarios
+# ---------------------------------------------------------------------------
+
+
+def _ok_runner(_repo):
+    return 0, "deployed\n", ""
+
+
+def _fail_runner(_repo):
+    return 1, "", "compose: yaml.scanner.ScannerError: mapping values not allowed here"
+
+
+class TestCheckAndRepair:
+
+    def test_clean_install_no_compose_run(self, tmp_path):
+        # AC6(a): stored checksum matches current source-tree → no
+        # compose, no state change.
+        repo = _stage_minimal_repo(tmp_path)
+        current = cf.compute_compose_checksum(repo)
+        runner_calls = []
+
+        def tracking_runner(r):
+            runner_calls.append(r)
+            return _ok_runner(r)
+
+        result = cf.check_and_repair(
+            repo_root=repo,
+            stored_checksum=current,
+            runner=tracking_runner,
+        )
+        assert result.status == "clean"
+        assert result.new_checksum == current
+        assert runner_calls == []  # compose NOT invoked
+
+    def test_drift_runs_compose_and_updates_checksum(self, tmp_path):
+        # AC6(b): stored checksum differs → compose runs → result
+        # carries the post-compose checksum.
+        repo = _stage_minimal_repo(tmp_path)
+        runner_calls = []
+
+        def tracking(r):
+            runner_calls.append(r)
+            return _ok_runner(r)
+
+        result = cf.check_and_repair(
+            repo_root=repo,
+            stored_checksum="0" * 64,  # bogus prior checksum
+            runner=tracking,
+        )
+        assert result.status == "repaired"
+        # The post-compose checksum is computed against the same source
+        # tree (compose writes outputs elsewhere) so it equals current.
+        assert result.new_checksum == cf.compute_compose_checksum(repo)
+        assert len(runner_calls) == 1
+        assert "drift detected" in result.diagnostic
+
+    def test_first_boot_no_stored_checksum_runs_compose(self, tmp_path):
+        # AC6(c): legacy state file (no checksum field) OR fresh
+        # install (no state file) → triggers compose.
+        repo = _stage_minimal_repo(tmp_path)
+        runner_calls = []
+
+        def tracking(r):
+            runner_calls.append(r)
+            return _ok_runner(r)
+
+        result = cf.check_and_repair(
+            repo_root=repo,
+            stored_checksum=None,
+            runner=tracking,
+        )
+        assert result.status == "repaired"
+        assert "first boot" in result.diagnostic
+        assert len(runner_calls) == 1
+
+    def test_empty_string_checksum_treated_as_first_boot(self, tmp_path):
+        repo = _stage_minimal_repo(tmp_path)
+
+        def ok(r):
+            return _ok_runner(r)
+
+        result = cf.check_and_repair(
+            repo_root=repo, stored_checksum="", runner=ok,
+        )
+        assert result.status == "repaired"
+
+    def test_compose_failure_returns_failed_status(self, tmp_path):
+        # AC6(d): compose itself fails → status="failed" + diagnostic
+        # + stderr captured. Per AC4 the caller refuses to spawn.
+        repo = _stage_minimal_repo(tmp_path)
+        result = cf.check_and_repair(
+            repo_root=repo,
+            stored_checksum=None,  # forces compose
+            runner=_fail_runner,
+        )
+        assert result.status == "failed"
+        assert result.new_checksum == ""  # nothing to persist
+        assert "WILL NOT" in result.diagnostic.upper() or \
+               "refuses" in result.diagnostic.lower() or \
+               "fix" in result.diagnostic.lower() or \
+               "non-zero" in result.diagnostic.lower()
+        assert "yaml.scanner" in result.compose_stderr
+
+    def test_compose_runner_raise_is_treated_as_failure(self, tmp_path):
+        repo = _stage_minimal_repo(tmp_path)
+
+        def boom(_repo):
+            raise RuntimeError("subprocess unavailable")
+
+        result = cf.check_and_repair(
+            repo_root=repo, stored_checksum=None, runner=boom,
+        )
+        assert result.status == "failed"
+        assert "subprocess unavailable" in result.diagnostic
+
+
+# ---------------------------------------------------------------------------
+# Harness wiring — static-grep gate per feedback-no-deferred-wiring
+# ---------------------------------------------------------------------------
+
+
+class TestHarnessWiring:
+    """The AC names the harness as the actor: 'on every harness start,
+    BEFORE spawning any agent...'. Per the audit-pattern memo, the
+    wiring is in-scope, not a follow-up. These guards block the
+    regression at parse time."""
+
+    def test_harness_imports_compose_freshness(self):
+        src = (SCRIPTS / "harness.py").read_text(encoding="utf-8")
+        assert "import compose_freshness" in src, (
+            "harness.py must import compose_freshness so the E1 boot "
+            "gate actually runs (per feedback-no-deferred-wiring)"
+        )
+
+    def test_deferred_init_calls_check_and_repair(self):
+        src = (SCRIPTS / "harness.py").read_text(encoding="utf-8")
+        # Locate the deferred-init block where the wiring lives.
+        start = src.index("def _deferred_init")
+        # The deferred init body ends at the threading.Thread call
+        # that schedules it.
+        end = src.index("threading.Thread(target=_deferred_init", start)
+        block = src[start:end]
+        assert "check_and_repair" in block, (
+            "_deferred_init must call check_and_repair so the freshness "
+            "gate fires on the boot path"
+        )
+        assert "compose_freshness_failed" in block, (
+            "_deferred_init must set state.compose_freshness_failed on "
+            "compose failure per AC4 — without it the caller can't enforce "
+            "the spawn-refusal contract"
+        )
+
+    def test_harness_state_carries_failure_flag(self):
+        # The flag must live on HarnessState so spawn paths beyond
+        # _deferred_init's auto-start loop can also gate on it.
+        try:
+            import harness
+        except Exception:
+            pytest.skip("harness module unavailable (likely missing fastapi)")
+        s = harness.HarnessState()
+        assert hasattr(s, "compose_freshness_failed")
+        assert s.compose_freshness_failed is False
+
+    def test_lifespan_runs_check_synchronously_before_yield(self):
+        # DS-10680 review F3: the check must run in lifespan() BEFORE
+        # ``yield``, not inside the deferred-init thread, otherwise the
+        # server accepts spawn requests while the gate is still
+        # deciding (10-60s race during compose subprocess).
+        src = (SCRIPTS / "harness.py").read_text(encoding="utf-8")
+        start = src.index("async def lifespan(")
+        # lifespan() ends at the next top-level FastAPI binding.
+        end = src.index("app = FastAPI(", start)
+        block = src[start:end]
+        # The synchronous check uses the module-level import +
+        # check_and_repair call before the threading.Thread launch.
+        # Use line-anchored match for the actual ``yield`` statement
+        # so comments mentioning "yield" don't false-positive.
+        import re as _re
+        check_idx = block.find("check_and_repair")
+        thread_idx = block.find("threading.Thread(target=_deferred_init")
+        yield_match = _re.search(r"(?m)^\s+yield\s*$", block)
+        assert check_idx != -1, (
+            "lifespan() must call check_and_repair synchronously "
+            "(DS-10680 F3 regression — TOCTOU race against spawn "
+            "requests during compose subprocess)"
+        )
+        assert check_idx < thread_idx, (
+            "check_and_repair must run BEFORE deferred-init thread starts"
+        )
+        assert yield_match is not None, (
+            "lifespan() must contain a ``yield`` statement"
+        )
+        assert check_idx < yield_match.start(), (
+            "check_and_repair must run BEFORE lifespan yields — the "
+            "server must not accept connections while the gate is "
+            "still deciding"
+        )
+
+    def test_http_start_endpoints_gate_on_failure_flag(self):
+        # DS-10680 review F1: both /agents/all/start and
+        # /agents/{role}/start must read compose_freshness_failed and
+        # return 503. Static-grep the endpoint bodies.
+        src = (SCRIPTS / "harness.py").read_text(encoding="utf-8")
+        for endpoint_marker in (
+            'app.post("/agents/all/start")',
+            'app.post("/agents/{role}/start")',
+        ):
+            start = src.index(endpoint_marker)
+            # Endpoint body ends at the next @app or top-level def.
+            try:
+                end_app = src.index("\n@app.", start + 1)
+            except ValueError:
+                end_app = len(src)
+            try:
+                end_def = src.index("\ndef ", start + 1)
+            except ValueError:
+                end_def = len(src)
+            end = min(end_app, end_def)
+            block = src[start:end]
+            assert "compose_freshness_failed" in block, (
+                f"endpoint {endpoint_marker} must gate on "
+                f"compose_freshness_failed (DS-10680 F1 — every spawn "
+                f"path enforces AC4's refusal contract)"
+            )
+            assert "503" in block, (
+                f"endpoint {endpoint_marker} must return 503 on the "
+                f"freshness-failed branch (DS-10680 F1)"
+            )
+
+    def test_health_poller_reboot_gates_on_failure_flag(self):
+        # DS-10680 review F4: the auto-reboot loop in update_health
+        # must also check the flag — otherwise a harness restart with
+        # alive-running agents would auto-respawn them past the gate.
+        src = (SCRIPTS / "harness.py").read_text(encoding="utf-8")
+        update_health_start = src.index("def update_health(self)")
+        # Reboot loop ends at the next def (start_poller).
+        update_health_end = src.index("\n    def start_poller", update_health_start)
+        block = src[update_health_start:update_health_end]
+        assert "self.compose_freshness_failed" in block, (
+            "update_health auto-reboot loop must gate on the flag "
+            "(DS-10680 F4 — defense-in-depth complement to F1)"
+        )


### PR DESCRIPTION
## Summary

- New `references/scripts/compose_freshness.py` — `compute_compose_checksum` + `check_and_repair` with injection seams.
- Harness wiring: lifespan runs the check **synchronously before yield** so the server never accepts spawn requests while the gate is still deciding.
- Every spawn path gates on `state.compose_freshness_failed`: auto-start short-circuits, HTTP `/agents/*/start` returns 503, health-poller auto-reboot skips.
- 16 unit tests; **all 4 DS code-review findings fixed pre-commit**.

## Closes

Closes #10680.

## AC coverage

1. ✅ New harness boot-sequence step between state-file read and agent spawn — runs in lifespan() after `state.load_state()`, before the deferred-init thread launches.
2. ✅ Checksum inputs cover `config.md` + `project/*.md` + `sub-skills/**/*.md` + `roles/**/*` + `sub-skills/manifest.md` (the last covered by the `**/*.md` glob).
3. ✅ Drift / first boot / missing checksum triggers `compose.py deploy-all`; post-compose checksum re-computed and stored.
4. ✅ Compose failure → `compose_freshness_failed=True`, harness refuses to spawn agents on ALL paths (auto-start, HTTP, health-poller reboot).
5. ✅ Successful or no-drift compose proceeds to auto-start.
6. ✅ Tests cover all 4 scenarios + checksum determinism/sensitivity + harness wiring static-grep gates.

## DS code-review

`.squidsquad/skill/planning/ds-10680-review.md` archived. 4 findings, all fixed:

- **F1 (error)** — `/agents/all/start` + `/agents/{role}/start` bypassed the gate. Now both raise `HTTPException(503)` with operator instructions.
- **F2 (warning)** — `manifest.md` double-hashed by overlapping globs (`**/*.md` + explicit `manifest.md`). Dropped the explicit entry; added dedup in `compute_compose_checksum` as belt-and-suspenders.
- **F3 (warning)** — TOCTOU race: `_deferred_init` thread races the server-accepting-connections moment. Moved E1 check into lifespan synchronously BEFORE `yield`. Static-grep regression asserts the order.
- **F4 (warning)** — `update_health` auto-reboot loop bypassed the gate. Now skips reboot when flag is set.

## Test plan

- [x] `pytest tests/test_compose_freshness_e1.py` — 16/16 pass
- [x] Wider sweep (compose_freshness + E2 + harness + E3 + §9a) — 247 pass, no regressions
- [x] `STATIC_TEST_MODULES` registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)