### PR TITLE
skill: #11403 — declare + provision harness runtime deps

### DIFF
--- a/references/installer-files.txt
+++ b/references/installer-files.txt
@@ -1,7 +1,7 @@
 # SquidSquad installer file manifest
 # Every file the wizard needs, fetched by npx squidsquad before
 # launching Claude. One path per line, relative to repo root.
-# Total: 182 files
+# Total: 183 files
 #
 # Maintained alongside the wizard - when you add a new role,
 # capability, preset, or sub-skill, add its files here too.
@@ -207,3 +207,7 @@ references/sub-skills/roles/worker/ralph-loop-overview.md
 references/sub-skills/roles/verifier/ralph-loop-overview.md
 references/sub-skills/roles/pm/ralph-loop-overview.md
 references/sub-skills/roles/dm/ralph-loop-overview.md
+
+# Harness runtime dependency manifest (#11403) — seeded so the wizard's
+# Step 7.5b `pip install -r requirements.txt` provisioning step can run.
+requirements.txt

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -607,7 +607,13 @@ class HarnessState:
             try:
                 new_observer, new_debouncer = starter()
             except Exception as e:
-                _log(f"L4 file-watcher start failed: {e!r}")
+                # #11403 AC3: surface the remediation in plain text (str, not
+                # repr) and name the operator impact, so a missing `watchdog`
+                # dependency is actionable rather than buried in a traceback
+                # repr. The harness still degrades gracefully (returns
+                # "start-failed"); only L4 auto-recompose is disabled.
+                _log(f"WARNING: L4 file-watcher start failed — PRD-E E3 "
+                     f"auto-recompose on L4 edits is DISABLED this run. {e}")
                 return "start-failed"
             self._l4_observer = new_observer
             self._l4_debouncer = new_debouncer

--- a/references/wizard/WIZARD.md
+++ b/references/wizard/WIZARD.md
@@ -662,6 +662,23 @@ git push
 Push is optional but recommended — the user can opt out with a one-
 line prompt if you're unsure.
 
+### 7.5b — Install harness Python dependencies (#11403)
+
+The harness and its subsystems need a few Python packages — FastAPI +
+uvicorn for the HTTP server (hard requirements; the harness exits without
+them) and `watchdog` for PRD-E E3 L4 auto-recompose. They are declared in
+`requirements.txt` (seeded with the install). Install them:
+
+```bash
+pip install -r requirements.txt
+```
+
+If `pip` is unavailable or the install fails, do NOT roll back — the on-disk
+`.squidsquad/` is valid; this is a provisioning step the user can retry. Tell
+them plainly that the harness will not start until the deps are installed, and
+show the exact command. (Without `watchdog` specifically, the harness still
+boots but L4 auto-recompose is silently disabled — see #11403.)
+
 ### 7.6 — Print the "ready" message and exit
 
 Print exactly this (adjust the boot command per OS):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+# SquidSquad harness runtime dependencies (#11403).
+#
+# These are required to RUN the harness (references/scripts/harness.py) and its
+# subsystems. Install with:  pip install -r requirements.txt
+#
+# Dev/test-only dependencies (pytest, etc.) live in requirements-dev.txt and are
+# NOT needed to run a SquidSquad install.
+#
+# Drift guard: tests/test_runtime_requirements.py asserts every top-level
+# third-party import the harness needs at runtime is declared here.
+
+fastapi>=0.100.0      # harness HTTP server (hard requirement — harness exits without it)
+starlette>=0.27.0     # imported directly (harness.py JSONResponse); fastapi's tighter pin governs resolution
+uvicorn>=0.23.0       # ASGI server that runs the FastAPI app (hard requirement)
+watchdog>=3.0.0       # PRD-E E3 L4 file-watch Observer (auto-recompose on L4 edit)

--- a/tests/test_runtime_requirements.py
+++ b/tests/test_runtime_requirements.py
@@ -1,0 +1,109 @@
+"""Drift guard: requirements.txt must declare every runtime third-party
+import the harness needs (#11403 AC4).
+
+Static (``ast``-based) — does NOT import the harness or its dependencies, so
+it runs even when watchdog / fastapi / uvicorn are not installed (which is the
+exact failure mode #11403 fixes). It catches a NEW third-party import added to
+the harness runtime surface without a matching requirements.txt entry.
+"""
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO_ROOT / "references" / "scripts"
+REQUIREMENTS = REPO_ROOT / "requirements.txt"
+
+# Harness runtime modules to scan: the server itself plus the L4 file-watch
+# subsystem it supervises (watchdog is lazily imported there, not in harness.py
+# directly — but it IS a harness runtime dependency).
+RUNTIME_MODULES = ["harness.py", "l4_file_watcher.py"]
+
+# import-name -> distribution-name for the rare cases they differ. Our current
+# deps all match their import name; the hook keeps the guard correct if e.g.
+# a module imported as `yaml` (dist `pyyaml`) ever becomes a harness runtime
+# dependency.
+IMPORT_TO_DIST = {
+    "yaml": "pyyaml",
+}
+
+
+def _local_module_names() -> set[str]:
+    """Module names that resolve to local references/scripts/ files."""
+    return {p.stem for p in SCRIPTS.glob("*.py")}
+
+
+def _imported_top_modules(path: Path) -> set[str]:
+    """Top-level module names imported anywhere in `path` — including guarded
+    (try/except) and lazy (in-function) imports, which ``ast.walk`` reaches."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    mods: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                mods.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            # Absolute imports only (level == 0); relative imports are local.
+            if node.level == 0 and node.module:
+                mods.add(node.module.split(".")[0])
+    return mods
+
+
+def _declared_dists() -> set[str]:
+    dists: set[str] = set()
+    for raw in REQUIREMENTS.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        name = re.split(r"[<>=!~ \[]", line, 1)[0].strip().lower()
+        if name:
+            dists.add(name)
+    return dists
+
+
+def _third_party_imports() -> set[str]:
+    local = _local_module_names()
+    stdlib = set(sys.stdlib_module_names)  # py3.10+
+    third: set[str] = set()
+    for module_file in RUNTIME_MODULES:
+        for mod in _imported_top_modules(SCRIPTS / module_file):
+            if mod in stdlib or mod in local or mod.startswith("_"):
+                continue
+            third.add(mod)
+    return third
+
+
+def test_requirements_txt_exists():
+    assert REQUIREMENTS.exists(), (
+        "requirements.txt (runtime deps) is missing — #11403 declares the "
+        "harness runtime dependencies there."
+    )
+
+
+def test_runtime_third_party_imports_are_declared():
+    """Every third-party import on the harness runtime surface must be
+    declared in requirements.txt. Fails loudly on drift."""
+    declared = _declared_dists()
+    missing = []
+    for mod in sorted(_third_party_imports()):
+        dist = IMPORT_TO_DIST.get(mod, mod).lower()
+        if dist not in declared:
+            missing.append(f"{mod} (distribution: {dist})")
+    assert not missing, (
+        "Harness runtime imports not declared in requirements.txt: "
+        + ", ".join(missing)
+        + ". Add them to requirements.txt (or extend IMPORT_TO_DIST if the "
+        "import name differs from the PyPI distribution name)."
+    )
+
+
+def test_known_harness_deps_present():
+    """Explicit pin: the three deps #11403 declared must stay declared."""
+    declared = _declared_dists()
+    for required in ("fastapi", "uvicorn", "watchdog"):
+        assert required in declared, (
+            f"{required} missing from requirements.txt — it is a harness "
+            "runtime dependency (#11403)."
+        )


### PR DESCRIPTION
## Summary

Declares and provisions the harness runtime dependencies, closing #11403 (new-arch readiness **Gate 3**). The harness deps (`fastapi`, `uvicorn`, `watchdog`) were undeclared in any manifest — so a fresh install's **PRD-E E3 L4 file-watch auto-recompose silently dies** when `watchdog` is absent (surfaced during the #11331 Monitor e2e).

Bases on `main` — independent of the polish bundle.

## ACs

- **AC1** — `requirements.txt` (runtime, separate from `requirements-dev.txt`) declares `fastapi`, `starlette`, `uvicorn`, `watchdog`. `starlette` is imported directly (`harness.py:2264`) and was caught by the AC4 drift guard, so it's declared explicitly rather than relied on transitively.
- **AC2** — `requirements.txt` added to `references/installer-files.txt` (the npx CLI seeds it); `WIZARD.md` Step 7.5b provisions it via `pip install -r requirements.txt` after the on-disk install exists, with graceful-failure guidance. The INSTALLER-ARCH TRD §dependency-provisioning is PM-owned → cross-filed.
- **AC3** — the `watchdog`-missing message now logs in plain text (str, not repr) with a `WARNING:` prefix + operator impact ("L4 auto-recompose DISABLED this run"), instead of burying the `pip install watchdog` remediation in a `RuntimeError` repr.
- **AC4** — `tests/test_runtime_requirements.py`: a static (`ast`) drift guard asserting every third-party import on the harness runtime surface (`harness.py` + `l4_file_watcher.py`) is declared in `requirements.txt`. Runs **without** the deps installed (the exact failure mode), so it catches future undeclared imports.

## Test plan

- [ ] `pytest tests/test_runtime_requirements.py tests/test_installer_wiring.py` green (25 passing)
- [ ] Verifier: confirm `pip install -r requirements.txt` resolves cleanly
- [ ] Verifier: with `watchdog` uninstalled, harness boots and logs the AC3 WARNING; L4 file-watch is the only disabled subsystem
- [ ] PM: INSTALLER-ARCH §dependency-provisioning doc (cross-filed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)