### PR TITLE
fix #11046: rebind TestAc6M62ManifestWiring fixture to post-cutover unified includes.yml

### DIFF
--- a/tests/test_event_mode_fragments.py
+++ b/tests/test_event_mode_fragments.py
@@ -158,17 +158,25 @@ class TestAc7TopicCoverage:
 
 
 class TestAc6M62ManifestWiring:
-    """AC-6 M-6.2 (post-#9588): the event-mode L1 base fragment + its four
-    supporting common-events fragments must reach the agent at runtime via
-    the boot bootstrap, NOT via compose-time inlining.
+    """AC-6 M-6.2 (post-#9588 + post-E6 cutover #10999): the event-mode L1
+    base fragment + its four supporting common-events fragments must reach
+    the agent at runtime via the boot bootstrap, NOT via compose-time
+    inlining.
 
     #9588 swapped the wiring mechanism: instead of every event-mode manifest
     listing all six common-events fragments and the template having matching
     `{{include:}}` directives, the manifest now contains `common/boot-bootstrap`
     only, and the bootstrap's content carries `Read references/sub-skills/
     common-events/<name>.md` directives that fire when the agent boots in
-    event mode. The previous compose-time-inline contract (#8915) is the old
-    contract; this class enforces the new one.
+    event mode.
+
+    #11046: post-E6 cutover (#10999, commit 1050bfe0) consolidated the v1
+    polling/event manifest split (``includes.yml`` + ``includes-events.yml``)
+    into a single mode-agnostic ``includes.yml`` per role. The per-role
+    ``includes-events.yml`` files are GONE — wake mode is a runtime
+    concern handled by ``common/boot-bootstrap`` at session start. This
+    fixture and the manifest test rebind from the retired file to the
+    surviving unified manifest. The wiring contract is unchanged.
     """
 
     REQUIRED_COMMON_EVENTS = [
@@ -184,11 +192,13 @@ class TestAc6M62ManifestWiring:
 
     @pytest.fixture(scope="class")
     def includes_by_role(self):
+        """#11046: switched from the retired ``includes-events.yml`` to the
+        post-cutover unified ``includes.yml``."""
         import yaml
         roles_dir = REPO_ROOT / "references" / "roles"
         out = {}
         for role in self.ROLES:
-            path = roles_dir / role / "includes-events.yml"
+            path = roles_dir / role / "includes.yml"
             assert path.exists(), f"missing manifest: {path}"
             data = yaml.safe_load(path.read_text(encoding="utf-8"))
             out[role] = data.get("includes", [])
@@ -212,7 +222,7 @@ class TestAc6M62ManifestWiring:
         are Read at runtime by the bootstrap instead."""
         includes = includes_by_role[role]
         assert "common/boot-bootstrap" in includes, (
-            f"references/roles/{role}/includes-events.yml must list "
+            f"references/roles/{role}/includes.yml must list "
             f"`common/boot-bootstrap` — #9588 made it the manifest entry "
             f"that gets the agent into event mode (or fallback polling)."
         )


### PR DESCRIPTION
Closes #11046.

## Architectural call

The issue body asked PM to decide between "event-mode is retired (delete the test class)" or "event-mode is dormant (restore the manifests)". Neither is right after re-reading the cutover commit + current `includes.yml` files. The post-E6 picture:

- **Event-mode runtime concept**: still active. `common/boot-bootstrap.md` detects polling vs event mode at session start (per #9588's lazy-load contract). The 6 `common-events/*` fragments are still `Read` at runtime by the bootstrap when event mode binds.
- **Per-role `includes-events.yml` manifest files**: retired. E6 cutover (#10999 / commit `1050bfe0`) consolidated the v1 polling/event manifest split into a single mode-agnostic `includes.yml` per role. Wake mode is a runtime concern handled by `boot-bootstrap`, not a compose-time concern.

So the test's intent (each role's manifest lists `common/boot-bootstrap`; bootstrap.md references each `common-events/*` fragment; DM's bootstrap also references `pr-merge-wait`) is unchanged — only the file the fixture opens needs to point at the surviving unified manifest.

## Change

`tests/test_event_mode_fragments.py::TestAc6M62ManifestWiring` — single-file fixture path update:

- `includes_by_role` fixture: `includes-events.yml` → `includes.yml`. Schema is identical (yaml dict with `includes:` key); only the filename changed in the cutover. Confirmed by reading `references/roles/{worker,pm,verifier,dm}/includes.yml` — all four list `common/boot-bootstrap` as the first include per #9588's lazy-load contract.
- Class docstring updated to capture the #11046 rebinding alongside the #9588 swap.
- `bootstrap_text` fixture and the `test_bootstrap_references_*` tests unchanged — they were already content-only and survived the cutover.

## AC verification

- [x] `tests/test_event_mode_fragments.py`: **72/72 PASS** (was 60 passed / 4 errors at setup of the `includes_by_role` fixture + the 8 manifest-dependent parametrizations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)