### PR TITLE
fix #11047: TC-07 doc path stale — re-point at consolidated AGENT-RUNTIME.md

### DIFF
--- a/tests/test_feat_9415_event_id_widening_live.py
+++ b/tests/test_feat_9415_event_id_widening_live.py
@@ -120,7 +120,12 @@ def test_tc_06_event_poll_treats_ids_as_opaque_strings():
 
 # TC-7
 def test_tc_07_docs_event_bus_no_stale_8_char_references():
-    doc = (DOCS_DIR / "EVENT-BUS-ARCHITECTURE.md").read_text(encoding="utf-8")
+    """#11047: ``docs/EVENT-BUS-ARCHITECTURE.md`` was consolidated into
+    ``docs/AGENT-RUNTIME.md`` by commit 4012500fc ("pm: consolidate
+    event/runtime docs"); this test was missed in that move. Re-point
+    at the surviving document and keep the same #9415 invariants.
+    """
+    doc = (DOCS_DIR / "AGENT-RUNTIME.md").read_text(encoding="utf-8")
     # No "8 hex char" / "8-char" / "32-bit" claims about event ids.
     forbidden = [
         r"\b8[- ]?hex[- ]?(char|character|digit)",
@@ -132,12 +137,12 @@ def test_tc_07_docs_event_bus_no_stale_8_char_references():
     for pat in forbidden:
         m = re.search(pat, doc, re.IGNORECASE)
         assert m is None, (
-            f"EVENT-BUS-ARCHITECTURE.md contains stale 8-char reference "
+            f"AGENT-RUNTIME.md contains stale 8-char reference "
             f"matching /{pat}/: {m.group(0) if m else ''!r}"
         )
     # Positive marker: the new width or nonce should be reflected.
     assert ("16" in doc and "hex" in doc.lower()) or "nonce" in doc.lower(), (
-        "EVENT-BUS-ARCHITECTURE.md should reference 16-char width or nonce "
+        "AGENT-RUNTIME.md should reference 16-char width or nonce "
         "after #9415 widening"
     )
 


### PR DESCRIPTION
Closes #11047.

The issue body called this a "stale 8-char event_id references in docs/event-bus.md" sweep. Actual failure mode turned out different: the file no longer exists.

## Root cause

Commit `4012500fc` ("pm: consolidate event/runtime docs into docs/AGENT-RUNTIME.md") moved `docs/EVENT-BUS-ARCHITECTURE.md` contents into `docs/AGENT-RUNTIME.md`. `tests/test_feat_9415_event_id_widening_live.py::test_tc_07_docs_event_bus_no_stale_8_char_references` was not updated in that consolidation; it reads from the pre-consolidation path and hits `FileNotFoundError`.

## Fix

Single-line path change: `EVENT-BUS-ARCHITECTURE.md` → `AGENT-RUNTIME.md`. The #9415 invariants (no `8-char` / `32-bit` / `os.urandom(4)` / `hexdigest()[:8]` claims about event ids + a positive 16-char-or-nonce marker) survive unchanged because the consolidated doc carries the post-#9415 vocabulary already — line 369 has `sha256(...)[:16] — 16-char hex (64-bit, per #9415)`. Docstring captures the consolidation history for the next reader.

## AC verification

- [x] `tests/test_feat_9415_event_id_widening_live.py`: **8/8 PASS** (was 7/8 pre-fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)