### PR TITLE
PRD-E E5 (#10684): wire freshness check into harness restart-safety (step 1b)

### DIFF
--- a/.squidsquad/skill/planning/ds-10684-review.md
+++ b/.squidsquad/skill/planning/ds-10684-review.md
@@ -1,0 +1,53 @@
+Here are my findings:
+
+---
+
+### Finding 1
+
+- **File**: `references/scripts/harness.py`
+- **Line**: 626–653 (`save_state`), 676–680 (`load_state`), 234 (`__init__`), 108–110 (comment)
+- **Severity**: error
+- **Issue**: `compose_freshness_failed` is documented as "persisted" but is never written to or read from `.harness-state.json`. The module comment at line 108–110 says: *"if a previous boot persisted `compose_freshness_failed=True`, that's still honored."* The E5 task description says the escape hatch *"leaves any persisted compose_freshness_failed flag alone (intentional — operator bypass shouldn't clear a real prior failure)."* But:
+  - `save_state()` (line 653) constructs `state_data` with keys `harness_pid`, `start_time`, `port`, `last_compose_checksum`, and `agents` — **no `compose_freshness_failed` key**.
+  - `load_state()` (line 680) restores only `last_compose_checksum` — **no `compose_freshness_failed` restoration**.
+  - `HarnessState.__init__` (line 234) always sets `self.compose_freshness_failed = False`.
+
+  **Consequence**: On a harness restart with `--no-freshness-check` after a prior compose failure, the flag is always `False` (initialized by `__init__`, never restored from disk). The `_deferred_init` thread at line 1397 reads `False` → proceeds to auto-start agents against a potentially broken compose set. The escape hatch's documented protection ("operator bypass shouldn't clear a real prior failure") is dead code.
+
+  The test at `test_harness_freshness_restart_e5.py` line 180–181 even assumes this persistence works: *"load_state() reads from disk and could restore it from a prior crash"* — but `load_state()` does not do this.
+
+- **Evidence**: AC4 requires "failed compose restart" to refuse spawning. The code does this for the current boot (in-memory flag), but a restart with the escape hatch silently clears it. The comment explicitly claims cross-boot persistence that doesn't exist.
+
+- **Suggested fix**: 
+  1. Add `"compose_freshness_failed": self.compose_freshness_failed` to the `state_data` dict in `save_state()` (line 626–653).
+  2. In `load_state()`, after restoring `last_compose_checksum` (line 680), add:
+     ```python
+     self.compose_freshness_failed = state_data.get("compose_freshness_failed", False)
+     ```
+  3. As a forward-compat migration, use `.get("compose_freshness_failed", False)` so legacy state files without the key default safely.
+
+---
+
+### Finding 2
+
+- **File**: `references/scripts/harness.py`
+- **Line**: 1491–1502
+- **Severity**: warning
+- **Issue**: The "failed" freshness branch sets `state.compose_freshness_failed = True` (line 1492) but does **not** call `state.save_state()`. Only the "repaired" branch (line 1505) calls `save_state()`. If Finding 1 is fixed and `compose_freshness_failed` is added to `save_state`'s output, the failed path must also flush to disk. Otherwise the flag lives only in memory and is lost if the harness crashes before any other code path triggers `save_state()` (e.g., the health poller, an agent event, or a stop/restart request).
+
+- **Evidence**: Compare lines 1503–1505 (`elif _freshness.status == "repaired":` → `state.save_state()`) with lines 1491–1502 (`if _freshness.status == "failed":` → no `save_state()`). The "clean" path (line 1510) also doesn't call `save_state()`, but that's correct — no persistent state changed. The "failed" path changes `compose_freshness_failed`, so it should persist that change.
+
+- **Suggested fix**: After the failed-path log block (line 1502), add `state.save_state()` — placed so it fires after the flag is set and the diagnostic logs are emitted, matching the "repaired" branch's pattern.
+
+---
+
+### Finding 3
+
+- **File**: `references/scripts/harness.py`
+- **Line**: 229–230 (comment in `HarnessState.__init__`)
+- **Severity**: warning
+- **Issue**: The comment says `compose_freshness_failed` is *"Set to True by `_deferred_init` when `compose_freshness.check_and_repair` returns `status='failed'"`*. This is wrong — the flag is set in `lifespan` (line 1492), not in `_deferred_init`. `_deferred_init` only *reads* the flag (line 1397) to short-circuit auto-start. The incorrect comment misleads future readers about where the mutation occurs.
+
+- **Evidence**: Line 1492 (`state.compose_freshness_failed = True`) is inside `async def lifespan(...)`, not inside `def _deferred_init()`. `_deferred_init` at line 1397 only checks `if state.compose_freshness_failed:`.
+
+- **Suggested fix**: Change the comment to: *"Set to True by the lifespan freshness-check block when `compose_freshness.check_and_repair` returns `status='failed'`. The deferred-init thread and all spawn endpoints read this flag to refuse spawning."*

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -98,6 +98,19 @@ _NO_AUTO_START = False
 # (HARNESS-ARCH §14) during a harness restart.
 _NO_AUTO_REBOOT = False
 
+# PRD-E E5 (#10684): operator escape hatch for the E1 boot/restart
+# freshness gate. When True (set by ``main()`` from
+# ``--no-freshness-check`` or ``SQUIDSQUAD_HARNESS_NO_FRESHNESS_CHECK=1``),
+# the lifespan SKIPS ``compose_freshness.check_and_repair`` entirely
+# and proceeds straight to deferred-init. Use ONLY for emergency boots
+# where the operator already knows the compose set is correct and
+# needs the harness up before the (potentially slow) compose subprocess
+# can run. The flag does NOT bypass the spawn-refusal contract — if a
+# previous boot persisted ``compose_freshness_failed=True``, that's
+# still honored. Operators bypassing the check are responsible for
+# verifying source freshness themselves.
+_NO_FRESHNESS_CHECK = False
+
 import boot_remote
 import health_check
 import reboot_agent
@@ -213,11 +226,15 @@ class HarnessState:
         self._l4_watcher_thread = None
         self._l4_observer = None
         self._l4_debouncer = None
-        # PRD-E E1 (#10680) — boot-time freshness gate. Set to True by
-        # ``_deferred_init`` when ``compose_freshness.check_and_repair``
-        # returns ``status="failed"``. The auto-start loop short-
-        # circuits when this is True; per AC4 the harness refuses to
-        # spawn agents until the operator fixes the source + restarts.
+        # PRD-E E1 (#10680) / E5 (#10684) — boot-time freshness gate.
+        # Set to True by the lifespan freshness-check block when
+        # ``compose_freshness.check_and_repair`` returns
+        # ``status="failed"``. The deferred-init thread, the HTTP
+        # ``/agents/*/start`` endpoints, and the health-poller auto-
+        # reboot loop all read this flag to refuse spawning. Per E5
+        # AC2 the flag is persisted to ``.harness-state.json`` so it
+        # survives harness restart — a prior failure stays in effect
+        # until the operator fixes the source set + restarts.
         self.compose_freshness_failed = False
 
     def get_agent(self, role: str) -> AgentState | None:
@@ -618,6 +635,12 @@ class HarnessState:
                 # Persisted at the top level (not per-agent) since the
                 # checksum spans the whole compose-input set.
                 "last_compose_checksum": self.last_compose_checksum,
+                # PRD-E E5 (#10684) / DS-10684 F1: persist the failure
+                # flag so a `--no-freshness-check` restart after a prior
+                # failure still sees the failure and refuses to spawn.
+                # Legacy state files without the key default to False
+                # on read (see load_state).
+                "compose_freshness_failed": self.compose_freshness_failed,
                 "agents": {
                     role: {
                         "intent": a.intent,
@@ -665,6 +688,12 @@ class HarnessState:
             # (which E1 reads as drift on first boot, triggering compose).
             # An explicit null in the file is also honored.
             self.last_compose_checksum = state_data.get("last_compose_checksum")
+            # PRD-E E5 (#10684) / DS-10684 F1: restore the failure flag
+            # so a prior failed boot stays in effect across restart.
+            # Legacy state files default safely to False.
+            self.compose_freshness_failed = bool(
+                state_data.get("compose_freshness_failed", False)
+            )
             for role, agent_data in state_data.get("agents", {}).items():
                 if role not in self.agents:
                     self.agents[role] = AgentState(
@@ -1452,21 +1481,36 @@ async def lifespan(app: FastAPI):
     # health poller's auto-reboot loop also gates on the flag.
     _log("Loading saved state...")
     state.load_state()
-    try:
-        import compose_freshness as _cf
-        _freshness = _cf.check_and_repair(
-            repo_root=REPO_ROOT,
-            stored_checksum=state.get_last_compose_checksum(),
-        )
-    except Exception as e:  # noqa: BLE001 — defensive against import bugs
+    if _NO_FRESHNESS_CHECK:
+        # PRD-E E5 (#10684) AC3: operator escape hatch for emergency
+        # boots. Logs ONCE so the bypass surfaces in the audit trail.
         _log(
-            f"WARNING: compose_freshness check raised {e!r}; proceeding "
-            f"without the E1 gate (degraded boot)"
+            "compose freshness check SKIPPED — `--no-freshness-check` "
+            "or `SQUIDSQUAD_HARNESS_NO_FRESHNESS_CHECK=1` is set. "
+            "Operator is responsible for source-tree freshness."
         )
         _freshness = None
+    else:
+        try:
+            import compose_freshness as _cf
+            _freshness = _cf.check_and_repair(
+                repo_root=REPO_ROOT,
+                stored_checksum=state.get_last_compose_checksum(),
+            )
+        except Exception as e:  # noqa: BLE001 — defensive against import bugs
+            _log(
+                f"WARNING: compose_freshness check raised {e!r}; proceeding "
+                f"without the E1 gate (degraded boot)"
+            )
+            _freshness = None
     if _freshness is not None:
         if _freshness.status == "failed":
             state.compose_freshness_failed = True
+            # DS-10684 F2: persist the flag immediately so a harness
+            # crash between here and the next save_state-triggering
+            # event doesn't lose the failure signal. Matches the
+            # `repaired` branch's flush pattern below.
+            state.save_state()
             _log(
                 "ERROR: compose freshness check FAILED — harness will NOT "
                 "spawn agents. Operator: fix the source issue + restart "
@@ -3196,6 +3240,20 @@ def main():
             "Honors `SQUIDSQUAD_HARNESS_NO_AUTO_REBOOT=1` too."
         ),
     )
+    parser.add_argument(
+        "--no-freshness-check",
+        action="store_true",
+        help=(
+            "Skip the PRD-E E1 boot-time compose freshness check (#10684 / "
+            "E5 escape hatch). The lifespan still loads state and gates "
+            "spawn paths on a persisted `compose_freshness_failed=True`, "
+            "but does NOT re-run `compose.py deploy-all`. Use ONLY for "
+            "emergency boots where the operator already knows the compose "
+            "set is correct and needs the harness up before the compose "
+            "subprocess can run. Honors "
+            "`SQUIDSQUAD_HARNESS_NO_FRESHNESS_CHECK=1` too."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -3203,11 +3261,16 @@ def main():
     # honors the `SQUIDSQUAD_HARNESS_NO_AUTO_START=1` env var so callers
     # that don't go through argparse (e.g. test harnesses, restart
     # scripts) can opt in too.
-    global _NO_AUTO_START, _NO_AUTO_REBOOT
+    global _NO_AUTO_START, _NO_AUTO_REBOOT, _NO_FRESHNESS_CHECK
     env_flag = os.environ.get("SQUIDSQUAD_HARNESS_NO_AUTO_START", "")
     _NO_AUTO_START = args.no_auto_start or env_flag.lower() in ("1", "true", "yes")
     env_reboot = os.environ.get("SQUIDSQUAD_HARNESS_NO_AUTO_REBOOT", "")
     _NO_AUTO_REBOOT = args.no_auto_reboot or env_reboot.lower() in ("1", "true", "yes")
+    env_freshness = os.environ.get("SQUIDSQUAD_HARNESS_NO_FRESHNESS_CHECK", "")
+    _NO_FRESHNESS_CHECK = (
+        args.no_freshness_check
+        or env_freshness.lower() in ("1", "true", "yes")
+    )
 
     # Determine port
     desired_port = args.port or _read_config_port()

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -150,6 +150,7 @@ STATIC_TEST_MODULES = [
     "test_manifest_v2_d5",
     "test_l4_file_watcher_e3",
     "test_compose_freshness_e1",
+    "test_harness_freshness_restart_e5",
 ]
 
 

--- a/tests/test_harness_freshness_restart_e5.py
+++ b/tests/test_harness_freshness_restart_e5.py
@@ -1,0 +1,289 @@
+"""Tests for PRD-E E5 (#10684): wire freshness check into harness
+restart-safety (step 1b).
+
+E1 (#10680) wired ``compose_freshness.check_and_repair`` into the
+lifespan synchronously before yield — which IS the restart-safety
+path on harness reboot (the lifespan body runs every time the
+harness starts, fresh or after a crash). E5 adds the operator
+escape hatch (``--no-freshness-check`` / env var) and pins the
+restart-specific contracts:
+
+- AC1 (step 1b ordering): the freshness check lives in lifespan
+  AFTER ``state.load_state()`` (step 1) and BEFORE the deferred-init
+  thread launches the PID-verification + auto-start sequence
+  (step 2+). E1's tests already locked this; this module adds an
+  end-to-end view of the order.
+- AC2 (restart-abort semantics): on compose failure, the lifespan
+  flips ``compose_freshness_failed=True`` and the rest of the boot
+  flow refuses to spawn — restart "aborts" in the sense that no
+  agents start. Locked by E1's tests.
+- AC3 (escape hatch): ``--no-freshness-check`` and
+  ``SQUIDSQUAD_HARNESS_NO_FRESHNESS_CHECK=1`` skip the check
+  entirely; the lifespan logs ONCE that the gate was bypassed.
+- AC4 (test scenarios): clean restart / drift restart / failed-
+  compose restart all surface in static-grep + module surface
+  shape tests below.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+
+def _harness_source():
+    return (SCRIPTS / "harness.py").read_text(encoding="utf-8")
+
+
+class TestEscapeHatchFlag:
+    """AC3 — `--no-freshness-check` CLI flag + env var bypass the gate.
+
+    Static-grep instead of subprocess so the test runs without spinning
+    up FastAPI or actually invoking the harness binary."""
+
+    def test_module_level_flag_defaults_false(self):
+        try:
+            import harness
+        except Exception:
+            pytest.skip("harness module unavailable (likely missing fastapi)")
+        assert hasattr(harness, "_NO_FRESHNESS_CHECK")
+        assert harness._NO_FRESHNESS_CHECK is False
+
+    def test_argparse_registers_no_freshness_check(self):
+        src = _harness_source()
+        # `main()`'s argparse block must register the flag.
+        assert '"--no-freshness-check"' in src, (
+            "main() must register the --no-freshness-check argparse flag "
+            "per AC3"
+        )
+
+    def test_argparse_reads_env_var(self):
+        src = _harness_source()
+        assert "SQUIDSQUAD_HARNESS_NO_FRESHNESS_CHECK" in src, (
+            "main() must honor SQUIDSQUAD_HARNESS_NO_FRESHNESS_CHECK env "
+            "var so callers that don't go through argparse (test "
+            "harnesses, restart scripts) can opt in"
+        )
+
+    def test_argparse_or_env_drives_module_flag(self):
+        # Both should land in _NO_FRESHNESS_CHECK via the same logical-
+        # OR pattern the other escape hatches use.
+        src = _harness_source()
+        # Find the env-var assignment block.
+        idx = src.index("env_freshness =")
+        # The assignment to _NO_FRESHNESS_CHECK must come right after.
+        block = src[idx:idx + 400]
+        assert "_NO_FRESHNESS_CHECK" in block, (
+            "the env-var read must drive _NO_FRESHNESS_CHECK"
+        )
+        assert "args.no_freshness_check" in block, (
+            "the CLI flag must drive _NO_FRESHNESS_CHECK (logical-or "
+            "with the env var)"
+        )
+
+    def test_lifespan_skips_check_when_flag_set(self):
+        src = _harness_source()
+        start = src.index("async def lifespan(")
+        end = src.index("app = FastAPI(", start)
+        block = src[start:end]
+        # The flag is consulted before the check fires.
+        flag_idx = block.find("_NO_FRESHNESS_CHECK")
+        check_idx = block.find("check_and_repair")
+        assert flag_idx != -1, (
+            "lifespan must consult _NO_FRESHNESS_CHECK before running "
+            "the freshness check"
+        )
+        assert flag_idx < check_idx, (
+            "_NO_FRESHNESS_CHECK guard must come BEFORE the "
+            "check_and_repair call so the flag actually short-circuits "
+            "the compose subprocess"
+        )
+
+    def test_lifespan_logs_bypass(self):
+        src = _harness_source()
+        start = src.index("async def lifespan(")
+        end = src.index("app = FastAPI(", start)
+        block = src[start:end]
+        # The bypass must surface in the log so the audit trail
+        # captures who opted out and when (AC3's "logged once" intent).
+        assert "SKIPPED" in block and "no-freshness-check" in block, (
+            "lifespan must log the bypass (operator audit trail) when "
+            "_NO_FRESHNESS_CHECK is set"
+        )
+
+
+class TestRestartStep1bOrdering:
+    """AC1 — the freshness check runs at HARNESS-ARCH §10 step 1b,
+    AFTER state.load_state() (step 1) and BEFORE the PID-verification
+    path (step 2+) which lives in update_health / deferred init."""
+
+    def test_load_state_runs_before_freshness_check(self):
+        src = _harness_source()
+        start = src.index("async def lifespan(")
+        end = src.index("app = FastAPI(", start)
+        block = src[start:end]
+        # Use the lifespan-local sites (not the docstrings).
+        load_idx = block.index("state.load_state()")
+        check_idx = block.index("check_and_repair")
+        assert load_idx < check_idx, (
+            "step 1 (load_state) must run BEFORE step 1b (freshness "
+            "check) per HARNESS-ARCH §10"
+        )
+
+    def test_freshness_check_runs_before_deferred_init_thread(self):
+        # The deferred-init thread runs the auto-start sequence which
+        # IS the spawn path that step 2+ leads into; the freshness
+        # gate must decide BEFORE that thread launches so a failed
+        # compose can short-circuit auto-start.
+        src = _harness_source()
+        start = src.index("async def lifespan(")
+        end = src.index("app = FastAPI(", start)
+        block = src[start:end]
+        check_idx = block.index("check_and_repair")
+        thread_idx = block.index("threading.Thread(target=_deferred_init")
+        assert check_idx < thread_idx, (
+            "freshness check (step 1b) must run BEFORE the deferred-init "
+            "thread launches the spawn sequence (step 2+)"
+        )
+
+
+class TestRestartAbortContract:
+    """AC2 — on compose failure the restart aborts in the sense that no
+    agents are spawned. Implementation lives in E1; this test pins the
+    contract from the restart-safety perspective."""
+
+    def test_failed_status_sets_persistent_flag(self):
+        src = _harness_source()
+        start = src.index("async def lifespan(")
+        end = src.index("app = FastAPI(", start)
+        block = src[start:end]
+        assert 'status == "failed"' in block, (
+            "lifespan must branch on the failed status returned by "
+            "check_and_repair"
+        )
+        assert "compose_freshness_failed = True" in block, (
+            "lifespan must persist the failed flag on HarnessState so "
+            "every downstream spawn path can refuse"
+        )
+
+
+class TestEscapeHatchDoesNotBypassPersistedFailure:
+    """The escape hatch skips the CHECK, but does NOT clear a previously-
+    persisted `compose_freshness_failed=True`. If a prior boot failed
+    and the operator restarts with --no-freshness-check, spawn paths
+    still see the persisted flag and refuse."""
+
+    def test_no_freshness_check_does_not_reset_failed_flag(self):
+        # HarnessState.__init__ initializes compose_freshness_failed=False,
+        # but load_state() reads from disk and could restore it from a
+        # prior crash. The escape hatch must NOT call
+        # state.compose_freshness_failed = False.
+        src = _harness_source()
+        start = src.index("async def lifespan(")
+        end = src.index("app = FastAPI(", start)
+        block = src[start:end]
+        # In the `_NO_FRESHNESS_CHECK` branch we set _freshness = None
+        # and continue. The branch must NOT write False to the flag.
+        nfc_idx = block.index("_NO_FRESHNESS_CHECK")
+        # Look forward 1000 chars at the bypass block.
+        bypass_block = block[nfc_idx:nfc_idx + 800]
+        assert "compose_freshness_failed = False" not in bypass_block, (
+            "the escape hatch must NOT reset compose_freshness_failed — "
+            "a prior persisted failure should still block spawns"
+        )
+
+
+class TestPersistenceAcrossRestart:
+    """DS-10684 F1 + F2 regression — ``compose_freshness_failed`` must
+    survive harness restart. The escape hatch's documented protection
+    against a prior failure depends on the flag being persisted to
+    ``.harness-state.json`` and restored on the next boot."""
+
+    def test_save_state_writes_failed_flag(self, tmp_path, monkeypatch):
+        try:
+            import harness
+        except Exception:
+            pytest.skip("harness module unavailable (likely missing fastapi)")
+        # Redirect the state file to tmp_path so we don't clobber the
+        # real one. The module reads HARNESS_STATE_FILE at write time.
+        state_file = tmp_path / ".harness-state.json"
+        monkeypatch.setattr(harness, "HARNESS_STATE_FILE", state_file)
+        s = harness.HarnessState()
+        s.compose_freshness_failed = True
+        s.save_state()
+        import json
+        data = json.loads(state_file.read_text(encoding="utf-8"))
+        assert data["compose_freshness_failed"] is True
+
+    def test_load_state_restores_failed_flag(self, tmp_path, monkeypatch):
+        try:
+            import harness
+        except Exception:
+            pytest.skip("harness module unavailable (likely missing fastapi)")
+        state_file = tmp_path / ".harness-state.json"
+        monkeypatch.setattr(harness, "HARNESS_STATE_FILE", state_file)
+        # Hand-write a state file with the flag set.
+        import json
+        state_file.write_text(json.dumps({
+            "harness_pid": 0,
+            "start_time": 0,
+            "port": 7373,
+            "last_compose_checksum": None,
+            "compose_freshness_failed": True,
+            "agents": {},
+        }), encoding="utf-8")
+        s = harness.HarnessState()
+        assert s.compose_freshness_failed is False  # default
+        s.load_state()
+        assert s.compose_freshness_failed is True, (
+            "load_state() must restore compose_freshness_failed so a "
+            "prior boot's failure persists across restart"
+        )
+
+    def test_legacy_state_file_defaults_failed_flag_to_false(
+        self, tmp_path, monkeypatch,
+    ):
+        # Legacy state files (written before E5) lack the field. The
+        # restore must default safely to False so a clean install
+        # doesn't suddenly refuse to spawn.
+        try:
+            import harness
+        except Exception:
+            pytest.skip("harness module unavailable (likely missing fastapi)")
+        state_file = tmp_path / ".harness-state.json"
+        monkeypatch.setattr(harness, "HARNESS_STATE_FILE", state_file)
+        import json
+        state_file.write_text(json.dumps({
+            "harness_pid": 0,
+            "start_time": 0,
+            "port": 7373,
+            "last_compose_checksum": None,
+            # No compose_freshness_failed key — legacy state file.
+            "agents": {},
+        }), encoding="utf-8")
+        s = harness.HarnessState()
+        s.load_state()
+        assert s.compose_freshness_failed is False
+
+    def test_lifespan_failed_branch_flushes_state(self):
+        # DS-10684 F2: the failed branch must call state.save_state()
+        # so the flag persists even if the harness crashes before any
+        # other path triggers a save. Static-grep instead of running
+        # the lifespan.
+        src = _harness_source()
+        start = src.index("async def lifespan(")
+        end = src.index("app = FastAPI(", start)
+        block = src[start:end]
+        failed_idx = block.index('status == "failed"')
+        # The save_state() call must appear AFTER the flag-set line
+        # AND BEFORE the diagnostic logs end the branch — within the
+        # next ~500 chars.
+        branch_block = block[failed_idx:failed_idx + 800]
+        assert "state.save_state()" in branch_block, (
+            "the failed branch must call state.save_state() so the "
+            "flag persists across a crash before the next save-state-"
+            "triggering event (DS-10684 F2)"
+        )


### PR DESCRIPTION
## Summary

Builds on E1 (#10680 / PR #10759 — shipped). E1 already wires `compose_freshness.check_and_repair` into lifespan synchronously before yield — which IS the restart-safety path on every harness boot. E5 adds the operator escape hatch + closes the cross-restart persistence gap that DS-10684 surfaced.

- `--no-freshness-check` CLI flag + `SQUIDSQUAD_HARNESS_NO_FRESHNESS_CHECK=1` env var.
- Lifespan `_NO_FRESHNESS_CHECK` guard fires BEFORE `check_and_repair`. Bypass logs once.
- `compose_freshness_failed` now persisted to `.harness-state.json` and restored on next boot — the documented "prior failure survives `--no-freshness-check` restart" contract is now real, not just commented.
- 14 unit tests; **all 3 DS findings fixed pre-commit**.

## Closes

Closes #10684.

## AC coverage

1. ✅ Step 1b ordering: freshness check runs in lifespan AFTER `state.load_state()` (step 1) and BEFORE deferred-init thread (step 2+ PID verification path). Static-grep regression locks the order.
2. ✅ Restart-abort semantics: compose failure → `state.compose_freshness_failed=True` → save_state flush → every spawn path refuses.
3. ✅ Escape hatch: `--no-freshness-check` CLI flag + env var; bypass logs once; does NOT clear a persisted prior failure.
4. ✅ Tests: clean restart / drift restart / failed-compose restart / escape-hatch / persistence-across-restart all covered.

## DS code-review

`.squidsquad/skill/planning/ds-10684-review.md` archived. 3 findings, all fixed:

- **F1 (error)** — `compose_freshness_failed` documented as persisted but never written/read. Round-tripped through `save_state` + `load_state`; legacy state files default safely to False. 3 regression tests.
- **F2 (warning)** — failed lifespan branch set the flag but didn't flush. Added `save_state()` after the assignment.
- **F3 (warning)** — incorrect docstring claimed `_deferred_init` mutates the flag (lifespan does). Corrected.

## Test plan

- [x] `pytest tests/test_harness_freshness_restart_e5.py tests/test_compose_freshness_e1.py tests/test_harness.py tests/test_feat_10681_compose_checksum.py` — 228/228 pass
- [x] `STATIC_TEST_MODULES` registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)