### PR TITLE
skill: add docs/sub-skill-catalog.md to compose-freshness inputs (#10762)

### DIFF
--- a/references/scripts/compose_freshness.py
+++ b/references/scripts/compose_freshness.py
@@ -57,6 +57,13 @@ COMPOSE_INPUT_GLOBS = (
     # L1-L3 source files — base roles + per-role-class subdirs +
     # variant subdirs (worker/skill etc.).
     "references/roles/**/*",
+    # Sub-skill catalog (#10762) — a genuine compose-time input:
+    # ``v2_catalog_gate.validate_v2_compose`` reads it to resolve
+    # ``→ run sub-skill: <name>`` references at v2 deploy time, and
+    # ``catalog_drift.scan_drift`` / ``compose.py drift-check`` (D4)
+    # read it for the drift CLI. Edits here MUST roll the source-tree
+    # checksum so E1 triggers a recompose at next harness boot.
+    "docs/sub-skill-catalog.md",
 )
 
 

--- a/tests/test_compose_freshness_e1.py
+++ b/tests/test_compose_freshness_e1.py
@@ -45,6 +45,10 @@ def _stage_minimal_repo(tmp_path):
     (repo / "references" / "roles" / "pm").mkdir()
     (repo / "references" / "roles" / "pm" / "instructions.md").write_text(
         "# pm instructions\n", encoding="utf-8")
+    # #10762: docs/sub-skill-catalog.md is a compose-time input.
+    (repo / "docs").mkdir()
+    (repo / "docs" / "sub-skill-catalog.md").write_text(
+        "# catalog\n", encoding="utf-8")
     return repo
 
 
@@ -81,6 +85,20 @@ class TestComputeChecksum:
         b = cf.compute_compose_checksum(repo)
         assert a != b, (
             "rename must roll the checksum (path is part of the hash)"
+        )
+
+    def test_catalog_change_rolls_checksum(self, tmp_path):
+        # #10762: docs/sub-skill-catalog.md is a genuine compose-time
+        # input (read by v2_catalog_gate + catalog_drift). Edits MUST
+        # roll the checksum so E1 triggers a recompose at boot.
+        repo = _stage_minimal_repo(tmp_path)
+        a = cf.compute_compose_checksum(repo)
+        (repo / "docs" / "sub-skill-catalog.md").write_text(
+            "# catalog v2\n", encoding="utf-8")
+        b = cf.compute_compose_checksum(repo)
+        assert a != b, (
+            "edits to docs/sub-skill-catalog.md must roll the source-"
+            "tree checksum so E1 triggers a recompose at next boot"
         )
 
     def test_unrelated_file_does_not_affect_checksum(self, tmp_path):


### PR DESCRIPTION
## Summary

- `docs/sub-skill-catalog.md` is a genuine compose-time input: read by `v2_catalog_gate.validate_v2_compose` on every `deploy_alias_v2` to resolve `→ run sub-skill: <name>` references, and by `catalog_drift.scan_drift` / `compose.py drift-check` for the D4 drift CLI.
- It was missing from `COMPOSE_INPUT_GLOBS` in `references/scripts/compose_freshness.py`, so edits to the catalog did not roll the E1 source-tree checksum. Effect: E1 thought boots were clean even when the catalog had changed (e.g. PM editing rows for #10743 catalog cleanup).
- Fix: append the catalog path to `COMPOSE_INPUT_GLOBS`. Regression test asserts the checksum rolls when the catalog content changes.

Closes #10762.

## Test plan

- [x] `tests/test_compose_freshness_e1.py` — 17/17 pass (was 16; added `test_catalog_change_rolls_checksum`).
- [x] Staged-repo helper `_stage_minimal_repo` now creates a `docs/sub-skill-catalog.md` so the new glob has a target. Existing tests (deterministic, content-change, rename, unrelated-file, all four `check_and_repair` AC6 scenarios, all six harness-wiring static-grep gates) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)