### PR TITLE
skill: fix boot_remote._get_all_roles missed #6274 rename (#10855)

### DIFF
--- a/references/scripts/boot_remote.py
+++ b/references/scripts/boot_remote.py
@@ -148,8 +148,13 @@ def _get_all_roles():
     is deleted and this line switches to `_parse_workers()`.
     """
     roles = set(_parse_dev_agents())
-    # Fixed team: PM + QA + DM always present (#6261)
-    roles.update({"pm", "qa", "dm"})
+    # Fixed team: PM + verifier + DM always present (#6261/#6274 D5: qa→verifier).
+    # Missed call-site from the #6274 rename — root cause for #10855
+    # (harness rejected ``/agents/verifier/start`` with ``Unknown role:
+    # verifier`` because the configured roster still listed ``qa``).
+    # config.py:_collect_install_agents already uses "verifier" (line 742);
+    # this brings boot_remote in sync.
+    roles.update({"pm", "verifier", "dm"})
     return sorted(roles)
 
 

--- a/tests/test_9242_harness_wedge_fixes.py
+++ b/tests/test_9242_harness_wedge_fixes.py
@@ -330,7 +330,7 @@ class TestHarnessRejectsUnknownRoleAtBoundary(unittest.TestCase):
 
         cls._roles_patch = mock.patch.object(
             _harness.boot_remote, "_get_all_roles",
-            return_value=["skill", "qa", "dm"],
+            return_value=["skill", "verifier", "dm"],
         )
         cls._roles_patch.start()
         cls._health_patch = mock.patch.object(_harness.state, "update_health")

--- a/tests/test_boot_remote.py
+++ b/tests/test_boot_remote.py
@@ -372,7 +372,7 @@ class TestBootAgentLock:
 
 
 class TestGetAllRoles:
-    @patch("boot_remote._parse_dev_agents", return_value=["skill", "qa"])
+    @patch("boot_remote._parse_dev_agents", return_value=["skill", "verifier"])
     @patch("boot_remote._parse_local_config", return_value={"skill": Path("/tmp")})
     def test_includes_pm_from_config(self, mock_local, mock_devs, tmp_path):
         config = tmp_path / "config.md"
@@ -383,16 +383,18 @@ class TestGetAllRoles:
             roles = boot_remote._get_all_roles()
             assert "pm" in roles
             assert "skill" in roles
-            assert "qa" in roles
+            assert "verifier" in roles
             assert "dm" in roles
 
     @patch("boot_remote._parse_dev_agents", return_value=["skill"])
     @patch("boot_remote._parse_local_config", return_value={"skill": Path("/tmp")})
     def test_mandatory_roles_always_present(self, mock_local, mock_devs):
-        """Fixed team: PM + QA + DM always present regardless of config (#6261)."""
+        """Fixed team: PM + verifier + DM always present regardless of config
+        (#6261/#6274 D5: qa→verifier — fixed #10855 missed call-site).
+        """
         roles = boot_remote._get_all_roles()
         assert "pm" in roles
-        assert "qa" in roles
+        assert "verifier" in roles
         assert "dm" in roles
         assert "skill" in roles
 


### PR DESCRIPTION
## Summary
- Root cause for #10855: `boot_remote._get_all_roles()` hardcoded `{"pm", "qa", "dm"}` as the fixed-team trio. Post-#6274 D5 rename (qa→verifier), `.local-config` writes `- **verifier**:` but the harness's role validator (`harness.py::_validate_role` via `_get_all_roles`) still listed `qa`. `/agents/verifier/start` returned 404; `/agents/qa/start` matched but fell back to REPO_ROOT (PM's clone) because `.local-config` has no `qa` entry — so qa spawns landed in PM's clone, idled, and never wrote `.claude-pid` or `current-state`.
- One-line fix: change the fixed-team trio to `{"pm", "verifier", "dm"}`. Mirrors `config.py:_collect_install_agents` (line 742, already renamed).
- Two test files updated (`test_boot_remote.py`, `test_9242_harness_wedge_fixes.py`) to assert the post-rename canonical form.
- 243 smoke tests pass / 1 skip; zero new regressions.

PM's parallel manual repair of `.harness-state.json` (option 1 in the #10855 cycle-2094 analysis — rename `qa`→`verifier` + fix `clone_path`) remains required for installs whose state file was corrupted in the cutover window. This code fix prevents the corruption from recurring on subsequent restarts.

## Test plan
- [x] `pytest tests/test_boot_remote.py tests/test_9242_harness_wedge_fixes.py tests/test_harness.py` — 243 pass, 1 skip
- [ ] Verifier QA verification of the fix once the harness state file is repaired

🤖 Generated with [Claude Code](https://claude.com/claude-code)