### PR TITLE
Fix #6274 catalog drift in sub-skill-catalog.md + tests (#10817)

### DIFF
--- a/docs/sub-skill-catalog.md
+++ b/docs/sub-skill-catalog.md
@@ -213,16 +213,16 @@ Role-specific event extras:
 | `roles/pm/ralph-loop-overview` | Runtime-loaded polling-mode cycle contract — slash-bearing per #10743 |
 | Domain context | Per-stack PM notes: `android/`, `ios/`, `web/`, `fullstack/`, `skill/` |
 
-### QA (`roles/qa/`)
+### Verifier (`roles/verifier/`)
 
 | Sub-skill | One-liner |
 |---|---|
 | `verification` | Steps 2–6 — E2E tests, AC verification, health check |
-| `roles/qa/issue-filing` | QA's bug template (with reproduction + AC reference) — slash-bearing per #10743 |
-| `roles/qa/discussion-protocol` | QA's comment format (→ retires; common/`discussion` is the canonical) — slash-bearing per #10743 |
-| `roles/qa/ralph-loop-overview` | Runtime-loaded polling-mode cycle contract — slash-bearing per #10743 |
-| Domain context | Per-stack QA notes: `android/`, `ios/`, `web/`, `fullstack/`, `skill/` |
-| `skill/finding-categories` | Skill-domain finding taxonomy for QA reports |
+| `roles/verifier/issue-filing` | Verifier's bug template (with reproduction + AC reference) — slash-bearing per #10743 |
+| `roles/verifier/discussion-protocol` | Verifier's comment format (→ retires; common/`discussion` is the canonical) — slash-bearing per #10743 |
+| `roles/verifier/ralph-loop-overview` | Runtime-loaded polling-mode cycle contract — slash-bearing per #10743 |
+| Domain context | Per-stack verifier notes: `android/`, `ios/`, `web/`, `fullstack/`, `skill/` |
+| `skill/finding-categories` | Skill-domain finding taxonomy for verifier reports |
 
 ### DM (`roles/dm/`)
 
@@ -238,14 +238,14 @@ Role-specific event extras:
 | `roles/dm/ralph-loop-overview` | Runtime-loaded polling-mode cycle contract — slash-bearing per #10743 |
 | Domain context | Per-stack DM notes: `android/`, `ios/`, `web/`, `fullstack/`, `skill/` |
 
-### Dev (`roles/dev/`)
+### Worker (`roles/worker/`)
 
 | Sub-skill | One-liner |
 |---|---|
 | `triage-issues` | Step 2 — deterministic work-queue triage |
 | `implement-tasks` | Step 2b — pick up approved tasks; commit on feature branch; open PR |
-| `roles/dev/ralph-loop-overview` | Runtime-loaded polling-mode cycle contract — slash-bearing per #10743 |
-| Domain context | Per-stack dev notes: `android/`, `ios/`, `web/`, `fullstack/`, `skill/` |
+| `roles/worker/ralph-loop-overview` | Runtime-loaded polling-mode cycle contract — slash-bearing per #10743 |
+| Domain context | Per-stack worker notes: `android/`, `ios/`, `web/`, `fullstack/`, `skill/` |
 
 > Removed from all per-role tables: `responsibility`, `file-conventions`, `status-line`. These are no longer sub-skills (see the migration notes earlier in this section). Source files remain on disk under `references/sub-skills/roles/<role>/` until #10360 implements the migration; this catalog reflects target architecture, not v1 disk state.
 

--- a/tests/test_catalog_parser_d1.py
+++ b/tests/test_catalog_parser_d1.py
@@ -83,11 +83,11 @@ class TestCleanParse:
         | `pm-planning` | Phase 1/2 research | PM |
         | `pm-orphan-cleanup` | Stale ticket sweep | PM |
 
-        ### Dev (`roles/dev/`)
+        ### Worker (`roles/worker/`)
 
         | Sub-skill | One-liner | Used by |
         |---|---|---|
-        | `implement-tasks` | Task implementation flow | dev |
+        | `implement-tasks` | Task implementation flow | worker |
         """)
         out = cp.parse_catalog(catalog)
         assert out == {
@@ -95,7 +95,7 @@ class TestCleanParse:
             "pm-orphan-cleanup":
                 "references/sub-skills/roles/pm/pm-orphan-cleanup.md",
             "implement-tasks":
-                "references/sub-skills/roles/dev/implement-tasks.md",
+                "references/sub-skills/roles/worker/implement-tasks.md",
         }
 
     def test_slash_bearing_name_overrides_h2_directory(self, tmp_path):
@@ -121,23 +121,24 @@ class TestCleanParse:
         }
 
     def test_slash_bearing_name_under_role_h3(self, tmp_path):
-        """Live-catalog row at line 225 — `skill/finding-categories`
-        under `### QA (\`roles/qa/\`)` — uses the slash-name override
-        even when the H3 has its own role directory.
+        r"""Live-catalog row — ``skill/finding-categories`` under
+        ``### Verifier (\`roles/verifier/\`)`` — uses the slash-name
+        override even when the H3 has its own role directory.
         """
         catalog = _write_catalog(tmp_path, """
         ## `roles/<role>/` — Role-specific sub-skills
 
-        ### QA (`roles/qa/`)
+        ### Verifier (`roles/verifier/`)
 
         | Sub-skill | One-liner |
         |---|---|
-        | `verification` | E2E tests | QA |
-        | `skill/finding-categories` | Skill-domain finding taxonomy | QA |
+        | `verification` | E2E tests | Verifier |
+        | `skill/finding-categories` | Skill-domain finding taxonomy | Verifier |
         """)
         out = cp.parse_catalog(catalog)
         assert out == {
-            "verification": "references/sub-skills/roles/qa/verification.md",
+            "verification":
+                "references/sub-skills/roles/verifier/verification.md",
             # Slash-name overrides the H3 directory — it's an absolute
             # path under references/sub-skills/
             "skill/finding-categories":

--- a/tests/test_feat_9588_lazy_load_bootstrap.py
+++ b/tests/test_feat_9588_lazy_load_bootstrap.py
@@ -321,9 +321,9 @@ def test_tc_14_compose_runtime_read_frozenset_present():
     src = (SCRIPTS_DIR / "compose.py").read_text(encoding="utf-8")
     assert "RUNTIME_READ_FRAGMENTS = frozenset" in src
     required = [
-        "roles/dev/ralph-loop-overview",
+        "roles/worker/ralph-loop-overview",
         "roles/pm/ralph-loop-overview",
-        "roles/qa/ralph-loop-overview",
+        "roles/verifier/ralph-loop-overview",
         "roles/dm/ralph-loop-overview",
         "common-events/event-driven-workflow",
         "common-events/l1-base",


### PR DESCRIPTION
## Summary

Closes #10817. Renames catalog section headers and matching test fixtures to align with the post-#6274 `dev`→`worker` / `qa`→`verifier` filesystem layout. Unblocks E6 #10685 Phase 3c Path B's wizard.py migration to `deploy_role_v2`.

- `docs/sub-skill-catalog.md` — `### QA (roles/qa/)` → `### Verifier (roles/verifier/)`, `### Dev (roles/dev/)` → `### Worker (roles/worker/)`. Row keys updated to match.
- `tests/test_catalog_parser_d1.py` — parser fixtures renamed for consistency. Docstring SyntaxWarning silenced with `r"""`.
- `tests/test_feat_9588_lazy_load_bootstrap.py` — TC-14 `RUNTIME_READ_FRAGMENTS` audit (line 324-326) updated from `roles/dev/` + `roles/qa/` to `roles/worker/` + `roles/verifier/` to match the live frozenset.

## Scope deferred to #10818

`ROLE_TO_ENTRY` at line 36 still has the pre-#6274 mapping, and `.squidsquad/qa/CLAUDE.md` is stale (still references `roles/qa/ralph-loop-overview.md`). Fixing them is coupled: regenerating qa CLAUDE.md (+437 lines) trips TC-09's 200-line tolerance. Filed as #10818 — separate concern from catalog drift.

## Test plan

- [x] `python -m pytest tests/test_catalog_parser_d1.py` — 26/26 pass.
- [x] `tests/test_feat_9588_lazy_load_bootstrap.py::test_tc_14_compose_runtime_read_frozenset_present` passes.
- [x] No diff to live `.squidsquad/qa/CLAUDE.md` (kept stale on purpose; see #10818 for the regen path).
- [ ] QA confirms the v2 catalog gate now resolves `triage-issues` and `implement-tasks` to `roles/worker/...` (the gap that motivated #10817).