### PR TITLE
skill: #11166 — collapse cycle_post REQUIRED_FIELDS (mode-agnostic, #11092 D4)

### DIFF
--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -48,11 +48,12 @@ except ImportError:
 
 from shared_fs import atomic_write_text  # #10007
 
-# Required top-level fields in cycle-output.json. Mode-gated (#8918): event
-# mode replaces `cycle_number` with `task` — the task IS the cycle in event
-# mode (DECISIONS-4792.md Q7 + CONTEXT.md §5.5 + TEST-PLAN-8701 §3.2 UT-10).
-LOOP_REQUIRED_FIELDS = {"role", "cycle_number", "cycle_type"}
-EVENT_REQUIRED_FIELDS = {"role", "task", "cycle_type"}
+# Required top-level fields in cycle-output.json. Mode-agnostic under
+# pull-only (#11092 Decision 4): polling and event cycles have an identical
+# shape from cycle_post's perspective, so the #8918 mode gate is removed.
+# `task` is now OPTIONAL — present on active cycles, omitted on quiet cycles —
+# neither required nor forbidden.
+REQUIRED_FIELDS = {"role", "cycle_number", "cycle_type"}
 VALID_CYCLE_TYPES = {"active", "quiet", "suppressed"}
 
 # ---------------------------------------------------------------------------
@@ -91,6 +92,11 @@ def _get_role_wake_mode(role):
     Thin wrapper retained so cycle_post-internal callers don't need
     import-path churn. See ``config.get_wake_mode`` for the resolution
     rules — that is the single source of truth referenced by bootstrap.md.
+
+    Note (#11166): the cycle-output validation gate that called this was
+    removed under pull-only (#11092 Decision 4). The wrapper is retained per
+    that task's explicit scope — wake mode is still the boot-bootstrap
+    concept; this wrapper stays available for future cycle_post use.
     """
     script_dir_str = str(SCRIPT_DIR)
     if script_dir_str not in sys.path:
@@ -140,23 +146,19 @@ def _write_status_bar(role, phase, description):
 def _validate_output(data, role=None):
     """Validate cycle-output.json structure. Returns list of errors.
 
-    Mode-gated (#8918): event-driven roles use ``EVENT_REQUIRED_FIELDS``
-    (``task`` replaces ``cycle_number``); loop-mode roles use
-    ``LOOP_REQUIRED_FIELDS``. The role argument is optional so existing test
-    fixtures that build `data` directly still validate against the loop set —
-    callers that need event-mode validation pass the role so wake mode is
-    looked up via ``_get_role_wake_mode``.
+    Mode-agnostic (#11092 Decision 4 / pull-only): every cycle — polling or
+    event, active or quiet — validates against the same ``REQUIRED_FIELDS``.
+    ``task`` is optional (the #8918 event-mode `task`-required gate was removed
+    once pull-only made the two modes' output shape identical). The ``role``
+    argument is retained for caller-signature compatibility but no longer
+    affects which fields are required.
     """
     errors = []
 
     if not isinstance(data, dict):
         return ["cycle-output.json must be a JSON object"]
 
-    if role is not None and _get_role_wake_mode(role) == "event-driven":
-        required = EVENT_REQUIRED_FIELDS
-    else:
-        required = LOOP_REQUIRED_FIELDS
-    for field in required:
+    for field in REQUIRED_FIELDS:
         if field not in data:
             errors.append(f"Missing required field: {field}")
 
@@ -955,7 +957,7 @@ def main():
         print(f"[🦑 {ts}] ERROR: Invalid JSON in cycle-output.json: {e}", file=sys.stderr)
         sys.exit(1)
 
-    # Validate (mode-gated — event-driven roles use EVENT_REQUIRED_FIELDS, #8918)
+    # Validate (mode-agnostic REQUIRED_FIELDS, #11092 Decision 4)
     errors = _validate_output(data, role)
     if errors:
         print(f"[🦑 {ts}] ERROR: Invalid cycle-output.json:", file=sys.stderr)

--- a/tests/test_cycle_post.py
+++ b/tests/test_cycle_post.py
@@ -99,52 +99,54 @@ class TestValidateOutput:
         assert cycle_post._validate_output(data) == []
 
 
-class TestValidateOutputModeGated:
-    """#8918 (UT-10): _validate_output picks REQUIRED_FIELDS by role wake mode.
+class TestValidateOutputModeAgnostic:
+    """#11166 (#11092 Decision 4): under pull-only, _validate_output is
+    mode-agnostic. The same REQUIRED_FIELDS {role, cycle_number, cycle_type}
+    apply to polling and event cycles; `task` is optional (present on active
+    cycles, absent on quiet) — neither required nor forbidden. Replaces the
+    #8918 mode-gated behavior."""
 
-    Loop mode keeps {role, cycle_number, cycle_type}. Event mode swaps in
-    `task` (the task IS the cycle in event mode) so a cycle-output without
-    cycle_number but with task passes, and one without either fails clearly.
-    """
+    def test_legacy_mode_gated_constants_removed(self):
+        """AC1: the two mode-gated constants are collapsed to one."""
+        assert not hasattr(cycle_post, "EVENT_REQUIRED_FIELDS")
+        assert not hasattr(cycle_post, "LOOP_REQUIRED_FIELDS")
+        assert hasattr(cycle_post, "REQUIRED_FIELDS")
 
-    def test_event_mode_passes_with_task(self, monkeypatch):
-        """UT-10a: event-mode role + task identifier present → validation passes."""
-        monkeypatch.setattr(
-            cycle_post, "_get_role_wake_mode", lambda r: "event-driven",
-        )
-        data = {"role": "skill", "task": "100", "cycle_type": "active"}
+    def test_polling_quiet_cycle_validates(self):
+        """AC3: a quiet polling cycle (cycle_type=quiet, no task) validates."""
+        data = {"role": "skill", "cycle_number": 42, "cycle_type": "quiet"}
         assert cycle_post._validate_output(data, "skill") == []
 
-    def test_loop_mode_rejects_missing_cycle_number(self, monkeypatch):
-        """UT-10b: loop-mode role without cycle_number → validation fails on it."""
-        monkeypatch.setattr(
-            cycle_post, "_get_role_wake_mode", lambda r: "polling",
-        )
+    def test_event_quiet_cycle_validates(self):
+        """AC4: an event-mode quiet cycle (same shape, no task) validates —
+        previously rejected by the #8918 task-required gate."""
+        data = {"role": "skill", "cycle_number": 42, "cycle_type": "quiet"}
+        assert cycle_post._validate_output(data, "skill") == []
+
+    def test_active_cycle_with_task_validates(self):
+        """AC5: an active cycle with `task` present validates — task is
+        optional, neither required nor forbidden."""
+        data = {"role": "skill", "cycle_number": 42, "task": "100",
+                "cycle_type": "active"}
+        assert cycle_post._validate_output(data, "skill") == []
+
+    def test_missing_cycle_number_still_fails(self):
         data = {"role": "skill", "cycle_type": "active"}
         errors = cycle_post._validate_output(data, "skill")
         assert any("cycle_number" in e for e in errors), errors
-        # And task is NOT required in loop mode — error list mentions only
-        # cycle_number, not task.
+
+    def test_task_never_required(self):
+        """A cycle without `task` never errors on task, regardless of role."""
+        data = {"role": "skill", "cycle_number": 42, "cycle_type": "active"}
+        errors = cycle_post._validate_output(data, "skill")
         assert not any("task" in e for e in errors), errors
 
-    def test_event_mode_rejects_missing_task(self, monkeypatch):
-        """UT-10c: event-mode role with no task identifier → validation fails on it."""
-        monkeypatch.setattr(
-            cycle_post, "_get_role_wake_mode", lambda r: "event-driven",
-        )
-        data = {"role": "skill", "cycle_type": "active"}
-        errors = cycle_post._validate_output(data, "skill")
-        assert any("task" in e for e in errors), errors
-        # cycle_number is NOT required in event mode, so it must NOT appear.
-        assert not any("cycle_number" in e for e in errors), errors
-
-    def test_default_role_none_uses_loop_required(self):
-        """Existing callers that pass no role keep the pre-refactor behavior:
-        validate against LOOP_REQUIRED_FIELDS. Preserves backwards compat for
-        tests that don't yet thread a role through."""
-        data = {"role": "skill", "cycle_type": "active"}
-        errors = cycle_post._validate_output(data)
-        assert any("cycle_number" in e for e in errors)
+    def test_role_argument_does_not_change_required_fields(self):
+        """The role arg is signature-compat only — passing it or not yields
+        identical required-field validation (mode no longer gates)."""
+        data = {"role": "skill", "cycle_type": "active"}  # missing cycle_number
+        assert (cycle_post._validate_output(data, "skill")
+                == cycle_post._validate_output(data, None))
 
 
 class TestAdvanceEventCursorRemoved:


### PR DESCRIPTION
## Summary

Collapses `cycle_post.py`'s mode-gated `REQUIRED_FIELDS` to a single mode-agnostic constant per the operator-locked **#11092 Decision 4** (pull-only). Closes #11166.

Under pull-only, polling and event cycles have identical `cycle-output.json` shape, so the #8918 mode gate (which made `task` mandatory in event mode) no longer reflects how the squad operates — event-mode *quiet* cycles need to omit `task` and were being rejected.

Bases on `main` — independent of the polish bundle.

## ACs

- **AC1** — `LOOP_REQUIRED_FIELDS` + `EVENT_REQUIRED_FIELDS` → single `REQUIRED_FIELDS = {role, cycle_number, cycle_type}`; `task` is optional.
- **AC2** — removed the `_get_role_wake_mode()` call from the validation path. The thin wrapper is retained per the issue's explicit "What stays" scope (now uncalled within cycle_post — documented on the function).
- **AC3/AC4/AC5** — polling-quiet, event-quiet (no `task`), and active-with-`task` cycle-outputs all validate cleanly. Event-mode quiet cycles were previously rejected; now accepted.
- **AC6** — rewrote the #8918 mode-gated test class as `TestValidateOutputModeAgnostic`; full `cycle_post` suite green (113).

## Test plan

- [ ] `pytest tests/test_cycle_post.py` green (113)
- [ ] `grep "EVENT_REQUIRED_FIELDS\|LOOP_REQUIRED_FIELDS" references/scripts/cycle_post.py` → 0
- [ ] Verifier: an event-mode quiet cycle-output (no `task`) validates; an active cycle (`task` present) still validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)