### PR TITLE
fix #11066: update test_corrupted_l4_aborts_with_parse_error for post-#10987 prose-H3 routing

### DIFF
--- a/tests/test_a3_golden_link_stage.py
+++ b/tests/test_a3_golden_link_stage.py
@@ -128,18 +128,26 @@ def test_fixture_worker_fe_has_l3_subtree():
 # ---------------------------------------------------------------------------
 
 def test_corrupted_l4_aborts_with_parse_error(tmp_path):
-    """AC: 'corrupted L4 op → compose aborts (does not silently produce drift)'."""
+    """AC: 'corrupted L4 op → compose aborts (does not silently produce drift)'.
+
+    #11066: post-#10987 the parser routes non-op-like H3 headings into the
+    prose-append path (so doc-style sub-headings like ``### Worker``
+    survive a link-stage build instead of erroring). The corrupted L4
+    fixture must use an *op-like-but-malformed* H3 to still exercise
+    the parse-error path. ``### replace garbage`` matches the op-keyword
+    grammar at ``_OP_LIKE_RE`` but fails the full ``_OP_RE`` parse at
+    ``l4_parser.py:_parse_h3_op``, which raises ``L4ParseError`` — the
+    aborts-on-corruption semantics the test was written to guard.
+    """
     # Copy the pm fixture into a tmp tree so we can mutate it safely.
     src = FIXTURES / "pm"
     shutil.copytree(src, tmp_path / "pm")
     bad_root = tmp_path / "pm"
     l4_path = bad_root / ".squidsquad" / "project" / "pm.md"
-    # Corrupt: introduce an H3 line that does NOT match any legal op
-    # grammar. A2b's parser rejects this with L4ParseError.
     l4_path.write_text(
         "## Instructions\n\n"
-        "### frobnicate step:cycle/work\n\n"
-        "Not a legal op heading.\n",
+        "### replace garbage\n\n"
+        "Not a legal op heading — `replace` is op-like but the rest is malformed.\n",
         encoding="utf-8",
     )
     with pytest.raises(L4ParseError):


### PR DESCRIPTION
Closes #11066.

## Root cause

`tests/test_a3_golden_link_stage.py::test_corrupted_l4_aborts_with_parse_error` writes an L4 file with `### frobnicate step:cycle/work` and expects `v2_link_stage.emit_v2_linked` to raise `L4ParseError`. After #10987 made `l4_parser.py:212` route non-op-like H3 headings into the prose-append path (to let doc-style sub-headings like `### Worker` survive a link-stage build instead of erroring), `frobnicate` isn't a reserved op keyword → falls into the prose path → no error raised → `DID NOT RAISE`.

## Fix

Replace the fixture's H3 with `### replace garbage`. `replace` matches `_OP_LIKE_RE`'s op-keyword grammar so the parser commits to parsing the line as an op, but the rest of the heading fails the full `_OP_RE` match at `_parse_h3_op` (line 238), which raises `L4ParseError` as the test intends. The "aborts on corruption" semantics the test was written to guard are preserved against the surviving error path.

The sibling `test_corrupted_l4_does_not_silently_match_golden` keeps the `### frobnicate` fixture intentionally — its assertion `actual != golden` holds correctly via the prose-append path that #10987 added, so it ALSO exercises a useful invariant (malformed-prose-shaped H3 is reflected in the output, not silently dropped).

## AC verification

- [x] `tests/test_a3_golden_link_stage.py` — 8/8 PASS (was 7/8 pre-fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)