### PR TITLE
skill: fix test_no_orphan_sub_skills blind to '→ run sub-skill:' grammar (#10862)

### DIFF
--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -183,6 +183,21 @@ class TestManifestIntegrity:
                         ralph.relative_to(self.sub_skills_dir).as_posix()
                     )
 
+        # #10862: role instructions reference sub-skills via the
+        # ``→ run sub-skill: <name>`` directive grammar (per
+        # ``common/base-l1-instructions.md`` step-id contract). These
+        # references are resolved by compose at inline time, not via
+        # ``includes.yml``, so the manifest-only scan above doesn't see
+        # them. Walk every ``references/roles/**/instructions.md`` for
+        # the directive and mark any file whose stem matches the named
+        # sub-skill as referenced.
+        directive_names = self._collect_run_subskill_directive_names()
+        if directive_names:
+            for md_rel in all_md:
+                stem = Path(md_rel).stem
+                if stem in directive_names:
+                    referenced.add(md_rel)
+
         # #8697: common/event-reactions.md exists but isn't referenced by
         # any current role manifest. It's a sub-skill that may be wired in
         # for future event-driven needs; explicitly tolerate its
@@ -190,6 +205,29 @@ class TestManifestIntegrity:
         known_unused = {"common/event-reactions.md"}
         orphans = all_md - referenced - known_unused
         assert not orphans, f"Sub-skill files not referenced in manifest: {orphans}"
+
+    @staticmethod
+    def _collect_run_subskill_directive_names() -> set:
+        """Return the set of bare sub-skill names referenced via the
+        ``→ run sub-skill: <name>`` directive grammar in any
+        ``references/roles/**/instructions.md`` file.
+
+        The directive is the base-layer mechanism by which role
+        instructions point at a sub-skill that compose will inline; it
+        does NOT live in any ``includes.yml``. Names are bare kebab-case
+        identifiers (e.g. ``l4-curation``) — file resolution happens at
+        compose time across ``common/`` and ``roles/<role>/``.
+        """
+        roles_dir = REFERENCES_DIR / "roles"
+        if not roles_dir.exists():
+            return set()
+        directive_re = re.compile(r'→\s*run\s+sub-skill:\s*([A-Za-z0-9][\w-]*)')
+        names = set()
+        for instr in roles_dir.rglob("instructions.md"):
+            text = instr.read_text(encoding="utf-8")
+            for m in directive_re.finditer(text):
+                names.add(m.group(1))
+        return names
 
     def test_legacy_souls_namespace_gone(self):
         """Manifest must no longer reference a `souls/` include namespace."""


### PR DESCRIPTION
## Summary

- `test_no_orphan_sub_skills` was failing because `common/l4-curation.md` was reported as orphan even though every role's `instructions.md` references it via the base-layer directive grammar `→ run sub-skill: l4-curation`.
- The orphan detector only walked `includes.yml` files, so directive-based references were invisible.
- Fix extends the referenced-set computation to also scan every `references/roles/**/instructions.md` for `→ run sub-skill: <name>` directives. Any sub-skill file whose stem matches a captured name is treated as referenced.

Mirrors PR #10863's per-issue scoped helper pattern (small static helper + inline reference at the existing referenced-set merge point).

Closes #10862.

## Test plan

- [x] `tests/test_manifest.py` — 14/14 pass (was 13 passed + 1 fail on this test).
- [x] `tests/test_compose.py` — 103/104 pass; the 1 failure is the pre-existing `test_event_driven_workflow_has_no_frontmatter` slated for E6 Phase 5 D6 retirement, unrelated to this change.
- [x] Audit: confirmed via `git grep "→ run sub-skill:"` that `l4-curation` was the only directive name currently producing an orphan; all other directives (`agent-lifecycle`, `boot-bootstrap`, `git-commit`, etc.) are already covered by existing `includes.yml` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)