### PR TITLE
PRD-E E4 (#10683): squidsquad_cli check operator CLI (Layer 3)

### DIFF
--- a/.squidsquad/skill/planning/ds-10683-review.md
+++ b/.squidsquad/skill/planning/ds-10683-review.md
@@ -1,0 +1,78 @@
+I now have all the information needed. Here are my findings:
+
+---
+
+### Finding 1
+
+- **File**: `references/scripts/squidsquad_cli.py`
+- **Line**: 557–559 (the `elif stored != current:` branch and its `return 1`)
+- **Severity**: error
+- **Issue**: When `stored != current` (checksum drift detected) **and** `--full` is passed, the compose.py dry-run **never executes**. The `return 1` at line 559 exits `cmd_check` before the `if not full:` guard at line 565 is reached. The `--full` flag is silently ignored.
+- **Evidence**:
+  - AC4 states `--full` **adds** the A4 drift check — the word "adds" implies it runs *in addition to* the checksum comparison, not only when the checksum matches.
+  - The compose.py dry-run provides per-output-file detail about *which composed files* are stale. When checksums differ, the operator gets only the checksum-mismatch report (which says "something changed" but not *what composed outputs need regeneration*). The operator never sees the more detailed A4 diagnostics they explicitly requested.
+  - All three `TestFullFlag` tests (lines 199, 218, 233) only exercise the path where checksums **match**. No test covers `full=True` + `stored != current`, which would have caught this.
+  - Control-flow trace: line 557 `elif stored != current:` → line 559 `return 1` — function exits **before** line 564 `# AC4: --full adds the A4 drift check` and line 565 `if not full:`.
+
+- **Suggested fix**: Defer the drift exit so `--full` always runs when passed. Replace the early `return 1` with a flag, then decide the exit code after the optional dry-run:
+
+  ```python
+  drift = False
+  if stored is None:
+      print("compose freshness: no stored checksum ...")
+  elif stored != current:
+      print(_format_drift_report(stored, current, repo_root), file=sys.stderr)
+      drift = True
+  else:
+      print("compose freshness: clean")
+
+  if not full:
+      return 1 if drift else 0
+
+  # --full: always run the dry-run ...
+  # ... after dry-run, if it also returns 1, drift stays True
+  # Final exit: return 1 if drift else 0 (or 2 on error)
+  ```
+
+---
+
+### Finding 2
+
+- **File**: `references/scripts/squidsquad_cli.py`
+- **Line**: 480–489 (`_enumerate_drifted_paths`)
+- **Severity**: warning
+- **Issue**: The drift report enumerates **ALL** compose-input files (not just changed ones) by calling a **private** function `_cf._iter_compose_input_files` with **no error handling**. If that private function is renamed, removed, or raises an exception (e.g. permission error during `repo_root.glob()`), the exception propagates unhandled through `_format_drift_report` → `cmd_check`, causing a Python traceback instead of a clean exit 2.
+- **Evidence**:
+  - Line 482: `for path in _cf._iter_compose_input_files(repo_root):` — the underscore prefix marks this as a private API of `compose_freshness`. The public API is `compute_compose_checksum` (used correctly on line 544); `_iter_compose_input_files` is an implementation detail.
+  - There is no `try`/`except` around this call. If `_iter_compose_input_files` is removed or its signature changes in a future compose_freshness refactor, the drift report crashes instead of surfacing exit 2.
+  - Listing *all* files in a large repo (hundreds of paths) produces a noisy report. The docstring on line 471–478 acknowledges per-file hashes aren't stored, but the report still claims to help the operator diagnose "WHICH files changed" on line 504 — while actually listing every file rather than the diff.
+- **Suggested fix**: Either:
+  - (a) Wrap the enumeration call in `try`/`except` and on failure append a fallback line like `(could not enumerate input files: <reason>)` to the report instead of crashing; or
+  - (b) Expose `_iter_compose_input_files` as a public function in `compose_freshness` (rename to `iter_compose_input_files`), making the dependency explicit and stable.
+
+---
+
+### Finding 3
+
+- **File**: `references/scripts/squidsquad_cli.py`
+- **Line**: 591–593
+- **Severity**: warning
+- **Issue**: The `--full` dry-run exit-code mapping trusts that `compose.py deploy-all --check` uses exit code 1 **exclusively** for "drift detected" and exit codes ≥2 for "error." If `compose.py` ever returns exit code 1 for a non-drift failure (e.g., an unhandled Python exception, which `sys.exit(1)` would produce), the CLI misreports it as "drift detected" (exit 1) instead of "error" (exit 2).
+- **Evidence**:
+  - The comment at line 592 says `# A4's drift exit. Map onto our exit 1` and line 594 says `# A4 maps unhandled errors to exit 2 / sys.exit`. This assumes compose.py strictly partitions exit codes: 0=clean, 1=drift, ≥2=error.
+  - `compose_freshness.py` line 239 shows a different treatment: `if returncode != 0:` treats *any* non-zero from `compose.py deploy-all` (without `--check`) as failure. This demonstrates that compose.py exit code semantics vary by flag, making the mapping fragile.
+  - A `compose.py` bug that triggers `sys.exit(1)` (the Python default for unhandled exceptions in some frameworks) would be reported as "drift" rather than "error," misleading the operator about the nature of the problem.
+- **Suggested fix**: Capture and log the compose.py stderr regardless of exit code, and consider distinguishing "known drift" (exit 1 with parseable drift output) from "unexpected exit 1" (exit 1 with a traceback on stderr). At minimum, document the contract assumption explicitly so future compose.py maintainers know the exit code partition is load-bearing.
+
+---
+
+### No State Mutation Found (AC7)
+
+I specifically traced every code path in `cmd_check`, `_load_state_checksum`, `_enumerate_drifted_paths`, `_format_drift_report`, and the subprocess invocation for AC7 violations. The code is genuinely read-only regarding project state:
+
+- The state file is only **read** (line 461, `state_file.read_text`), never written.
+- The subprocess always passes `--check` (line 574), never the mutating `deploy-all`.
+- `sys.path.insert(0, ...)` at line 530 mutates global interpreter state (not project state files); it's a one-shot CLI process so accumulation is harmless.
+- The drift report's advice text at line 503 (`Run ... compose.py deploy-all`) is purely informational — the CLI does not execute it.
+
+The AC7 test at line 163–171 correctly confirms the state file is byte-identical before/after.

--- a/references/scripts/compose_freshness.py
+++ b/references/scripts/compose_freshness.py
@@ -96,8 +96,13 @@ class FreshnessResult:
 _COMPOSE_STDERR_MAX = 4000
 
 
-def _iter_compose_input_files(repo_root):
+def iter_compose_input_files(repo_root):
     """Yield every file path that contributes to the checksum.
+
+    Public API per DS-10683 F2 (used by ``squidsquad_cli.cmd_check``'s
+    drift report). The leading-underscore private name still exists
+    as an alias below for backwards compatibility with any pre-#10683
+    importer.
 
     Resolution: each glob in ``COMPOSE_INPUT_GLOBS`` is expanded
     against ``repo_root``. Symlinks are followed only one level
@@ -113,6 +118,10 @@ def _iter_compose_input_files(repo_root):
         for path in repo_root.glob(pattern):
             if path.is_file():
                 yield path
+
+
+# Backwards-compat alias for any pre-#10683 importer.
+_iter_compose_input_files = iter_compose_input_files
 
 
 def compute_compose_checksum(repo_root):

--- a/references/scripts/squidsquad_cli.py
+++ b/references/scripts/squidsquad_cli.py
@@ -411,13 +411,231 @@ Commands:
   restart <role>     Restart a single agent
   status             Show harness + agent health
   shutdown           Stop all agents and exit harness
+  check [--full]     Diagnose compose freshness (read-only — no spawn,
+                     no mutation). With --full also runs `compose.py
+                     deploy-all --check` to verify on-disk outputs match
+                     source-tree composition.
 
 Examples:
   squidsquad start
   squidsquad restart skill
   squidsquad status
+  squidsquad check
+  squidsquad check --full
   squidsquad shutdown
 """
+
+
+# PRD-E E4 (#10683): operator-driven freshness diagnostic. Pure read-
+# only — never spawns agents, never mutates state, never runs
+# ``compose.py deploy-all`` (only the ``--check`` dry-run when
+# ``--full`` is passed).
+#
+# Exit codes per AC5:
+#   0 — clean (no drift, sources compose cleanly)
+#   1 — drift detected (structured report on stderr)
+#   2 — error (couldn't read sources, malformed config, compose
+#       dry-run errored)
+_STATE_FILE = (
+    Path(__file__).resolve().parent.parent.parent
+    / ".squidsquad" / ".harness-state.json"
+)
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _load_state_checksum(state_file=_STATE_FILE):
+    """Return ``(stored_checksum_or_None, error_message_or_None)``.
+
+    The checksum can be ``None`` when:
+    - state file does not exist (fresh install, never booted),
+    - state file exists but has no ``last_compose_checksum`` field
+      (legacy file, pre-E2).
+
+    Both cases are normal "first boot" states the operator should be
+    informed about — not exit-2 errors. A malformed JSON file IS an
+    exit-2 error.
+    """
+    if not state_file.is_file():
+        return None, None
+    try:
+        raw = state_file.read_text(encoding="utf-8")
+    except OSError as e:
+        return None, f"could not read {state_file}: {e}"
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        return None, f"malformed JSON in {state_file}: {e}"
+    return data.get("last_compose_checksum"), None
+
+
+def _enumerate_drifted_paths(repo_root):
+    """Return the sorted list of compose-input paths that exist on
+    disk today. Used by the drift report so the operator can see what
+    the gate would hash; pinpointing WHICH files changed requires
+    keeping the prior file-by-file hash list, which today's state file
+    does not store. AC6 asks for a "human-readable summary" — listing
+    the input set + the current checksum is the honest answer until a
+    future story adds a per-file manifest.
+
+    Per DS-10683 F2: uses ``compose_freshness.iter_compose_input_files``
+    (public API) and returns ``None`` on enumeration failure so the
+    drift report can render a clean fallback line instead of crashing.
+    """
+    try:
+        import compose_freshness as _cf  # lazy — avoid module import on usage-only paths
+        paths = []
+        for path in _cf.iter_compose_input_files(repo_root):
+            try:
+                rel = path.relative_to(repo_root).as_posix()
+            except ValueError:
+                continue
+            if rel not in paths:
+                paths.append(rel)
+        return sorted(paths)
+    except Exception:  # noqa: BLE001 — operator-facing fallback
+        return None
+
+
+def _format_drift_report(stored, current, repo_root):
+    """Render the AC6 drift report for stderr."""
+    lines = [
+        "compose freshness: DRIFT DETECTED",
+        "",
+        f"  stored checksum (.harness-state.json): {stored}",
+        f"  current checksum (live source tree):   {current}",
+        "",
+        (
+            "  The compose-input set has changed since the last "
+            "successful boot. Run `python references/scripts/"
+            "compose.py deploy-all` to bring composed outputs back in "
+            "sync. To diagnose WHICH files changed, compare git diff "
+            "against the boot point that wrote the stored checksum."
+        ),
+        "",
+        "  Compose-input set (current files on disk):",
+    ]
+    paths = _enumerate_drifted_paths(repo_root)
+    if paths is None:
+        # DS-10683 F2 fallback: enumeration failed (private API
+        # broke, filesystem permission error, etc.). Report it so
+        # the operator sees the drift summary anyway.
+        lines.append(
+            "    (could not enumerate compose-input files — see "
+            "compose_freshness.iter_compose_input_files)"
+        )
+    else:
+        for rel in paths:
+            lines.append(f"    - {rel}")
+    return "\n".join(lines)
+
+
+def cmd_check(full=False, *, repo_root=None, state_file=None):
+    """Run the E4 read-only freshness diagnostic.
+
+    Returns the AC5 exit code: 0 / 1 / 2.
+
+    ``repo_root`` + ``state_file`` are injection seams for tests.
+    """
+    if repo_root is None:
+        repo_root = _REPO_ROOT
+    if state_file is None:
+        state_file = _STATE_FILE
+
+    # Import E1's checksum helper. Lazy so the CLI's other subcommands
+    # don't pay the import cost when they don't need it.
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        import compose_freshness as _cf
+    except Exception as e:  # noqa: BLE001
+        print(
+            f"check: could not import compose_freshness: {e}", file=sys.stderr
+        )
+        return 2
+
+    stored, error = _load_state_checksum(state_file=state_file)
+    if error:
+        print(f"check: {error}", file=sys.stderr)
+        return 2
+
+    try:
+        current = _cf.compute_compose_checksum(repo_root)
+    except Exception as e:  # noqa: BLE001 — surface as exit 2
+        print(f"check: could not compute checksum: {e}", file=sys.stderr)
+        return 2
+
+    # DS-10683 F1 fix: track drift as a flag instead of exiting early.
+    # If --full is passed AND the checksum already mismatched, the
+    # operator still wants the A4 dry-run output (which names the
+    # specific composed files that need regeneration). Pre-fix, the
+    # early ``return 1`` silently swallowed --full on drift.
+    drift = False
+    if stored is None:
+        # AC8 covers clean / drifted / broken — first-boot isn't
+        # called out, but the honest read is "no stored checksum to
+        # compare against; the harness will run compose at next boot."
+        # That's not drift; treat as clean from the diagnostic POV so
+        # operators don't see a red signal on a fresh install.
+        print("compose freshness: no stored checksum (first boot / fresh install)")
+        print(f"  current checksum: {current}")
+    elif stored != current:
+        print(_format_drift_report(stored, current, repo_root), file=sys.stderr)
+        drift = True
+    else:
+        print("compose freshness: clean")
+        print(f"  checksum: {current}")
+
+    # AC4: --full adds the A4 drift check (compose.py deploy-all --check)
+    # IN ADDITION TO the checksum comparison above. The two checks are
+    # complementary: checksum says "the source tree changed," the
+    # dry-run says "the composed outputs are stale relative to the
+    # source tree" — only the dry-run pinpoints which composed files
+    # need regeneration.
+    if not full:
+        return 1 if drift else 0
+
+    print("\nrunning compose.py deploy-all --check ...")
+    cmd = [
+        sys.executable,
+        str(Path(repo_root) / "references" / "scripts" / "compose.py"),
+        "deploy-all",
+        "--check",
+    ]
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, cwd=str(repo_root),
+        )
+    except Exception as e:  # noqa: BLE001
+        print(f"check: --full failed to invoke compose.py: {e}", file=sys.stderr)
+        return 2
+
+    # DS-10683 F3: always emit compose.py's stderr regardless of exit
+    # code so an unexpected exit-1 traceback is at least visible to
+    # the operator (we still map exit codes per A4's contract below;
+    # the contract is documented in compose.py's CHECK_EXIT_CLEAN /
+    # CHECK_EXIT_DRIFT / CHECK_EXIT_ERROR constants).
+    if proc.stdout:
+        print(proc.stdout, end="" if proc.stdout.endswith("\n") else "\n")
+    if proc.stderr:
+        print(proc.stderr, end="" if proc.stderr.endswith("\n") else "\n",
+              file=sys.stderr)
+    # Map A4's exit codes to our AC5 codes:
+    #   0 = clean, 1 = drift, ≥2 = error.
+    # Contract is load-bearing — see compose.py CHECK_EXIT_* constants.
+    if proc.returncode == 0:
+        print("compose dry-run: clean")
+        # Even if the dry-run was clean, a checksum mismatch above
+        # still means the operator should look at why the input set
+        # hashed differently — exit 1 surfaces that.
+        return 1 if drift else 0
+    if proc.returncode == 1:
+        # A4 drift — same exit semantic as our checksum drift.
+        return 1
+    # Any other non-zero (A4 maps unhandled errors to exit 2).
+    print(
+        f"check: compose dry-run exited {proc.returncode} (setup/parse error)",
+        file=sys.stderr,
+    )
+    return 2
 
 
 def main():
@@ -444,6 +662,17 @@ def main():
         return cmd_status()
     elif cmd == "shutdown":
         return cmd_shutdown()
+    elif cmd == "check":
+        full = "--full" in args[1:]
+        extra = [a for a in args[1:] if a != "--full"]
+        if extra:
+            print(
+                f"check: unrecognized arguments: {' '.join(extra)}",
+                file=sys.stderr,
+            )
+            print("Usage: squidsquad check [--full]", file=sys.stderr)
+            return 2
+        return cmd_check(full=full)
     else:
         print(f"Unknown command: {cmd}", file=sys.stderr)
         print(USAGE)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -151,6 +151,7 @@ STATIC_TEST_MODULES = [
     "test_l4_file_watcher_e3",
     "test_compose_freshness_e1",
     "test_harness_freshness_restart_e5",
+    "test_squidsquad_cli_check_e4",
 ]
 
 

--- a/tests/test_squidsquad_cli_check_e4.py
+++ b/tests/test_squidsquad_cli_check_e4.py
@@ -1,0 +1,372 @@
+"""Tests for `squidsquad_cli.py check` (#10683, PRD-E E4).
+
+AC8 mandates tests for:
+  (a) clean install (stored == current) → exit 0
+  (b) drifted install (stored != current) → exit 1 + stderr report
+  (c) broken config (malformed state file) → exit 2
+
+Plus AC1/AC2/AC3/AC4/AC7 coverage:
+  - subcommand registered + usage string carries `check`
+  - reuses compose_freshness.compute_compose_checksum (single source of truth)
+  - reads `last_compose_checksum` from `.harness-state.json` (read-only)
+  - --full delegates to `compose.py deploy-all --check` (A4)
+  - does NOT spawn agents, does NOT mutate state, does NOT run
+    `deploy-all` without --check
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import squidsquad_cli as cli  # noqa: E402
+import compose_freshness as cf  # noqa: E402
+
+
+def _stage_minimal_repo(tmp_path):
+    """Reuse compose_freshness's minimal-repo shape so the checksum
+    helper finds at least one file in each glob."""
+    repo = tmp_path
+    (repo / ".squidsquad").mkdir()
+    (repo / ".squidsquad" / "config.md").write_text("- v: 1\n", encoding="utf-8")
+    (repo / ".squidsquad" / "project").mkdir()
+    (repo / ".squidsquad" / "project" / "pm.md").write_text("# pm\n", encoding="utf-8")
+    (repo / "references" / "sub-skills" / "common").mkdir(parents=True)
+    (repo / "references" / "sub-skills" / "common" / "boot.md").write_text(
+        "# boot\n", encoding="utf-8")
+    (repo / "references" / "sub-skills" / "manifest.md").write_text(
+        "# manifest\n", encoding="utf-8")
+    (repo / "references" / "roles").mkdir(parents=True)
+    (repo / "references" / "roles" / "identity.md").write_text(
+        "# identity\n", encoding="utf-8")
+    return repo
+
+
+def _write_state(repo, *, checksum):
+    state_dir = repo / ".squidsquad"
+    state_dir.mkdir(exist_ok=True)
+    state = state_dir / ".harness-state.json"
+    state.write_text(json.dumps({
+        "harness_pid": 0,
+        "start_time": 0,
+        "port": 7373,
+        "last_compose_checksum": checksum,
+        "compose_freshness_failed": False,
+        "agents": {},
+    }), encoding="utf-8")
+    return state
+
+
+# ---------------------------------------------------------------------------
+# AC8 — happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestCleanInstall:
+    """AC8(a): stored matches current → exit 0, stdout reports clean."""
+
+    def test_exit_zero_when_stored_matches_current(self, tmp_path, capsys):
+        repo = _stage_minimal_repo(tmp_path)
+        state = _write_state(repo, checksum=cf.compute_compose_checksum(repo))
+        rc = cli.cmd_check(repo_root=repo, state_file=state)
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "clean" in captured.out.lower()
+        assert captured.err == ""
+
+
+class TestDriftedInstall:
+    """AC8(b) + AC6: stored differs from current → exit 1 + structured
+    report on stderr."""
+
+    def test_exit_one_with_stderr_report_when_drift(self, tmp_path, capsys):
+        repo = _stage_minimal_repo(tmp_path)
+        state = _write_state(repo, checksum="0" * 64)  # bogus prior checksum
+        rc = cli.cmd_check(repo_root=repo, state_file=state)
+        assert rc == 1
+        captured = capsys.readouterr()
+        # Report goes to STDERR per AC5.
+        assert "DRIFT DETECTED" in captured.err
+        # Both checksums named (operator can audit).
+        assert "0000000000000000" in captured.err
+        # Some compose-input files enumerated.
+        assert "references/sub-skills/" in captured.err
+
+    def test_drift_report_names_stored_and_current(self, tmp_path, capsys):
+        repo = _stage_minimal_repo(tmp_path)
+        stored = "a" * 64
+        state = _write_state(repo, checksum=stored)
+        current = cf.compute_compose_checksum(repo)
+        cli.cmd_check(repo_root=repo, state_file=state)
+        captured = capsys.readouterr()
+        assert stored in captured.err
+        assert current in captured.err
+
+
+class TestBrokenConfig:
+    """AC8(c): malformed state file → exit 2."""
+
+    def test_exit_two_on_malformed_state_json(self, tmp_path, capsys):
+        repo = _stage_minimal_repo(tmp_path)
+        state = repo / ".squidsquad" / ".harness-state.json"
+        state.parent.mkdir(parents=True, exist_ok=True)
+        state.write_text("{not valid json", encoding="utf-8")
+        rc = cli.cmd_check(repo_root=repo, state_file=state)
+        assert rc == 2
+        assert "malformed JSON" in capsys.readouterr().err
+
+
+class TestFirstBootNoStoredChecksum:
+    """A fresh install with no state file — or a legacy state file
+    without the field — reports first-boot status and exits 0
+    (treating it as drift would surface a red signal on a green
+    install)."""
+
+    def test_no_state_file_reports_first_boot_and_exits_zero(
+        self, tmp_path, capsys,
+    ):
+        repo = _stage_minimal_repo(tmp_path)
+        # state file path that doesn't exist
+        missing = repo / ".squidsquad" / "missing.json"
+        rc = cli.cmd_check(repo_root=repo, state_file=missing)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "first boot" in out.lower() or "no stored checksum" in out.lower()
+
+    def test_legacy_state_file_without_checksum_reports_first_boot(
+        self, tmp_path, capsys,
+    ):
+        repo = _stage_minimal_repo(tmp_path)
+        state = repo / ".squidsquad" / ".harness-state.json"
+        state.parent.mkdir(parents=True, exist_ok=True)
+        # Legacy file shape — has agents but no last_compose_checksum.
+        state.write_text(json.dumps({
+            "harness_pid": 0, "start_time": 0, "port": 7373, "agents": {},
+        }), encoding="utf-8")
+        rc = cli.cmd_check(repo_root=repo, state_file=state)
+        assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# AC7 — pure read-only (no spawn, no mutation)
+# ---------------------------------------------------------------------------
+
+
+class TestReadOnly:
+    """AC7: check must not spawn agents, mutate state, or run compose
+    deploy-all (only the --check dry-run via --full)."""
+
+    def test_does_not_mutate_state_file(self, tmp_path):
+        repo = _stage_minimal_repo(tmp_path)
+        state = _write_state(repo, checksum=cf.compute_compose_checksum(repo))
+        prior = state.read_text(encoding="utf-8")
+        cli.cmd_check(repo_root=repo, state_file=state)
+        after = state.read_text(encoding="utf-8")
+        assert prior == after, (
+            "check must not mutate the state file (AC7 read-only)"
+        )
+
+    def test_does_not_invoke_deploy_all_without_full(self, tmp_path, monkeypatch):
+        # Stub subprocess.run so any sneaky invocation would surface.
+        repo = _stage_minimal_repo(tmp_path)
+        state = _write_state(repo, checksum=cf.compute_compose_checksum(repo))
+        calls = []
+
+        def tracking(*args, **kwargs):
+            calls.append((args, kwargs))
+            return subprocess.CompletedProcess(args[0], 0, "", "")
+
+        import subprocess
+        monkeypatch.setattr(cli.subprocess, "run", tracking)
+        cli.cmd_check(repo_root=repo, state_file=state, full=False)
+        assert calls == [], (
+            "check without --full must NOT invoke compose.py "
+            "(AC7 + AC4 — only --full runs the dry-run)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC4 — --full delegates to A4's compose.py deploy-all --check
+# ---------------------------------------------------------------------------
+
+
+class TestFullFlag:
+
+    def test_full_invokes_compose_deploy_all_check(self, tmp_path, monkeypatch):
+        repo = _stage_minimal_repo(tmp_path)
+        state = _write_state(repo, checksum=cf.compute_compose_checksum(repo))
+        calls = []
+
+        def tracking(argv, **kwargs):
+            calls.append(argv)
+            import subprocess
+            return subprocess.CompletedProcess(argv, 0, "all clean\n", "")
+
+        monkeypatch.setattr(cli.subprocess, "run", tracking)
+        rc = cli.cmd_check(repo_root=repo, state_file=state, full=True)
+        assert rc == 0
+        assert len(calls) == 1
+        # First three argv entries are python, compose.py path, "deploy-all".
+        assert calls[0][1].endswith("compose.py"), calls[0]
+        assert calls[0][2] == "deploy-all"
+        assert "--check" in calls[0]
+
+    def test_full_returns_one_when_dry_run_reports_drift(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        repo = _stage_minimal_repo(tmp_path)
+        state = _write_state(repo, checksum=cf.compute_compose_checksum(repo))
+
+        def fake(argv, **kwargs):
+            import subprocess
+            return subprocess.CompletedProcess(argv, 1, "", "  pm: DRIFT\n")
+
+        monkeypatch.setattr(cli.subprocess, "run", fake)
+        rc = cli.cmd_check(repo_root=repo, state_file=state, full=True)
+        assert rc == 1
+        assert "DRIFT" in capsys.readouterr().err
+
+    def test_full_returns_two_when_dry_run_setup_error(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        repo = _stage_minimal_repo(tmp_path)
+        state = _write_state(repo, checksum=cf.compute_compose_checksum(repo))
+
+        def fake(argv, **kwargs):
+            import subprocess
+            return subprocess.CompletedProcess(argv, 2, "", "config parse error\n")
+
+        monkeypatch.setattr(cli.subprocess, "run", fake)
+        rc = cli.cmd_check(repo_root=repo, state_file=state, full=True)
+        assert rc == 2
+
+    def test_full_runs_dry_run_even_when_checksum_already_drifted(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        # DS-10683 F1 regression: prior to the fix, ``return 1`` fired
+        # before ``--full`` could run, so the operator never got the
+        # A4 dry-run output on the drift path. The dry-run names the
+        # specific composed files that need regeneration — exactly
+        # what an operator running ``check --full`` is asking for.
+        repo = _stage_minimal_repo(tmp_path)
+        state = _write_state(repo, checksum="z" * 64)  # bogus → drift
+        calls = []
+
+        def tracking(argv, **kwargs):
+            calls.append(argv)
+            import subprocess
+            return subprocess.CompletedProcess(argv, 0, "all aliases clean\n", "")
+
+        monkeypatch.setattr(cli.subprocess, "run", tracking)
+        rc = cli.cmd_check(repo_root=repo, state_file=state, full=True)
+        # Checksum still mismatched even though the dry-run was clean;
+        # surface as drift (exit 1) so the operator sees both signals.
+        assert rc == 1, (
+            "checksum mismatch must still surface as drift even if the "
+            "dry-run is clean (exit 1) — DS-10683 F1 regression"
+        )
+        assert len(calls) == 1, (
+            "--full must invoke compose.py deploy-all --check EVEN WHEN "
+            "the checksum already mismatched (DS-10683 F1 regression)"
+        )
+        # Drift report still in stderr.
+        assert "DRIFT DETECTED" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# AC1 — subcommand registered in main() + usage string carries it
+# ---------------------------------------------------------------------------
+
+
+class TestSubcommandWiring:
+
+    def test_main_dispatch_includes_check(self, monkeypatch):
+        # Static-grep on the cli module's main() body.
+        src = (SCRIPTS / "squidsquad_cli.py").read_text(encoding="utf-8")
+        # main() body must dispatch to cmd_check when cmd == "check".
+        main_start = src.index("def main(")
+        main_end = src.index('if __name__ == "__main__":', main_start)
+        block = src[main_start:main_end]
+        assert 'cmd == "check"' in block, (
+            "main() must register the check subcommand (AC1)"
+        )
+        assert "cmd_check" in block
+
+    def test_usage_string_lists_check(self):
+        assert "check" in cli.USAGE, (
+            "USAGE help must list the check subcommand so operators "
+            "discover it (AC1)"
+        )
+
+    def test_unrecognized_argument_after_check_returns_2(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        # Drive through main() to exercise the arg-parser branch.
+        monkeypatch.setattr(cli, "_REPO_ROOT", tmp_path)
+        monkeypatch.setattr(cli, "_STATE_FILE", tmp_path / ".harness-state.json")
+        monkeypatch.setattr(sys, "argv", ["squidsquad", "check", "--bogus"])
+        rc = cli.main()
+        assert rc == 2
+        assert "unrecognized arguments" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# AC2 — reuses compose_freshness.compute_compose_checksum (one source of truth)
+# ---------------------------------------------------------------------------
+
+
+class TestReusesE1Checksum:
+    """AC2 requires reuse of E1's checksum function so the diagnostic
+    and the boot gate agree on what 'drift' means."""
+
+    def test_check_call_path_imports_compose_freshness(self):
+        # cmd_check's body does the lazy import at runtime; reading
+        # the source confirms it doesn't reimplement the algorithm.
+        src = (SCRIPTS / "squidsquad_cli.py").read_text(encoding="utf-8")
+        cmd_start = src.index("def cmd_check(")
+        cmd_end = src.index("\ndef ", cmd_start + 1)
+        body = src[cmd_start:cmd_end]
+        assert "compose_freshness" in body, (
+            "cmd_check must reuse compose_freshness.compute_compose_checksum "
+            "instead of re-implementing the algorithm (AC2)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# DS-10683 F2 regression — drift report tolerates enumeration failure
+# ---------------------------------------------------------------------------
+
+
+class TestDriftReportEnumerationFallback:
+
+    def test_iter_compose_input_files_is_public_api(self):
+        # The CLI should consume a public name so a future rename in
+        # compose_freshness doesn't break the drift report silently.
+        assert hasattr(cf, "iter_compose_input_files"), (
+            "compose_freshness must expose iter_compose_input_files "
+            "as a public name (DS-10683 F2)"
+        )
+        # Underscore alias stays for backwards compatibility.
+        assert cf._iter_compose_input_files is cf.iter_compose_input_files
+
+    def test_drift_report_falls_back_when_enumeration_raises(
+        self, tmp_path, capsys, monkeypatch,
+    ):
+        repo = _stage_minimal_repo(tmp_path)
+        state = _write_state(repo, checksum="b" * 64)  # drift
+
+        def boom(_repo):
+            raise RuntimeError("simulated enumeration failure")
+
+        monkeypatch.setattr(cf, "iter_compose_input_files", boom)
+        rc = cli.cmd_check(repo_root=repo, state_file=state)
+        # Exit code is still 1 (drift) — fallback is in the REPORT,
+        # not the exit semantics.
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "DRIFT DETECTED" in err
+        assert "could not enumerate compose-input files" in err


### PR DESCRIPTION
## Summary

- New `squidsquad check [--full]` subcommand — read-only diagnostic.
- Reuses E1's `compute_compose_checksum` (single source of truth per AC2).
- Reads `last_compose_checksum` from `.harness-state.json` (AC3 read-only).
- `--full` delegates to A4's `compose.py deploy-all --check` for per-output detail (AC4).
- 18 unit tests; all 3 DS findings fixed pre-commit.

## Closes

Closes #10683.

## AC coverage

1. ✅ Subcommand `squidsquad check [--full]` registered in `main()` + listed in USAGE.
2. ✅ Lazy-imports `compose_freshness.compute_compose_checksum` — no algorithm duplication.
3. ✅ Reads stored checksum (read-only); never writes the state file.
4. ✅ `--full` runs `compose.py deploy-all --check` (A4); always emits its stderr.
5. ✅ Exit codes 0 / 1 / 2 per scenario.
6. ✅ Stderr drift report names both checksums + enumerates current compose-input files; gracefully falls back to "(could not enumerate ...)" if the iterator raises.
7. ✅ Never spawns agents, never mutates state, never runs `deploy-all` without `--check`.
8. ✅ Tests for clean / drifted / broken-config scenarios.

## DS code-review

`.squidsquad/skill/planning/ds-10683-review.md` archived. 3 findings, all fixed:

- **F1 (error)** — `--full` was silently ignored on the drift path because of an early `return 1`. The operator running `check --full` precisely wants the A4 dry-run output when there's drift. Refactored to a `drift` flag; final exit happens after the dry-run. Regression test covers it.
- **F2 (warning)** — drift report consumed the private `_iter_compose_input_files`. Promoted to public `iter_compose_input_files`; underscore alias preserved. Enumeration wrapped in try/except with a clean fallback line.
- **F3 (warning)** — documented the A4 exit-code partition (0/1/≥2) as load-bearing; compose.py stderr always emitted regardless of exit code.

## Test plan

- [x] `pytest tests/test_squidsquad_cli_check_e4.py` — 18/18 pass
- [x] Adjacent regression (E1 + E5 + CLI) — 48 pass, no regressions
- [x] `STATIC_TEST_MODULES` registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)