### PR TITLE
skill: cycle_post — surface silent commit-role-scoped failures (#10820)

### DIFF
--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -449,6 +449,58 @@ def _check_disposable_files():
         )
 
 
+def _warn_if_role_files_uncommitted(role, target_label):
+    """Verify ``commit-role-scoped`` actually committed the role's work (#10820).
+
+    ``git_ops.commit_role_scoped`` silently no-ops when an unresolved merge
+    blocks ``git commit``, or when the working tree is sitting on a branch
+    where the role's files can't be staged. The CLI shim has no exit-code
+    signal (its return value is ambiguous between "noop, nothing to commit"
+    and "tried and failed"), so we re-check the working tree post-call.
+
+    If role-owned files are still ``M`` in the working tree after
+    commit-role-scoped, emit a loud stderr WARNING with the file list — this
+    is the failure mode that stranded DM's SKILL.md doc fixes for 70+ cycles
+    before #10820 surfaced it.
+
+    Always prints the success line on stdout (we don't have a clean signal
+    to suppress it) but the WARNING on stderr is the loud one the operator
+    will actually notice.
+    """
+    print(f"  Committed and pushed{f' ({target_label})' if target_label else ''}")
+    try:
+        sys.path.insert(0, str(SCRIPT_DIR))
+        from git_ops import _role_owned_patterns, _path_matches
+    except Exception:
+        return
+    result = _run(["git", "status", "--porcelain"], check=False)
+    if result.returncode != 0 or not result.stdout.strip():
+        return
+    patterns = _role_owned_patterns(role)
+    stranded = []
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        path = line[3:].strip().strip('"')
+        if " -> " in path:
+            path = path.split(" -> ")[1]
+        if _path_matches(path, patterns):
+            stranded.append(path)
+    if stranded:
+        print(
+            f"WARNING (#10820): commit-role-scoped left {len(stranded)} role-owned "
+            f"file(s) uncommitted in the working tree for '{role}'. "
+            f"This is the silent-failure mode that stranded DM SKILL.md fixes "
+            f"for 70+ cycles. Likely cause: unresolved merge path or wrong "
+            f"branch. Stranded files:",
+            file=sys.stderr,
+        )
+        for f in stranded[:20]:
+            print(f"  {f}", file=sys.stderr)
+        if len(stranded) > 20:
+            print(f"  ... and {len(stranded) - 20} more", file=sys.stderr)
+
+
 def _do_commit_push(data, role):
     """Handle git commit and push operations."""
     _check_disposable_files()
@@ -551,12 +603,22 @@ def _do_commit_push(data, role):
         # #8691: scope commit to QA's domain so foreign uncommitted files
         # (other agents' work in the same clone) don't get bundled in.
         _run_script("git_ops.py", "commit-role-scoped", role, commit_msg)
-        print(f"  Committed and pushed (QA → main)")
+        _warn_if_role_files_uncommitted(role, "QA → main")
 
     else:
         # #8691: PM/DM/other roles also commit only their own domain.
+        # #10820: mirror the QA arm's pre-checkout — without this the DM
+        # arm could be sitting on a task branch (mid-cycle branch switches
+        # don't reliably bounce back) and commit-role-scoped would land
+        # the commit on the wrong branch.
+        working = _get_working_branch()
+        current = _run(["git", "branch", "--show-current"], check=False)
+        current_branch = current.stdout.strip() if current.returncode == 0 else ""
+        if current_branch != working:
+            _run(["git", "checkout", working], check=False)
+
         _run_script("git_ops.py", "commit-role-scoped", role, commit_msg)
-        print(f"  Committed and pushed")
+        _warn_if_role_files_uncommitted(role, working)
 
     # Commit state files to state branch if worktree exists (#3664)
     if _worktree_exists():

--- a/tests/test_cycle_post.py
+++ b/tests/test_cycle_post.py
@@ -2083,3 +2083,164 @@ class TestTaskModeLog:
         assert len(list(log_dir.glob("task-8701-*.md"))) == \
             cycle_post._TASK_LOG_RETENTION_PER_TASK
 
+
+# ---------------------------------------------------------------------------
+# #10820: DM/PM/other arm pre-checkout + _warn_if_role_files_uncommitted
+# ---------------------------------------------------------------------------
+
+class TestCommitPushDmArmPreCheckout:
+    """#10820 AC-4: DM/PM/other arm must checkout the working branch before
+    commit-role-scoped, mirroring the QA arm. Without this, a mid-cycle
+    branch switch (e.g. DM left on a task branch from doc-improvement-loop)
+    would land the commit on the wrong branch."""
+
+    def test_dm_arm_checks_out_working_branch_when_on_other_branch(self, monkeypatch):
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            # Simulate being on a stale task branch — `git branch --show-current`
+            # is what the arm uses to detect the mismatch.
+            if isinstance(cmd, list) and cmd[:3] == ["git", "branch", "--show-current"]:
+                r.stdout = "squidsquad/task/9999\n"
+            else:
+                r.stdout = ""
+            r.stderr = ""
+            return r
+
+        def fake_run_script(script, *args, **kwargs):
+            calls.append((script, args))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(cycle_post, "_run", fake_run)
+        monkeypatch.setattr(cycle_post, "_run_script", fake_run_script)
+        monkeypatch.setattr(cycle_post, "_get_working_branch", lambda: "develop")
+        monkeypatch.setattr(cycle_post, "_check_disposable_files", lambda: None)
+        monkeypatch.setattr(cycle_post, "_worktree_exists", lambda: False)
+        # _warn_if_role_files_uncommitted runs git status; stub to silent.
+        monkeypatch.setattr(cycle_post, "_warn_if_role_files_uncommitted",
+                            lambda role, label: None)
+
+        data = {
+            "cycle_type": "active",
+            "cycle_number": 10820,
+            "commit_message": "dm cycle test",
+        }
+        cycle_post._do_commit_push(data, "dm")
+
+        # Locate ['git', 'checkout', 'develop'] BEFORE the commit-role-scoped call.
+        commit_idx = next(
+            (i for i, c in enumerate(calls)
+             if isinstance(c, tuple) and c[0] == "git_ops.py"
+             and len(c[1]) >= 1 and c[1][0] == "commit-role-scoped"),
+            None,
+        )
+        assert commit_idx is not None, f"commit-role-scoped never invoked; calls={calls}"
+        checkout_idx = next(
+            (i for i, c in enumerate(calls[:commit_idx])
+             if isinstance(c, list) and c == ["git", "checkout", "develop"]),
+            None,
+        )
+        assert checkout_idx is not None, (
+            f"DM arm missing pre-checkout to working branch before commit-role-scoped; "
+            f"calls before commit: {calls[:commit_idx]}"
+        )
+
+    def test_dm_arm_skips_checkout_when_already_on_working_branch(self, monkeypatch):
+        """Don't issue a redundant checkout when already on the working branch."""
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            if isinstance(cmd, list) and cmd[:3] == ["git", "branch", "--show-current"]:
+                r.stdout = "develop\n"
+            else:
+                r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(cycle_post, "_run", fake_run)
+        monkeypatch.setattr(cycle_post, "_run_script",
+                            lambda *a, **kw: MagicMock(returncode=0, stdout="", stderr=""))
+        monkeypatch.setattr(cycle_post, "_get_working_branch", lambda: "develop")
+        monkeypatch.setattr(cycle_post, "_check_disposable_files", lambda: None)
+        monkeypatch.setattr(cycle_post, "_worktree_exists", lambda: False)
+        monkeypatch.setattr(cycle_post, "_warn_if_role_files_uncommitted",
+                            lambda role, label: None)
+
+        data = {"cycle_type": "active", "cycle_number": 1, "commit_message": "x"}
+        cycle_post._do_commit_push(data, "dm")
+
+        assert not any(c == ["git", "checkout", "develop"] for c in calls if isinstance(c, list)), (
+            f"Should not issue checkout when already on working branch; calls={calls}"
+        )
+
+
+class TestWarnIfRoleFilesUncommitted:
+    """#10820 AC-5: _warn_if_role_files_uncommitted re-checks the working tree
+    after commit-role-scoped and emits a stderr WARNING listing role-owned
+    files still M. Three observable cases must be covered."""
+
+    def test_stranded_role_owned_file_emits_warning(self, monkeypatch, capsys):
+        """Role-owned M file → WARNING (#10820) + file list on stderr."""
+        # DM owns SKILL.md per git_ops._role_owned_patterns. Simulate it left M.
+        status_output = " M SKILL.md\n M docs/foo.md\n"
+
+        def fake_run(cmd, **kwargs):
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = status_output if cmd == ["git", "status", "--porcelain"] else ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(cycle_post, "_run", fake_run)
+        cycle_post._warn_if_role_files_uncommitted("dm", "develop")
+        captured = capsys.readouterr()
+        assert "WARNING (#10820)" in captured.err
+        assert "SKILL.md" in captured.err
+        assert "docs/foo.md" in captured.err
+        # The success line still prints to stdout.
+        assert "Committed and pushed" in captured.out
+
+    def test_clean_working_tree_is_silent(self, monkeypatch, capsys):
+        """Empty `git status --porcelain` output → no WARNING."""
+        def fake_run(cmd, **kwargs):
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(cycle_post, "_run", fake_run)
+        cycle_post._warn_if_role_files_uncommitted("dm", "develop")
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.err
+        assert captured.err == ""
+        # The success line still prints (the function's first action).
+        assert "Committed and pushed" in captured.out
+
+    def test_non_role_owned_modifications_are_silent(self, monkeypatch, capsys):
+        """M files outside the role's owned patterns → no WARNING.
+
+        DM owns SKILL.md / docs/ / .squidsquad/dm/ / config.md but NOT
+        arbitrary source paths like src/foo.py — those belong to the skill
+        worker's PR flow, not DM's domain commit.
+        """
+        status_output = " M src/foo.py\n M tests/test_bar.py\n"
+
+        def fake_run(cmd, **kwargs):
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = status_output if cmd == ["git", "status", "--porcelain"] else ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(cycle_post, "_run", fake_run)
+        cycle_post._warn_if_role_files_uncommitted("dm", "develop")
+        captured = capsys.readouterr()
+        assert "WARNING" not in captured.err
+        assert captured.err == ""


### PR DESCRIPTION
## Summary
- DM-filed bug: SKILL.md R74 doc fixes have been stuck `M` in DM's working tree for 70+ cycles. `cycle_post.py` prints "Committed and pushed" each cycle but no SKILL.md commit ever lands on `main` (per DM cycle 1816 forensics on the issue thread).
- Root cause: `commit_role_scoped` returns False for BOTH noop and tried-but-failed cases (ambiguous), and the CLI shim discards the return value. Plus the DM/PM/other arm in `cycle_post` doesn't pre-checkout the working branch (the QA arm does).
- This fix adds a post-call `_warn_if_role_files_uncommitted(role, ...)` helper that re-checks `git status --porcelain` after `commit-role-scoped`. If any role-owned files (per `git_ops._role_owned_patterns`) are still `M`, it emits a loud stderr WARNING listing the stranded files. Plus the DM/PM/other arm now mirrors the QA arm's pre-checkout.
- 224 smoke tests pass; the 1 failure is a pre-existing `.backlog-cache` gitignore noise unrelated to this change.

**What this does NOT fix** (separate concerns out of #10820 scope): the `commit_role_scoped` return-value contract change (would break 5+ existing tests asserting `result is False` for empty-status), `.claude/scheduled_tasks.lock` gitignore, and a `cycle_pre.py` pre-flight merge-state check. The post-check above gives operators the loud signal without changing function semantics. If recurrence proves operationally costly, the pre-flight check is a follow-up.

DM's stranded SKILL.md commits in the operator's clones still need a one-shot manual resolution (resolve the merge conflict, rebase off the stale branch). After that, subsequent cycles will commit cleanly and the post-check WARNING shows nothing.

## Test plan
- [x] `pytest tests/test_cycle_post.py tests/test_git_ops.py` — 224 pass / 1 pre-existing failure
- [ ] DM verifier verification once the operator's stale-branch state is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)