### PR TITLE
#11519: retire vestigial ~/.squidsquad/clones/ helpers

### DIFF
--- a/.squidsquad/qa/planning/QA-RESULTS-11519.md
+++ b/.squidsquad/qa/planning/QA-RESULTS-11519.md
@@ -1,0 +1,22 @@
+# QA-RESULTS-11519 — VERDICT: PASS (zero gaps)
+
+**Issue**: #11519 (type:issue, severity:low, role:skill) — retire vestigial `~/.squidsquad/clones/` helpers in `shared_fs.py` (dead since #3100).
+**PR**: #11530 (`squidsquad/task/11519` → main). Bug = auto-approved.
+**Verified by**: verifier, 2026-06-12 on branch `squidsquad/task/11519`. Plan: TEST-PLAN-11519.md.
+
+## AC walk (independent)
+| AC | Verdict | Evidence |
+|----|---------|----------|
+| AC-1 helpers retired | **PASS** | diff removes `read_clones`, `write_clone`, `read-clones`/`write-clone` subcommands, `init`'s `clones/` mkdir, and unused `import json` (−47 LOC). |
+| AC-2 no remaining consumer | **PASS** | grep `read_clones\|write_clone\|read-clones\|write-clone` over references/, tests/, start.sh → zero external consumers. Remaining `clones/` refs are only: #3100 removal-docstrings (boot_remote.py:57, health_check.py:85) + regression tests asserting the path stays dead (test_boot_remote:92, test_health_check:83, test_feat_1496). |
+| AC-3 docs synced | **PASS** | WIZARD.md `init` description drops "and clones/"; now matches code. |
+| AC-4 no regression | **PASS** | `test_shared_fs` + `test_feat_1496` (clones-ignored fallback) + `test_boot_remote` + `test_health_check` → **137 passed, 1 skipped**. `json` fully removed from shared_fs.py (import drop safe). Canonical gate `tests/run_tests.py` → **OK**. |
+
+## CQ assessment
+WIZARD.md is LLM-consumed (installer-agent runbook, "You are the installer agent Q-new21"). Audience-checked per [[learning-cq-applies-to-launcher-injected-prompts]] rather than auto-N/A. The changed line is **descriptive** (states what `shared_fs.py init` creates), not a **directive** the agent acts on (the agent runs `init` and checks JSON `ok`), and is now **verified-accurate against code** (test_shared_fs asserts init no longer creates clones/). → **CQ N/A** (documented). Distinct from #11512, where the changed string was the agent's behavioral first-turn prompt.
+
+## Merge note for DM
+Clean merge: main has no independent changes to `shared_fs.py` / `WIZARD.md` / `test_shared_fs.py` since merge-base (`a22281ad7`). Branch 3 behind main = unrelated state/skill commits.
+
+## Transition
+pending-test → pending-ship. No `review:human-required`. Ready for DM ship.

--- a/.squidsquad/qa/planning/TEST-PLAN-11519.md
+++ b/.squidsquad/qa/planning/TEST-PLAN-11519.md
@@ -1,0 +1,24 @@
+# TEST-PLAN-11519 — Retire vestigial ~/.squidsquad/clones/ helpers in shared_fs.py
+
+**Issue**: #11519 (type:issue, severity:low, role:skill) — dead clones/ helpers (dead since #3100). PR #11530. Bug = auto-approved.
+**Derived from**: issue "Expected" (independent of worker code).
+
+## ACs (verifier interpretation)
+- **AC-1**: Unused clones helpers retired — `read_clones`, `write_clone`, `read-clones`/`write-clone` subcommands, and `init`'s `~/.squidsquad/clones/` creation removed (plus any now-unused imports).
+- **AC-2**: No remaining production consumer — OR if one exists, it's confirmed and preserved. (Issue: "Skill judges whether anything still legitimately needs them.")
+- **AC-3**: Docs synced — WIZARD.md `init` description no longer claims `clones/` is created.
+- **AC-4**: No regression — `test_shared_fs`, #1496 fallback test, #3100 regression (`test_boot_remote`/`test_health_check`), canonical gate all green.
+
+## Test Cases
+| TC | AC | Method | Expected |
+|----|----|--------|----------|
+| TC-1 | AC-1 | diff `shared_fs.py` | helpers + subcommands + init dir + `json` import removed |
+| TC-2 | AC-2 | grep `read_clones\|write_clone\|read-clones\|write-clone` over references/, tests/, start.sh | no external consumer |
+| TC-3 | AC-2 | grep `squidsquad/clones\|clones_dir` | remaining refs are only #3100 removal-docstrings + regression tests asserting clones/ stays dead |
+| TC-4 | AC-1 | grep `json` in shared_fs.py | none (import drop safe) |
+| TC-5 | AC-3 | diff WIZARD.md | line drops "and clones/"; matches code |
+| TC-6 | AC-4 | pytest test_shared_fs + test_feat_1496 + test_boot_remote + test_health_check | all green (137p/1s) |
+| TC-7 | AC-4 | canonical gate `tests/run_tests.py` | OK |
+
+## CQ note
+WIZARD.md is LLM-consumed (installer-agent runbook), so audience-checked per [[learning-cq-applies-to-launcher-injected-prompts]]. The changed line is **descriptive** (states what `shared_fs.py init` creates), not a directive the agent acts on, and is now verified-accurate against code. → CQ N/A (documented, not hand-waved).

--- a/references/scripts/shared_fs.py
+++ b/references/scripts/shared_fs.py
@@ -8,12 +8,9 @@ Usage:
     python scripts/shared_fs.py init                    # Create ~/.squidsquad/ structure
     python scripts/shared_fs.py read-secret KEY         # Read a secret value
     python scripts/shared_fs.py write-secret KEY VALUE  # Write a secret (chmod 600)
-    python scripts/shared_fs.py read-clones             # Read cross-clone paths (JSON)
-    python scripts/shared_fs.py write-clone ROLE PATH   # Register a clone path
     python scripts/shared_fs.py home                    # Print ~/.squidsquad/ path
 """
 
-import json
 import os
 import stat
 import sys
@@ -33,7 +30,6 @@ def init():
         ~/.squidsquad/
         ~/.squidsquad/secrets      (chmod 600)
         ~/.squidsquad/config
-        ~/.squidsquad/clones/
     """
     home = get_home()
     home.mkdir(parents=True, exist_ok=True)
@@ -53,9 +49,6 @@ def init():
             "# SquidSquad global config — shared across all clones\n",
             encoding="utf-8",
         )
-
-    clones_dir = home / "clones"
-    clones_dir.mkdir(exist_ok=True)
 
     print(f"Initialized {home}")
     return str(home)
@@ -236,38 +229,6 @@ def write_secret(key, value):
     print(f"Secret '{key}' written to {secrets_file}")
 
 
-def read_clones():
-    """Read cross-clone paths from ~/.squidsquad/clones/.
-
-    Returns dict: {role: path_string}
-    """
-    clones_dir = get_home() / "clones"
-    if not clones_dir.exists():
-        return {}
-
-    result = {}
-    for clone_file in clones_dir.iterdir():
-        if clone_file.is_file() and not clone_file.name.startswith("."):
-            try:
-                path = clone_file.read_text(encoding="utf-8").strip()
-                if path:
-                    result[clone_file.name] = path
-            except (OSError, UnicodeDecodeError):
-                continue
-    return result
-
-
-def write_clone(role, path):
-    """Register a clone path in ~/.squidsquad/clones/."""
-    clones_dir = get_home() / "clones"
-    if not clones_dir.exists():
-        init()
-
-    clone_file = clones_dir / role
-    clone_file.write_text(str(path) + "\n", encoding="utf-8")
-    print(f"Clone '{role}' registered: {path}")
-
-
 def main():
     args = sys.argv[1:]
     if not args or args[0] in ("--help", "-h"):
@@ -295,14 +256,6 @@ def main():
             print("Usage: shared_fs.py write-secret KEY VALUE", file=sys.stderr)
             return 2
         write_secret(args[1], args[2])
-    elif cmd == "read-clones":
-        clones = read_clones()
-        print(json.dumps(clones, indent=2))
-    elif cmd == "write-clone":
-        if len(args) < 3:
-            print("Usage: shared_fs.py write-clone ROLE PATH", file=sys.stderr)
-            return 2
-        write_clone(args[1], args[2])
     else:
         print(f"Unknown command: {cmd}", file=sys.stderr)
         return 2

--- a/references/wizard/WIZARD.md
+++ b/references/wizard/WIZARD.md
@@ -56,7 +56,7 @@ Initialize the shared filesystem at `~/.squidsquad/`:
 python references/scripts/shared_fs.py init
 ```
 
-This creates `~/.squidsquad/`, `secrets` (restricted permissions), `config`, and `clones/` if they don't already exist. Idempotent — safe to run on re-installs.
+This creates `~/.squidsquad/`, `secrets` (restricted permissions), and `config` if they don't already exist. Idempotent — safe to run on re-installs.
 
 ---
 

--- a/tests/test_shared_fs.py
+++ b/tests/test_shared_fs.py
@@ -30,7 +30,9 @@ class TestInit:
         assert fake_home.exists()
         assert (fake_home / "secrets").exists()
         assert (fake_home / "config").exists()
-        assert (fake_home / "clones").is_dir()
+        # #11519: init no longer creates the vestigial ~/.squidsquad/clones/
+        # (dead since #3100 — .squidsquad/.local-config is the sole clone registry).
+        assert not (fake_home / "clones").exists()
 
     def test_idempotent(self, tmp_path):
         fake_home = tmp_path / ".squidsquad"
@@ -135,29 +137,17 @@ class TestReadSecretOrEnv:
         assert value == ""
 
 
-class TestClones:
-    def test_write_and_read(self, tmp_path):
-        fake_home = tmp_path / ".squidsquad"
-        with patch.object(shared_fs, "get_home", return_value=fake_home):
-            shared_fs.init()
-            shared_fs.write_clone("skill", "/path/to/skill-clone")
-            shared_fs.write_clone("pm", "/path/to/pm-clone")
-            clones = shared_fs.read_clones()
-        assert clones["skill"] == "/path/to/skill-clone"
-        assert clones["pm"] == "/path/to/pm-clone"
+class TestClonesHelpersRetired:
+    """#11519: read_clones/write_clone + the clones dir were retired (dead since #3100)."""
 
-    def test_empty_clones(self, tmp_path):
-        fake_home = tmp_path / ".squidsquad"
-        with patch.object(shared_fs, "get_home", return_value=fake_home):
-            shared_fs.init()
-            clones = shared_fs.read_clones()
-        assert clones == {}
+    def test_clone_helpers_removed(self):
+        assert not hasattr(shared_fs, "read_clones")
+        assert not hasattr(shared_fs, "write_clone")
 
-    def test_no_clones_dir(self, tmp_path):
-        fake_home = tmp_path / ".squidsquad-missing"
-        with patch.object(shared_fs, "get_home", return_value=fake_home):
-            clones = shared_fs.read_clones()
-        assert clones == {}
+    def test_clone_subcommands_rejected(self, capsys):
+        for sub in ("read-clones", "write-clone"):
+            sys.argv = ["shared_fs.py", sub]
+            assert shared_fs.main() == 2  # unknown command
 
 
 class TestCLI:


### PR DESCRIPTION
## #11519 — retire vestigial `~/.squidsquad/clones/` helpers (dead since #3100)

### Problem
`boot_remote.py`/`health_check.py` document that the global `~/.squidsquad/clones/` clone-path fallback was removed in #3100 (`.squidsquad/.local-config` is now the sole registry). But `shared_fs.py` still carried the dead infrastructure: `read_clones()`, `write_clone()`, the `read-clones`/`write-clone` subcommands, and `init()` creating `clones/`. Nothing consumes them for boot — pure deadwood that misleads readers (the drift that caused the INSTALLER-ARCH E1 contradiction).

### Change
- Removed `read_clones()` / `write_clone()`, the `read-clones`/`write-clone` CLI subcommands, the usage-doc lines, and `init()`s `clones/` creation. Dropped the now-unused `json` import.
- `WIZARD.md` `init` description updated to match (no longer lists `clones/`).

### Verification
- Confirmed **no production consumer** — only `shared_fs.py` itself and `test_shared_fs.py` referenced these helpers (`grep` over `references/`, `tests/`, `start.sh`). The widely-imported `atomic_write_text` / `read_secret_or_env` are untouched; module imports clean.
- Tests: `TestClones` → `TestClonesHelpersRetired` (helpers absent, subcommands rejected with exit 2); `TestInit` now asserts `clones/` is NOT created. The #3100 regression tests (`test_boot_remote` / `test_health_check`: "clones/ never used") stay green. `test_feat_1496_shared_fs_fallback` green. 137 pass.
- Canonical `run_tests.py` → OK.

### Notes
- Low blast radius: removal of unused utility functions, no live-path behavior change → DS review not triggered (not base/role-shared instructions, compose, or shared sub-skills).
- Follow-up deferred to PM per issue: INSTALLER-ARCH §3.2/§4.2/§5 "still created" caveats can now drop (PM-owned TRD).
- Sibling to #11505 (capabilities deadwood).

🤖 Generated with [Claude Code](https://claude.com/claude-code)