### PR TITLE
skill: #11401 — align Python wake-mode with harness probe

### DIFF
--- a/docs/AGENT-RUNTIME.md
+++ b/docs/AGENT-RUNTIME.md
@@ -67,6 +67,8 @@ The cycle wrapper (pre → creative → post) is the same regardless. Only *what
 
 **Bus-fallback granularity at runtime.** Even within a successful event-mode session, an individual `GET /events/for/<alias>` that fails (transient harness blip) silently degrades that cycle's reactions to tracker reads. The cursor is not advanced past a failed read; the next successful poll resumes from the unchanged cursor. The harness staying unreachable past one cycle is not a mode flip — the agent stays event-mode and keeps probing.
 
+**Python-runtime alignment (#11401).** The boot probe is also the source of truth for any Python script that needs to know the wake mode (e.g. the statusline mode badge via `statusline_data.py mode`). `config.get_wake_mode()` probes `GET /status` rather than reading a config field, so the scripts never disagree with the agent's actual mode. Before #11401 they read an `event-driven:` field from `config.md`, which could diverge from harness reachability (config said event, harness down → agent polled but scripts reported event). The field is no longer consulted by the runtime.
+
 ### 2.1 Why both exist
 
 Loop mode has three persistent problems v2's event-driven mode fixes:

--- a/references/scripts/config.py
+++ b/references/scripts/config.py
@@ -31,12 +31,26 @@ about agents (e.g. `get interval`) work unchanged against either schema.
 import json
 import re
 import sys
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 # Auto-detect repo root (walk up from script location)
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent
 CONFIG_PATH = REPO_ROOT / ".squidsquad" / "config.md"
+
+# Harness wake-mode probe (#11401). Per AGENT-RUNTIME §2 the wake mechanism
+# is selected solely by the boot-time harness probe — there is no
+# `event-driven:` config field. These mirror the agent boot probe target.
+_HARNESS_PORT_FILE = REPO_ROOT / ".squidsquad" / ".harness-port"
+_DEFAULT_HARNESS_PORT = 7373
+# Tight timeout: the only live caller (statusline `mode` badge) runs under a
+# 1s shell `timeout`, and that budget also has to cover Python startup. Keep
+# the probe well inside it. A healthy local harness answers /status in
+# milliseconds; this bound only delays the "polling" answer when the harness
+# is actually down.
+_WAKE_PROBE_TIMEOUT = 0.5
 
 sys.path.insert(0, str(SCRIPT_DIR))
 from shared_fs import atomic_write_text  # #10007
@@ -219,44 +233,56 @@ _DUAL_AWARE_CONFIG_FIELDS_6274 = {
 }
 
 
-def get_wake_mode(role):
-    """Canonical wake-mode resolution for a role (#9745).
+def _harness_wake_port():
+    """Resolve the harness port from the port file, default 7373.
 
-    Lookup precedence:
-        1. `event-driven-<role>`  (per-role override)
-        2. `event-driven`         (global default)
-        3. fallback to `"polling"`
-
-    Returns the literal string ``"event-driven"`` or ``"polling"`` — never
-    ``None``, never raises. Values normalize: ``yes/true/1/event-driven`` →
-    ``event-driven``; ``no/false/0/polling`` → ``polling``; anything else
-    falls through to the next field, then to the polling default.
-
-    Stderr from missing fields is suppressed (``get_field`` prints
-    ``ERROR: Field 'X' not found`` and ``sys.exit(1)`` — field absence is
-    the *documented* default for both wake-mode fields, so the noise is
-    spurious during normal operation per #8697 R3). All exceptions are
-    caught to keep this safe for use during compose/statusline/cycle-post
-    where a hard exit is unacceptable.
-
-    This is the single source of truth referenced by ``boot-bootstrap.md``
-    Step 1 (prose) and three Python callers (compose, cycle_post,
-    statusline_data). If you need to change the resolution rules, change
-    them here and update bootstrap.md's prose to match.
+    Mirrors the agent boot probe (AGENT-RUNTIME §8.0) and
+    ``statusline_data._harness_port``. Never raises.
     """
-    import contextlib
-    import io
-    for field in (f"event-driven-{role}", "event-driven"):
-        try:
-            with contextlib.redirect_stderr(io.StringIO()):
-                v = (get_field(field) or "").strip().lower()
-        except BaseException:
-            v = ""
-        if v in ("yes", "true", "1", "event-driven"):
-            return "event-driven"
-        if v in ("no", "false", "0", "polling"):
-            return "polling"
-    return "polling"
+    try:
+        return int(_HARNESS_PORT_FILE.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return _DEFAULT_HARNESS_PORT
+
+
+def _harness_reachable():
+    """True iff the harness answers ``GET /status`` with HTTP 200 in time.
+
+    This is the same signal the agent boot uses to select event vs. polling
+    mode. Any failure (missing/unreachable port, timeout, non-200, no curl
+    equivalent) means "not reachable" → polling. Never raises.
+    """
+    url = f"http://127.0.0.1:{_harness_wake_port()}/status"
+    try:
+        with urllib.request.urlopen(url, timeout=_WAKE_PROBE_TIMEOUT) as resp:
+            return resp.status == 200
+    except (urllib.error.URLError, OSError, ValueError, TimeoutError):
+        return False
+
+
+def get_wake_mode(role=None):
+    """Resolve the wake mode by probing the harness (#11401).
+
+    Per AGENT-RUNTIME §2, event mode is the unconditional architecture and
+    the wake mechanism is selected **solely by the boot-time harness
+    probe** — there is no ``event-driven:`` config field, no per-role
+    override, and no operator-flipped flag. This function mirrors that
+    contract for the Python runtime so the scripts never disagree with the
+    agent's actual mode: a reachable harness (``GET /status`` → 200) means
+    event-driven; any failure means polling.
+
+    Before #11401 this read ``event-driven[-<role>]`` from ``config.md``,
+    which could diverge from the agent (e.g. ``event-driven: yes`` in
+    config while the harness was down → agent polled but scripts reported
+    event). The probe removes that divergence at the source.
+
+    ``role`` is accepted for caller-signature compatibility but unused —
+    harness reachability is global, not per-role.
+
+    Returns ``"event-driven"`` or ``"polling"`` — never ``None``, never
+    raises.
+    """
+    return "event-driven" if _harness_reachable() else "polling"
 
 
 def set_field(field, value):

--- a/references/scripts/config.py
+++ b/references/scripts/config.py
@@ -31,7 +31,6 @@ about agents (e.g. `get interval`) work unchanged against either schema.
 import json
 import re
 import sys
-import urllib.error
 import urllib.request
 from pathlib import Path
 
@@ -256,7 +255,11 @@ def _harness_reachable():
     try:
         with urllib.request.urlopen(url, timeout=_WAKE_PROBE_TIMEOUT) as resp:
             return resp.status == 200
-    except (urllib.error.URLError, OSError, ValueError, TimeoutError):
+    except Exception:
+        # Any probe failure means "not reachable" → polling. Catch broadly
+        # (not just URLError/OSError) so a malformed response mid-restart
+        # — e.g. http.client.BadStatusLine, which is NOT an OSError — can't
+        # break the never-raises contract this helper owes statusline.
         return False
 
 

--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -86,28 +86,6 @@ def _config_get(field):
         return ""
 
 
-def _get_role_wake_mode(role):
-    """Delegate to canonical config.get_wake_mode (#9745).
-
-    Thin wrapper retained so cycle_post-internal callers don't need
-    import-path churn. See ``config.get_wake_mode`` for the resolution
-    rules — that is the single source of truth referenced by bootstrap.md.
-
-    Note (#11166): the cycle-output validation gate that called this was
-    removed under pull-only (#11092 Decision 4). The wrapper is retained per
-    that task's explicit scope — wake mode is still the boot-bootstrap
-    concept; this wrapper stays available for future cycle_post use.
-    """
-    script_dir_str = str(SCRIPT_DIR)
-    if script_dir_str not in sys.path:
-        sys.path.insert(0, script_dir_str)
-    try:
-        from config import get_wake_mode
-    except Exception:
-        return "polling"
-    return get_wake_mode(role)
-
-
 def _get_working_branch():
     """Get the configured working branch name. Falls back to 'main'."""
     branch = _config_get("working-branch")

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -146,6 +146,7 @@ STATIC_TEST_MODULES = [
     "test_harness_route_contract",  # #11093
     "test_l4_op_header_strip_11139",  # #11139
     "test_compose_author_comments_11142",  # #11142
+    "test_feat_9745_wake_mode_canonical",  # #9745 + #11401 (harness-probe)
 ]
 
 

--- a/tests/test_feat_9745_wake_mode_canonical.py
+++ b/tests/test_feat_9745_wake_mode_canonical.py
@@ -1,18 +1,27 @@
-"""Tests for the canonical config.get_wake_mode helper (#9745).
+"""Tests for config.get_wake_mode — harness-probe contract (#9745, #11401).
 
-Before #9745 wake-mode resolution was duplicated across compose.py,
-cycle_post.py, and statusline_data.py with subtly different stderr-handling.
-#9745 consolidates the logic into config.get_wake_mode and reduces the
-duplicates to thin delegating wrappers. These tests cover:
+#9745 consolidated wake-mode resolution into config.get_wake_mode. #11401
+changed *how* it resolves: per AGENT-RUNTIME §2 the wake mechanism is
+selected solely by the boot-time harness probe (GET /status → 200 =
+event-driven; any failure = polling). There is no `event-driven:` config
+field anymore, so the Python runtime probes the harness instead of reading
+config.md — removing the divergence where config said one thing and the
+agent (driven by harness reachability) did another.
 
-- The canonical helper's resolution rules + stderr suppression.
-- Each of the 3 wrapper sites delegates to the canonical helper.
-- The bootstrap.md prose still describes the same precedence.
+These tests cover the resolution table from #11401:
+
+| harness reachable | result        |
+|-------------------|---------------|
+| yes (200)         | event-driven  |
+| no (refused/timeout/non-200/no port) | polling |
+
+…and the two divergence cases that motivated the fix: config.md content is
+now irrelevant — a down harness yields polling even if config said
+`event-driven: yes`, and an up harness yields event-driven even if config
+never set the field.
 """
 
-import io
 import sys
-from contextlib import redirect_stderr
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -24,132 +33,118 @@ sys.path.insert(0, str(SCRIPTS))
 import config
 
 
+def _mock_resp(status=200):
+    """A urlopen context-manager mock returning a response with ``status``."""
+    resp = MagicMock()
+    resp.status = status
+    cm = MagicMock()
+    cm.__enter__.return_value = resp
+    cm.__exit__.return_value = False
+    return cm
+
+
 # ---------------------------------------------------------------------------
-# Canonical helper
+# Probe-based resolution
 # ---------------------------------------------------------------------------
 
 class TestGetWakeMode:
-    """config.get_wake_mode is the single source of truth."""
+    def test_event_driven_when_harness_returns_200(self):
+        with patch.object(config.urllib.request, "urlopen", return_value=_mock_resp(200)):
+            assert config.get_wake_mode("skill") == "event-driven"
 
-    def test_returns_event_driven_when_per_role_yes(self, monkeypatch):
-        monkeypatch.setattr(config, "get_field", lambda f: "yes" if f == "event-driven-skill" else None)
-        assert config.get_wake_mode("skill") == "event-driven"
+    def test_polling_when_connection_refused(self):
+        import urllib.error
+        with patch.object(config.urllib.request, "urlopen",
+                          side_effect=urllib.error.URLError("refused")):
+            assert config.get_wake_mode("skill") == "polling"
 
-    def test_returns_event_driven_when_global_yes(self, monkeypatch):
-        monkeypatch.setattr(config, "get_field", lambda f: "yes" if f == "event-driven" else "")
-        assert config.get_wake_mode("skill") == "event-driven"
+    def test_polling_on_timeout(self):
+        with patch.object(config.urllib.request, "urlopen", side_effect=TimeoutError()):
+            assert config.get_wake_mode("skill") == "polling"
 
-    def test_per_role_overrides_global(self, monkeypatch):
-        """Per-role value beats global."""
-        def gf(f):
-            return {"event-driven-skill": "no", "event-driven": "yes"}.get(f, "")
-        monkeypatch.setattr(config, "get_field", gf)
-        assert config.get_wake_mode("skill") == "polling"
+    def test_polling_on_non_200(self):
+        with patch.object(config.urllib.request, "urlopen", return_value=_mock_resp(503)):
+            assert config.get_wake_mode("skill") == "polling"
 
-    def test_per_role_true_variants(self, monkeypatch):
-        for val in ("yes", "true", "1", "event-driven", "YES", "True", "EVENT-DRIVEN"):
-            monkeypatch.setattr(config, "get_field", lambda f, v=val: v if f == "event-driven-pm" else "")
-            assert config.get_wake_mode("pm") == "event-driven", f"value {val!r} should resolve to event-driven"
+    def test_polling_on_oserror(self):
+        with patch.object(config.urllib.request, "urlopen", side_effect=OSError("socket")):
+            assert config.get_wake_mode("skill") == "polling"
 
-    def test_per_role_polling_variants(self, monkeypatch):
-        for val in ("no", "false", "0", "polling", "POLLING"):
-            monkeypatch.setattr(config, "get_field", lambda f, v=val: v if f == "event-driven-pm" else "")
-            assert config.get_wake_mode("pm") == "polling", f"value {val!r} should resolve to polling"
+    def test_role_arg_is_ignored(self):
+        """Reachability is global, not per-role: same result for any role,
+        and role is optional."""
+        with patch.object(config.urllib.request, "urlopen", return_value=_mock_resp(200)):
+            assert config.get_wake_mode("pm") == "event-driven"
+            assert config.get_wake_mode("dm") == "event-driven"
+            assert config.get_wake_mode() == "event-driven"
 
-    def test_defaults_to_polling_when_both_fields_missing(self, monkeypatch):
-        """get_field raises SystemExit on missing field; helper catches and falls back."""
-        def gf(f):
-            print(f"ERROR: Field '{f}' not found in config.md", file=sys.stderr)
-            raise SystemExit(1)
-        monkeypatch.setattr(config, "get_field", gf)
-        assert config.get_wake_mode("skill") == "polling"
-
-    def test_stderr_suppressed_on_missing_fields(self, monkeypatch, capsys):
-        """#8697 R3 regression: spurious ERROR output during normal probing is suppressed."""
-        def gf(f):
-            print(f"ERROR: Field '{f}' not found in config.md", file=sys.stderr)
-            raise SystemExit(1)
-        monkeypatch.setattr(config, "get_field", gf)
-        config.get_wake_mode("skill")
-        # Caller-observable stderr must be clean.
-        assert capsys.readouterr().err == ""
-
-    def test_tolerates_oserror_from_config_read(self, monkeypatch):
-        """A TOCTOU race on config.md must not crash callers."""
-        def gf(f):
-            raise OSError("config.md vanished mid-read")
-        monkeypatch.setattr(config, "get_field", gf)
-        assert config.get_wake_mode("skill") == "polling"
-
-    def test_unrecognized_value_falls_through_to_global(self, monkeypatch):
-        """Per-role with garbage value falls through to global."""
-        def gf(f):
-            return {"event-driven-skill": "maybe", "event-driven": "yes"}.get(f, "")
-        monkeypatch.setattr(config, "get_field", gf)
-        assert config.get_wake_mode("skill") == "event-driven"
-
-    def test_unrecognized_global_falls_through_to_polling(self, monkeypatch):
-        def gf(f):
-            return "garbage"
-        monkeypatch.setattr(config, "get_field", gf)
-        assert config.get_wake_mode("skill") == "polling"
+    def test_returns_literal_strings_only(self):
+        with patch.object(config.urllib.request, "urlopen", return_value=_mock_resp(200)):
+            assert config.get_wake_mode("skill") in ("event-driven", "polling")
 
 
 # ---------------------------------------------------------------------------
-# Delegation: 3 wrappers must call config.get_wake_mode
+# Divergence cases from #11401 — config.md is now irrelevant
 # ---------------------------------------------------------------------------
 
-class TestWrappersDelegate:
-    """compose / cycle_post / statusline_data delegate to config.get_wake_mode."""
+class TestConfigIsIgnored:
+    def test_down_harness_polls_even_if_config_says_event(self, monkeypatch):
+        """The original bug: config `event-driven: yes` while harness down
+        made scripts report event while the agent polled. Now: polling."""
+        monkeypatch.setattr(config, "get_field", lambda f: "yes")
+        import urllib.error
+        with patch.object(config.urllib.request, "urlopen",
+                          side_effect=urllib.error.URLError("down")):
+            assert config.get_wake_mode("skill") == "polling"
 
-    def _import_module(self, name):
-        # Fresh import — these modules sit next to config.py on sys.path
-        sys.modules.pop(name, None)
-        return __import__(name)
+    def test_up_harness_events_even_if_config_unset(self, monkeypatch):
+        """The mirror bug: no config field but harness up → agent events,
+        scripts must agree."""
+        def gf(f):
+            raise SystemExit(1)  # field absent (get_field's behavior)
+        monkeypatch.setattr(config, "get_field", gf)
+        with patch.object(config.urllib.request, "urlopen", return_value=_mock_resp(200)):
+            assert config.get_wake_mode("skill") == "event-driven"
 
-    # test_compose_delegates retired in E6 #10685 Phase 5 along with
-    # ``compose._get_wake_mode`` (orphan after Phase 3d.5 deleted the v1
-    # ``compose_role`` chain that was its only caller).
 
-    def test_cycle_post_delegates(self, monkeypatch):
-        cycle_post = self._import_module("cycle_post")
-        called_with = []
-        monkeypatch.setattr(config, "get_wake_mode", lambda r: called_with.append(r) or "polling")
-        assert cycle_post._get_role_wake_mode("qa") == "polling"
-        assert called_with == ["qa"]
+# ---------------------------------------------------------------------------
+# Probe helper internals
+# ---------------------------------------------------------------------------
 
+class TestHarnessReachable:
+    def test_reachable_true_on_200(self):
+        with patch.object(config.urllib.request, "urlopen", return_value=_mock_resp(200)):
+            assert config._harness_reachable() is True
+
+    def test_reachable_false_and_never_raises(self):
+        for exc in (OSError("x"), TimeoutError(), ValueError("x")):
+            with patch.object(config.urllib.request, "urlopen", side_effect=exc):
+                assert config._harness_reachable() is False
+
+    def test_port_from_file(self, tmp_path, monkeypatch):
+        pf = tmp_path / ".harness-port"
+        pf.write_text("9999", encoding="utf-8")
+        monkeypatch.setattr(config, "_HARNESS_PORT_FILE", pf)
+        assert config._harness_wake_port() == 9999
+
+    def test_port_default_when_file_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(config, "_HARNESS_PORT_FILE", tmp_path / "nope")
+        assert config._harness_wake_port() == config._DEFAULT_HARNESS_PORT
+
+    def test_port_default_when_file_garbage(self, tmp_path, monkeypatch):
+        pf = tmp_path / ".harness-port"
+        pf.write_text("not-an-int", encoding="utf-8")
+        monkeypatch.setattr(config, "_HARNESS_PORT_FILE", pf)
+        assert config._harness_wake_port() == config._DEFAULT_HARNESS_PORT
+
+
+# ---------------------------------------------------------------------------
+# statusline_data still delegates to the canonical helper
+# ---------------------------------------------------------------------------
+
+class TestStatuslineDelegates:
     def test_statusline_data_delegates(self, monkeypatch):
-        statusline_data = self._import_module("statusline_data")
-        called_with = []
-        monkeypatch.setattr(config, "get_wake_mode", lambda r: called_with.append(r) or "event-driven")
+        sys.modules.pop("statusline_data", None)
+        statusline_data = __import__("statusline_data")
+        monkeypatch.setattr(config, "get_wake_mode", lambda r: "event-driven")
         assert statusline_data._get_wake_mode("dm") == "event-driven"
-        assert called_with == ["dm"]
-
-
-# ---------------------------------------------------------------------------
-# Bootstrap prose audit
-# ---------------------------------------------------------------------------
-
-class TestBootstrapProseAudit:
-    """boot-bootstrap.md Step 1 must still describe the canonical precedence."""
-
-    BOOTSTRAP = Path(__file__).resolve().parent.parent / "references" / "sub-skills" / "common" / "boot-bootstrap.md"
-
-    def test_bootstrap_exists(self):
-        assert self.BOOTSTRAP.exists(), f"{self.BOOTSTRAP} not found"
-
-    def test_bootstrap_mentions_per_role_override(self):
-        """Per-role override `event-driven-<role>` must be documented."""
-        text = self.BOOTSTRAP.read_text(encoding="utf-8")
-        assert "event-driven-skill" in text or "event-driven-<role>" in text or "event-driven-pm" in text or "event-driven-" in text
-
-    def test_bootstrap_mentions_global_default(self):
-        """Global `event-driven:` field must be documented."""
-        text = self.BOOTSTRAP.read_text(encoding="utf-8")
-        assert "event-driven:" in text or "`event-driven`" in text
-
-    def test_bootstrap_mentions_polling_fallback(self):
-        """Polling fallback when neither field is set must be documented."""
-        text = self.BOOTSTRAP.read_text(encoding="utf-8")
-        # The bootstrap explicitly says polling is the safe fallback per CONTEXT-9588 D3.
-        assert "polling" in text.lower()

--- a/tests/test_feat_9745_wake_mode_canonical.py
+++ b/tests/test_feat_9745_wake_mode_canonical.py
@@ -117,9 +117,21 @@ class TestHarnessReachable:
             assert config._harness_reachable() is True
 
     def test_reachable_false_and_never_raises(self):
-        for exc in (OSError("x"), TimeoutError(), ValueError("x")):
+        import http.client
+        # Includes http.client.HTTPException (BadStatusLine) — NOT an OSError,
+        # realistic mid-restart failure — and AttributeError (atypical resp
+        # object). The contract is "any failure → polling, never raise".
+        exceptions = (
+            OSError("x"),
+            TimeoutError(),
+            ValueError("x"),
+            http.client.BadStatusLine("garbage"),
+            http.client.HTTPException("incomplete read"),
+            AttributeError("no status"),
+        )
+        for exc in exceptions:
             with patch.object(config.urllib.request, "urlopen", side_effect=exc):
-                assert config._harness_reachable() is False
+                assert config._harness_reachable() is False, f"{type(exc).__name__} must degrade to False"
 
     def test_port_from_file(self, tmp_path, monkeypatch):
         pf = tmp_path / ".harness-port"


### PR DESCRIPTION
Closes #11401

## Summary
Per AGENT-RUNTIME §2 the wake mechanism is selected **solely by the boot-time harness probe** — there is no `event-driven:` config field. The Python runtime still read that field, so scripts could disagree with the agent's actual mode (config `event-driven: yes` + harness down → agent polls but `statusline_data.py`/`cycle_post.py` reported event). This aligns the runtime to the probe.

Operator-directed (PM comment on #11401, 2026-06-12): cutover-blocking, pick up ahead of queue, land before the #11331 cutover PR.

## Changes
- **`config.get_wake_mode()`** now probes `GET /status` (HTTP 200 = event-driven, else polling) instead of reading `event-driven[-<role>]`. Tight 0.5s timeout (statusline `mode` badge runs under a 1s shell timeout); never raises (`_harness_reachable` catches broadly so a mid-restart `BadStatusLine` can't escape), never None. `role` arg kept for signature compat but unused — reachability is global. **(AC1)**
- **`cycle_post._get_role_wake_mode` deleted** — dead since #11166 removed its only caller. `statusline_data._get_wake_mode` already delegates to the repointed helper. **(AC2)**
- **`tests/test_feat_9745_wake_mode_canonical.py`** rewritten for the probe contract incl. the two divergence cases (config now irrelevant) + port-file edges + the never-raises set (URLError/OSError/TimeoutError/BadStatusLine/HTTPException/AttributeError); registered in the static suite. **(AC3)**
- **AGENT-RUNTIME §2** runtime-alignment note. **(AC4)**

## Verification
- Changed-module tests all green: `test_feat_9745_wake_mode_canonical` (15), `test_config`, `test_cycle_post`, `test_statusline_schema` (focused runs, 148–164 passed). `statusline_data.py mode skill` → `polling` with no harness.
- Code-reviewed (Claude); R1 broadened the probe catch to honor the never-raises contract; added `BadStatusLine`/`HTTPException`/`AttributeError` coverage.
- **Pre-existing failures**: the full static suite has the same ~21 pre-existing composed-output/terminology failures present on `main` (unrelated to this change — those modules share no code path with `config.get_wake_mode`/`cycle_post`/`statusline`). No new failures introduced.

## Scope notes for verifier / DM
- The `event-driven:` field still exists in `config.py` FIELD_MAP/DEFAULTS as a now-unread vestige; fully removing it from the schema + installer wizard is a follow-up (out of AC scope).
- Boot-instruction prose (`boot-bootstrap.md` / `references/roles/instructions.md` boot Step 1) still describes config-based mode selection — that instruction-level drift is the polish-session's (#11331/#11144) domain, separate from this Python-runtime fix.
- Cutover-blocking: should land before the #11331 cutover PR per operator direction. Based on `main` (not stacked on the polish branch) per the no-stacked-PR rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)