### PR TITLE
skill: #11165 — delete dead dispatch infrastructure + cycle_pre --task (pull-only)

### DIFF
--- a/.squidsquad/skill/planning/DS-11165.diff
+++ b/.squidsquad/skill/planning/DS-11165.diff
@@ -1,0 +1,936 @@
+commit dbb1c92374f4a844b113a978b08e902b74845849
+Author: Wallace Chan <naahtec@hotmail.com>
+Date:   Fri Jun 12 00:00:56 2026 -0400
+
+    skill: #11165 — delete dead dispatch infrastructure + cycle_pre --task flag (pull-only, #11092 D2+D3)
+    
+    #11092 locked pull-only (operator-confirmed 2026-06-05): the harness nudges,
+    agents poll the forge + advance the cursor via ack-cursor. This carries out
+    the CONTEXT-11092 §Decision 2+3 cascade deletion of the dead dispatch path.
+    
+    harness.py (Decision 2):
+    - Deleted EventLifecycleManager.dispatch() / ack() / get_in_flight(), the
+      _in_flight / _dispatched / _dispatch_times / _retry_counts state, and the
+      timeout_scan / start/stop_timeout_scanner / _scan_loop thread (+ its boot
+      start invocation). Stripped the four fields from _persist()/_load() — legacy
+      state files carrying them load cleanly (keys silently ignored).
+    - POST /events/{id}/complete → 410 Gone shell (AC3). GET /events/in-flight/{role}
+      removed entirely — caller survey found no invoker (AC4). GET /events/lifecycle
+      drops the in_flight field (AC5).
+    
+    cycle_pre.py (Decision 3):
+    - Deleted the per-task CLI flag, _parse_cli_args task branch, and the task-mode
+      role_input branch — every cycle is now a normal pull cycle (AC1/AC2: 0 grep
+      matches for the dispatch surface / task flag).
+    
+    tests (AC6): deleted the obsolete dispatch/ack/in-flight/timeout test classes;
+    rewrote TestCompleteEventEndpoint to assert 410-always; added a legacy-state-
+    file load test (migration safety) + an /events/lifecycle no-in_flight test;
+    removed the stale route-contract entry. test_harness (179) + cycle_pre +
+    route-contract + e2e all green.
+    
+    AC7 (boot smoke): persistence + app construction verified via the passing
+    TestClient suite + legacy-load test (no AttributeError, no thread-start on
+    boot); full live-agent boot is a verifier step.
+    
+    Bases on main. NOTE: cycle_pre task_id deletion is adjacent to #11329's
+    unmerged #5622 edit on polish — expect a small conflict at the #11402
+    polish→main merge (flagged on the issue).
+    
+    Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+
+diff --git a/references/scripts/cycle_pre.py b/references/scripts/cycle_pre.py
+index 251a0de74..899f04150 100644
+--- a/references/scripts/cycle_pre.py
++++ b/references/scripts/cycle_pre.py
+@@ -5,14 +5,10 @@ Runs before the agent's creative phase. Handles git pull, context pressure,
+ working state, triage, branch setup, and writes cycle-input.json.
+ 
+ Usage:
+-    python references/scripts/cycle_pre.py <role>             # /loop mode
+-    python references/scripts/cycle_pre.py <role> --task <n>  # event-driven, task-scoped (#8701)
++    python references/scripts/cycle_pre.py <role>
+ 
+-In task mode (#8701, used by event-driven agents), `cycle_pre` skips the
+-work-queue scan and writes a `cycle-input.json` scoped to the single task
+-passed via `--task`. `cycle_post.py` detects task mode by the presence of
+-a `task` field in `cycle-output.json` and uses task-log files keyed by
+-task id + timestamp rather than monotonic cycle numbers.
++Under pull-only (#11092 / #11165) every cycle is a normal pull cycle — the
++per-task CLI flag and its task-scoped `cycle-input.json` branch were removed.
+ 
+ Exit codes:
+     0 — success (cycle-input.json written, possibly degraded)
+@@ -1204,23 +1200,14 @@ ROLE_BUILDERS = {
+ 
+ 
+ def _parse_cli_args(argv):
+-    """Parse `<role> [--task <number>]` from argv (post-script-name).
++    """Parse `<role>` from argv (post-script-name). Returns role or None.
+ 
+-    Returns (role, task) where task is a string or None. Kept lightweight
+-    so cycle_pre stays callable from tests without rebuilding argv.
++    Kept lightweight so cycle_pre stays callable from tests without rebuilding
++    argv. (#11165: the per-task CLI flag was removed under pull-only.)
+     """
+     if not argv:
+-        return None, None
+-    role = argv[0]
+-    task = None
+-    i = 1
+-    while i < len(argv):
+-        if argv[i] == "--task" and i + 1 < len(argv):
+-            task = argv[i + 1]
+-            i += 2
+-        else:
+-            i += 1
+-    return role, task
++        return None
++    return argv[0]
+ 
+ 
+ def _reconcile_ship_counter():
+@@ -1321,9 +1308,9 @@ def _reconcile_ship_counter():
+ 
+ 
+ def main():
+-    role, task_id = _parse_cli_args(sys.argv[1:])
++    role = _parse_cli_args(sys.argv[1:])
+     if not role:
+-        print("Usage: cycle_pre.py <role> [--task <number>]", file=sys.stderr)
++        print("Usage: cycle_pre.py <role>", file=sys.stderr)
+         sys.exit(1)
+     if role not in ROLE_BUILDERS:
+         print(f"ERROR: Unknown role '{role}'. Valid: {list(ROLE_BUILDERS.keys())}",
+@@ -1331,10 +1318,7 @@ def main():
+         sys.exit(1)
+ 
+     ts = _timestamp_short()
+-    if task_id:
+-        print(f"[🦑 {ts}] cycle_pre starting for {role} (task #{task_id}, event-driven mode)...")
+-    else:
+-        print(f"[🦑 {ts}] cycle_pre starting for {role}...")
++    print(f"[🦑 {ts}] cycle_pre starting for {role}...")
+     _write_status_bar(role, "pulling", "pull-latest — Syncing with remote...")
+ 
+     # 1a. Read working state early to determine correct branch (#4942)
+@@ -1355,7 +1339,7 @@ def main():
+     # 1f. #9772: DM-only self-heal for `Shipped Since Last Bump` clobbers.
+     # Runs after pull so the counter check sees the freshest main state.
+     ship_counter_repair = None
+-    if role == "dm" and not task_id:
++    if role == "dm":
+         ship_counter_repair = _reconcile_ship_counter()
+ 
+     # 2. Context pressure
+@@ -1372,19 +1356,9 @@ def main():
+     # 6. Status bar
+     _write_status_bar(role, "triaging", "tracker-protocol — Building work queue...")
+ 
+-    # 7. Role-specific input
+-    # #8701: task mode skips the role-specific work-queue scan. The harness
+-    # already chose this task; cycle_pre's only forge-side responsibility is
+-    # to surface the task itself plus the standard branch/state context.
+-    if task_id:
+-        role_input = {
+-            "task": task_id,
+-            "task_mode": True,
+-            # Cross-agent health checks intentionally omitted in event-driven
+-            # mode (per #8701 design: the harness owns liveness).
+-        }
+-    else:
+-        role_input = ROLE_BUILDERS[role](role)
++    # 7. Role-specific input. #11165: under pull-only every cycle is a normal
++    # pull cycle — the #8701 task-mode branch was removed.
++    role_input = ROLE_BUILDERS[role](role)
+ 
+     # 7b. Read event bus (#5622)
+     recent_events = []
+diff --git a/references/scripts/harness.py b/references/scripts/harness.py
+index cce97876d..4380e1b7d 100644
+--- a/references/scripts/harness.py
++++ b/references/scripts/harness.py
+@@ -891,78 +891,30 @@ EVENT_STATE_FILE = SQUIDSQUAD_DIR / ".event-state.json"
+ 
+ 
+ class EventLifecycleManager:
+-    """Manages event dispatch, per-role queues, and disk persistence (#7630 P-1/P-3).
++    """Manages the event stream's disk persistence and per-role cursors.
+ 
+     Wraps EventStream with:
+-    - Disk persistence: events survive harness restarts
+-    - Per-role in-flight tracking: one event at a time per role
+-    - Dispatch/ack lifecycle for future event-driven mode
+-    """
++    - Disk persistence: events survive harness restarts (.event-state.json)
++    - Per-role consumer cursors (#9873-A), advanced via ``ack-cursor``.
+ 
+-    DEFAULT_TIMEOUT_MINUTES = 10
+-    DEFAULT_MAX_RETRIES = 3
+-    SCAN_INTERVAL = 30  # seconds between timeout scans
++    #11165 (#11092 Decision 2): the dispatch / ack / in-flight tracking
++    machinery was removed under pull-only — the harness only nudges and
++    agents poll the forge + advance the cursor themselves.
++    """
+ 
+-    def __init__(self, stream: EventStream, max_in_flight: int = 50,
+-                 timeout_minutes: int = 10, max_retries: int = 3):
++    def __init__(self, stream: EventStream):
+         self._stream = stream
+         self._lock = threading.Lock()
+-        self._in_flight: dict[str, list[str]] = {}  # role → [event_ids]
+-        self._max_in_flight = max_in_flight
+-        self._dispatched: dict[str, dict] = {}  # event_id → event dict
+-        self._dispatch_times: dict[str, float] = {}  # event_id → dispatch timestamp
+-        self._retry_counts: dict[str, int] = {}  # event_id → retry count
+         # #9873-A: per-role consumer cursor. Populated by ack-cursor handler.
+         # Persisted under "cursors" key in .event-state.json.
+         self._cursors: dict[str, str] = {}
+-        self._timeout_minutes = timeout_minutes
+-        self._max_retries = max_retries
+         self._loaded = False
+-        self._scanner_running = False
+-        self._scanner_thread = None
+ 
+     def append(self, event: dict):
+         """Store event in stream and persist to disk."""
+         self._stream.append(event)
+         self._persist()
+ 
+-    def dispatch(self, event_id: str, role: str, event: dict):
+-        """Mark an event as dispatched to a role (in-flight tracking).
+-
+-        NOTE: Not yet wired into POST /events — Phase 4 plumbing. Currently
+-        dormant; will be activated when event-driven mode replaces the loop.
+-        """
+-        with self._lock:
+-            if role not in self._in_flight:
+-                self._in_flight[role] = []
+-            # Skip if already dispatched (prevents re-dispatch on cursor loss)
+-            if event_id in self._dispatched:
+-                return
+-            if len(self._in_flight[role]) < self._max_in_flight:
+-                self._in_flight[role].append(event_id)
+-                self._dispatched[event_id] = event
+-                self._dispatch_times[event_id] = time.time()
+-        self._persist()
+-
+-    def ack(self, event_id: str, role: str) -> bool:
+-        """Acknowledge event completion. Returns True if event was in-flight."""
+-        found = False
+-        with self._lock:
+-            if role in self._in_flight and event_id in self._in_flight[role]:
+-                self._in_flight[role].remove(event_id)
+-                self._dispatched.pop(event_id, None)
+-                self._dispatch_times.pop(event_id, None)
+-                self._retry_counts.pop(event_id, None)
+-                found = True
+-        if found:
+-            self._persist()
+-        return found
+-
+-    def get_in_flight(self, role: str) -> list[str]:
+-        """Get list of in-flight event IDs for a role."""
+-        with self._lock:
+-            return list(self._in_flight.get(role, []))
+-
+     def get_cursor(self, role: str):
+         """Return the current cursor event_id for ``role``, or ``None`` if no
+         cursor exists yet (first boot, or role has never sent ack-cursor).
+@@ -1048,10 +1000,6 @@ class EventLifecycleManager:
+             recent_events = list(self._stream.get_recent(200))
+             data = {
+                 "events": recent_events,
+-                "in_flight": {r: list(ids) for r, ids in self._in_flight.items()},
+-                "dispatched": {eid: ev for eid, ev in self._dispatched.items()},
+-                "dispatch_times": dict(self._dispatch_times),
+-                "retry_counts": dict(self._retry_counts),
+                 # #9873-A: per-role consumer cursors. Pre-migration state
+                 # files lack this key — load() uses .get("cursors", {}).
+                 "cursors": dict(self._cursors),
+@@ -1099,20 +1047,12 @@ class EventLifecycleManager:
+         except (json.JSONDecodeError, OSError):
+             return
+ 
+-        # Restore in-flight/dispatch state under lock, then load events outside
+-        # to maintain consistent lock ordering: self._lock → EventStream._lock
++        # Restore cursors under lock, then load events outside to maintain
++        # consistent lock ordering: self._lock → EventStream._lock.
++        # #11165: the in-flight/dispatch state was deleted under pull-only;
++        # old state files that still carry those keys are silently ignored.
+         events_to_load = data.get("events", [])
+         with self._lock:
+-            self._in_flight = {
+-                r: list(ids) for r, ids in data.get("in_flight", {}).items()
+-            }
+-            self._dispatched = data.get("dispatched", {})
+-            self._dispatch_times = {
+-                k: float(v) for k, v in data.get("dispatch_times", {}).items()
+-            }
+-            self._retry_counts = {
+-                k: int(v) for k, v in data.get("retry_counts", {}).items()
+-            }
+             # #9873-A AC-1 / R2 F5: backward-compat — pre-migration state
+             # files have no "cursors" key. data.get(..., {}) prevents a
+             # KeyError that would crash harness boot on existing deployments.
+@@ -1124,75 +1064,6 @@ class EventLifecycleManager:
+         for event in events_to_load:
+             self._stream.append(event)
+ 
+-    def timeout_scan(self):
+-        """Check for overdue in-flight events and escalate (#7630 2-3).
+-
+-        For each overdue event:
+-        - If retries < max: increment retry count, reset dispatch time
+-        - If retries >= max: mark as timed-out, remove from in-flight
+-        All logging happens outside the lock to prevent deadlock with print().
+-        """
+-        now = time.time()
+-        timeout_secs = self._timeout_minutes * 60
+-        timed_out = []
+-        retry_messages = []
+-
+-        with self._lock:
+-            for role, event_ids in list(self._in_flight.items()):
+-                to_remove = []
+-                for event_id in list(event_ids):
+-                    dispatch_time = self._dispatch_times.get(event_id, now)
+-                    if now - dispatch_time > timeout_secs:
+-                        retries = self._retry_counts.get(event_id, 0)
+-                        if retries < self._max_retries:
+-                            self._retry_counts[event_id] = retries + 1
+-                            self._dispatch_times[event_id] = now
+-                            retry_messages.append(
+-                                f"Event {event_id} overdue for {role} "
+-                                f"(retry {retries + 1}/{self._max_retries})")
+-                        else:
+-                            timed_out.append((role, event_id))
+-                            to_remove.append(event_id)
+-                            self._dispatched.pop(event_id, None)
+-                            self._dispatch_times.pop(event_id, None)
+-                            self._retry_counts.pop(event_id, None)
+-                # Remove timed-out events from live list
+-                for eid in to_remove:
+-                    if eid in event_ids:
+-                        event_ids.remove(eid)
+-
+-        # Log outside lock
+-        for msg in retry_messages:
+-            _log(msg)
+-        for role, event_id in timed_out:
+-            _log(f"Event {event_id} TIMED OUT for {role} after {self._max_retries} retries — escalating")
+-
+-        if timed_out or retry_messages:
+-            self._persist()
+-
+-        return timed_out
+-
+-    def start_timeout_scanner(self):
+-        """Start background thread that scans for overdue events."""
+-        if self._scanner_running:
+-            return
+-        self._scanner_running = True
+-        self._scanner_thread = threading.Thread(
+-            target=self._scan_loop, daemon=True, name="event-timeout-scanner"
+-        )
+-        self._scanner_thread.start()
+-
+-    def stop_timeout_scanner(self):
+-        self._scanner_running = False
+-
+-    def _scan_loop(self):
+-        while self._scanner_running:
+-            try:
+-                self.timeout_scan()
+-            except Exception:
+-                pass  # Don't crash scanner on transient errors
+-            time.sleep(self.SCAN_INTERVAL)
+-
+     @property
+     def stream(self) -> EventStream:
+         return self._stream
+@@ -1407,7 +1278,6 @@ async def lifespan(app: FastAPI):
+             _log(f"WARNING: Could not distribute port to clones: {e}")
+ 
+         event_lifecycle.load()
+-        event_lifecycle.start_timeout_scanner()
+         activity_detector.start()
+         _log(f"Event state loaded: {len(event_stream)} events in stream")
+ 
+@@ -2038,9 +1908,10 @@ async def receive_event(request: Request):
+ 
+     # Ack processing (#9873-A): the previous single ``ack`` event type is
+     # split into ``ack-cursor`` (advance consumer cursor) and ``ack-stop``
+-    # (preserve stop-confirmed branch). D6 locks the split; D9/AC-18 mandate
+-    # that ack-cursor MUST NOT call the old ``event_lifecycle.ack()`` — that
+-    # in-flight tracker is dead code since #9741 stripped dispatch().
++    # (preserve stop-confirmed branch). D6 locks the split. The old
++    # dispatch-side ``event_lifecycle.ack()`` / in-flight tracker was deleted
++    # outright under pull-only (#11165 / #11092 D2); only cursor advancement
++    # remains.
+     if event_type == "ack-cursor":
+         # #9902 F4: guard against payload being present-but-not-dict (e.g.
+         # a string from a malformed POST). The default `{}` only triggers
+@@ -2257,67 +2128,27 @@ async def get_events_cursor(role: str):
+ 
+ @app.post("/events/{event_id}/complete")
+ async def complete_event(event_id: str, request: Request):
+-    """Mark an event as completed by the processing agent (#7630 Phase 4).
+-
+-    Called by agents after they finish processing an event. The harness:
+-    1. Marks the event as acked in EventLifecycleManager
+-    2. Executes any mechanical side effects (status transitions, commits)
+-    3. Returns success/failure
+-
+-    Request body:
+-        role: str — the agent role completing the event
+-        status: str — "success" or "failure"
+-        summary: str — brief description of what was done
+-        transitions: list — optional status transitions to execute
+-        comments: list — optional tracker comments to post
+-        commit_message: str — optional commit message for git commit
+-    """
+-    body = await request.json()
+-    role = body.get("role")
+-    if not role:
+-        raise HTTPException(status_code=400, detail="role is required")
+-
+-    # Ack the event in lifecycle manager
+-    acked = event_lifecycle.ack(event_id, role)
+-    if not acked:
+-        # Event not in-flight — may have timed out or already been acked
+-        from starlette.responses import JSONResponse
+-        return JSONResponse(
+-            status_code=410,
+-            content={"status": "gone", "detail": f"Event {event_id} not in-flight for {role}"},
+-        )
+-
+-    _log(f"Event {event_id} completed by {role}: {body.get('summary', 'no summary')}")
++    """REMOVED (#11165 / #11092 Decision 2 — pull-only).
+ 
+-    # Execute mechanical side effects
+-    errors = []
+-
+-    # Status transitions
+-    for transition in body.get("transitions", []):
+-        try:
+-            _execute_transition(transition)
+-        except Exception as ex:
+-            errors.append(f"transition error: {ex}")
+-
+-    # Tracker comments
+-    for comment in body.get("comments", []):
+-        try:
+-            _execute_comment(comment)
+-        except Exception as ex:
+-            errors.append(f"comment error: {ex}")
+-
+-    return {
+-        "status": "ok" if not errors else "partial",
+-        "event_id": event_id,
+-        "errors": errors,
+-    }
++    The dispatch/ack lifecycle this endpoint drove was deleted: under
++    pull-only the harness only nudges, and agents poll the forge + advance
++    the cursor via ``ack-cursor`` (AGENT-RUNTIME §2/§7). Retained as a
++    410 Gone shell so any stale caller fails loudly rather than silently.
++    """
++    from starlette.responses import JSONResponse
++    return JSONResponse(
++        status_code=410,
++        content={
++            "status": "gone",
++            "detail": "POST /events/{id}/complete removed under pull-only "
++                      "(#11165) — agents advance the cursor via ack-cursor.",
++        },
++    )
+ 
+ 
+-@app.get("/events/in-flight/{role}")
+-async def get_in_flight_events(role: str):
+-    """Get in-flight event IDs for a role (#7630 P-3)."""
+-    _validate_role(role)
+-    return {"role": role, "in_flight": event_lifecycle.get_in_flight(role)}
++# GET /events/in-flight/{role} removed (#11165 / #11092 Decision 2): in-flight
++# dispatch tracking no longer exists under pull-only, and no caller invoked
++# the route (caller survey 2026-06-11).
+ 
+ 
+ # Status priority/severity rank for /human/queue ordering (high → low).
+@@ -2454,19 +2285,13 @@ async def get_human_queue():
+ 
+ @app.get("/events/lifecycle")
+ async def get_event_lifecycle():
+-    """Event lifecycle overview — stream size, in-flight per role, persistence state (#7630 2-7)."""
+-    in_flight = {}
+-    try:
+-        roles = boot_remote._get_all_roles()
+-        for role in roles:
+-            ids = event_lifecycle.get_in_flight(role)
+-            if ids:
+-                in_flight[role] = ids
+-    except (SystemExit, Exception):
+-        pass
++    """Event lifecycle overview — stream size + persistence state (#7630 2-7).
++
++    The ``in_flight`` field was dropped (#11165 / #11092 Decision 2): under
++    pull-only there is no dispatch in-flight tracking.
++    """
+     return {
+         "stream_size": len(event_stream),
+-        "in_flight": in_flight,
+         "persisted": EVENT_STATE_FILE.exists(),
+     }
+ 
+diff --git a/tests/test_cycle_pre.py b/tests/test_cycle_pre.py
+index a12930653..d0bf0ae8e 100644
+--- a/tests/test_cycle_pre.py
++++ b/tests/test_cycle_pre.py
+@@ -1729,31 +1729,18 @@ class TestRunMechanicalReactions:
+ 
+ 
+ class TestParseCliArgs:
+-    def test_role_only_no_task(self):
+-        role, task = cycle_pre._parse_cli_args(["skill"])
+-        assert role == "skill"
+-        assert task is None
+-
+-    def test_role_with_task_flag(self):
+-        role, task = cycle_pre._parse_cli_args(["skill", "--task", "42"])
+-        assert role == "skill"
+-        assert task == "42"
+-
+-    def test_task_flag_with_no_value_ignored(self):
+-        """Trailing `--task` without a value should not crash."""
+-        role, task = cycle_pre._parse_cli_args(["skill", "--task"])
+-        assert role == "skill"
+-        assert task is None
++    """#11165: _parse_cli_args returns the role only — the per-task CLI flag
++    was removed under pull-only (#11092 Decision 3)."""
++
++    def test_role_only(self):
++        assert cycle_pre._parse_cli_args(["skill"]) == "skill"
+ 
+     def test_empty_argv(self):
+-        role, task = cycle_pre._parse_cli_args([])
+-        assert role is None
+-        assert task is None
+-
+-    def test_extra_args_after_task(self):
+-        role, task = cycle_pre._parse_cli_args(["pm", "--task", "100", "--ignored"])
+-        assert role == "pm"
+-        assert task == "100"
++        assert cycle_pre._parse_cli_args([]) is None
++
++    def test_extra_args_ignored(self):
++        # Only the role (argv[0]) is parsed; any trailing args are ignored.
++        assert cycle_pre._parse_cli_args(["pm", "--whatever", "x"]) == "pm"
+ 
+ 
+ # ---------------------------------------------------------------------------
+diff --git a/tests/test_harness.py b/tests/test_harness.py
+index be1c4f4da..86dbc6634 100644
+--- a/tests/test_harness.py
++++ b/tests/test_harness.py
+@@ -1159,6 +1159,16 @@ class TestEndpointsViaTestClient(unittest.TestCase):
+         self.assertEqual(resp.status_code, 204)
+         mock_append.assert_not_called()
+ 
++    def test_events_lifecycle_omits_in_flight(self):
++        """#11165 AC5: GET /events/lifecycle no longer reports `in_flight`
++        (dispatch in-flight tracking was deleted under pull-only)."""
++        resp = self.client.get("/events/lifecycle")
++        self.assertEqual(resp.status_code, 200)
++        data = resp.json()
++        self.assertNotIn("in_flight", data)
++        self.assertIn("stream_size", data)
++        self.assertIn("persisted", data)
++
+     def test_post_agents_all_start(self):
+         """POST /agents/all/start returns 200 with results."""
+         mock_result = {"role": "skill", "action": "skip", "success": True,
+@@ -1699,10 +1709,11 @@ class TestManualRebootClearsStoppingIntent(unittest.TestCase):
+ 
+ 
+ class TestEventLifecycleManager(unittest.TestCase):
+-    """#7630 P-1/P-3: EventLifecycleManager disk persistence and in-flight tracking."""
++    """EventLifecycleManager disk persistence (#7630 P-1). The dispatch /
++    in-flight tracking was deleted in #11165 (pull-only)."""
+ 
+     def test_persist_and_load_round_trip(self):
+-        """Event state (events + in_flight + dispatched) survives harness restart."""
++        """Event state survives a harness restart (append → load)."""
+         import tempfile
+         from harness import EventStream, EventLifecycleManager
+ 
+@@ -1711,64 +1722,41 @@ class TestEventLifecycleManager(unittest.TestCase):
+             with patch("harness.EVENT_STATE_FILE", state_file):
+                 stream = EventStream()
+                 mgr = EventLifecycleManager(stream)
+-
+-                event = {"id": "abc12345", "event_type": "test", "role": "skill"}
+-                mgr.append(event)
+-                mgr.dispatch("abc12345", "skill", event)
+-
++                mgr.append({"id": "abc12345", "event_type": "test", "role": "skill"})
+                 self.assertTrue(state_file.exists())
+ 
+-                # Load into new manager
+                 stream2 = EventStream()
+                 mgr2 = EventLifecycleManager(stream2)
+                 mgr2.load()
+-
+                 events = stream2.get_all()
+                 self.assertEqual(len(events), 1)
+                 self.assertEqual(events[0]["id"], "abc12345")
+-                # In-flight state also restored
+-                self.assertEqual(mgr2.get_in_flight("skill"), ["abc12345"])
+-
+-    def test_in_flight_tracking(self):
+-        """Dispatch/ack lifecycle tracks per-role in-flight events."""
+-        from harness import EventStream, EventLifecycleManager
+ 
+-        with patch("harness.EVENT_STATE_FILE", Path("/nonexistent")):
+-            stream = EventStream()
+-            mgr = EventLifecycleManager(stream)
+-
+-            mgr.dispatch("evt1", "skill", {"id": "evt1"})
+-            self.assertEqual(mgr.get_in_flight("skill"), ["evt1"])
+-
+-            result = mgr.ack("evt1", "skill")
+-            self.assertTrue(result)
+-            self.assertEqual(mgr.get_in_flight("skill"), [])
+-
+-    def test_ack_unknown_event_returns_false(self):
+-        """Acking an event not in-flight returns False."""
+-        from harness import EventStream, EventLifecycleManager
+-
+-        with patch("harness.EVENT_STATE_FILE", Path("/nonexistent")):
+-            stream = EventStream()
+-            mgr = EventLifecycleManager(stream)
+-
+-            result = mgr.ack("nonexistent", "skill")
+-            self.assertFalse(result)
+-
+-    def test_in_flight_cap(self):
+-        """Per-role in-flight queue respects cap. Dropped events excluded from _dispatched."""
++    def test_load_ignores_legacy_dispatch_fields(self):
++        """#11165: a legacy state file still carrying in_flight/dispatched/
++        dispatch_times/retry_counts loads cleanly — those keys are silently
++        ignored, cursors + events still restore, no AttributeError."""
++        import tempfile
++        import json
+         from harness import EventStream, EventLifecycleManager
+ 
+-        with patch("harness.EVENT_STATE_FILE", Path("/nonexistent")):
+-            stream = EventStream()
+-            mgr = EventLifecycleManager(stream, max_in_flight=2)
+-
+-            mgr.dispatch("evt1", "skill", {"id": "evt1"})
+-            mgr.dispatch("evt2", "skill", {"id": "evt2"})
+-            mgr.dispatch("evt3", "skill", {"id": "evt3"})  # should be dropped
+-
+-            self.assertEqual(len(mgr.get_in_flight("skill")), 2)
+-            self.assertNotIn("evt3", mgr._dispatched)
++        with tempfile.TemporaryDirectory() as tmpdir:
++            state_file = Path(tmpdir) / ".event-state.json"
++            state_file.write_text(json.dumps({
++                "events": [{"id": "e1", "event_type": "t", "role": "skill"}],
++                "in_flight": {"skill": ["e1"]},
++                "dispatched": {"e1": {}},
++                "dispatch_times": {"e1": 1.0},
++                "retry_counts": {"e1": 0},
++                "cursors": {"skill": "e1"},
++            }), encoding="utf-8")
++            with patch("harness.EVENT_STATE_FILE", state_file):
++                stream = EventStream()
++                mgr = EventLifecycleManager(stream)
++                mgr.load()  # must not raise on the legacy keys
++                self.assertEqual(len(stream.get_all()), 1)
++                self.assertEqual(mgr.get_cursor("skill"), "e1")
++                self.assertFalse(hasattr(mgr, "_in_flight"))
+ 
+     def test_load_is_idempotent(self):
+         """Calling load() twice does not duplicate events (#7630 CRITICAL-2)."""
+@@ -2197,46 +2185,6 @@ class TestTerminalPidInAgentState(unittest.TestCase):
+                 self.assertEqual(loaded.terminal_pid, 99999)
+ 
+ 
+-class TestTimeoutScanner(unittest.TestCase):
+-    """#7630 2-3: EventLifecycleManager timeout detection."""
+-
+-    def test_overdue_event_detected(self):
+-        """Events past timeout are detected by timeout_scan."""
+-        from harness import EventStream, EventLifecycleManager
+-
+-        with patch("harness.EVENT_STATE_FILE", Path("/nonexistent")), \
+-             patch("harness._log"):
+-            stream = EventStream()
+-            mgr = EventLifecycleManager(stream, timeout_minutes=0)  # 0 = immediate timeout
+-
+-            mgr.dispatch("evt1", "skill", {"id": "evt1"})
+-            # Backdate dispatch time to force timeout
+-            mgr._dispatch_times["evt1"] = time.time() - 1
+-
+-            timed_out = mgr.timeout_scan()
+-            # First scan: retry (not yet at max retries)
+-            self.assertEqual(len(timed_out), 0)  # retried, not timed out
+-            self.assertEqual(mgr._retry_counts.get("evt1"), 1)
+-
+-    def test_max_retries_causes_timeout(self):
+-        """After max retries, event is removed from in-flight."""
+-        from harness import EventStream, EventLifecycleManager
+-
+-        with patch("harness.EVENT_STATE_FILE", Path("/nonexistent")), \
+-             patch("harness._log"):
+-            stream = EventStream()
+-            mgr = EventLifecycleManager(stream, timeout_minutes=0, max_retries=1)
+-
+-            mgr.dispatch("evt1", "skill", {"id": "evt1"})
+-            mgr._dispatch_times["evt1"] = time.time() - 1
+-            mgr._retry_counts["evt1"] = 1  # Already at max
+-
+-            timed_out = mgr.timeout_scan()
+-            self.assertEqual(len(timed_out), 1)
+-            self.assertEqual(timed_out[0], ("skill", "evt1"))
+-            self.assertEqual(mgr.get_in_flight("skill"), [])
+-
+-
+ class TestEventDrivenPhase4(unittest.TestCase):
+     """#7630 Phase 4: Event-driven wake prototype — config, endpoints, poll."""
+ 
+@@ -2371,22 +2319,6 @@ class TestEventDrivenPhase4(unittest.TestCase):
+         with self.assertRaises(ValueError):
+             _execute_comment({"number": 1, "message": "hello\x00world"})
+ 
+-    def test_dispatch_skips_already_dispatched(self):
+-        """dispatch() skips events that are already in _dispatched."""
+-        from harness import EventStream, EventLifecycleManager
+-
+-        with patch("harness.EVENT_STATE_FILE", Path("/nonexistent")):
+-            stream = EventStream()
+-            mgr = EventLifecycleManager(stream)
+-
+-            mgr.dispatch("evt1", "skill", {"id": "evt1"})
+-            self.assertEqual(mgr.get_in_flight("skill"), ["evt1"])
+-
+-            # Dispatch same event again — should not duplicate
+-            mgr.dispatch("evt1", "skill", {"id": "evt1"})
+-            self.assertEqual(mgr.get_in_flight("skill"), ["evt1"])
+-
+-
+ class TestGetEventsForRole(unittest.TestCase):
+     """#7630 Phase 4: GET /events/for/{role} endpoint tests."""
+ 
+@@ -2403,10 +2335,6 @@ class TestGetEventsForRole(unittest.TestCase):
+         """Clear event stream between tests."""
+         with self.event_stream._lock:
+             self.event_stream._events.clear()
+-        with self.event_lifecycle._lock:
+-            self.event_lifecycle._in_flight.clear()
+-            self.event_lifecycle._dispatched.clear()
+-            self.event_lifecycle._dispatch_times.clear()
+ 
+     def test_filters_by_target_role(self):
+         """GET /events/for/skill returns only events targeted at skill."""
+@@ -2430,28 +2358,6 @@ class TestGetEventsForRole(unittest.TestCase):
+         self.assertEqual(len(data["events"]), 1)
+         self.assertEqual(data["events"][0]["id"], "e1")
+ 
+-    def test_does_not_dispatch(self):
+-        """#9741: GET /events/for/skill must NOT add events to in-flight.
+-
+-        Before #9741 the endpoint called event_lifecycle.dispatch() on every
+-        delivered event, but there is no ack consumer wired yet — every
+-        event would eventually time out, growing .event-state.json and
+-        spamming the timeout-scanner log. CONTEXT-9741 D1 strips the call;
+-        the endpoint is a pure filtered-read with no lifecycle side effects.
+-        """
+-        from harness import event_stream, event_lifecycle
+-
+-        event_stream.append({
+-            "id": "e3", "event_type": "assigned-to", "role": "harness",
+-            "payload": {"target_role": "skill", "issue_number": "3"},
+-        })
+-
+-        with patch("harness._validate_role"):
+-            self.client.get("/events/for/skill")
+-
+-        # Endpoint delivers the event but does not touch in-flight state.
+-        self.assertNotIn("e3", event_lifecycle.get_in_flight("skill"))
+-
+     def test_since_cursor_filters_events(self):
+         """GET /events/for/skill?since=X returns only events after cursor."""
+         from harness import event_stream
+@@ -2473,146 +2379,30 @@ class TestGetEventsForRole(unittest.TestCase):
+         self.assertNotIn("old1", ids)
+         self.assertIn("new1", ids)
+ 
+-    def test_endpoint_does_not_touch_lifecycle_state(self):
+-        """#9741: with dispatch stripped, the endpoint must not mutate in-flight.
+-
+-        Even when an event was pre-dispatched by some other path, calling
+-        the read endpoint must not re-dispatch, re-add, or otherwise mutate
+-        the lifecycle state. CONTEXT-9741 D2 — the idempotency guard test
+-        is irrelevant once dispatch is stripped; this test instead verifies
+-        the read-only invariant.
+-        """
+-        from harness import event_stream, event_lifecycle
+-
+-        event_stream.append({
+-            "id": "e4", "event_type": "assigned-to", "role": "harness",
+-            "payload": {"target_role": "skill"},
+-        })
+-
+-        # Pre-dispatch via the lifecycle manager directly (NOT via the endpoint).
+-        event_lifecycle.dispatch("e4", "skill", {"id": "e4"})
+-        before = list(event_lifecycle.get_in_flight("skill"))
+-
+-        with patch("harness._validate_role"):
+-            self.client.get("/events/for/skill")
+-
+-        # In-flight state must be identical — endpoint touched nothing.
+-        after = list(event_lifecycle.get_in_flight("skill"))
+-        self.assertEqual(before, after)
+-        # And specifically: e4 still appears exactly once (the pre-dispatch),
+-        # not zero (would mean endpoint cleared it) or two (would mean
+-        # endpoint re-dispatched).
+-        self.assertEqual(after.count("e4"), 1)
+-
+-
+ class TestCompleteEventEndpoint(unittest.TestCase):
+-    """#7630 Phase 4: POST /events/{event_id}/complete endpoint tests."""
++    """#11165: POST /events/{event_id}/complete was removed under pull-only —
++    it now returns 410 Gone unconditionally. The dispatch/ack lifecycle it
++    drove was deleted (#11092 Decision 2)."""
+ 
+     @classmethod
+     def setUpClass(cls):
+         from fastapi.testclient import TestClient
+-        from harness import app, event_stream, event_lifecycle
++        from harness import app
+ 
+         cls.client = TestClient(app, raise_server_exceptions=False)
+-        cls.event_stream = event_stream
+-        cls.event_lifecycle = event_lifecycle
+ 
+-    def setUp(self):
+-        """Clear lifecycle state between tests."""
+-        with self.event_lifecycle._lock:
+-            self.event_lifecycle._in_flight.clear()
+-            self.event_lifecycle._dispatched.clear()
+-            self.event_lifecycle._dispatch_times.clear()
+-
+-    def test_complete_acks_in_flight_event(self):
+-        """POST /events/evt1/complete acks an in-flight event."""
+-        self.event_lifecycle.dispatch("evt1", "skill", {"id": "evt1"})
+-        self.assertIn("evt1", self.event_lifecycle.get_in_flight("skill"))
+-
+-        resp = self.client.post("/events/evt1/complete", json={
+-            "role": "skill",
+-            "status": "success",
+-            "summary": "Done",
++    def test_complete_returns_410_always(self):
++        """AC3: a well-formed completion POST returns 410 Gone."""
++        resp = self.client.post("/events/any-id/complete", json={
++            "role": "skill", "status": "success", "summary": "Done",
+         })
+-
+-        self.assertEqual(resp.status_code, 200)
+-        data = resp.json()
+-        self.assertEqual(data["status"], "ok")
+-        self.assertNotIn("evt1", self.event_lifecycle.get_in_flight("skill"))
+-
+-    def test_complete_returns_410_for_unknown_event(self):
+-        """POST /events/unknown/complete returns 410 when event not in-flight."""
+-        resp = self.client.post("/events/unknown-id/complete", json={
+-            "role": "skill",
+-            "status": "success",
+-            "summary": "Done",
+-        })
+-
+         self.assertEqual(resp.status_code, 410)
+-        data = resp.json()
+-        self.assertEqual(data["status"], "gone")
+-
+-    def test_complete_executes_transitions(self):
+-        """POST /events/evt2/complete executes status transitions."""
+-        self.event_lifecycle.dispatch("evt2", "skill", {"id": "evt2"})
+-
+-        with patch("harness._execute_transition") as mock_trans:
+-            resp = self.client.post("/events/evt2/complete", json={
+-                "role": "skill",
+-                "status": "success",
+-                "summary": "Fixed",
+-                "transitions": [
+-                    {"number": 123, "from": "in-progress", "to": "pending-test", "role": "skill-lead"}
+-                ],
+-            })
+-
+-        self.assertEqual(resp.status_code, 200)
+-        mock_trans.assert_called_once()
+-
+-    def test_complete_executes_comments(self):
+-        """POST /events/evt3/complete executes tracker comments."""
+-        self.event_lifecycle.dispatch("evt3", "skill", {"id": "evt3"})
+-
+-        with patch("harness._execute_comment") as mock_comment:
+-            resp = self.client.post("/events/evt3/complete", json={
+-                "role": "skill",
+-                "status": "success",
+-                "summary": "Commented",
+-                "comments": [
+-                    {"number": 123, "role": "skill-lead", "message": "Done."}
+-                ],
+-            })
+-
+-        self.assertEqual(resp.status_code, 200)
+-        mock_comment.assert_called_once()
+-
+-    def test_complete_reports_partial_on_side_effect_failure(self):
+-        """POST /events/evt4/complete returns partial on transition errors."""
+-        self.event_lifecycle.dispatch("evt4", "skill", {"id": "evt4"})
+-
+-        with patch("harness._execute_transition", side_effect=RuntimeError("tracker fail")):
+-            resp = self.client.post("/events/evt4/complete", json={
+-                "role": "skill",
+-                "status": "success",
+-                "summary": "Partial",
+-                "transitions": [
+-                    {"number": 1, "from": "a", "to": "b"}
+-                ],
+-            })
++        self.assertEqual(resp.json()["status"], "gone")
+ 
+-        self.assertEqual(resp.status_code, 200)
+-        data = resp.json()
+-        self.assertEqual(data["status"], "partial")
+-        self.assertTrue(len(data["errors"]) > 0)
+-
+-    def test_complete_requires_role(self):
+-        """POST /events/evt5/complete returns 400 without role."""
+-        resp = self.client.post("/events/evt5/complete", json={
+-            "status": "success",
+-            "summary": "No role",
+-        })
+-
+-        self.assertEqual(resp.status_code, 400)
++    def test_complete_returns_410_even_without_role(self):
++        """The 410 fires before any body validation — pure deprecation shell."""
++        resp = self.client.post("/events/any-id/complete", json={})
++        self.assertEqual(resp.status_code, 410)
+ 
+ 
+ # ---------------------------------------------------------------------------
+diff --git a/tests/test_harness_route_contract.py b/tests/test_harness_route_contract.py
+index 246af629c..a2f8a27c6 100644
+--- a/tests/test_harness_route_contract.py
++++ b/tests/test_harness_route_contract.py
+@@ -61,7 +61,6 @@ EXPECTED_CALLERS = {
+     ("GET",  "/events/for/{role}"):             ["event_poll"],
+     ("GET",  "/events/cursor/{role}"):          _EXTERNAL,
+     ("POST", "/events/{event_id}/complete"):    _EXTERNAL,
+-    ("GET",  "/events/in-flight/{role}"):       _EXTERNAL,
+     ("GET",  "/events/lifecycle"):              _EXTERNAL,
+     ("GET",  "/human/queue"):                   _EXTERNAL,
+     ("POST", "/shutdown"):                      ["squidsquad_cli"],

--- a/.squidsquad/skill/planning/DS-REVIEW-11165.md
+++ b/.squidsquad/skill/planning/DS-REVIEW-11165.md
@@ -1,0 +1,27 @@
+I've carefully reviewed all the changed files. Let me verify the key claims systematically:
+
+1. **Deleted surface callers**: Grep confirms zero remaining references to `dispatch()`, `ack()`, `get_in_flight()`, `timeout_scan()`, `start_timeout_scanner()`, `stop_timeout_scanner()`, `_scan_loop`, `_in_flight`, `_dispatched`, `_dispatch_times`, `_retry_counts` in the changed production files (harness.py, cycle_pre.py) — only the docstring comment at `harness.py:1912` mentions the old `ack()` in explaining what was removed.
+
+2. **Legacy state file loading**: `load()` at `harness.py:1054` reads `data.get("events", [])` and `data.get("cursors", {})` only. The old keys (`in_flight`, `dispatched`, `dispatch_times`, `retry_counts`) are never accessed — silently ignored as claimed. The legacy-load test at `test_harness.py:1735-1759` validates this: it creates a state file with all four legacy keys, calls `load()`, and confirms events + cursors restore correctly without `AttributeError`.
+
+3. **Lock ordering**: The `advance_cursor()` method at `harness.py:931-990` acquires `EventLifecycleManager._lock` (outer) then calls `EventStream.has_event`/`find_positions` which acquire `EventStream._lock` (inner). `_persist()` at `harness.py:992-1012` does the same: `self._lock` → `self._stream.get_recent()`. `load()` at `harness.py:1055-1065` acquires `self._lock` for cursor restoration, releases it, then calls `self._stream.append()` (acquires `EventStream._lock` externally). No inversion — consistent outer→inner ordering.
+
+4. **Constructor signature**: All callers in the changed files use `EventLifecycleManager(stream)` with a single argument — matches the new `__init__(self, stream: EventStream)` signature at `harness.py:905`. The global instantiation at `harness.py:1075` was updated. Test instantiations all use single-arg form.
+
+5. **`_parse_cli_args` return type change**: The caller `main()` at `cycle_pre.py:1311` correctly unpacks the single return value. All `task_id` branches were removed. The `TestParseCliArgs` tests were updated to match the new signature.
+
+6. **POST /events/{id}/complete → 410**: The endpoint at `harness.py:2129` unconditionally returns a 410 `JSONResponse` — no body parsing, no lifecycle access. Tests confirm 410 for both well-formed and empty bodies.
+
+7. **GET /events/lifecycle drops in_flight**: The endpoint at `harness.py:2286-2297` returns only `stream_size` and `persisted`. Test `test_events_lifecycle_omits_in_flight` at `test_harness.py:1162-1170` confirms `in_flight` is absent.
+
+8. **GET /events/in-flight/{role} removed**: Deleted entirely; route-contract entry at `test_harness_route_contract.py` was removed.
+
+9. **Timeout scanner removed**: `start_timeout_scanner()` call removed from `lifespan` at `harness.py:1280` (previously followed `event_lifecycle.load()`).
+
+10. **Test cleanup**: `TestGetEventsForRole.setUp` at `test_harness.py:2334-2337` no longer tries to clear `_in_flight`/`_dispatched`/`_dispatch_times` (those attributes don't exist); remaining tests in that class don't reference them. `TestCompleteEventEndpoint` no longer requires any lifecycle state setup.
+
+No correctness defects, regressions, or integration issues found in the changed files.
+
+```
+NO_FINDINGS
+```

--- a/references/scripts/cycle_pre.py
+++ b/references/scripts/cycle_pre.py
@@ -5,14 +5,10 @@ Runs before the agent's creative phase. Handles git pull, context pressure,
 working state, triage, branch setup, and writes cycle-input.json.
 
 Usage:
-    python references/scripts/cycle_pre.py <role>             # /loop mode
-    python references/scripts/cycle_pre.py <role> --task <n>  # event-driven, task-scoped (#8701)
+    python references/scripts/cycle_pre.py <role>
 
-In task mode (#8701, used by event-driven agents), `cycle_pre` skips the
-work-queue scan and writes a `cycle-input.json` scoped to the single task
-passed via `--task`. `cycle_post.py` detects task mode by the presence of
-a `task` field in `cycle-output.json` and uses task-log files keyed by
-task id + timestamp rather than monotonic cycle numbers.
+Under pull-only (#11092 / #11165) every cycle is a normal pull cycle — the
+per-task CLI flag and its task-scoped `cycle-input.json` branch were removed.
 
 Exit codes:
     0 — success (cycle-input.json written, possibly degraded)
@@ -1204,23 +1200,14 @@ ROLE_BUILDERS = {
 
 
 def _parse_cli_args(argv):
-    """Parse `<role> [--task <number>]` from argv (post-script-name).
+    """Parse `<role>` from argv (post-script-name). Returns role or None.
 
-    Returns (role, task) where task is a string or None. Kept lightweight
-    so cycle_pre stays callable from tests without rebuilding argv.
+    Kept lightweight so cycle_pre stays callable from tests without rebuilding
+    argv. (#11165: the per-task CLI flag was removed under pull-only.)
     """
     if not argv:
-        return None, None
-    role = argv[0]
-    task = None
-    i = 1
-    while i < len(argv):
-        if argv[i] == "--task" and i + 1 < len(argv):
-            task = argv[i + 1]
-            i += 2
-        else:
-            i += 1
-    return role, task
+        return None
+    return argv[0]
 
 
 def _reconcile_ship_counter():
@@ -1321,9 +1308,9 @@ def _reconcile_ship_counter():
 
 
 def main():
-    role, task_id = _parse_cli_args(sys.argv[1:])
+    role = _parse_cli_args(sys.argv[1:])
     if not role:
-        print("Usage: cycle_pre.py <role> [--task <number>]", file=sys.stderr)
+        print("Usage: cycle_pre.py <role>", file=sys.stderr)
         sys.exit(1)
     if role not in ROLE_BUILDERS:
         print(f"ERROR: Unknown role '{role}'. Valid: {list(ROLE_BUILDERS.keys())}",
@@ -1331,10 +1318,7 @@ def main():
         sys.exit(1)
 
     ts = _timestamp_short()
-    if task_id:
-        print(f"[🦑 {ts}] cycle_pre starting for {role} (task #{task_id}, event-driven mode)...")
-    else:
-        print(f"[🦑 {ts}] cycle_pre starting for {role}...")
+    print(f"[🦑 {ts}] cycle_pre starting for {role}...")
     _write_status_bar(role, "pulling", "pull-latest — Syncing with remote...")
 
     # 1a. Read working state early to determine correct branch (#4942)
@@ -1355,7 +1339,7 @@ def main():
     # 1f. #9772: DM-only self-heal for `Shipped Since Last Bump` clobbers.
     # Runs after pull so the counter check sees the freshest main state.
     ship_counter_repair = None
-    if role == "dm" and not task_id:
+    if role == "dm":
         ship_counter_repair = _reconcile_ship_counter()
 
     # 2. Context pressure
@@ -1372,19 +1356,9 @@ def main():
     # 6. Status bar
     _write_status_bar(role, "triaging", "tracker-protocol — Building work queue...")
 
-    # 7. Role-specific input
-    # #8701: task mode skips the role-specific work-queue scan. The harness
-    # already chose this task; cycle_pre's only forge-side responsibility is
-    # to surface the task itself plus the standard branch/state context.
-    if task_id:
-        role_input = {
-            "task": task_id,
-            "task_mode": True,
-            # Cross-agent health checks intentionally omitted in event-driven
-            # mode (per #8701 design: the harness owns liveness).
-        }
-    else:
-        role_input = ROLE_BUILDERS[role](role)
+    # 7. Role-specific input. #11165: under pull-only every cycle is a normal
+    # pull cycle — the #8701 task-mode branch was removed.
+    role_input = ROLE_BUILDERS[role](role)
 
     # 7b. Read event bus (#5622)
     recent_events = []

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -891,77 +891,29 @@ EVENT_STATE_FILE = SQUIDSQUAD_DIR / ".event-state.json"
 
 
 class EventLifecycleManager:
-    """Manages event dispatch, per-role queues, and disk persistence (#7630 P-1/P-3).
+    """Manages the event stream's disk persistence and per-role cursors.
 
     Wraps EventStream with:
-    - Disk persistence: events survive harness restarts
-    - Per-role in-flight tracking: one event at a time per role
-    - Dispatch/ack lifecycle for future event-driven mode
+    - Disk persistence: events survive harness restarts (.event-state.json)
+    - Per-role consumer cursors (#9873-A), advanced via ``ack-cursor``.
+
+    #11165 (#11092 Decision 2): the dispatch / ack / in-flight tracking
+    machinery was removed under pull-only — the harness only nudges and
+    agents poll the forge + advance the cursor themselves.
     """
 
-    DEFAULT_TIMEOUT_MINUTES = 10
-    DEFAULT_MAX_RETRIES = 3
-    SCAN_INTERVAL = 30  # seconds between timeout scans
-
-    def __init__(self, stream: EventStream, max_in_flight: int = 50,
-                 timeout_minutes: int = 10, max_retries: int = 3):
+    def __init__(self, stream: EventStream):
         self._stream = stream
         self._lock = threading.Lock()
-        self._in_flight: dict[str, list[str]] = {}  # role → [event_ids]
-        self._max_in_flight = max_in_flight
-        self._dispatched: dict[str, dict] = {}  # event_id → event dict
-        self._dispatch_times: dict[str, float] = {}  # event_id → dispatch timestamp
-        self._retry_counts: dict[str, int] = {}  # event_id → retry count
         # #9873-A: per-role consumer cursor. Populated by ack-cursor handler.
         # Persisted under "cursors" key in .event-state.json.
         self._cursors: dict[str, str] = {}
-        self._timeout_minutes = timeout_minutes
-        self._max_retries = max_retries
         self._loaded = False
-        self._scanner_running = False
-        self._scanner_thread = None
 
     def append(self, event: dict):
         """Store event in stream and persist to disk."""
         self._stream.append(event)
         self._persist()
-
-    def dispatch(self, event_id: str, role: str, event: dict):
-        """Mark an event as dispatched to a role (in-flight tracking).
-
-        NOTE: Not yet wired into POST /events — Phase 4 plumbing. Currently
-        dormant; will be activated when event-driven mode replaces the loop.
-        """
-        with self._lock:
-            if role not in self._in_flight:
-                self._in_flight[role] = []
-            # Skip if already dispatched (prevents re-dispatch on cursor loss)
-            if event_id in self._dispatched:
-                return
-            if len(self._in_flight[role]) < self._max_in_flight:
-                self._in_flight[role].append(event_id)
-                self._dispatched[event_id] = event
-                self._dispatch_times[event_id] = time.time()
-        self._persist()
-
-    def ack(self, event_id: str, role: str) -> bool:
-        """Acknowledge event completion. Returns True if event was in-flight."""
-        found = False
-        with self._lock:
-            if role in self._in_flight and event_id in self._in_flight[role]:
-                self._in_flight[role].remove(event_id)
-                self._dispatched.pop(event_id, None)
-                self._dispatch_times.pop(event_id, None)
-                self._retry_counts.pop(event_id, None)
-                found = True
-        if found:
-            self._persist()
-        return found
-
-    def get_in_flight(self, role: str) -> list[str]:
-        """Get list of in-flight event IDs for a role."""
-        with self._lock:
-            return list(self._in_flight.get(role, []))
 
     def get_cursor(self, role: str):
         """Return the current cursor event_id for ``role``, or ``None`` if no
@@ -1048,10 +1000,6 @@ class EventLifecycleManager:
             recent_events = list(self._stream.get_recent(200))
             data = {
                 "events": recent_events,
-                "in_flight": {r: list(ids) for r, ids in self._in_flight.items()},
-                "dispatched": {eid: ev for eid, ev in self._dispatched.items()},
-                "dispatch_times": dict(self._dispatch_times),
-                "retry_counts": dict(self._retry_counts),
                 # #9873-A: per-role consumer cursors. Pre-migration state
                 # files lack this key — load() uses .get("cursors", {}).
                 "cursors": dict(self._cursors),
@@ -1099,20 +1047,12 @@ class EventLifecycleManager:
         except (json.JSONDecodeError, OSError):
             return
 
-        # Restore in-flight/dispatch state under lock, then load events outside
-        # to maintain consistent lock ordering: self._lock → EventStream._lock
+        # Restore cursors under lock, then load events outside to maintain
+        # consistent lock ordering: self._lock → EventStream._lock.
+        # #11165: the in-flight/dispatch state was deleted under pull-only;
+        # old state files that still carry those keys are silently ignored.
         events_to_load = data.get("events", [])
         with self._lock:
-            self._in_flight = {
-                r: list(ids) for r, ids in data.get("in_flight", {}).items()
-            }
-            self._dispatched = data.get("dispatched", {})
-            self._dispatch_times = {
-                k: float(v) for k, v in data.get("dispatch_times", {}).items()
-            }
-            self._retry_counts = {
-                k: int(v) for k, v in data.get("retry_counts", {}).items()
-            }
             # #9873-A AC-1 / R2 F5: backward-compat — pre-migration state
             # files have no "cursors" key. data.get(..., {}) prevents a
             # KeyError that would crash harness boot on existing deployments.
@@ -1123,75 +1063,6 @@ class EventLifecycleManager:
         # Append events outside self._lock (acquires EventStream._lock)
         for event in events_to_load:
             self._stream.append(event)
-
-    def timeout_scan(self):
-        """Check for overdue in-flight events and escalate (#7630 2-3).
-
-        For each overdue event:
-        - If retries < max: increment retry count, reset dispatch time
-        - If retries >= max: mark as timed-out, remove from in-flight
-        All logging happens outside the lock to prevent deadlock with print().
-        """
-        now = time.time()
-        timeout_secs = self._timeout_minutes * 60
-        timed_out = []
-        retry_messages = []
-
-        with self._lock:
-            for role, event_ids in list(self._in_flight.items()):
-                to_remove = []
-                for event_id in list(event_ids):
-                    dispatch_time = self._dispatch_times.get(event_id, now)
-                    if now - dispatch_time > timeout_secs:
-                        retries = self._retry_counts.get(event_id, 0)
-                        if retries < self._max_retries:
-                            self._retry_counts[event_id] = retries + 1
-                            self._dispatch_times[event_id] = now
-                            retry_messages.append(
-                                f"Event {event_id} overdue for {role} "
-                                f"(retry {retries + 1}/{self._max_retries})")
-                        else:
-                            timed_out.append((role, event_id))
-                            to_remove.append(event_id)
-                            self._dispatched.pop(event_id, None)
-                            self._dispatch_times.pop(event_id, None)
-                            self._retry_counts.pop(event_id, None)
-                # Remove timed-out events from live list
-                for eid in to_remove:
-                    if eid in event_ids:
-                        event_ids.remove(eid)
-
-        # Log outside lock
-        for msg in retry_messages:
-            _log(msg)
-        for role, event_id in timed_out:
-            _log(f"Event {event_id} TIMED OUT for {role} after {self._max_retries} retries — escalating")
-
-        if timed_out or retry_messages:
-            self._persist()
-
-        return timed_out
-
-    def start_timeout_scanner(self):
-        """Start background thread that scans for overdue events."""
-        if self._scanner_running:
-            return
-        self._scanner_running = True
-        self._scanner_thread = threading.Thread(
-            target=self._scan_loop, daemon=True, name="event-timeout-scanner"
-        )
-        self._scanner_thread.start()
-
-    def stop_timeout_scanner(self):
-        self._scanner_running = False
-
-    def _scan_loop(self):
-        while self._scanner_running:
-            try:
-                self.timeout_scan()
-            except Exception:
-                pass  # Don't crash scanner on transient errors
-            time.sleep(self.SCAN_INTERVAL)
 
     @property
     def stream(self) -> EventStream:
@@ -1407,7 +1278,6 @@ async def lifespan(app: FastAPI):
             _log(f"WARNING: Could not distribute port to clones: {e}")
 
         event_lifecycle.load()
-        event_lifecycle.start_timeout_scanner()
         activity_detector.start()
         _log(f"Event state loaded: {len(event_stream)} events in stream")
 
@@ -2038,9 +1908,10 @@ async def receive_event(request: Request):
 
     # Ack processing (#9873-A): the previous single ``ack`` event type is
     # split into ``ack-cursor`` (advance consumer cursor) and ``ack-stop``
-    # (preserve stop-confirmed branch). D6 locks the split; D9/AC-18 mandate
-    # that ack-cursor MUST NOT call the old ``event_lifecycle.ack()`` — that
-    # in-flight tracker is dead code since #9741 stripped dispatch().
+    # (preserve stop-confirmed branch). D6 locks the split. The old
+    # dispatch-side ``event_lifecycle.ack()`` / in-flight tracker was deleted
+    # outright under pull-only (#11165 / #11092 D2); only cursor advancement
+    # remains.
     if event_type == "ack-cursor":
         # #9902 F4: guard against payload being present-but-not-dict (e.g.
         # a string from a malformed POST). The default `{}` only triggers
@@ -2257,67 +2128,27 @@ async def get_events_cursor(role: str):
 
 @app.post("/events/{event_id}/complete")
 async def complete_event(event_id: str, request: Request):
-    """Mark an event as completed by the processing agent (#7630 Phase 4).
+    """REMOVED (#11165 / #11092 Decision 2 — pull-only).
 
-    Called by agents after they finish processing an event. The harness:
-    1. Marks the event as acked in EventLifecycleManager
-    2. Executes any mechanical side effects (status transitions, commits)
-    3. Returns success/failure
-
-    Request body:
-        role: str — the agent role completing the event
-        status: str — "success" or "failure"
-        summary: str — brief description of what was done
-        transitions: list — optional status transitions to execute
-        comments: list — optional tracker comments to post
-        commit_message: str — optional commit message for git commit
+    The dispatch/ack lifecycle this endpoint drove was deleted: under
+    pull-only the harness only nudges, and agents poll the forge + advance
+    the cursor via ``ack-cursor`` (AGENT-RUNTIME §2/§7). Retained as a
+    410 Gone shell so any stale caller fails loudly rather than silently.
     """
-    body = await request.json()
-    role = body.get("role")
-    if not role:
-        raise HTTPException(status_code=400, detail="role is required")
-
-    # Ack the event in lifecycle manager
-    acked = event_lifecycle.ack(event_id, role)
-    if not acked:
-        # Event not in-flight — may have timed out or already been acked
-        from starlette.responses import JSONResponse
-        return JSONResponse(
-            status_code=410,
-            content={"status": "gone", "detail": f"Event {event_id} not in-flight for {role}"},
-        )
-
-    _log(f"Event {event_id} completed by {role}: {body.get('summary', 'no summary')}")
-
-    # Execute mechanical side effects
-    errors = []
-
-    # Status transitions
-    for transition in body.get("transitions", []):
-        try:
-            _execute_transition(transition)
-        except Exception as ex:
-            errors.append(f"transition error: {ex}")
-
-    # Tracker comments
-    for comment in body.get("comments", []):
-        try:
-            _execute_comment(comment)
-        except Exception as ex:
-            errors.append(f"comment error: {ex}")
-
-    return {
-        "status": "ok" if not errors else "partial",
-        "event_id": event_id,
-        "errors": errors,
-    }
+    from starlette.responses import JSONResponse
+    return JSONResponse(
+        status_code=410,
+        content={
+            "status": "gone",
+            "detail": "POST /events/{id}/complete removed under pull-only "
+                      "(#11165) — agents advance the cursor via ack-cursor.",
+        },
+    )
 
 
-@app.get("/events/in-flight/{role}")
-async def get_in_flight_events(role: str):
-    """Get in-flight event IDs for a role (#7630 P-3)."""
-    _validate_role(role)
-    return {"role": role, "in_flight": event_lifecycle.get_in_flight(role)}
+# GET /events/in-flight/{role} removed (#11165 / #11092 Decision 2): in-flight
+# dispatch tracking no longer exists under pull-only, and no caller invoked
+# the route (caller survey 2026-06-11).
 
 
 # Status priority/severity rank for /human/queue ordering (high → low).
@@ -2454,19 +2285,13 @@ async def get_human_queue():
 
 @app.get("/events/lifecycle")
 async def get_event_lifecycle():
-    """Event lifecycle overview — stream size, in-flight per role, persistence state (#7630 2-7)."""
-    in_flight = {}
-    try:
-        roles = boot_remote._get_all_roles()
-        for role in roles:
-            ids = event_lifecycle.get_in_flight(role)
-            if ids:
-                in_flight[role] = ids
-    except (SystemExit, Exception):
-        pass
+    """Event lifecycle overview — stream size + persistence state (#7630 2-7).
+
+    The ``in_flight`` field was dropped (#11165 / #11092 Decision 2): under
+    pull-only there is no dispatch in-flight tracking.
+    """
     return {
         "stream_size": len(event_stream),
-        "in_flight": in_flight,
         "persisted": EVENT_STATE_FILE.exists(),
     }
 

--- a/tests/test_cycle_pre.py
+++ b/tests/test_cycle_pre.py
@@ -1729,31 +1729,18 @@ class TestRunMechanicalReactions:
 
 
 class TestParseCliArgs:
-    def test_role_only_no_task(self):
-        role, task = cycle_pre._parse_cli_args(["skill"])
-        assert role == "skill"
-        assert task is None
+    """#11165: _parse_cli_args returns the role only — the per-task CLI flag
+    was removed under pull-only (#11092 Decision 3)."""
 
-    def test_role_with_task_flag(self):
-        role, task = cycle_pre._parse_cli_args(["skill", "--task", "42"])
-        assert role == "skill"
-        assert task == "42"
-
-    def test_task_flag_with_no_value_ignored(self):
-        """Trailing `--task` without a value should not crash."""
-        role, task = cycle_pre._parse_cli_args(["skill", "--task"])
-        assert role == "skill"
-        assert task is None
+    def test_role_only(self):
+        assert cycle_pre._parse_cli_args(["skill"]) == "skill"
 
     def test_empty_argv(self):
-        role, task = cycle_pre._parse_cli_args([])
-        assert role is None
-        assert task is None
+        assert cycle_pre._parse_cli_args([]) is None
 
-    def test_extra_args_after_task(self):
-        role, task = cycle_pre._parse_cli_args(["pm", "--task", "100", "--ignored"])
-        assert role == "pm"
-        assert task == "100"
+    def test_extra_args_ignored(self):
+        # Only the role (argv[0]) is parsed; any trailing args are ignored.
+        assert cycle_pre._parse_cli_args(["pm", "--whatever", "x"]) == "pm"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1159,6 +1159,16 @@ class TestEndpointsViaTestClient(unittest.TestCase):
         self.assertEqual(resp.status_code, 204)
         mock_append.assert_not_called()
 
+    def test_events_lifecycle_omits_in_flight(self):
+        """#11165 AC5: GET /events/lifecycle no longer reports `in_flight`
+        (dispatch in-flight tracking was deleted under pull-only)."""
+        resp = self.client.get("/events/lifecycle")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertNotIn("in_flight", data)
+        self.assertIn("stream_size", data)
+        self.assertIn("persisted", data)
+
     def test_post_agents_all_start(self):
         """POST /agents/all/start returns 200 with results."""
         mock_result = {"role": "skill", "action": "skip", "success": True,
@@ -1699,10 +1709,11 @@ class TestManualRebootClearsStoppingIntent(unittest.TestCase):
 
 
 class TestEventLifecycleManager(unittest.TestCase):
-    """#7630 P-1/P-3: EventLifecycleManager disk persistence and in-flight tracking."""
+    """EventLifecycleManager disk persistence (#7630 P-1). The dispatch /
+    in-flight tracking was deleted in #11165 (pull-only)."""
 
     def test_persist_and_load_round_trip(self):
-        """Event state (events + in_flight + dispatched) survives harness restart."""
+        """Event state survives a harness restart (append → load)."""
         import tempfile
         from harness import EventStream, EventLifecycleManager
 
@@ -1711,64 +1722,41 @@ class TestEventLifecycleManager(unittest.TestCase):
             with patch("harness.EVENT_STATE_FILE", state_file):
                 stream = EventStream()
                 mgr = EventLifecycleManager(stream)
-
-                event = {"id": "abc12345", "event_type": "test", "role": "skill"}
-                mgr.append(event)
-                mgr.dispatch("abc12345", "skill", event)
-
+                mgr.append({"id": "abc12345", "event_type": "test", "role": "skill"})
                 self.assertTrue(state_file.exists())
 
-                # Load into new manager
                 stream2 = EventStream()
                 mgr2 = EventLifecycleManager(stream2)
                 mgr2.load()
-
                 events = stream2.get_all()
                 self.assertEqual(len(events), 1)
                 self.assertEqual(events[0]["id"], "abc12345")
-                # In-flight state also restored
-                self.assertEqual(mgr2.get_in_flight("skill"), ["abc12345"])
 
-    def test_in_flight_tracking(self):
-        """Dispatch/ack lifecycle tracks per-role in-flight events."""
+    def test_load_ignores_legacy_dispatch_fields(self):
+        """#11165: a legacy state file still carrying in_flight/dispatched/
+        dispatch_times/retry_counts loads cleanly — those keys are silently
+        ignored, cursors + events still restore, no AttributeError."""
+        import tempfile
+        import json
         from harness import EventStream, EventLifecycleManager
 
-        with patch("harness.EVENT_STATE_FILE", Path("/nonexistent")):
-            stream = EventStream()
-            mgr = EventLifecycleManager(stream)
-
-            mgr.dispatch("evt1", "skill", {"id": "evt1"})
-            self.assertEqual(mgr.get_in_flight("skill"), ["evt1"])
-
-            result = mgr.ack("evt1", "skill")
-            self.assertTrue(result)
-            self.assertEqual(mgr.get_in_flight("skill"), [])
-
-    def test_ack_unknown_event_returns_false(self):
-        """Acking an event not in-flight returns False."""
-        from harness import EventStream, EventLifecycleManager
-
-        with patch("harness.EVENT_STATE_FILE", Path("/nonexistent")):
-            stream = EventStream()
-            mgr = EventLifecycleManager(stream)
-
-            result = mgr.ack("nonexistent", "skill")
-            self.assertFalse(result)
-
-    def test_in_flight_cap(self):
-        """Per-role in-flight queue respects cap. Dropped events excluded from _dispatched."""
-        from harness import EventStream, EventLifecycleManager
-
-        with patch("harness.EVENT_STATE_FILE", Path("/nonexistent")):
-            stream = EventStream()
-            mgr = EventLifecycleManager(stream, max_in_flight=2)
-
-            mgr.dispatch("evt1", "skill", {"id": "evt1"})
-            mgr.dispatch("evt2", "skill", {"id": "evt2"})
-            mgr.dispatch("evt3", "skill", {"id": "evt3"})  # should be dropped
-
-            self.assertEqual(len(mgr.get_in_flight("skill")), 2)
-            self.assertNotIn("evt3", mgr._dispatched)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_file = Path(tmpdir) / ".event-state.json"
+            state_file.write_text(json.dumps({
+                "events": [{"id": "e1", "event_type": "t", "role": "skill"}],
+                "in_flight": {"skill": ["e1"]},
+                "dispatched": {"e1": {}},
+                "dispatch_times": {"e1": 1.0},
+                "retry_counts": {"e1": 0},
+                "cursors": {"skill": "e1"},
+            }), encoding="utf-8")
+            with patch("harness.EVENT_STATE_FILE", state_file):
+                stream = EventStream()
+                mgr = EventLifecycleManager(stream)
+                mgr.load()  # must not raise on the legacy keys
+                self.assertEqual(len(stream.get_all()), 1)
+                self.assertEqual(mgr.get_cursor("skill"), "e1")
+                self.assertFalse(hasattr(mgr, "_in_flight"))
 
     def test_load_is_idempotent(self):
         """Calling load() twice does not duplicate events (#7630 CRITICAL-2)."""
@@ -2197,46 +2185,6 @@ class TestTerminalPidInAgentState(unittest.TestCase):
                 self.assertEqual(loaded.terminal_pid, 99999)
 
 
-class TestTimeoutScanner(unittest.TestCase):
-    """#7630 2-3: EventLifecycleManager timeout detection."""
-
-    def test_overdue_event_detected(self):
-        """Events past timeout are detected by timeout_scan."""
-        from harness import EventStream, EventLifecycleManager
-
-        with patch("harness.EVENT_STATE_FILE", Path("/nonexistent")), \
-             patch("harness._log"):
-            stream = EventStream()
-            mgr = EventLifecycleManager(stream, timeout_minutes=0)  # 0 = immediate timeout
-
-            mgr.dispatch("evt1", "skill", {"id": "evt1"})
-            # Backdate dispatch time to force timeout
-            mgr._dispatch_times["evt1"] = time.time() - 1
-
-            timed_out = mgr.timeout_scan()
-            # First scan: retry (not yet at max retries)
-            self.assertEqual(len(timed_out), 0)  # retried, not timed out
-            self.assertEqual(mgr._retry_counts.get("evt1"), 1)
-
-    def test_max_retries_causes_timeout(self):
-        """After max retries, event is removed from in-flight."""
-        from harness import EventStream, EventLifecycleManager
-
-        with patch("harness.EVENT_STATE_FILE", Path("/nonexistent")), \
-             patch("harness._log"):
-            stream = EventStream()
-            mgr = EventLifecycleManager(stream, timeout_minutes=0, max_retries=1)
-
-            mgr.dispatch("evt1", "skill", {"id": "evt1"})
-            mgr._dispatch_times["evt1"] = time.time() - 1
-            mgr._retry_counts["evt1"] = 1  # Already at max
-
-            timed_out = mgr.timeout_scan()
-            self.assertEqual(len(timed_out), 1)
-            self.assertEqual(timed_out[0], ("skill", "evt1"))
-            self.assertEqual(mgr.get_in_flight("skill"), [])
-
-
 class TestEventDrivenPhase4(unittest.TestCase):
     """#7630 Phase 4: Event-driven wake prototype — config, endpoints, poll."""
 
@@ -2371,22 +2319,6 @@ class TestEventDrivenPhase4(unittest.TestCase):
         with self.assertRaises(ValueError):
             _execute_comment({"number": 1, "message": "hello\x00world"})
 
-    def test_dispatch_skips_already_dispatched(self):
-        """dispatch() skips events that are already in _dispatched."""
-        from harness import EventStream, EventLifecycleManager
-
-        with patch("harness.EVENT_STATE_FILE", Path("/nonexistent")):
-            stream = EventStream()
-            mgr = EventLifecycleManager(stream)
-
-            mgr.dispatch("evt1", "skill", {"id": "evt1"})
-            self.assertEqual(mgr.get_in_flight("skill"), ["evt1"])
-
-            # Dispatch same event again — should not duplicate
-            mgr.dispatch("evt1", "skill", {"id": "evt1"})
-            self.assertEqual(mgr.get_in_flight("skill"), ["evt1"])
-
-
 class TestGetEventsForRole(unittest.TestCase):
     """#7630 Phase 4: GET /events/for/{role} endpoint tests."""
 
@@ -2403,10 +2335,6 @@ class TestGetEventsForRole(unittest.TestCase):
         """Clear event stream between tests."""
         with self.event_stream._lock:
             self.event_stream._events.clear()
-        with self.event_lifecycle._lock:
-            self.event_lifecycle._in_flight.clear()
-            self.event_lifecycle._dispatched.clear()
-            self.event_lifecycle._dispatch_times.clear()
 
     def test_filters_by_target_role(self):
         """GET /events/for/skill returns only events targeted at skill."""
@@ -2430,28 +2358,6 @@ class TestGetEventsForRole(unittest.TestCase):
         self.assertEqual(len(data["events"]), 1)
         self.assertEqual(data["events"][0]["id"], "e1")
 
-    def test_does_not_dispatch(self):
-        """#9741: GET /events/for/skill must NOT add events to in-flight.
-
-        Before #9741 the endpoint called event_lifecycle.dispatch() on every
-        delivered event, but there is no ack consumer wired yet — every
-        event would eventually time out, growing .event-state.json and
-        spamming the timeout-scanner log. CONTEXT-9741 D1 strips the call;
-        the endpoint is a pure filtered-read with no lifecycle side effects.
-        """
-        from harness import event_stream, event_lifecycle
-
-        event_stream.append({
-            "id": "e3", "event_type": "assigned-to", "role": "harness",
-            "payload": {"target_role": "skill", "issue_number": "3"},
-        })
-
-        with patch("harness._validate_role"):
-            self.client.get("/events/for/skill")
-
-        # Endpoint delivers the event but does not touch in-flight state.
-        self.assertNotIn("e3", event_lifecycle.get_in_flight("skill"))
-
     def test_since_cursor_filters_events(self):
         """GET /events/for/skill?since=X returns only events after cursor."""
         from harness import event_stream
@@ -2473,146 +2379,30 @@ class TestGetEventsForRole(unittest.TestCase):
         self.assertNotIn("old1", ids)
         self.assertIn("new1", ids)
 
-    def test_endpoint_does_not_touch_lifecycle_state(self):
-        """#9741: with dispatch stripped, the endpoint must not mutate in-flight.
-
-        Even when an event was pre-dispatched by some other path, calling
-        the read endpoint must not re-dispatch, re-add, or otherwise mutate
-        the lifecycle state. CONTEXT-9741 D2 — the idempotency guard test
-        is irrelevant once dispatch is stripped; this test instead verifies
-        the read-only invariant.
-        """
-        from harness import event_stream, event_lifecycle
-
-        event_stream.append({
-            "id": "e4", "event_type": "assigned-to", "role": "harness",
-            "payload": {"target_role": "skill"},
-        })
-
-        # Pre-dispatch via the lifecycle manager directly (NOT via the endpoint).
-        event_lifecycle.dispatch("e4", "skill", {"id": "e4"})
-        before = list(event_lifecycle.get_in_flight("skill"))
-
-        with patch("harness._validate_role"):
-            self.client.get("/events/for/skill")
-
-        # In-flight state must be identical — endpoint touched nothing.
-        after = list(event_lifecycle.get_in_flight("skill"))
-        self.assertEqual(before, after)
-        # And specifically: e4 still appears exactly once (the pre-dispatch),
-        # not zero (would mean endpoint cleared it) or two (would mean
-        # endpoint re-dispatched).
-        self.assertEqual(after.count("e4"), 1)
-
-
 class TestCompleteEventEndpoint(unittest.TestCase):
-    """#7630 Phase 4: POST /events/{event_id}/complete endpoint tests."""
+    """#11165: POST /events/{event_id}/complete was removed under pull-only —
+    it now returns 410 Gone unconditionally. The dispatch/ack lifecycle it
+    drove was deleted (#11092 Decision 2)."""
 
     @classmethod
     def setUpClass(cls):
         from fastapi.testclient import TestClient
-        from harness import app, event_stream, event_lifecycle
+        from harness import app
 
         cls.client = TestClient(app, raise_server_exceptions=False)
-        cls.event_stream = event_stream
-        cls.event_lifecycle = event_lifecycle
 
-    def setUp(self):
-        """Clear lifecycle state between tests."""
-        with self.event_lifecycle._lock:
-            self.event_lifecycle._in_flight.clear()
-            self.event_lifecycle._dispatched.clear()
-            self.event_lifecycle._dispatch_times.clear()
-
-    def test_complete_acks_in_flight_event(self):
-        """POST /events/evt1/complete acks an in-flight event."""
-        self.event_lifecycle.dispatch("evt1", "skill", {"id": "evt1"})
-        self.assertIn("evt1", self.event_lifecycle.get_in_flight("skill"))
-
-        resp = self.client.post("/events/evt1/complete", json={
-            "role": "skill",
-            "status": "success",
-            "summary": "Done",
+    def test_complete_returns_410_always(self):
+        """AC3: a well-formed completion POST returns 410 Gone."""
+        resp = self.client.post("/events/any-id/complete", json={
+            "role": "skill", "status": "success", "summary": "Done",
         })
-
-        self.assertEqual(resp.status_code, 200)
-        data = resp.json()
-        self.assertEqual(data["status"], "ok")
-        self.assertNotIn("evt1", self.event_lifecycle.get_in_flight("skill"))
-
-    def test_complete_returns_410_for_unknown_event(self):
-        """POST /events/unknown/complete returns 410 when event not in-flight."""
-        resp = self.client.post("/events/unknown-id/complete", json={
-            "role": "skill",
-            "status": "success",
-            "summary": "Done",
-        })
-
         self.assertEqual(resp.status_code, 410)
-        data = resp.json()
-        self.assertEqual(data["status"], "gone")
+        self.assertEqual(resp.json()["status"], "gone")
 
-    def test_complete_executes_transitions(self):
-        """POST /events/evt2/complete executes status transitions."""
-        self.event_lifecycle.dispatch("evt2", "skill", {"id": "evt2"})
-
-        with patch("harness._execute_transition") as mock_trans:
-            resp = self.client.post("/events/evt2/complete", json={
-                "role": "skill",
-                "status": "success",
-                "summary": "Fixed",
-                "transitions": [
-                    {"number": 123, "from": "in-progress", "to": "pending-test", "role": "skill-lead"}
-                ],
-            })
-
-        self.assertEqual(resp.status_code, 200)
-        mock_trans.assert_called_once()
-
-    def test_complete_executes_comments(self):
-        """POST /events/evt3/complete executes tracker comments."""
-        self.event_lifecycle.dispatch("evt3", "skill", {"id": "evt3"})
-
-        with patch("harness._execute_comment") as mock_comment:
-            resp = self.client.post("/events/evt3/complete", json={
-                "role": "skill",
-                "status": "success",
-                "summary": "Commented",
-                "comments": [
-                    {"number": 123, "role": "skill-lead", "message": "Done."}
-                ],
-            })
-
-        self.assertEqual(resp.status_code, 200)
-        mock_comment.assert_called_once()
-
-    def test_complete_reports_partial_on_side_effect_failure(self):
-        """POST /events/evt4/complete returns partial on transition errors."""
-        self.event_lifecycle.dispatch("evt4", "skill", {"id": "evt4"})
-
-        with patch("harness._execute_transition", side_effect=RuntimeError("tracker fail")):
-            resp = self.client.post("/events/evt4/complete", json={
-                "role": "skill",
-                "status": "success",
-                "summary": "Partial",
-                "transitions": [
-                    {"number": 1, "from": "a", "to": "b"}
-                ],
-            })
-
-        self.assertEqual(resp.status_code, 200)
-        data = resp.json()
-        self.assertEqual(data["status"], "partial")
-        self.assertTrue(len(data["errors"]) > 0)
-
-    def test_complete_requires_role(self):
-        """POST /events/evt5/complete returns 400 without role."""
-        resp = self.client.post("/events/evt5/complete", json={
-            "status": "success",
-            "summary": "No role",
-        })
-
-        self.assertEqual(resp.status_code, 400)
+    def test_complete_returns_410_even_without_role(self):
+        """The 410 fires before any body validation — pure deprecation shell."""
+        resp = self.client.post("/events/any-id/complete", json={})
+        self.assertEqual(resp.status_code, 410)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_harness_route_contract.py
+++ b/tests/test_harness_route_contract.py
@@ -61,7 +61,6 @@ EXPECTED_CALLERS = {
     ("GET",  "/events/for/{role}"):             ["event_poll"],
     ("GET",  "/events/cursor/{role}"):          _EXTERNAL,
     ("POST", "/events/{event_id}/complete"):    _EXTERNAL,
-    ("GET",  "/events/in-flight/{role}"):       _EXTERNAL,
     ("GET",  "/events/lifecycle"):              _EXTERNAL,
     ("GET",  "/human/queue"):                   _EXTERNAL,
     ("POST", "/shutdown"):                      ["squidsquad_cli"],


### PR DESCRIPTION
## Summary

Cascade deletion of the dead **dispatch infrastructure** + the `cycle_pre.py` per-task CLI flag, ratifying pull-only (operator-locked #11092 Decision 2+3, per the CONTEXT-11092 disposition table). Under pull-only the harness only nudges; agents poll the forge and advance the cursor via `ack-cursor`. Closes #11165. Net **−425 lines**.

Bases on `main`. **Merge note**: the `cycle_pre.py` task_id deletion is adjacent to #11329's unmerged #5622 edit (on polish) — expect a small, mechanical conflict at the #11402 polish→main merge (flagged on the issue).

## ACs

- **AC1** — deleted `EventLifecycleManager.dispatch/ack/get_in_flight`, the `_in_flight/_dispatched/_dispatch_times/_retry_counts` state, and the `timeout_scan`/scanner thread (+ boot start). `grep` → 0.
- **AC2** — deleted the `cycle_pre.py` per-task flag + task branches. `grep "--task|task_id|task_mode"` → 0.
- **AC3** — `POST /events/{id}/complete` → 410 Gone shell.
- **AC4** — `GET /events/in-flight/{role}` **removed** (caller survey found no invoker — documented choice).
- **AC5** — `GET /events/lifecycle` drops the `in_flight` field.
- **AC6** — deleted the obsolete dispatch/ack/in-flight/timeout test classes; rewrote `TestCompleteEventEndpoint` (410-always); added a **legacy-state-file load test** (migration safety: old `.event-state.json` with the 4 keys loads cleanly) + an `/events/lifecycle` no-`in_flight` test; removed the stale route-contract entry. test_harness (179) + cycle_pre + route-contract + e2e all green.
- **AC7** — persistence + app construction verified via the passing TestClient suite + the legacy-load test (no `AttributeError`, no thread-start on boot). Full live-agent boot is a verifier step.

DS review (high-blast-radius) running; findings will land as a follow-up commit.

## Test plan

- [ ] `pytest tests/test_harness.py tests/test_cycle_pre.py tests/test_harness_route_contract.py`
- [ ] Verifier: boot a role, confirm a full cycle completes with no AttributeError on the persistence path / no scanner thread-start error (AC7)
- [ ] Verifier: `POST /events/x/complete` → 410; `GET /events/in-flight/skill` → 404; `GET /events/lifecycle` has no `in_flight`

🤖 Generated with [Claude Code](https://claude.com/claude-code)