### PR TITLE
skill: #11091 — Add Improvement Scan Cool-Down config field (30-min default)

### DIFF
--- a/.squidsquad/config.md
+++ b/.squidsquad/config.md
@@ -61,6 +61,7 @@
 ## Improvement Scanning
 
 - **Enabled**: yes
+- **Improvement Scan Cool-Down**: 30
 
 ## Vault Optimize
 

--- a/references/scripts/config.py
+++ b/references/scripts/config.py
@@ -63,6 +63,7 @@ FIELD_MAP = {
     "context-threshold": ("Context Pressure", "Threshold"),
     "pr-flow": ("PR Flow", "Enabled"),
     "improvement-scanning": ("Improvement Scanning", "Enabled"),
+    "improvement-scan-cool-down": ("Improvement Scanning", "Improvement Scan Cool-Down"),  # #11091
     "ship-threshold": ("Auto Versioning", "Ship Threshold"),
     "shipped-since-bump": ("Auto Versioning", "Shipped Since Last Bump"),
     "alias-skill": ("Aliases", "skill"),
@@ -165,6 +166,8 @@ def _parse_all(text):
 # Fields that default to a value when absent from config.md (rather than exiting)
 _FIELD_DEFAULTS = {
     "event-driven": "no",
+    # #11091 — minutes between idle improvement-scans (event-mode cool-down loop)
+    "improvement-scan-cool-down": "30",
 }
 
 

--- a/references/scripts/wizard.py
+++ b/references/scripts/wizard.py
@@ -731,6 +731,15 @@ def build_config_md(spec):
         lines.append("- (none)")
     lines.append("")
 
+    # --- ## Improvement Scanning ---
+    # #11091 — cool-down field for event-mode idle scan loop. Default 30 min
+    # matches Iteration Interval > Minutes so cool-down semantically equals
+    # "at most one improvement scan per iteration cycle" even in event mode.
+    lines.append("## Improvement Scanning")
+    lines.append("")
+    lines.append("- **Improvement Scan Cool-Down**: 30")
+    lines.append("")
+
     # --- ## Git Branches ---
     lines.append("## Git Branches")
     lines.append("")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -189,6 +189,47 @@ class TestGetField:
 
 
 # ---------------------------------------------------------------------------
+# Improvement Scan Cool-Down field default (#11091)
+# ---------------------------------------------------------------------------
+
+class TestImprovementScanCoolDownDefault:
+    """#11091 — `improvement-scan-cool-down` falls back to '30' when absent."""
+
+    def test_default_when_field_absent(self, tmp_path):
+        # Section exists with only Enabled; cool-down field omitted (pre-#11091 install)
+        text = (
+            "## Improvement Scanning\n\n"
+            "- **Enabled**: yes\n"
+        )
+        f = tmp_path / "config.md"
+        f.write_text(text, encoding="utf-8")
+        with patch.object(config, "CONFIG_PATH", f):
+            assert config.get_field("improvement-scan-cool-down") == "30"
+
+    def test_default_when_section_absent(self, tmp_path):
+        # Entire section missing (truly minimal install)
+        f = tmp_path / "config.md"
+        f.write_text("# Config\n\n- **SquidSquad Version**: 0.0.0\n", encoding="utf-8")
+        with patch.object(config, "CONFIG_PATH", f):
+            assert config.get_field("improvement-scan-cool-down") == "30"
+
+    def test_explicit_value_overrides_default(self, tmp_path):
+        text = (
+            "## Improvement Scanning\n\n"
+            "- **Enabled**: yes\n"
+            "- **Improvement Scan Cool-Down**: 45\n"
+        )
+        f = tmp_path / "config.md"
+        f.write_text(text, encoding="utf-8")
+        with patch.object(config, "CONFIG_PATH", f):
+            assert config.get_field("improvement-scan-cool-down") == "45"
+
+    def test_field_in_defaults_registry(self):
+        # Lock the contract — _FIELD_DEFAULTS must carry the cool-down key
+        assert config._FIELD_DEFAULTS["improvement-scan-cool-down"] == "30"
+
+
+# ---------------------------------------------------------------------------
 # set_field — happy path (#4879)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -600,10 +600,17 @@ class TestBuildConfigMdStructure:
             "## Tools",
             "## Loop",
             "## Flags",
+            "## Improvement Scanning",  # #11091
             "## Git Branches",
             "## Forge Backend",
             "## Model Routing",
         ]
+
+    def test_improvement_scanning_section_carries_cool_down(self):
+        """#11091 — wizard emits cool-down field with 30-min default."""
+        text = wizard.build_config_md(_minimal_spec())
+        assert "## Improvement Scanning" in text
+        assert "- **Improvement Scan Cool-Down**: 30" in text
 
     def test_header_includes_version_and_architecture(self):
         text = wizard.build_config_md(_minimal_spec())


### PR DESCRIPTION
Closes #11091

### Summary

Adds the `Improvement Scan Cool-Down` config field with a 30-minute default. Closes Gap 1 of #11090 (QA end-to-end v2 event-mode audit). Without this field, `references/sub-skills/common-events/idle-cooldown-loop.md` cannot compute `Next scan after` for event-mode agents — the gap is latent today but activates the moment any role's `event-driven-<role>: yes` lands in `config.md`.

### Acceptance Criteria

- [x] AC1: `python references/scripts/config.py get "improvement-scan-cool-down"` returns `30` on fresh install OR when the field is absent in an existing install
- [x] AC2: `wizard.py` generates `## Improvement Scanning` with the cool-down field on a fresh `build-config-md` invocation
- [x] AC3: `.squidsquad/config.md` in this repo contains the new field at value `30` under `## Improvement Scanning`
- [x] AC4: `idle-cooldown-loop.md` references resolve — agent reading the sub-skill can resolve the cool-down value via the config getter without error (prose unchanged; existing wording already names the field)
- [x] AC5: Existing test suite continues to pass — full suite 2561 PASS / 15 pre-existing failures unchanged (verified by baseline `git stash` run on the same touched test files)

### Changes

- **`references/scripts/config.py`** — adds `improvement-scan-cool-down → ("Improvement Scanning", "Improvement Scan Cool-Down")` to `FIELD_MAP`, and `"improvement-scan-cool-down": "30"` to `_FIELD_DEFAULTS` (mirrors the existing `event-driven: "no"` default pattern).
- **`references/scripts/wizard.py`** — inserts a new `## Improvement Scanning` section between `## Flags` and `## Git Branches` containing `- **Improvement Scan Cool-Down**: 30`. v2 schema's existing `## Flags` continues to carry the boolean `improvement_scan` enable flag; the cool-down (non-boolean duration) gets its own dedicated section as PM specified in AC2.
- **`.squidsquad/config.md`** — adds the field under the existing `## Improvement Scanning` section (v1 schema).
- **`tests/test_config.py`** — new `TestImprovementScanCoolDownDefault` class with 4 cases: default when field absent, default when section absent, explicit value override, registry lock.
- **`tests/test_wizard.py`** — updates `test_section_order_matches_spec` to include the new section, adds `test_improvement_scanning_section_carries_cool_down`.

### Why

- 30-min default matches `Iteration Interval > Minutes` — semantically "at most one improvement scan per iteration cycle" even when an agent is otherwise event-driven, per PM's locked design call in the issue body.
- Hybrid Flags+section approach respects both schemas without bleeding into the v1↔v2 FIELD_MAP gap that `improvement-scanning` separately has.

### Verifier Notes

- [ ] AC1-AC5 all pass
- [ ] Full test suite unchanged from baseline (only 15 pre-existing failures, none related to config/wizard)
- [ ] `python references/scripts/config.py get improvement-scan-cool-down` returns `30` post-merge
- [ ] No test pollution — the conftest session-scoped `_snapshot_restore_live_config_md` fixture (added in #11044) snapshots the current state at suite start and restores after; the snapshot now includes the new field so re-running the suite preserves it