### PR TITLE
#11512: mode-neutral spawn prompt — stop forcing loop mode at boot

### DIFF
--- a/.squidsquad/qa/planning/QA-RESULTS-11512.md
+++ b/.squidsquad/qa/planning/QA-RESULTS-11512.md
@@ -1,0 +1,33 @@
+# QA-RESULTS-11512 — VERDICT: PASS (zero gaps)
+
+**Issue**: #11512 (type:issue, severity:high, role:skill) — thin_launcher hardcodes `/loop` spawn prompt → agents always boot loop mode.
+**PR**: #11518 (`squidsquad/task/11512` → main)
+**Verified by**: verifier, 2026-06-12 18:20 on branch `squidsquad/task/11512`.
+**Plan**: TEST-PLAN-11512.md. Bug = auto-approved (no human approval gate).
+
+## AC walk (independent, from issue "Expected")
+
+| AC | Verdict | Evidence |
+|----|---------|----------|
+| AC-1 launcher does NOT force loop mode (no `/loop` in spawned cmd) | **PASS** | `_SPAWN_PROMPT` replaces the `/loop {interval}m …` positional; unit `TestSpawnPromptIsModeNeutral` asserts no arg starts with `/loop` and `cmd[-1] == _SPAWN_PROMPT`. |
+| AC-2 mode selection stays with boot Step 1 probe | **PASS** | `_SPAWN_PROMPT` text: "Execute your composed boot sequence starting at Step 1 (step:cycle/boot): probe harness reachability and proceed in whichever wake mode the probe selects. Do not pre-commit to a mode before the probe runs." |
+| AC-3 dead `_get_interval` removed, no callers | **PASS** | Removed from `thin_launcher.py`; grep on branch shows only tests asserting `not hasattr(thin_launcher,'_get_interval')`. |
+| AC-4 comprehension: fresh agent probes-first, no loop pre-commit | **PASS** | Live CQ (fresh sonnet agent, _SPAWN_PROMPT + boot Step 1 only): 5/5 correct — check-gh first, probe exit-code decides mode, harness-UP→EVENT + no /loop, arms Monitor, premature /loop forbidden. Preserved at `tests/comprehension/11512_spec.json`. |
+| AC-5 no stall / regression | **PASS** | `test_thin_launcher.py` 31/31; `test_feat_9725_…_live.py` 3/3; canonical gate `tests/run_tests.py` 54/54 OK. |
+
+## Test execution
+
+- `python -m pytest tests/test_thin_launcher.py -q` → **31 passed** (55.5s)
+- `python -m pytest tests/test_feat_9725_spawn_loop_registration_live.py -q` → **3 passed** (61.6s)
+- `python tests/run_tests.py` (canonical gate) → **Ran 54 tests … OK** (50.4s)
+- Comprehension CQ (sonnet fresh agent) → **5/5 correct**
+
+## Notes / non-gaps
+
+- **Full event-mode end-to-end live spawn** (real agent spawned via new launcher → arms Monitor under harness-UP) is NOT an AC of this bug — the AC is "launcher must not force loop mode; mode selection stays with Step 1," fully covered by command-shape (AC-1/2) + comprehension (AC-4). The broader event-mode smoke is its own BRIEFING priority (now unblocked by this fix). Not a ship gate.
+- **Meta-confirmation of the bug**: this very QA session was spawned via the OLD `/loop` prompt with the harness UP — exactly the inverted-default the fix corrects.
+- Pre-existing 18 `test_feat_9588` reds are #11503 test-debt (boot-bootstrap.md move); PR touches none of those files — independent, confirmed by changed-file set.
+- DS review (PR): NO_FINDINGS, 5/5 invariants (DS-REVIEW-11512.md).
+
+## Transition
+pending-test → pending-ship. PR #11518 ready for DM to ship (merge brings fix + comprehension spec to main). No `review:human-required` label.

--- a/.squidsquad/qa/planning/TEST-PLAN-11512.md
+++ b/.squidsquad/qa/planning/TEST-PLAN-11512.md
@@ -1,0 +1,29 @@
+# TEST-PLAN-11512 — thin_launcher mode-neutral spawn prompt
+
+**Issue**: #11512 (type:issue, severity:high, role:skill) — thin_launcher hardcodes `/loop` spawn prompt → agents always boot loop mode, event mode never reached.
+**PR**: #11518 (`squidsquad/task/11512` → main)
+**Derived from**: issue body "Expected" section (independent of worker code). Bug = auto-approved.
+
+## Acceptance Criteria (verifier interpretation of "Expected")
+
+- **AC-1**: The launcher's spawn prompt must NOT force loop mode — the spawned command contains NO `/loop` directive.
+- **AC-2**: Mode selection remains with composed boot Step 1 — the spawn prompt instructs the agent to run Step 1 / probe harness reachability and defer mode choice to the probe.
+- **AC-3**: The `/loop`-only support code (`_get_interval`) is removed (dead once the `/loop` prompt is gone) with no dangling callers.
+- **AC-4** (comprehension): A fresh agent reading the new spawn prompt correctly understands it must probe harness reachability first and NOT pre-commit to loop mode.
+- **AC-5** (regression/no-stall): existing thin_launcher unit + live tests pass; neither wake mode stalls (event→Monitor, polling→Step1 self-schedules /loop).
+
+## Test Cases
+
+| TC | AC | Method | Expected |
+|----|----|--------|----------|
+| TC-1 | AC-1 | Inspect spawned cmd (unit `TestSpawnPromptIsModeNeutral`) | no arg starts with `/loop` |
+| TC-2 | AC-1/2 | Read `_SPAWN_PROMPT` content | mode-neutral; names Step 1 + probe; "do not pre-commit to a mode" |
+| TC-3 | AC-3 | `hasattr(thin_launcher,'_get_interval')` + grep callers | False; zero callers |
+| TC-4 | AC-5 | Run `tests/test_thin_launcher.py` | all pass |
+| TC-5 | AC-5 | Run `tests/test_feat_9725_spawn_loop_registration_live.py` | all pass |
+| TC-6 | AC-4 | Fresh-agent comprehension on `_SPAWN_PROMPT` + boot Step 1 excerpt | agent says probe-first, no loop pre-commit |
+| TC-7 | AC-5 | Canonical gate `run_tests.py` | green (note #11394 static-gate state) |
+
+## Notes
+- Live full end-to-end (spawn agent w/ harness up → arms Monitor) is the ideal but requires a real spawn; covered indirectly by TC-1/TC-2 (command shape) + TC-6 (comprehension). Flag if a true live spawn is HUMAN-REQUIRED.
+- Pre-existing 18 `test_feat_9588` reds attributed by skill to #11503 test-debt (boot-bootstrap.md move) — confirm independent of this change.

--- a/.squidsquad/skill/planning/11512-diff.txt
+++ b/.squidsquad/skill/planning/11512-diff.txt
@@ -1,0 +1,58 @@
+diff --git a/references/scripts/thin_launcher.py b/references/scripts/thin_launcher.py
+index ea53b0cd4..e3ca183ef 100644
+--- a/references/scripts/thin_launcher.py
++++ b/references/scripts/thin_launcher.py
+@@ -60,23 +60,22 @@ def _get_effort_level(role):
+         return "high"
+ 
+ 
+-def _get_interval():
+-    """Read iteration interval (minutes) from config.md. Falls back to '30' (#9725).
+-
+-    Used to construct the spawn /loop prompt so freshly spawned agents register
+-    a recurring loop on their first turn rather than running one inline cycle
+-    and stalling (CONTEXT-9725 §2).
+-    """
+-    try:
+-        sys.path.insert(0, str(SCRIPT_DIR))
+-        from config import get_field
+-        val = get_field("interval")
+-        if val is None:
+-            return "30"
+-        s = str(val).strip()
+-        return s if s else "30"
+-    except (Exception, SystemExit):
+-        return "30"
++# #11512: the spawn prompt must NOT force loop mode. The composed CLAUDE.md
++# boot Step 1 (step:cycle/boot) probes harness reachability and selects the
++# wake mode itself — EVENT (arm Monitor) when the harness is up, POLLING
++# (which self-schedules /loop) when it is down. Injecting a literal
++# `/loop {interval}m ...` here (the pre-#11512 behavior added by #9725)
++# preempted that probe: the agent's first turn ran the /loop skill instead of
++# Step 1, so every agent booted loop mode and event mode was never reached.
++# A mode-neutral boot trigger hands mode selection back to the single source
++# of truth (boot Step 1). Neither mode stalls afterward: event mode arms a
++# persistent Monitor idle-wait, polling mode schedules its own /loop cron.
++_SPAWN_PROMPT = (
++    "Begin your SquidSquad agent session now. Execute your composed boot "
++    "sequence starting at Step 1 (step:cycle/boot): probe harness reachability "
++    "and proceed in whichever wake mode the probe selects. Do not pre-commit "
++    "to a mode before the probe runs."
++)
+ 
+ 
+ def _is_process_alive(pid):
+@@ -496,10 +495,9 @@ def main():
+             "--name", f"squidsquad-{role}",
+             "--effort", effort,
+             "--dangerously-skip-permissions",
+-            # #9725: spawn prompt IS the /loop registration. The agent's first
+-            # turn registers the recurring schedule; subsequent cycles fire via
+-            # cron, not via a stalled-in-Step-1 inline cycle. See CONTEXT-9725.
+-            f"/loop {_get_interval()}m execute one Ralph Loop cycle",
++            # #11512: mode-neutral boot trigger — boot Step 1 selects the wake
++            # mode (event when harness reachable, /loop only on polling fallback).
++            _SPAWN_PROMPT,
+         ])
+ 
+         proc = subprocess.Popen(

--- a/.squidsquad/skill/planning/11512-spec.md
+++ b/.squidsquad/skill/planning/11512-spec.md
@@ -1,0 +1,19 @@
+# Behavioral spec for #11512 review
+
+## Bug
+thin_launcher.py injected `/loop {interval}m execute one Ralph Loop cycle` as the spawned agent's literal first-turn prompt. Because the first turn was a /loop slash command, the agent ran the loop skill (scheduled a cron + ran one inline cycle) and NEVER executed composed CLAUDE.md boot Step 1 (step:cycle/boot) — the harness-reachability probe that selects EVENT vs POLLING wake mode. Net: every agent booted loop mode even when the harness was up; event mode was dead-on-arrival.
+
+## Fix (option 1: mode-neutral spawn prompt)
+- Replace the `/loop ...` spawn prompt with `_SPAWN_PROMPT`, a mode-neutral boot trigger telling the agent to execute boot Step 1 and proceed in whichever mode the probe selects.
+- Mode-selection authority stays solely in boot Step 1 (single source of truth). Boot Step 1's POLLING block already self-schedules /loop, so the launcher's /loop injection was redundant + harmful. Options 2/3 (launcher-side probe / conditional /loop) were rejected because they duplicate the harness probe in Python = parallel control path, which HARNESS-ARCH forbids.
+- `_get_interval()` removed: its sole purpose was constructing the /loop spawn prompt.
+
+## Invariants to verify (no regression)
+1. Spawned command's last positional arg is now `_SPAWN_PROMPT`, never a `/loop` directive.
+2. Neither wake mode stalls afterward: event mode arms a persistent Monitor idle-wait; polling mode schedules its own /loop cron via boot Step 1.
+3. The pre-#9725 "Boot. Begin your first Ralph Loop cycle now." prompt remains absent.
+4. No remaining live caller of `_get_interval`.
+5. Change is confined to the launcher spawn-prompt construction; boot Step 1 composed contract (the actual probe logic) is unchanged.
+
+## Question for reviewer
+Any unintended behavioral regression? Especially: could the neutral prompt fail to reliably trigger the agent's boot sequence (vs the old explicit /loop), leaving an agent idle without arming Monitor or scheduling cron?

--- a/.squidsquad/skill/planning/DS-REVIEW-11512.md
+++ b/.squidsquad/skill/planning/DS-REVIEW-11512.md
@@ -1,0 +1,19 @@
+I've completed a thorough review. Here's my assessment against all 5 invariants:
+
+**Invariant 1** ✅ — `_SPAWN_PROMPT` is the last positional arg at line 500 of `thin_launcher.py`. No `/loop` directive exists in executable code (only in comments at lines 66-68, 72, 499). Tests at `tests/test_thin_launcher.py:158` and `tests/test_feat_9725_spawn_loop_registration_live.py:86` both assert `cmd[-1] == thin_launcher._SPAWN_PROMPT`.
+
+**Invariant 2** ✅ — Verified by reading the composed CLAUDE.md Step 1 (`.squidsquad/skill/CLAUDE.md:454-526`): EVENT mode loads `event-mode-contract` which arms Monitor (persistent idle-wait), POLLING mode schedules `/loop` cron exactly once (line 504). Neither path stalls. The launcher change simply removes the preemption that prevented this from working.
+
+**Invariant 3** ✅ — Grep for `Boot. Begin` in `thin_launcher.py` returns zero matches. Test at `test_thin_launcher.py:174-177` explicitly asserts its absence.
+
+**Invariant 4** ✅ — `_get_interval` returns zero matches in `thin_launcher.py`. Test at `test_thin_launcher.py:179-181` asserts `not hasattr(thin_launcher, "_get_interval")`.
+
+**Invariant 5** ✅ — The change is entirely within the spawn-prompt construction (removal of `_get_interval` + new `_SPAWN_PROMPT` constant + updated argument at the `Popen` call site). Boot Step 1 in the composed CLAUDE.md files is unchanged.
+
+**On the reviewer question — "could the neutral prompt fail to reliably trigger the agent's boot sequence, leaving an agent idle?":**
+
+This is not a code defect. The agent's own CLAUDE.md mandates Step 1 as the first instruction to execute (line 455: *"Execute it BEFORE invoking any tool, BEFORE responding to the human, BEFORE acting on any other section"*), and the spawn prompt is a redundant nudge pointing to the same step. Both EVENT mode (Monitor idle-wait) and POLLING mode (/loop cron) result in a wake mechanism. The risk of LLM non-compliance with the natural-language prompt exists in theory, but the CLAUDE.md directive provides a backstop, and this tradeoff was explicitly chosen in the spec (Option 1 over Options 2/3).
+
+```
+NO_FINDINGS
+```

--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -1,27 +1,26 @@
 # Working State
 
-- **Task**: none active — on main
-- **Status**: none (idle)
-- **Updated**: 2026-06-12 17:43
+- **Task**: #11512 — thin_launcher hardcodes /loop spawn prompt (forces loop mode, event mode never reached)
+- **Status**: in-progress — impl committed + tested; awaiting DS review before pending-test
+- **Branch**: squidsquad/task/11512
+- **Updated**: 2026-06-12 18:05
 - **Last Processed Event ID**: 9d7c2489
 - **Quiet Cycle Counter**: 0
 
 ## ⚠️ Session note
-Booted PRE-v0.44.0; runs OLD composed CLAUDE.md (reboot pending per DM — do NOT self-reboot). /loop polling (cron 0bdc0ae0, 30m). Harness is UP (port 7373) but operator drives via /loop — staying loop-mode this session.
+Booted PRE-v0.44.0; runs OLD composed CLAUDE.md (reboot pending per DM — do NOT self-reboot). Harness UP (port 7373) but operator drives via /loop — staying loop-mode this session. NOTE: #11512 (this task) is the ROOT CAUSE of why I'm in loop mode — the launcher forces /loop. Fix does NOT affect already-running agents until respawn.
 
-## Last cycle (1636, iter-446): #11504 — proved cosmetic flap + filed durable fix #11511
-PR #11504 showed CONFLICTING/DIRTY; merge-tree CLEAN both dirs (zero real conflict). Merged main into branch, static gate 54 OK, pushed 76d59f6b0 → recompute → CLEAN. Then my own main push (transient commit) re-staled it to CONFLICTING within the same cycle — proving it's whack-a-mole, NOT fixable by hand-nudging. STOPPED nudging. Told QA (#11394) to merge on content. Filed #11511 (durable squad-wide fix).
+## Current task #11512 (cycle 1637, iter-447) — IMPL DONE, DS review pending
+Fix (option 1, mode-neutral spawn prompt): thin_launcher.py _SPAWN_PROMPT replaces `/loop {interval}m ...`; boot Step 1 owns mode selection (single source of truth; options 2/3 = parallel control path, HARNESS-ARCH forbids). Removed dead _get_interval. Rewrote #9725 unit (test_thin_launcher.py, 31 pass) + live (test_feat_9725...live.py, 3 pass) tests to #11512 contract. Canonical gate run_tests.py = 54 OK. Committed 9a2adacea on branch.
+- **DS review**: running in background (id b44sbq78t → DS-REVIEW-11512.md). On exit 1/2/3 fall back to Sonnet subagent. MUST confirm no regression before pending-test.
+- **NEXT (after DS PASS)**: transition pending-test, pr-create (check review:human-required), push. CQ: spawn prompt is a launcher constant (deterministic, unit-tested), NOT composed agent instructions — boot Step 1 contract unchanged; flag to PM/verifier whether CQ AC needed (do not self-gen).
+- 18 test_feat_9588 reds are PRE-EXISTING (#11503 test-debt, FileNotFoundError on moved boot-bootstrap.md) — confirmed via stash, independent of this change.
 
 ## Watch
-- **PR #11504 / #11394**: SUBSTANTIVELY mergeable (merge-tree exit 0 both dirs, zero real conflict); GitHub flag flaps CONFLICTING↔CLEAN as base advances. STOPPED hand-nudging. QA told to merge on content. **On merge → resume #11503 fixes + #11505** (statusline cp + dm-manifest orphan + stale-test updates + capabilities deadwood), each removing its KNOWN_FAILURES entry.
-- **#11511 (filed cycle 1636, medium)**: durable fix for transient-state merge flap (gitignore iterations/planning logs and/or .gitattributes merge=union on working-state). High blast radius → awaiting PM triage. THIS is the real fix for the recurring #11504 flap; do NOT keep hand-nudging #11504.
-- #11503 (high): umbrella; Group C triaged (2 real + 1 mixed + 1 stale). Groups A/B = stale-test/fixture cleanup, post-#11504.
-- #11505 (low): capabilities deadwood removal; AC5/AC7 touch run_tests.py KNOWN_FAILURES → gated on #11504.
-- #10690 / #10686 (E7, operator-manual): operator-gated, blocked.
-- #11329 (approved): runtime per-event ack-cursor, multi-cycle, post-cutover fresh-session.
+- **PR #11504 / #11394**: SUBSTANTIVELY mergeable (merge-tree clean both dirs); GitHub flag flaps. STOPPED hand-nudging. QA to merge on content. On merge → resume #11503 fixes + #11505.
+- **#11511 (filed cycle 1636)**: durable fix for transient-state merge flap — awaiting PM triage.
+- #11503 (high): test-debt umbrella, post-#11504.
+- #10690/#10686 (E7): operator-gated.
 
 ## ⚠️ Recurring conflict note
-Distinguish TWO failure modes on PR #11504:
-1. **Real content conflict** (merge-tree exits non-zero) → transient/shared state both sides edit → candidate for .gitattributes merge=union (see [[gitattributes_for_transient_state]]).
-2. **Stale GitHub mergeability** (merge-tree exits 0 but GitHub shows CONFLICTING) → base advanced via transient commits, GitHub cached old result → fix is merge-main-into-branch + push to force recompute. THIS is what cycles 1635/1636 hit. .gitattributes does NOT help mode 2.
-If mode 2 keeps recurring every cycle, root cause is cycle_post committing transient state (iterations/planning logs/working-state) to MAIN, advancing base. Candidate: stop tracking .squidsquad/<role>/planning logs on shared branches, or .gitignore them.
+Two #11504 failure modes: real conflict (merge-tree non-zero → .gitattributes union) vs stale GitHub mergeability (merge-tree zero → force recompute, whack-a-mole; root cause = transient state to main; tracked #11511). See [[learning-pr-conflicting-flag-can-be-cosmetic]].

--- a/references/scripts/thin_launcher.py
+++ b/references/scripts/thin_launcher.py
@@ -60,23 +60,22 @@ def _get_effort_level(role):
         return "high"
 
 
-def _get_interval():
-    """Read iteration interval (minutes) from config.md. Falls back to '30' (#9725).
-
-    Used to construct the spawn /loop prompt so freshly spawned agents register
-    a recurring loop on their first turn rather than running one inline cycle
-    and stalling (CONTEXT-9725 §2).
-    """
-    try:
-        sys.path.insert(0, str(SCRIPT_DIR))
-        from config import get_field
-        val = get_field("interval")
-        if val is None:
-            return "30"
-        s = str(val).strip()
-        return s if s else "30"
-    except (Exception, SystemExit):
-        return "30"
+# #11512: the spawn prompt must NOT force loop mode. The composed CLAUDE.md
+# boot Step 1 (step:cycle/boot) probes harness reachability and selects the
+# wake mode itself — EVENT (arm Monitor) when the harness is up, POLLING
+# (which self-schedules /loop) when it is down. Injecting a literal
+# `/loop {interval}m ...` here (the pre-#11512 behavior added by #9725)
+# preempted that probe: the agent's first turn ran the /loop skill instead of
+# Step 1, so every agent booted loop mode and event mode was never reached.
+# A mode-neutral boot trigger hands mode selection back to the single source
+# of truth (boot Step 1). Neither mode stalls afterward: event mode arms a
+# persistent Monitor idle-wait, polling mode schedules its own /loop cron.
+_SPAWN_PROMPT = (
+    "Begin your SquidSquad agent session now. Execute your composed boot "
+    "sequence starting at Step 1 (step:cycle/boot): probe harness reachability "
+    "and proceed in whichever wake mode the probe selects. Do not pre-commit "
+    "to a mode before the probe runs."
+)
 
 
 def _is_process_alive(pid):
@@ -496,10 +495,9 @@ def main():
             "--name", f"squidsquad-{role}",
             "--effort", effort,
             "--dangerously-skip-permissions",
-            # #9725: spawn prompt IS the /loop registration. The agent's first
-            # turn registers the recurring schedule; subsequent cycles fire via
-            # cron, not via a stalled-in-Step-1 inline cycle. See CONTEXT-9725.
-            f"/loop {_get_interval()}m execute one Ralph Loop cycle",
+            # #11512: mode-neutral boot trigger — boot Step 1 selects the wake
+            # mode (event when harness reachable, /loop only on polling fallback).
+            _SPAWN_PROMPT,
         ])
 
         proc = subprocess.Popen(

--- a/tests/comprehension/11512_spec.json
+++ b/tests/comprehension/11512_spec.json
@@ -1,0 +1,36 @@
+{
+  "issue": 11512,
+  "title": "thin_launcher mode-neutral spawn prompt — boot Step 1 owns wake-mode selection",
+  "files": [
+    "references/scripts/thin_launcher.py",
+    "references/roles/instructions.md"
+  ],
+  "note": "The LLM-consumed artifact changed by #11512 is the launcher's _SPAWN_PROMPT (agent's literal first-turn prompt). It must route the agent into composed-CLAUDE.md boot Step 1 (step:cycle/boot) so the harness-reachability probe — the sole wake-mode decider — selects EVENT vs POLLING, instead of forcing /loop. Verifier ran this CQ live on 2026-06-12: fresh sonnet agent given _SPAWN_PROMPT + boot Step 1 excerpt; 5/5 correct.",
+  "questions": [
+    {
+      "id": "1-first-command",
+      "question": "Given the spawn prompt as your first-turn instruction and the boot Step 1 contract, what is the FIRST concrete command you run this session?",
+      "expected": "python references/scripts/tracker.py check-gh — the GitHub Issues access gate runs before mode selection."
+    },
+    {
+      "id": "2-mode-decider",
+      "question": "After the GitHub check, what single observable result decides whether you enter EVENT mode or POLLING mode?",
+      "expected": "The exit code of the harness probe `curl -sf --max-time 5 http://127.0.0.1:<port>/status`: exit 0 = reachable = EVENT mode; any non-zero = unreachable = POLLING mode. The probe is the sole wake-mode decider."
+    },
+    {
+      "id": "3-harness-up-no-loop",
+      "question": "The harness is UP (curl /status returns exit code 0). Which mode do you enter, and do you schedule a /loop cron in that case?",
+      "expected": "EVENT mode. No — /loop is NOT scheduled when the harness is reachable. Scheduling /loop only happens in the POLLING fallback."
+    },
+    {
+      "id": "4-event-action",
+      "question": "In that same harness-UP case, what do you do instead of scheduling /loop?",
+      "expected": "Load the event-mode contract and arm a persistent Monitor idle-wait (wait for NUDGE on event_poll stdin)."
+    },
+    {
+      "id": "5-no-premature-loop",
+      "question": "Is it correct to schedule a /loop recurring cron immediately on your first turn, before running the probe? Why or why not?",
+      "expected": "No. The probe is the sole wake-mode decider; scheduling /loop before the probe pre-commits to POLLING before the result is known, which the spawn prompt ('Do not pre-commit to a mode before the probe runs') and boot Step 1 both forbid."
+    }
+  ]
+}

--- a/tests/test_feat_9725_spawn_loop_registration_live.py
+++ b/tests/test_feat_9725_spawn_loop_registration_live.py
@@ -1,30 +1,29 @@
-"""Live-system pytest for #9725 — spawn /loop registration in thin_launcher.
+"""Live-system pytest for the thin_launcher spawn prompt.
 
-AC-derived (without reading the diff) against #9725 issue body + CONTEXT-9725 §7.
+ORIGIN #9725 made the spawn prompt a literal `/loop <N>m ...` registration.
+#11512 SUPERSEDES that: forcing /loop on the first turn preempted composed
+CLAUDE.md boot Step 1 (the harness probe that selects event vs polling mode),
+so every agent booted loop mode and event mode was never reached. The spawn
+prompt is now a mode-neutral boot trigger (`thin_launcher._SPAWN_PROMPT`) and
+mode selection lives solely in boot Step 1. These cases assert the #11512
+contract.
 
 TC mapping:
-  TC-1 → AC-1: thin_launcher.main builds a command whose last positional is
-              `/loop <N>m execute one Ralph Loop cycle`
-  TC-2 → AC-4: interval is read from config.md (mock + verify substitution)
-  TC-3 → AC-4: interval defaults to '30' when config field is missing/None
-  TC-4 → AC-1: defensive — old "Boot. Begin your first Ralph Loop cycle now."
-              prompt is no longer present in the spawned command
+  TC-1 → #11512: thin_launcher.main builds a command whose last positional is
+              the mode-neutral _SPAWN_PROMPT, contains no /loop directive, and
+              still excludes the pre-#9725 "Boot. Begin your first Ralph Loop
+              cycle now." prompt.
   TC-5 → dev unit suite green (`tests/test_thin_launcher.py`)
-  TC-6 → AC-2 live-witness: this very session is the proof — QA was spawned via
-         the new spawn prompt and has been cycling regularly. Captured here as
-         a structural smoke check on the running clone's iter log directory.
+  TC-6 → live-witness: agents on this team commit one `<role>: cycle <N>`
+         per cycle regardless of wake mode (cycle_post fires under both event
+         and loop modes). Structural smoke check on origin/main history.
 """
 
 from __future__ import annotations
 
-import importlib
-import os
-import re
 import subprocess
 import sys
-import time
 from pathlib import Path
-from unittest import mock
 
 import pytest
 
@@ -44,9 +43,8 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 import thin_launcher  # noqa: E402
 
 
-# TC-1 + TC-4
-def test_tc_01_spawn_prompt_is_loop_directive(monkeypatch):
-    monkeypatch.setattr(thin_launcher, "_get_interval", lambda: "30")
+# TC-1
+def test_tc_01_spawn_prompt_is_mode_neutral_boot_trigger(monkeypatch):
     # Bypass the #8692 singleton check (this very session holds the role's
     # .claude-pid lock — without this, main() refuses to spawn).
     monkeypatch.setattr(thin_launcher, "_check_singleton", lambda cp, r: None)
@@ -84,41 +82,17 @@ def test_tc_01_spawn_prompt_is_loop_directive(monkeypatch):
     cmd = captured.get("cmd", [])
     assert cmd, "thin_launcher.main did not invoke subprocess.Popen"
     last = cmd[-1]
-    assert re.match(r"^/loop \d+m execute one Ralph Loop cycle$", last), (
-        f"spawn prompt should be `/loop <N>m execute one Ralph Loop cycle`; "
-        f"got {last!r}"
-    )
-    # TC-4 — defensive: old hard-imperative prompt must not appear anywhere
+    # #11512: last positional is the mode-neutral boot trigger, not a /loop cmd.
+    assert last == thin_launcher._SPAWN_PROMPT
+    assert not any(
+        isinstance(a, str) and a.startswith("/loop") for a in cmd
+    ), f"spawn command must not force loop mode; got {cmd!r}"
+    # Defensive: old hard-imperative prompt must not appear anywhere
     assert "Boot. Begin your first Ralph Loop cycle now." not in " ".join(cmd), (
         "Old pre-#9725 spawn prompt leaked into the command"
     )
-
-
-# TC-2
-def test_tc_02_interval_read_from_config_field():
-    """_get_interval reads the `interval` field from config and returns it as a string."""
-    # Import config + monkey-patch get_field to a sentinel value
-    sys.path.insert(0, str(SCRIPTS_DIR))
-    import config
-    with mock.patch.object(config, "get_field", return_value="45"):
-        # Re-import to refresh; or patch directly on thin_launcher's import.
-        # _get_interval uses `from config import get_field` at call time,
-        # so patching config.get_field is enough.
-        assert thin_launcher._get_interval() == "45"
-
-
-# TC-3
-def test_tc_03_interval_defaults_to_30_when_missing():
-    sys.path.insert(0, str(SCRIPTS_DIR))
-    import config
-    # config.get_field on missing fields raises SystemExit per its convention.
-    with mock.patch.object(config, "get_field", side_effect=SystemExit(1)):
-        assert thin_launcher._get_interval() == "30"
-    # Also handle None and empty-string returns
-    with mock.patch.object(config, "get_field", return_value=None):
-        assert thin_launcher._get_interval() == "30"
-    with mock.patch.object(config, "get_field", return_value=""):
-        assert thin_launcher._get_interval() == "30"
+    # _get_interval was removed with the /loop prompt (#11512).
+    assert not hasattr(thin_launcher, "_get_interval")
 
 
 # TC-5

--- a/tests/test_thin_launcher.py
+++ b/tests/test_thin_launcher.py
@@ -88,14 +88,17 @@ class TestClaudeInvocation:
         with patch("thin_launcher.subprocess.Popen", side_effect=mock_popen), \
              patch("thin_launcher.os.getcwd", return_value=str(tmp_path)), \
              patch("thin_launcher._get_effort_level", return_value="high"), \
-             patch("thin_launcher._get_interval", return_value="30"), \
              patch("sys.argv", ["thin_launcher.py", "skill"]):
             thin_launcher.main()
 
         assert "--strict-mcp-config" in captured_cmd
-        # Flag must appear before the spawn prompt (positional, last arg per #9725).
+        # #11512: spawn prompt is the mode-neutral boot trigger (last positional),
+        # NOT a /loop command — mode selection belongs to boot Step 1.
         prompt = captured_cmd[-1]
-        assert prompt.startswith("/loop "), f"Expected /loop spawn prompt, got: {prompt}"
+        assert prompt == thin_launcher._SPAWN_PROMPT
+        assert not prompt.startswith("/loop "), (
+            f"spawn prompt must not force loop mode; got {prompt!r}"
+        )
         flag_idx = captured_cmd.index("--strict-mcp-config")
         assert flag_idx < len(captured_cmd) - 1
 
@@ -115,7 +118,6 @@ class TestClaudeInvocation:
         with patch("thin_launcher.subprocess.Popen", side_effect=mock_popen), \
              patch("thin_launcher.os.getcwd", return_value=str(tmp_path)), \
              patch("thin_launcher._get_effort_level", return_value="high"), \
-             patch("thin_launcher._get_interval", return_value="30"), \
              patch("sys.argv", ["thin_launcher.py", "skill"]):
             thin_launcher.main()
 
@@ -123,12 +125,18 @@ class TestClaudeInvocation:
         assert captured_cmd[idx + 1] == "SQUIDSQUAD_ROLE=skill"
 
 
-class TestSpawnPromptIsLoopRegistration:
-    """#9725: spawn prompt registers /loop instead of running one inline cycle."""
+class TestSpawnPromptIsModeNeutral:
+    """#11512: spawn prompt is a mode-neutral boot trigger, NOT a /loop command.
 
-    def test_prompt_is_loop_command(self, tmp_path):
-        """Final positional arg starts with /loop."""
-        sqdir = tmp_path / ".squidsquad" / "skill"
+    Mode selection (event vs polling) belongs to composed CLAUDE.md boot
+    Step 1 (step:cycle/boot). The launcher must not preempt that probe by
+    forcing a /loop registration on the first turn (the pre-#11512 #9725
+    behavior), or event mode is never reached when the harness is up.
+    """
+
+    @staticmethod
+    def _spawn_cmd(tmp_path, role="skill"):
+        sqdir = tmp_path / ".squidsquad" / role
         sqdir.mkdir(parents=True)
         captured_cmd = []
 
@@ -140,90 +148,37 @@ class TestSpawnPromptIsLoopRegistration:
         with patch("thin_launcher.subprocess.Popen", side_effect=mock_popen), \
              patch("thin_launcher.os.getcwd", return_value=str(tmp_path)), \
              patch("thin_launcher._get_effort_level", return_value="high"), \
-             patch("thin_launcher._get_interval", return_value="30"), \
-             patch("sys.argv", ["thin_launcher.py", "skill"]):
+             patch("sys.argv", ["thin_launcher.py", role]):
             thin_launcher.main()
+        return captured_cmd
 
-        # Prompt is the final positional arg (after --dangerously-skip-permissions)
-        prompt = captured_cmd[-1]
-        assert prompt == "/loop 30m execute one Ralph Loop cycle"
+    def test_prompt_is_the_neutral_boot_trigger(self, tmp_path):
+        """Final positional arg is exactly _SPAWN_PROMPT."""
+        cmd = self._spawn_cmd(tmp_path)
+        assert cmd[-1] == thin_launcher._SPAWN_PROMPT
+
+    def test_prompt_does_not_force_loop_mode(self, tmp_path):
+        """No argument in the spawned command is a /loop directive."""
+        cmd = self._spawn_cmd(tmp_path)
+        assert not any(isinstance(a, str) and a.startswith("/loop") for a in cmd), (
+            f"spawn command must not contain a /loop directive; got {cmd!r}"
+        )
+
+    def test_prompt_defers_mode_to_boot_step_1(self, tmp_path):
+        """The neutral prompt directs the agent to the probe-then-decide boot step."""
+        cmd = self._spawn_cmd(tmp_path)
+        prompt = cmd[-1].lower()
+        assert "step 1" in prompt or "step:cycle/boot" in prompt
+        assert "probe" in prompt
 
     def test_legacy_boot_prompt_absent(self, tmp_path):
         """The pre-#9725 'Boot. Begin your first Ralph Loop cycle now.' prompt is gone."""
-        sqdir = tmp_path / ".squidsquad" / "skill"
-        sqdir.mkdir(parents=True)
-        captured_cmd = []
+        cmd = self._spawn_cmd(tmp_path)
+        assert "Boot. Begin your first Ralph Loop cycle now." not in cmd
 
-        def mock_popen(cmd, **kwargs):
-            captured_cmd.extend(cmd)
-            proc = MagicMock(); proc.pid = 99999; proc.wait.return_value = 0
-            return proc
-
-        with patch("thin_launcher.subprocess.Popen", side_effect=mock_popen), \
-             patch("thin_launcher.os.getcwd", return_value=str(tmp_path)), \
-             patch("thin_launcher._get_effort_level", return_value="high"), \
-             patch("thin_launcher._get_interval", return_value="30"), \
-             patch("sys.argv", ["thin_launcher.py", "skill"]):
-            thin_launcher.main()
-
-        assert "Boot. Begin your first Ralph Loop cycle now." not in captured_cmd
-
-    def test_interval_substituted_from_config(self, tmp_path):
-        """Interval value flows from _get_interval() into the spawn prompt."""
-        sqdir = tmp_path / ".squidsquad" / "skill"
-        sqdir.mkdir(parents=True)
-        captured_cmd = []
-
-        def mock_popen(cmd, **kwargs):
-            captured_cmd.extend(cmd)
-            proc = MagicMock(); proc.pid = 99999; proc.wait.return_value = 0
-            return proc
-
-        with patch("thin_launcher.subprocess.Popen", side_effect=mock_popen), \
-             patch("thin_launcher.os.getcwd", return_value=str(tmp_path)), \
-             patch("thin_launcher._get_effort_level", return_value="high"), \
-             patch("thin_launcher._get_interval", return_value="15"), \
-             patch("sys.argv", ["thin_launcher.py", "skill"]):
-            thin_launcher.main()
-
-        assert captured_cmd[-1] == "/loop 15m execute one Ralph Loop cycle"
-
-
-class TestGetInterval:
-    """#9725: _get_interval reads from config.md and falls back safely."""
-
-    def test_reads_interval_from_config(self):
-        with patch.dict("sys.modules", {"config": MagicMock()}), \
-             patch("config.get_field", return_value="20"):
-            assert thin_launcher._get_interval() == "20"
-
-    def test_defaults_to_30_when_missing(self):
-        with patch.dict("sys.modules", {"config": MagicMock()}), \
-             patch("config.get_field", return_value=None):
-            assert thin_launcher._get_interval() == "30"
-
-    def test_defaults_to_30_on_empty_string(self):
-        with patch.dict("sys.modules", {"config": MagicMock()}), \
-             patch("config.get_field", return_value=""):
-            assert thin_launcher._get_interval() == "30"
-
-    def test_defaults_to_30_when_config_raises(self):
-        def boom(_):
-            raise RuntimeError("config unreadable")
-        with patch.dict("sys.modules", {"config": MagicMock()}), \
-             patch("config.get_field", side_effect=boom):
-            assert thin_launcher._get_interval() == "30"
-
-    def test_handles_systemexit_from_config_get(self):
-        """config.get_field calls sys.exit(1) on missing field — must not propagate."""
-        with patch.dict("sys.modules", {"config": MagicMock()}), \
-             patch("config.get_field", side_effect=SystemExit(1)):
-            assert thin_launcher._get_interval() == "30"
-
-    def test_strips_whitespace(self):
-        with patch.dict("sys.modules", {"config": MagicMock()}), \
-             patch("config.get_field", return_value="  45  "):
-            assert thin_launcher._get_interval() == "45"
+    def test_no_interval_helper_remains(self):
+        """#11512: _get_interval was removed with the /loop spawn prompt."""
+        assert not hasattr(thin_launcher, "_get_interval")
 
 
 class TestThinLauncherBoot:


### PR DESCRIPTION
## #11512 — mode-neutral spawn prompt (stop forcing loop mode at boot)

### Problem
`thin_launcher.py` injected `/loop {interval}m execute one Ralph Loop cycle` as every spawned agent's literal first-turn prompt. The first turn therefore ran the `/loop` skill (scheduled a cron + ran one inline cycle) and never executed composed CLAUDE.md boot Step 1 (step:cycle/boot) — the harness-reachability probe that selects EVENT vs POLLING wake mode. Net: every agent booted loop mode even when the harness was up; event mode was dead-on-arrival (root cause of the un-validated event-mode path).

### Fix (option 1 — mode-neutral spawn prompt)
- Replace the `/loop` spawn prompt with `_SPAWN_PROMPT`, a mode-neutral boot trigger telling the agent to run boot Step 1 and proceed in whichever mode the probe selects.
- Mode-selection authority stays in ONE place (boot Step 1, the single source of truth). Its POLLING block already self-schedules `/loop`, so the launcher injection was redundant + harmful. Options 2/3 (launcher-side probe / conditional `/loop`) rejected — they duplicate the harness probe in Python = parallel control path, which HARNESS-ARCH forbids.
- Removed now-dead `_get_interval()` (sole purpose was constructing the `/loop` prompt).

### Tests
- Rewrote #9725 unit (`tests/test_thin_launcher.py`, 31 pass) and live (`tests/test_feat_9725_spawn_loop_registration_live.py`, 3 pass) suites to the #11512 contract: last positional == `_SPAWN_PROMPT`, no `/loop` directive in the spawned command, legacy boot prompt absent, `_get_interval` removed.
- Canonical gate `python tests/run_tests.py` → 54 OK.
- DS review (high blast radius): **NO_FINDINGS**, 5/5 invariants pass.

### Notes
- Already-running agents are unaffected until respawn (no live behavior change for current sessions).
- 18 `test_feat_9588` reds are PRE-EXISTING #11503 test-debt (FileNotFoundError on moved `boot-bootstrap.md`) — confirmed independent via stash.
- CQ: change is a deterministic launcher constant, NOT composed agent instructions (boot Step 1 contract unchanged per DS invariant 5) — assessed N/A; verifier to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)