### PR TITLE
skill: #11404 — POST /events id auto-assign + 204 drop contract

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -1952,6 +1952,18 @@ async def receive_event(request: Request):
     """Receive an event from an agent mechanical script.
 
     Stores in bounded stream, updates AgentState, logs to console.
+
+    Response contract (#11404):
+    - Missing ``event_type`` or ``role`` → ``400`` (hard reject).
+    - ``role`` not in the install's registered aliases (+ ``pm``) → ``204 No
+      Content``. This is an INTENTIONAL silent fire-and-forget drop (#9242):
+      the event is NOT stored, yet the caller still sees a 2xx. The internal
+      ``_emit_event`` path bypasses this guard, so production emits are
+      unaffected; a direct HTTP caller with a bad role is dropped on purpose
+      to keep malformed roles out of ``.event-state.json``.
+    - Otherwise stored with ``200``. If the body omits ``id``, one is
+      auto-assigned (#11404 AC1) so the event cannot be silently skipped by
+      id-tracking consumers (``event_poll`` skips id-less events).
     """
     body = await request.json()
 
@@ -1987,6 +1999,14 @@ async def receive_event(request: Request):
 
     # Stamp received_at for ordering (#5622)
     body["received_at"] = time.time()
+
+    # #11404 AC1: auto-assign an id when the caller omits one. event_poll and
+    # every consumer skip id-less events (the cursor cannot track them), so an
+    # id-less POST would be stored at 200 yet silently never delivered. Match
+    # the 16-hex shape _emit_event uses (#9415 D4) so both append paths produce
+    # the same id width.
+    if not body.get("id"):
+        body["id"] = os.urandom(8).hex()
 
     # Store in stream (with disk persistence via lifecycle manager)
     event_lifecycle.append(body)

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1123,6 +1123,42 @@ class TestEndpointsViaTestClient(unittest.TestCase):
         data = resp.json()
         self.assertIn("agents", data)
 
+    def test_post_events_assigns_id_when_missing(self):
+        """#11404 AC1: POST /events with no `id` auto-assigns a 16-hex id so
+        id-tracking consumers (event_poll) can't silently skip the event."""
+        from harness import event_lifecycle
+        with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+             patch.object(event_lifecycle, "append") as mock_append:
+            resp = self.client.post("/events", json={
+                "event_type": "status-transition", "role": "skill"})
+        self.assertEqual(resp.status_code, 200)
+        mock_append.assert_called_once()
+        stored = mock_append.call_args[0][0]
+        self.assertRegex(stored.get("id", ""), r"^[0-9a-f]{16}$")
+
+    def test_post_events_preserves_provided_id(self):
+        """A caller-provided id is not overwritten by the auto-assign."""
+        from harness import event_lifecycle
+        with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+             patch.object(event_lifecycle, "append") as mock_append:
+            resp = self.client.post("/events", json={
+                "event_type": "status-transition", "role": "skill",
+                "id": "caller-supplied-id"})
+        self.assertEqual(resp.status_code, 200)
+        stored = mock_append.call_args[0][0]
+        self.assertEqual(stored["id"], "caller-supplied-id")
+
+    def test_post_events_unknown_role_response_contract(self):
+        """#11404 AC2: an unregistered emitter role is dropped with 204 (the
+        INTENTIONAL fire-and-forget contract, #9242) and NOT stored."""
+        from harness import event_lifecycle
+        with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+             patch.object(event_lifecycle, "append") as mock_append:
+            resp = self.client.post("/events", json={
+                "event_type": "status-transition", "role": "bogus-role-xyz"})
+        self.assertEqual(resp.status_code, 204)
+        mock_append.assert_not_called()
+
     def test_post_agents_all_start(self):
         """POST /agents/all/start returns 200 with results."""
         mock_result = {"role": "skill", "action": "skip", "success": True,


### PR DESCRIPTION
## Summary

Fixes two silent-failure edges in the harness `POST /events` handler (closes #11404), found while hand-emitting test events during the #11329 e2e. Both are defense-in-depth against a future direct HTTP caller (the internal `_emit_event` path is already correct and unaffected).

Bases on `main` — independent of the polish bundle.

## ACs

- **AC1** — auto-assign a 16-hex `id` (matching `_emit_event`, #9415) when the POST body omits one. An id-less POST returned `200` but was then silently skipped by every consumer (`event_poll`: *"event has no id; skipping"*) because the cursor can't track an id-less event.
- **AC2** — the unknown-emitter-role `204` drop is an **intentional** fire-and-forget choice (#9242). Rather than reverse it to a 4xx, I documented the silent-drop contract explicitly in the endpoint docstring (the AC's "keep 204 but document" option), preserving the deliberate #9242 design.
- **AC3** — regression tests: `test_post_events_assigns_id_when_missing`, `test_post_events_preserves_provided_id`, `test_post_events_unknown_role_response_contract`.

## Test plan

- [ ] `pytest tests/test_harness.py` green (190 passing)
- [ ] Verifier: confirm an id-less POST is now stored with an auto-id and delivered to a consumer
- [ ] Verifier: confirm a caller-supplied id is preserved
- [ ] Verifier: confirm the 204 unknown-role contract is unchanged (only now documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)