### PR TITLE
skill: #11227 — activate L2 inline op anchoring (reduced scope)

### DIFF
--- a/.squidsquad/dm/CLAUDE.linked.md
+++ b/.squidsquad/dm/CLAUDE.linked.md
@@ -222,6 +222,11 @@ Verify tracker access, read `.squidsquad/config.md` for interval and mode, check
 
 Read `working-state.md`. If an active task exists (status `in-progress`), resume it and skip to `step:cycle/work`. Otherwise proceed normally.
 
+#### step:cycle/issue-triage
+
+→ run sub-skill: task-pickup
+
+Scan for pending-ship items. Check `delivery:skip` label before starting packaging — internal-only tasks skip delivery packaging. For each pending-ship item without `delivery:skip`: proceed to delivery-packaging.
 ### step:cycle/pickup
 
 → run sub-skill: task-pickup
@@ -874,12 +879,6 @@ The status line updates automatically after each assistant message.
 <!-- /sub-skill: prohibitions -->
 
 ---
-
-#### step:cycle/issue-triage
-
-→ run sub-skill: task-pickup
-
-Scan for pending-ship items. Check `delivery:skip` label before starting packaging — internal-only tasks skip delivery packaging. For each pending-ship item without `delivery:skip`: proceed to delivery-packaging.
 
 #### step:cycle/delivery-packaging
 

--- a/.squidsquad/dm/CLAUDE.md
+++ b/.squidsquad/dm/CLAUDE.md
@@ -195,6 +195,11 @@ Verify tracker access, read `.squidsquad/config.md` for interval and mode, check
 
 Read `working-state.md`. If an active task exists (status `in-progress`), resume it and skip to `step:cycle/work`. Otherwise proceed normally.
 
+#### step:cycle/issue-triage
+
+→ run sub-skill: task-pickup
+
+Scan for pending-ship items. Check `delivery:skip` label before starting packaging — internal-only tasks skip delivery packaging. For each pending-ship item without `delivery:skip`: proceed to delivery-packaging.
 ### step:cycle/pickup
 
 → run sub-skill: task-pickup
@@ -847,12 +852,6 @@ The status line updates automatically after each assistant message.
 <!-- /sub-skill: prohibitions -->
 
 ---
-
-#### step:cycle/issue-triage
-
-→ run sub-skill: task-pickup
-
-Scan for pending-ship items. Check `delivery:skip` label before starting packaging — internal-only tasks skip delivery packaging. For each pending-ship item without `delivery:skip`: proceed to delivery-packaging.
 
 #### step:cycle/delivery-packaging
 

--- a/.squidsquad/pm/CLAUDE.linked.md
+++ b/.squidsquad/pm/CLAUDE.linked.md
@@ -262,16 +262,37 @@ Verify tracker access, read `.squidsquad/config.md` for interval and mode, check
 
 Read `working-state.md`. If an active task exists (status `in-progress`), resume it and skip to `step:cycle/work`. Otherwise proceed normally.
 
+#### step:cycle/check-in
+
+→ run sub-skill: checkin
+
+Check in with the human. Read any new messages or issue comments since last cycle. Capture requirements, priority changes, or approvals. Note in Discussion. Do not block the cycle on human response — continue after acknowledging.
 ### step:cycle/pickup
 
 → run sub-skill: task-pickup
 
 Query tracker for approved tasks assigned to this role. Select highest-priority item. Record in `working-state.md`.
 
+#### step:cycle/task-intake
+
+→ run sub-skill: task-intake
+
+Run 5-phase task intake for pending items awaiting PM processing. Research → Discussion → Planning → (human approval gate) → mark Approved. Bug fixes skip to Approved immediately.
+
+#### step:cycle/task-approval
+
+→ run sub-skill: task-approval
+
+For pending-test items: hold verifier accountable. For planning-complete items awaiting human sign-off: surface for approval. Do NOT run test cases directly.
 ### step:cycle/work
 
 Do the unit of work for the current cycle. Content varies by role-class (see L2 additions below).
 
+#### step:cycle/pipeline-sentinel
+
+→ run sub-skill: pipeline-sentinel
+
+Scan pipeline state: stalled tasks, PR conflicts, stuck agents, misrouted work. Trace root cause. Comment on issues to nudge or route. Never touch branches — only tracker comments and notifications.
 ### step:cycle/checkpoint
 
 → run sub-skill: git-commit
@@ -288,6 +309,17 @@ Clear or update `working-state.md`. Write iteration log entry. Run vault-remembe
 
 If cycle was quiet (no task picked up), run improvement scan per configured policy.
 
+#### step:cycle/health-check
+
+→ run sub-skill: health-check
+
+Check agent health statuses. Boot dead agents via `boot_remote.py` if auto-boot is unavailable. Report stalls.
+
+#### step:cycle/vault-synthesis
+
+→ run sub-skill: vault-synthesis
+
+On quiet cycles (no task picked up), every 5 quiet cycles: synthesize cross-agent patterns from iteration logs into vault posture notes.
 ### step:cycle/exit
 
 → run sub-skill: agent-lifecycle
@@ -942,43 +974,6 @@ The status line updates automatically after each assistant message. No action is
 <!-- /sub-skill: prohibitions -->
 
 ---
-
-#### step:cycle/check-in
-
-→ run sub-skill: checkin
-
-Check in with the human. Read any new messages or issue comments since last cycle. Capture requirements, priority changes, or approvals. Note in Discussion. Do not block the cycle on human response — continue after acknowledging.
-
-#### step:cycle/task-intake
-
-→ run sub-skill: task-intake
-
-Run 5-phase task intake for pending items awaiting PM processing. Research → Discussion → Planning → (human approval gate) → mark Approved. Bug fixes skip to Approved immediately.
-
-#### step:cycle/task-approval
-
-→ run sub-skill: task-approval
-
-For pending-test items: hold verifier accountable. For planning-complete items awaiting human sign-off: surface for approval. Do NOT run test cases directly.
-
-#### step:cycle/pipeline-sentinel
-
-→ run sub-skill: pipeline-sentinel
-
-Scan pipeline state: stalled tasks, PR conflicts, stuck agents, misrouted work. Trace root cause. Comment on issues to nudge or route. Never touch branches — only tracker comments and notifications.
-
-#### step:cycle/health-check
-
-→ run sub-skill: health-check
-
-Check agent health statuses. Boot dead agents via `boot_remote.py` if auto-boot is unavailable. Report stalls.
-
-#### step:cycle/vault-synthesis
-
-→ run sub-skill: vault-synthesis
-
-On quiet cycles (no task picked up), every 5 quiet cycles: synthesize cross-agent patterns from iteration logs into vault posture notes.
-
 
 ## Reactive sub-skills
 

--- a/.squidsquad/pm/CLAUDE.md
+++ b/.squidsquad/pm/CLAUDE.md
@@ -235,16 +235,37 @@ Verify tracker access, read `.squidsquad/config.md` for interval and mode, check
 
 Read `working-state.md`. If an active task exists (status `in-progress`), resume it and skip to `step:cycle/work`. Otherwise proceed normally.
 
+#### step:cycle/check-in
+
+→ run sub-skill: checkin
+
+Check in with the human. Read any new messages or issue comments since last cycle. Capture requirements, priority changes, or approvals. Note in Discussion. Do not block the cycle on human response — continue after acknowledging.
 ### step:cycle/pickup
 
 → run sub-skill: task-pickup
 
 Query tracker for approved tasks assigned to this role. Select highest-priority item. Record in `working-state.md`.
 
+#### step:cycle/task-intake
+
+→ run sub-skill: task-intake
+
+Run 5-phase task intake for pending items awaiting PM processing. Research → Discussion → Planning → (human approval gate) → mark Approved. Bug fixes skip to Approved immediately.
+
+#### step:cycle/task-approval
+
+→ run sub-skill: task-approval
+
+For pending-test items: hold verifier accountable. For planning-complete items awaiting human sign-off: surface for approval. Do NOT run test cases directly.
 ### step:cycle/work
 
 Do the unit of work for the current cycle. Content varies by role-class (see L2 additions below).
 
+#### step:cycle/pipeline-sentinel
+
+→ run sub-skill: pipeline-sentinel
+
+Scan pipeline state: stalled tasks, PR conflicts, stuck agents, misrouted work. Trace root cause. Comment on issues to nudge or route. Never touch branches — only tracker comments and notifications.
 ### step:cycle/checkpoint
 
 → run sub-skill: git-commit
@@ -261,6 +282,17 @@ Clear or update `working-state.md`. Write iteration log entry. Run vault-remembe
 
 If cycle was quiet (no task picked up), run improvement scan per configured policy.
 
+#### step:cycle/health-check
+
+→ run sub-skill: health-check
+
+Check agent health statuses. Boot dead agents via `boot_remote.py` if auto-boot is unavailable. Report stalls.
+
+#### step:cycle/vault-synthesis
+
+→ run sub-skill: vault-synthesis
+
+On quiet cycles (no task picked up), every 5 quiet cycles: synthesize cross-agent patterns from iteration logs into vault posture notes.
 ### step:cycle/exit
 
 → run sub-skill: agent-lifecycle
@@ -915,43 +947,6 @@ The status line updates automatically after each assistant message. No action is
 <!-- /sub-skill: prohibitions -->
 
 ---
-
-#### step:cycle/check-in
-
-→ run sub-skill: checkin
-
-Check in with the human. Read any new messages or issue comments since last cycle. Capture requirements, priority changes, or approvals. Note in Discussion. Do not block the cycle on human response — continue after acknowledging.
-
-#### step:cycle/task-intake
-
-→ run sub-skill: task-intake
-
-Run 5-phase task intake for pending items awaiting PM processing. Research → Discussion → Planning → (human approval gate) → mark Approved. Bug fixes skip to Approved immediately.
-
-#### step:cycle/task-approval
-
-→ run sub-skill: task-approval
-
-For pending-test items: hold verifier accountable. For planning-complete items awaiting human sign-off: surface for approval. Do NOT run test cases directly.
-
-#### step:cycle/pipeline-sentinel
-
-→ run sub-skill: pipeline-sentinel
-
-Scan pipeline state: stalled tasks, PR conflicts, stuck agents, misrouted work. Trace root cause. Comment on issues to nudge or route. Never touch branches — only tracker comments and notifications.
-
-#### step:cycle/health-check
-
-→ run sub-skill: health-check
-
-Check agent health statuses. Boot dead agents via `boot_remote.py` if auto-boot is unavailable. Report stalls.
-
-#### step:cycle/vault-synthesis
-
-→ run sub-skill: vault-synthesis
-
-On quiet cycles (no task picked up), every 5 quiet cycles: synthesize cross-agent patterns from iteration logs into vault posture notes.
-
 
 ## Reactive sub-skills
 

--- a/.squidsquad/qa/CLAUDE.linked.md
+++ b/.squidsquad/qa/CLAUDE.linked.md
@@ -235,6 +235,11 @@ Verify tracker access, read `.squidsquad/config.md` for interval and mode, check
 
 Read `working-state.md`. If an active task exists (status `in-progress`), resume it and skip to `step:cycle/work`. Otherwise proceed normally.
 
+#### step:cycle/e2e-check
+
+→ run sub-skill: verification
+
+If E2E / integration test command is configured in `.squidsquad/config.md`, run it. Triage failures to the correct role via tracker comments. Do not fix failures yourself.
 ### step:cycle/pickup
 
 → run sub-skill: task-pickup
@@ -884,12 +889,6 @@ The status line updates automatically after each assistant message. No action is
 <!-- /sub-skill: prohibitions -->
 
 ---
-
-#### step:cycle/e2e-check
-
-→ run sub-skill: verification
-
-If E2E / integration test command is configured in `.squidsquad/config.md`, run it. Triage failures to the correct role via tracker comments. Do not fix failures yourself.
 
 #### step:cycle/verify
 

--- a/.squidsquad/qa/CLAUDE.md
+++ b/.squidsquad/qa/CLAUDE.md
@@ -208,6 +208,11 @@ Verify tracker access, read `.squidsquad/config.md` for interval and mode, check
 
 Read `working-state.md`. If an active task exists (status `in-progress`), resume it and skip to `step:cycle/work`. Otherwise proceed normally.
 
+#### step:cycle/e2e-check
+
+→ run sub-skill: verification
+
+If E2E / integration test command is configured in `.squidsquad/config.md`, run it. Triage failures to the correct role via tracker comments. Do not fix failures yourself.
 ### step:cycle/pickup
 
 → run sub-skill: task-pickup
@@ -857,12 +862,6 @@ The status line updates automatically after each assistant message. No action is
 <!-- /sub-skill: prohibitions -->
 
 ---
-
-#### step:cycle/e2e-check
-
-→ run sub-skill: verification
-
-If E2E / integration test command is configured in `.squidsquad/config.md`, run it. Triage failures to the correct role via tracker comments. Do not fix failures yourself.
 
 #### step:cycle/verify
 

--- a/.squidsquad/skill/CLAUDE.linked.md
+++ b/.squidsquad/skill/CLAUDE.linked.md
@@ -272,6 +272,11 @@ Verify tracker access, read `.squidsquad/config.md` for interval and mode, check
 
 Read `working-state.md`. If an active task exists (status `in-progress`), resume it and skip to `step:cycle/work`. Otherwise proceed normally.
 
+#### step:cycle/triage-issues
+
+→ run sub-skill: triage-issues
+
+Scan this role's open issues for bug reports. For each: investigate root cause, determine if it's in this domain, file cross-domain if not. Bugs are auto-approved; pick up immediately.
 ### step:cycle/pickup
 
 → run sub-skill: task-pickup
@@ -1054,12 +1059,6 @@ The status line updates automatically after each assistant message. No action is
 <!-- /sub-skill: prohibitions -->
 
 ---
-
-#### step:cycle/triage-issues
-
-→ run sub-skill: triage-issues
-
-Scan this role's open issues for bug reports. For each: investigate root cause, determine if it's in this domain, file cross-domain if not. Bugs are auto-approved; pick up immediately.
 
 #### step:cycle/implement
 

--- a/.squidsquad/skill/CLAUDE.md
+++ b/.squidsquad/skill/CLAUDE.md
@@ -241,6 +241,11 @@ Verify tracker access, read `.squidsquad/config.md` for interval and mode, check
 
 Read `working-state.md`. If an active task exists (status `in-progress`), resume it and skip to `step:cycle/work`. Otherwise proceed normally.
 
+#### step:cycle/triage-issues
+
+→ run sub-skill: triage-issues
+
+Scan this role's open issues for bug reports. For each: investigate root cause, determine if it's in this domain, file cross-domain if not. Bugs are auto-approved; pick up immediately.
 ### step:cycle/pickup
 
 → run sub-skill: task-pickup
@@ -1023,12 +1028,6 @@ The status line updates automatically after each assistant message. No action is
 <!-- /sub-skill: prohibitions -->
 
 ---
-
-#### step:cycle/triage-issues
-
-→ run sub-skill: triage-issues
-
-Scan this role's open issues for bug reports. For each: investigate root cause, determine if it's in this domain, file cross-domain if not. Bugs are auto-approved; pick up immediately.
 
 #### step:cycle/implement
 

--- a/docs/COMPOSE-ARCHITECTURE.md
+++ b/docs/COMPOSE-ARCHITECTURE.md
@@ -334,6 +334,18 @@ Each `## <Slot>` section holds the project's customizations for that slot. Withi
 
 Compose **must validate** that every `step:` reference in an `## Instructions` H3 resolves to a real L1-L3 step ID before emitting output. Unresolved references abort compose with a diagnostic.
 
+#### Inline ops in L1-L3 source bodies (#11227)
+
+Ops are **not L4-exclusive**. The same H3 op grammar (`### append`, `### insert-after step:cycle/<id>`, `### insert-before step:cycle/<id>`, `### replace step:cycle/<id>`) may appear **inline inside an L1-L3 source body**, not just in the L4 file. This lets a role-class (L2) or domain (L3) source anchor its own cycle steps at the shared L1 cycle positions instead of dumping them at the end of the slot. For example, `references/roles/pm/instructions.md` (L2) carries `### insert-after step:cycle/resume` whose body is the PM-specific `#### step:cycle/check-in` block — so in the composed PM `CLAUDE.md` the check-in step lands right after the L1 `### step:cycle/resume` step.
+
+The link stage (`v2_link_stage`) handles these during slot assembly:
+
+- **Step-targeted directives** (`insert-after` / `insert-before` / `replace step:cycle/<id>`) are extracted from each source body and applied — via the same `l4_op_processor.apply_l4_ops` used for L4 — against the `### step:cycle/<id>` **H3 anchors** present in the joined L1-L3 base content. Inline ops apply **before** the L4 file's ops for that slot.
+- **Bare `### append` / `### replace`** (no step target) in a source body: the op header is dropped and the body flows on as ordinary slot content (concatenation is equivalent to a slot-end append).
+- **Anchor must be an H3.** An inline step-targeted directive only anchors if its target appears as a top-level `### step:cycle/<id>` heading in the base. A directive whose target is absent **degrades to inline content** at its source position (compose stays green; nothing is lost, nothing raises).
+
+> **Current limitation — L3→L2 anchoring deferred (#11227 AC-6).** L2 sources define their cycle sub-steps as `#### step:cycle/<id>` (**H4**, nested under the H3 cycle step), but `l4_op_processor` anchors only on `### step:cycle/<id>` (**H3**). So an **L3** directive targeting an **L2-defined sub-step** (e.g. `dm/skill` → `insert-after step:cycle/delivery-packaging`, where `delivery-packaging` is an H4 in `dm/instructions.md`) currently degrades to inline rather than anchoring. Activating L3 anchoring requires a design decision (extend the op-processor anchor to H4, or promote L2 sub-steps to H3) tracked as a follow-up. L2 directives targeting L1 H3 steps (`resume`/`pickup`/`work`/`cleanup`) anchor today.
+
 #### Per-slot op constraints
 
 Not every op is legal on every slot. The soul slot is identity, not instruction, and is constrained to additive customization only:
@@ -427,14 +439,15 @@ Compose processes L1-L3 deterministically:
 2. **Filter by role-class**: each file may declare which role-classes it applies to (via `roles:` frontmatter list; default = all). Files not applicable to the current role-class are dropped.
 3. **Sort**: stable sort by `(slot_index, ordinal)`. `slot_index` is a fixed enum: identity=0, responsibility=1, soul=2, instructions=3, project-context=4, vault=5.
 4. **Emit orchestration**: under the appropriate top-level section header, emit each file's orchestration content verbatim. Inside the `instructions` slot, step bodies are **references to sub-skills by name** (e.g. `→ run sub-skill: pipeline-sentinel`) rather than inlined sub-skill content. The catalog of available sub-skills lives at [`sub-skill-catalog.md`](sub-skill-catalog.md) — composed CLAUDE.md never duplicates it.
+5. **Resolve inline ops** (#11227): a source body may itself carry H3 op directives (`### insert-after step:cycle/<id>`, `insert-before`, `replace step:cycle/<id>`, bare `### append`). Within each slot, the link stage splits every body into content vs. op directives, applies the step-targeted directives — via the same `apply_l4_ops` used for L4 — against the `### step:cycle/<id>` H3 anchors present in the joined base, and degrades any directive whose anchor is absent to inline content. This is what lets an L2/L3 source anchor its own cycle steps at the L1 cycle positions. See §3.3 "Inline ops in L1-L3 source bodies" for the grammar, ordering (inline ops before L4 ops), and the deferred L3→L2 (H4-anchor) limitation.
 
-The output of step 4 is the **L1-L3 base composition** — purely the SquidSquad-shipped orchestration, with sub-skill names referenced (not their bodies), and no project customization yet applied.
+The output of steps 4–5 is the **L1-L3 base composition** — the SquidSquad-shipped orchestration with each layer's inline ops resolved, sub-skill names referenced (not their bodies), and no project (L4) customization yet applied.
 
 **Why references and not inlining**: today's behavior inlined sub-skill bodies via `{{include}}` directives, producing 50KB+ composed CLAUDE.md files where most content was duplicated sub-skill text. Under v2, composed CLAUDE.md is the thin orchestration (5–10KB) and the model invokes sub-skills via the Skill tool when their description matches the situation. The transition is staged — see §10 migration plan.
 
 ### 4.2 Link: Creative L4 application
 
-After the L1-L3 base is in memory, compose reads exactly one L4 file: `.squidsquad/project/<role-class>.md` (the role-class being deployed). If the file is absent, the L4 step is a no-op — the composed output is L1-L3 only.
+After the L1-L3 base is in memory (with its own inline ops already resolved per §4.1 step 5), compose reads exactly one L4 file: `.squidsquad/project/<role-class>.md` (the role-class being deployed). If the file is absent, the L4 step is a no-op — the composed output is L1-L3 only. L4 ops apply **on top of** the inline-op-resolved base, so an L4 `insert-after step:cycle/<id>` can target a step that an L1-L3 inline op introduced.
 
 1. Parse the L4 file. Top-level H2 sections name the slot: `## Identity` / `## Responsibility` / `## Soul` / `## Instructions` / `## Project Context` / `## Vault`. Sections may appear in any order; missing sections are skipped.
 2. For each slot section present, apply ops in this order to the L1-L3 base for that slot:
@@ -1084,7 +1097,7 @@ Notes:
 
 ### 6.1 Step ID grammar and step ↔ sub-skill mapping
 
-Every L1-L3 instruction step declares a **stable step ID** that L4 can target.
+Every L1-L3 instruction step declares a **stable step ID** that ops can target — both L4 file ops and inline ops authored in L1-L3 source bodies (#11227, see §3.3). Step IDs surface in the composed output as `### step:cycle/<id>` H3 anchors; those H3 anchors are what the op processor resolves against.
 
 **Formal grammar** (BNF):
 
@@ -1343,7 +1356,7 @@ Maximum 4 files per install; fewer if some role-classes aren't in the team prese
 
 `compose.py deploy <alias>` resolves alias → role-class via `.squidsquad/config.md`'s `## Aliases` registry (§3.0), then reads `.squidsquad/project/<role-class>.md` to find the L4 file. The file is **created at install time by the installer** (see [§5.5](#55-project-context) and INSTALLER-ARCH §4.8 Phase 5 step 4 — the installer seeds the `## Project Context` block from Phase 1 intake answers; other slots start empty). The file then **grows over time** as more customizations are added via the runtime L4 write flow (`l4-curation`, §7).
 
-Internal structure mirrors the composed-output grammar (§5): top-level H2 sections name the slot; under `## Instructions`, H3 blocks name the op + target:
+Internal structure mirrors the composed-output grammar (§5): top-level H2 sections name the slot; under `## Instructions`, H3 blocks name the op + target. The **same H3 op grammar may also appear inline in L1-L3 source bodies** (#11227, §3.3) — the L4 file is the project-overlay surface, but it is not the only place ops live:
 
 ```markdown
 # Project L4 — PM

--- a/references/scripts/v2_link_stage.py
+++ b/references/scripts/v2_link_stage.py
@@ -48,7 +48,7 @@ from source_frontmatter import (  # noqa: E402
     LEGAL_SLOTS,
     parse_source_frontmatter_text,
 )
-from l4_parser import L4Document, parse_l4_file  # noqa: E402
+from l4_parser import L4Document, L4Op, parse_l4_file  # noqa: E402
 from l4_op_processor import apply_l4_ops  # noqa: E402
 from link_stage_validator import LinkStageSource  # noqa: E402
 
@@ -137,8 +137,8 @@ def emit_v2_linked(role_class, l3_domain, *, repo_root=None, l4_path=None):
 
     out_chunks = []
     for slot in CANONICAL_SLOT_ORDER:
-        combined = _join_bodies(slot_bodies[slot])
-        ops = l4_doc.slots.get(slot, [])
+        combined, inline_ops = _assemble_slot(slot, slot_bodies[slot])
+        ops = inline_ops + l4_doc.slots.get(slot, [])
         if ops:
             combined = apply_l4_ops(combined, ops)
         # Every H2 section starts with the canonical heading and a blank
@@ -338,47 +338,150 @@ def _strip_frontmatter(text):
     return text[m.end():]
 
 
-# #11139: L4-op-syntax H3 headers (`### append`, `### insert-after step:cycle/<id>`,
-# etc.) appear in many L1-L3 source files as authoring markers, but the
-# L1-L3 join pipeline doesn't process them as ops — only L4 ops are
-# applied. They survive into the composed CLAUDE.md as meaningless
-# meta-headers (e.g. PM CLAUDE.md lines 3, 90, 946, 954). Strip them
-# before join so the consuming agent doesn't see compose-machinery
-# headings interleaved with content. This does NOT affect L4 ops:
-# L4 ops are parsed from `.squidsquad/project/<role>.md` separately
-# and applied AFTER join, so they remain untouched.
-_L4_OP_HEADER_RE = re.compile(
-    r"^### (?:append|replace|"
-    r"(?:replace|insert-before|insert-after)\s+step:cycle/[A-Za-z0-9_-]+)\s*$",
-    re.MULTILINE,
-)
-
-
-def _strip_l4_op_headers(body):
-    """Remove L4-op-syntax H3 headers (and the trailing blank line that
-    typically follows them) from an L1-L3 source body. See #11139.
-    """
-    # Match the header line plus the optional blank line right after it,
-    # so removing the header doesn't leave a double-blank-line gap.
-    cleaned = re.sub(
-        r"^### (?:append|replace|"
-        r"(?:replace|insert-before|insert-after)\s+step:cycle/[A-Za-z0-9_-]+)"
-        r"\s*\n(?:\n)?",
-        "",
-        body,
-        flags=re.MULTILINE,
-    )
-    return cleaned
-
-
 def _join_bodies(bodies):
     """Concatenate per-file bodies with a single blank line between them.
 
     Each body is stripped of leading/trailing whitespace so the joined
     output has predictable spacing regardless of how each source file
-    terminates. L4-op-syntax H3 headers (#11139) are stripped per-body
-    before joining.
+    terminates.
     """
-    cleaned = [_strip_l4_op_headers(b).strip() for b in bodies]
-    cleaned = [b for b in cleaned if b]
+    cleaned = [b.strip() for b in bodies if b.strip()]
     return "\n\n".join(cleaned)
+
+
+# #11227: an `### step:cycle/<id>` H3 anchor in joined L1-L3 base content.
+# Used to decide whether an inline step-targeted op directive can anchor
+# (target present) or must degrade to inline content (target absent).
+# Same shape as l4_op_processor._STEP_HEADING_RE, kept local so this
+# module doesn't re-couple to A2c internals.
+_STEP_ANCHOR_RE = re.compile(
+    r"^### step:cycle/([A-Za-z0-9_-]+)\s*$", re.MULTILINE
+)
+# H3 heading text grammar (mirrors l4_parser._H3_RE).
+_H3_HEADING_RE = re.compile(r"^###\s+(.+?)\s*#*\s*$")
+# An H3 heading "looks like" an op directive (mirrors l4_parser._OP_LIKE_RE).
+_INLINE_OP_LIKE_RE = re.compile(
+    r"^(append|replace|insert-before|insert-after)(\s|$)"
+)
+# Strict op grammar (mirrors l4_parser._OP_RE): bare append/replace, or a
+# step-targeted replace/insert-before/insert-after.
+_INLINE_OP_RE = re.compile(
+    r"^(append|replace)$"
+    r"|^(replace|insert-before|insert-after)\s+step:cycle/([A-Za-z0-9_-]+)$"
+)
+
+
+def _split_body_segments(body, slot):
+    """Split an L1-L3 source body into ordered segments (#11227).
+
+    Returns a list of ``("content", text)`` and ``("op", L4Op)`` tuples in
+    source order. A focused line scanner — NOT the L4 file parser — because
+    L1-L3 bodies carry their own ``## <Section>`` headings, which the L4
+    parser would mis-read as slot boundaries.
+
+    - ``### insert-after|insert-before|replace step:cycle/<id>`` → an ``op``
+      segment (step-targeted ``L4Op``), its body running to the next op
+      directive, the next ``## `` section heading, or end of body.
+    - ``### append`` / whole-slot ``### replace`` (no target) → the header
+      is dropped and the body flows on as a fresh ``content`` segment;
+      concatenation is equivalent to a slot-end append and preserves
+      #11139's verified strip-header-keep-body behavior.
+    - Everything else (prose, ``### step:cycle/<id>`` anchor headings,
+      ``#### `` sub-steps, malformed op-like headings) is ``content``.
+    """
+    segments = []
+    buf = []
+    op_type = None
+    op_target = None
+    op_buf = []
+
+    def flush_content():
+        text = "\n".join(buf).strip()
+        buf.clear()
+        if text:
+            segments.append(("content", text))
+
+    def flush_op():
+        nonlocal op_type, op_target
+        segments.append(("op", L4Op(
+            op_type=op_type,
+            target_step_id=op_target,
+            body_text="\n".join(op_buf).strip(),
+        )))
+        op_buf.clear()
+        op_type = op_target = None
+
+    for line in body.split("\n"):
+        if line.startswith("### "):
+            m = _H3_HEADING_RE.match(line)
+            heading = m.group(1).strip() if m else ""
+            if _INLINE_OP_LIKE_RE.match(heading):
+                mo = _INLINE_OP_RE.match(heading)
+                if mo is not None:
+                    if op_type is not None:
+                        flush_op()
+                    else:
+                        flush_content()
+                    if mo.group(1) is None:
+                        # step-targeted op → accumulate its body
+                        op_type, op_target = mo.group(2), mo.group(3)
+                    # else bare append/replace: header dropped, body
+                    # continues as a fresh content segment.
+                    continue
+                # malformed op-like heading → fall through as content
+        if line.startswith("## ") and op_type is not None:
+            # A section heading ends the current op body and is content.
+            flush_op()
+            buf.append(line)
+            continue
+        if op_type is not None:
+            op_buf.append(line)
+        else:
+            buf.append(line)
+
+    if op_type is not None:
+        flush_op()
+    else:
+        flush_content()
+    return segments
+
+
+def _assemble_slot(slot, bodies):
+    """Build a slot's base content and the inline ops to apply to it (#11227).
+
+    Returns ``(combined_base, inline_ops)``:
+    - ``combined_base`` — all content segments across ``bodies`` (in sort
+      order), plus the bodies of any step-targeted ops whose anchor is
+      NOT present (degraded to inline at source position — keeps compose
+      green for L3 ops targeting L2-defined H4 sub-steps, AC-6 deferred).
+    - ``inline_ops`` — the step-targeted ops whose ``### step:cycle/<id>``
+      anchor IS present in the combined base, to be applied via
+      ``apply_l4_ops`` so their content anchors at the right cycle step
+      (AC-4/AC-5).
+
+    Two passes: collect the anchor set from content first, then partition
+    ops into anchorable (applied) vs non-anchorable (degraded inline) so
+    anchorability doesn't depend on body ordering.
+    """
+    segments = []
+    for body in bodies:
+        segments.extend(_split_body_segments(body, slot))
+
+    anchor_ids = set()
+    for kind, val in segments:
+        if kind == "content":
+            anchor_ids.update(m.group(1) for m in _STEP_ANCHOR_RE.finditer(val))
+
+    base_parts = []
+    inline_ops = []
+    for kind, val in segments:
+        if kind == "content":
+            base_parts.append(val)
+        elif val.target_step_id in anchor_ids:
+            inline_ops.append(val)
+        elif val.body_text:
+            # Target anchor absent → degrade to inline content in source
+            # position (the post-#11139 behavior), so compose stays green.
+            base_parts.append(val.body_text)
+
+    return _join_bodies(base_parts), inline_ops

--- a/references/scripts/v2_link_stage.py
+++ b/references/scripts/v2_link_stage.py
@@ -477,9 +477,14 @@ def _assemble_slot(slot, bodies):
     for kind, val in segments:
         if kind == "content":
             base_parts.append(val)
+        elif not val.body_text:
+            # An op with no body adds nothing whether applied or degraded
+            # (e.g. two op directives back-to-back). Drop it so it can't
+            # become a silent no-op insert.
+            continue
         elif val.target_step_id in anchor_ids:
             inline_ops.append(val)
-        elif val.body_text:
+        else:
             # Target anchor absent → degrade to inline content in source
             # position (the post-#11139 behavior), so compose stays green.
             base_parts.append(val.body_text)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -146,6 +146,7 @@ STATIC_TEST_MODULES = [
     "test_harness_route_contract",  # #11093
     "test_l4_op_header_strip_11139",  # #11139
     "test_compose_author_comments_11142",  # #11142
+    "test_l2_l3_op_anchoring_11227",  # #11227
 ]
 
 

--- a/tests/test_l2_l3_op_anchoring_11227.py
+++ b/tests/test_l2_l3_op_anchoring_11227.py
@@ -94,6 +94,52 @@ def test_split_malformed_op_like_heading_is_content():
     assert segs[0][1].startswith("### replace the foo")
 
 
+def test_split_consecutive_op_directives_yield_empty_body_op():
+    """Two op directives with nothing between them → the first parses with
+    an empty body. _assemble_slot drops empty-body ops (see below) so it
+    never becomes a silent no-op insert."""
+    body = (
+        "### insert-after step:cycle/resume\n"
+        "### insert-after step:cycle/pickup\n\n"
+        "#### step:cycle/x\n\nBody.\n"
+    )
+    segs = v._split_body_segments(body, "instructions")
+    assert [k for k, _ in segs] == ["op", "op"]
+    assert segs[0][1].body_text == ""          # first op: empty body
+    assert segs[0][1].target_step_id == "resume"
+    assert segs[1][1].body_text.startswith("#### step:cycle/x")
+
+
+def test_split_eof_while_in_op_mode():
+    """A body ending immediately after an op directive (no trailing
+    content) yields an op with an empty body — must not raise."""
+    segs = v._split_body_segments("### insert-after step:cycle/resume\n", "instructions")
+    assert [k for k, _ in segs] == ["op"]
+    assert segs[0][1].body_text == ""
+
+
+def test_split_inline_replace_step_op():
+    body = "### replace step:cycle/work\n\nNew work body.\n"
+    segs = v._split_body_segments(body, "instructions")
+    assert [k for k, _ in segs] == ["op"]
+    op = segs[0][1]
+    assert op.op_type == "replace"
+    assert op.target_step_id == "work"
+    assert op.body_text == "New work body."
+
+
+def test_assemble_drops_empty_body_op():
+    """An empty-body op (e.g. back-to-back directives) is dropped — neither
+    applied (silent no-op insert) nor degraded — even if its anchor exists."""
+    base = "### step:cycle/resume\n\nResume body.\n"
+    empties = "### insert-after step:cycle/resume\n### insert-after step:cycle/resume\n\nReal.\n"
+    combined, inline_ops = v._assemble_slot("instructions", [base, empties])
+    # One real op survives (the second, which has the "Real." body); the
+    # first (empty) is dropped.
+    assert len(inline_ops) == 1
+    assert inline_ops[0].body_text == "Real."
+
+
 # ---------------------------------------------------------------------------
 # _assemble_slot — AC-4/AC-5 apply, AC-6 graceful degrade
 # ---------------------------------------------------------------------------

--- a/tests/test_l2_l3_op_anchoring_11227.py
+++ b/tests/test_l2_l3_op_anchoring_11227.py
@@ -1,0 +1,173 @@
+"""#11227 — activate L2-L3 inline op anchoring in the link stage.
+
+L1-L3 source bodies may carry `### insert-after step:cycle/<id>` (and
+`insert-before` / `replace step:cycle/<id>`) directives that should anchor
+their content at the named cycle step rather than sit inline at the source
+file's position. #11139 stripped these headers (leaving content stranded);
+#11227 replaces the strip with extract-and-apply:
+
+- `v2_link_stage._split_body_segments` splits a body into ordered
+  content / op segments using a focused line scanner (NOT the L4 file
+  parser, which would mis-read the body's own `## ` headings).
+- `v2_link_stage._assemble_slot` collects the H3 anchor set from base
+  content, applies step-targeted ops whose anchor is present, and
+  degrades ops whose anchor is absent (e.g. L3 ops targeting L2-defined
+  H4 sub-steps — AC-6 deferred) to inline content so compose stays green.
+
+Covers AC-1 (extraction), AC-4/AC-5 (L2 ops anchor at L1 H3 steps),
+AC-6 graceful deferral (non-anchorable ops degrade, compose does not
+raise), AC-8 (these unit tests).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "references" / "scripts"))
+
+import v2_link_stage as v  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# _split_body_segments — AC-1 extraction grammar
+# ---------------------------------------------------------------------------
+
+def test_split_extracts_step_targeted_op_as_op_segment():
+    body = (
+        "Base prose for the slot.\n\n"
+        "### insert-after step:cycle/resume\n\n"
+        "#### step:cycle/check-in\n\nCheck in with the human.\n"
+    )
+    segs = v._split_body_segments(body, "instructions")
+    kinds = [k for k, _ in segs]
+    assert kinds == ["content", "op"]
+    assert segs[0][1] == "Base prose for the slot."
+    op = segs[1][1]
+    assert op.op_type == "insert-after"
+    assert op.target_step_id == "resume"
+    assert op.body_text == "#### step:cycle/check-in\n\nCheck in with the human."
+
+
+def test_split_bare_append_drops_header_body_is_content():
+    """A bare `### append` is not a step op — its header is dropped and the
+    body flows on as a content segment (concatenation == slot-end append)."""
+    body = "First chunk.\n\n### append\n\nAppended chunk.\n"
+    segs = v._split_body_segments(body, "identity")
+    assert [k for k, _ in segs] == ["content", "content"]
+    assert segs[0][1] == "First chunk."
+    assert segs[1][1] == "Appended chunk."
+
+
+def test_split_section_heading_ends_op_body():
+    """A `## Section` heading ends the current op body and is itself
+    content — the op must not swallow a following section."""
+    body = (
+        "### insert-after step:cycle/work\n\n"
+        "#### step:cycle/pipeline-sentinel\n\nScan pipeline.\n\n"
+        "## Reactive sub-skills\n\nThese run reactively.\n"
+    )
+    segs = v._split_body_segments(body, "instructions")
+    assert [k for k, _ in segs] == ["op", "content"]
+    assert segs[0][1].body_text == "#### step:cycle/pipeline-sentinel\n\nScan pipeline."
+    assert segs[1][1].startswith("## Reactive sub-skills")
+
+
+def test_split_step_anchor_heading_is_content_not_op():
+    """`### step:cycle/<id>` is an anchor, not an op directive — it must
+    stay in content so ops can target it."""
+    body = "### step:cycle/resume\n\nResume body.\n"
+    segs = v._split_body_segments(body, "instructions")
+    assert [k for k, _ in segs] == ["content"]
+    assert "### step:cycle/resume" in segs[0][1]
+
+
+def test_split_malformed_op_like_heading_is_content():
+    """An op-like-but-malformed H3 (e.g. `### replace the foo`) must NOT
+    raise — it degrades to content so compose stays robust to prose."""
+    body = "### replace the foo with bar\n\nProse.\n"
+    segs = v._split_body_segments(body, "soul")
+    assert [k for k, _ in segs] == ["content"]
+    assert segs[0][1].startswith("### replace the foo")
+
+
+# ---------------------------------------------------------------------------
+# _assemble_slot — AC-4/AC-5 apply, AC-6 graceful degrade
+# ---------------------------------------------------------------------------
+
+def test_assemble_applies_op_when_anchor_present():
+    base = "### step:cycle/resume\n\nResume body.\n"
+    op_body = (
+        "### insert-after step:cycle/resume\n\n"
+        "#### step:cycle/check-in\n\nCheck in.\n"
+    )
+    combined, inline_ops = v._assemble_slot("instructions", [base, op_body])
+    # The op anchors → it is returned as an inline op (applied by caller).
+    assert len(inline_ops) == 1
+    assert inline_ops[0].target_step_id == "resume"
+    # The anchor stays in the base; the op body is NOT inlined in base.
+    assert "### step:cycle/resume" in combined
+    assert "step:cycle/check-in" not in combined
+    # Applying confirms it lands right after the resume step.
+    from l4_op_processor import apply_l4_ops
+    applied = apply_l4_ops(combined, inline_ops)
+    r = applied.index("step:cycle/resume")
+    c = applied.index("step:cycle/check-in")
+    assert r < c
+
+
+def test_assemble_degrades_op_when_anchor_absent():
+    """An op whose target anchor is not present as an H3 (e.g. an L3 op
+    targeting an L2-defined H4 sub-step) degrades to inline content; no
+    inline op is emitted and the body is preserved in the base."""
+    base = "#### step:cycle/delivery-packaging\n\nPackage it.\n"  # H4, not an anchor
+    op_body = (
+        "### insert-after step:cycle/delivery-packaging\n\n"
+        "#### step:cycle/skill-delivery-doc\n\nWrite skill doc.\n"
+    )
+    combined, inline_ops = v._assemble_slot("instructions", [base, op_body])
+    assert inline_ops == []
+    # Degraded: the op body survives inline in the combined base.
+    assert "step:cycle/skill-delivery-doc" in combined
+    assert "Write skill doc." in combined
+
+
+def test_assemble_no_op_target_not_found_raised(monkeypatch):
+    """Regression: a non-anchorable op must never reach apply_l4_ops (which
+    would raise L4OpTargetNotFound). _assemble_slot filters it out first."""
+    base = "Base only, no anchors."
+    op_body = "### insert-after step:cycle/nonexistent\n\nOrphan content.\n"
+    combined, inline_ops = v._assemble_slot("soul", [base, op_body])
+    assert inline_ops == []
+    assert "Orphan content." in combined
+
+
+# ---------------------------------------------------------------------------
+# emit_v2_linked — integration against live sources (AC-4/AC-5/AC-6)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("role,anchor,inserted", [
+    ("pm", "### step:cycle/resume", "#### step:cycle/check-in"),
+    ("dm", "### step:cycle/resume", "#### step:cycle/issue-triage"),
+    ("verifier", "### step:cycle/resume", "#### step:cycle/e2e-check"),
+    ("worker", "### step:cycle/resume", "#### step:cycle/triage-issues"),
+])
+def test_emit_l2_insert_after_anchors_at_l1_step(role, anchor, inserted):
+    out = v.emit_v2_linked(role, None)
+    lines = out.splitlines()
+    ai = next((i for i, l in enumerate(lines) if l.strip() == anchor), -1)
+    ii = next((i for i, l in enumerate(lines) if l.strip() == inserted), -1)
+    assert ai >= 0, f"{role}: L1 anchor {anchor!r} missing"
+    assert ii >= 0, f"{role}: inserted step {inserted!r} missing"
+    assert ai < ii, f"{role}: {inserted!r} did not anchor after {anchor!r}"
+
+
+@pytest.mark.parametrize("role", ["dm", "pm", "verifier", "worker"])
+def test_emit_l3_compose_does_not_raise(role):
+    """AC-6 deferral: L3 ops target L2-defined H4 sub-steps that are not H3
+    anchors; they degrade to inline rather than raising L4OpTargetNotFound."""
+    out = v.emit_v2_linked(role, "skill")
+    assert out  # non-empty, no exception

--- a/tests/test_l4_op_header_strip_11139.py
+++ b/tests/test_l4_op_header_strip_11139.py
@@ -6,10 +6,14 @@ semantic value (only L4 ops are processed at compose time). They were
 surviving into the rendered CLAUDE.md output where the consuming agent
 saw meaningless compose-machinery headings interleaved with content.
 
-Fix: `v2_link_stage._strip_l4_op_headers` strips them from each L1-L3
-source body before `_join_bodies` concatenates. L4 ops are unaffected
-because they are parsed from `.squidsquad/project/<role>.md` separately
-and applied AFTER join.
+Original #11139 fix stripped these headers in
+`v2_link_stage._strip_l4_op_headers`. #11227 SUPERSEDED that strip with
+inline-op extraction (`v2_link_stage._split_body_segments` /
+`_assemble_slot`): step-targeted directives now anchor at their
+`### step:cycle/<id>` target, and bare `### append` headers are dropped
+with their body flowing on as content. Either way the op-type H3 header
+never survives into composed output — so the #11139 regression contract
+below still holds and is retained as a guard.
 
 Regression contract:
 - `^### (append|replace|insert-after step:cycle/<id>|insert-before step:cycle/<id>|replace step:cycle/<id>)$`
@@ -96,42 +100,6 @@ def test_l4_append_op_body_still_flows_into_composite():
     text = path.read_text(encoding="utf-8")
     sentinel = "You are PM on SquidSquad"
     assert sentinel in text, (
-        f"L4 append op body missing from {path}; the strip fix may "
+        f"L4 append op body missing from {path}; the op handling may "
         f"have removed too much. Expected sentinel: {sentinel!r}."
     )
-
-
-def test_strip_helper_is_idempotent():
-    """_strip_l4_op_headers should be a no-op on an already-clean body."""
-    sys.path.insert(0, str(REPO_ROOT / "references" / "scripts"))
-    from v2_link_stage import _strip_l4_op_headers
-    clean = "## Identity\n\nYou are a SquidSquad agent.\n\n### Boundaries\n\n- bullet\n"
-    assert _strip_l4_op_headers(clean) == clean
-
-
-def test_strip_helper_removes_append_with_trailing_blank():
-    sys.path.insert(0, str(REPO_ROOT / "references" / "scripts"))
-    from v2_link_stage import _strip_l4_op_headers
-    body = "## Identity\n\n### append\n\nYou are PM.\n"
-    expected = "## Identity\n\nYou are PM.\n"
-    assert _strip_l4_op_headers(body) == expected
-
-
-def test_strip_helper_removes_insert_after_step():
-    sys.path.insert(0, str(REPO_ROOT / "references" / "scripts"))
-    from v2_link_stage import _strip_l4_op_headers
-    body = (
-        "### insert-after step:cycle/resume\n\n"
-        "#### step:cycle/triage-issues\n\n"
-        "Triage prose.\n"
-    )
-    expected = "#### step:cycle/triage-issues\n\nTriage prose.\n"
-    assert _strip_l4_op_headers(body) == expected
-
-
-def test_strip_helper_preserves_non_op_h3_headings():
-    """Boundaries, What this role does, etc. must not be stripped."""
-    sys.path.insert(0, str(REPO_ROOT / "references" / "scripts"))
-    from v2_link_stage import _strip_l4_op_headers
-    body = "### Boundaries\n\n- bullet\n\n### What this role does\n\n- bullet\n"
-    assert _strip_l4_op_headers(body) == body


### PR DESCRIPTION
Closes #11227

## Summary
Activates L2 inline op anchoring in the compose link stage. L1-L3 source bodies carry `### insert-after step:cycle/<id>` directives; previously (#11139) those headers were stripped, leaving the content clumped at the end of the slot. Now the link stage extracts and applies them so role-specific cycle steps interleave at their L1 cycle positions (e.g. PM's check-in lands right after `### step:cycle/resume`).

Reduced scope per PM ratification on #11227 (AC-6 fork → defer, option c):
- **Part A (AC-1)** — `v2_link_stage._split_body_segments` + `_assemble_slot`: focused line scanner splits each body into content vs. op directives; step-targeted ops whose `### step:cycle/<id>` H3 anchor exists are applied via `apply_l4_ops`; non-anchorable ops degrade to inline content (compose stays green). Replaces `_strip_l4_op_headers`.
- **AC-4/AC-5** — PM/DM/verifier/worker L2 `insert-after` ops anchor at L1 cycle steps (resume/pickup/work/cleanup). Verified: content relocated, none lost.
- **Part C (AC-7)** — COMPOSE-ARCHITECTURE.md §3.3/§4.1-2/§6.1/§7.3: ops are no longer L4-exclusive.
- **AC-8** — `tests/test_l2_l3_op_anchoring_11227.py` (20 cases) + retained #11139 composed-output regression contract.
- **AC-2/AC-3** — verified pre-satisfied: L1 already uses `### step:cycle/<id>` H3 anchors since `f5833bf3f` (2026-05-30), predating the issue.
- **AC-6 (L3 ops)** — DEFERRED per PM: L3 ops target L2-defined `#### step:cycle/<id>` (H4) sub-steps, but `l4_op_processor` anchors only on H3. They degrade gracefully today; activating needs the H3/H4 fork decision (separate follow-up).

## Verification
- New + changed modules all green: `test_l2_l3_op_anchoring_11227`, `test_l4_op_header_strip_11139`, `test_compose`, `test_v2_link_stage`, `test_l4_op_processor`, `test_a3_golden_link_stage`, `test_compose_author_comments_11142` (229 passed).
- Code-reviewed (Claude review; empty-body-op guard added as R1; no `L4OpTargetNotFound` escape path).
- **Pre-existing failures**: the full static suite has 21 pre-existing failures (composed-output drift tests). Proven NOT regressions — `main` and this branch produce **identical** failures (23 failed / 175 passed) on the exact files containing all 21. My changed modules are all in the passing set.

## Note for verifier
- AC-10 (CQ: a fresh agent given the modified files can answer where L2 ops anchor) — the comprehension spec is verifier's to author per the TEST-PLAN; the §3.3 doc addition + the anchoring examples are the comprehension surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)