### PR TITLE
fix(#11538): persist RESTARTING intent until new PID appears

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -341,7 +341,14 @@ class HarnessState:
                 # intent eventually wins. CONTEXT-4792.md §3.3. Idempotent:
                 # the kill races against the cooperative exit and we re-check
                 # on the next poll either way.
-                if alive and pid and agent.intent in (
+                # #11538: skip when pid_changed — a NEW claude PID means the
+                # old process already died and the agent rebooted, so the
+                # STOPPING/RESTARTING intent has been fulfilled. intent_set_at
+                # still references the OLD process's clock; force-killing the
+                # freshly-booted replacement for that stale timer is wrong (the
+                # RESTARTING→RUNNING reset just below clears the intent on this
+                # same poll).
+                if alive and pid and not pid_changed and agent.intent in (
                     AgentState.INTENT_STOPPING, AgentState.INTENT_RESTARTING,
                 ) and agent.intent_set_at is not None and (
                     time.time() - agent.intent_set_at
@@ -371,10 +378,19 @@ class HarnessState:
                 # Update status
                 if alive:
                     agent.status = "running"
-                    if agent.intent == AgentState.INTENT_RESTARTING:
+                    # #11538: only clear a RESTARTING intent once a NEW claude
+                    # PID has appeared (pid_changed) — i.e. the old process
+                    # actually died and the agent rebooted. Resetting whenever
+                    # the SAME PID is merely alive silently undoes an in-flight
+                    # restart within one health poll (HEALTH_POLL_INTERVAL=5s)
+                    # AND disarms the 60s force-kill safety net, so a wedged /
+                    # non-cycling agent could never be restarted OR force-killed
+                    # via the documented endpoint. Mirrors the STOPPING branch.
+                    if agent.intent == AgentState.INTENT_RESTARTING and pid_changed:
                         agent.intent = AgentState.INTENT_RUNNING
                         agent.intent_set_at = None  # #4792 Phase 1
                         state_changed = True
+                        _log(f"{role}: alive with new PID (restart complete), reset to running (#11538)")
                     elif agent.intent in (
                         AgentState.INTENT_STOPPING,
                         AgentState.INTENT_STOPPED,

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -594,6 +594,130 @@ class TestForceKillSafetyNet(unittest.TestCase):
         self.assertIsNone(hs.get_agent("skill").intent_set_at)
 
 
+class TestRestartLifecycle(unittest.TestCase):
+    """#11538: update_health must not undo an in-flight RESTARTING intent.
+
+    Regression for the bug where a restart of a still-alive (incl. wedged /
+    non-cycling) agent was silently reverted within one health poll
+    (HEALTH_POLL_INTERVAL=5s) — the RESTARTING->RUNNING reset fired whenever the
+    SAME claude PID was merely alive, with no pid_changed guard. That also
+    disarmed the 60s force-kill safety net (scoped to STOPPING/RESTARTING), so a
+    wedged agent could never be restarted OR force-killed via the endpoint. The
+    reset must now wait for a genuinely NEW claude PID (pid_changed) — proof the
+    old process died and the agent rebooted.
+    """
+
+    def _make_state(self, intent, intent_set_at, stored_pid=12345):
+        from harness import HarnessState, AgentState
+        hs = HarnessState()
+        agent = AgentState("skill", "/clone")
+        agent.intent = intent
+        agent.intent_set_at = intent_set_at
+        agent.claude_pid = stored_pid
+        agent.status = "running"
+        hs.set_agent("skill", agent)
+        return hs, agent
+
+    def _run_health(self, hs, *, fake_now, stored_pid_alive, read_pid_return):
+        """Drive one update_health poll with deterministic PID detection.
+
+        stored_pid_alive: boot_remote._is_process_alive result for the
+            currently-stored claude_pid.
+        read_pid_return: (pid, alive) tuple from reboot_agent._read_claude_pid,
+            consulted only when the stored PID is not alive (mirrors
+            update_health's fall-through). A NEW pid here simulates a reboot
+            (pid_changed=True).
+        """
+        kill = MagicMock()
+        patches = [
+            patch("harness.boot_remote._get_all_roles", return_value=["skill"]),
+            patch("harness.boot_remote._get_clone_path", return_value="/clone"),
+            patch("harness.boot_remote._is_process_alive",
+                  return_value=stored_pid_alive),
+            patch("harness.reboot_agent._read_claude_pid",
+                  return_value=read_pid_return),
+            patch("harness.reboot_agent._kill_process", kill),
+            patch("harness.time.time", return_value=fake_now),
+            patch("harness._log"),
+        ]
+        for p in patches:
+            p.start()
+        try:
+            hs.update_health()
+        finally:
+            for p in patches:
+                p.stop()
+        return kill
+
+    def test_restarting_same_pid_alive_does_not_reset_intent(self):
+        """THE BUG: a RESTARTING agent whose same claude PID is still alive
+        must KEEP intent=RESTARTING (not silently revert to RUNNING). 10s
+        elapsed mirrors a real /status poll well inside the 60s window."""
+        from harness import AgentState
+        hs, _ = self._make_state(AgentState.INTENT_RESTARTING, 1000.0)
+        kill = self._run_health(
+            hs, fake_now=1010.0, stored_pid_alive=True,
+            read_pid_return=(None, False),
+        )
+        got = hs.get_agent("skill")
+        self.assertEqual(got.intent, AgentState.INTENT_RESTARTING)
+        self.assertEqual(got.intent_set_at, 1000.0)
+        kill.assert_not_called()
+
+    def test_restarting_new_pid_resets_to_running(self):
+        """Restart COMPLETED: old PID dead, a new claude PID booted. The
+        RESTARTING intent clears to RUNNING and intent_set_at resets. (This
+        happy path was preserved — passes on both old and new code.)"""
+        from harness import AgentState
+        hs, _ = self._make_state(AgentState.INTENT_RESTARTING, 1000.0,
+                                 stored_pid=12345)
+        kill = self._run_health(
+            hs, fake_now=1010.0, stored_pid_alive=False,
+            read_pid_return=(99999, True),
+        )
+        got = hs.get_agent("skill")
+        self.assertEqual(got.intent, AgentState.INTENT_RUNNING)
+        self.assertIsNone(got.intent_set_at)
+        self.assertEqual(got.claude_pid, 99999)
+        kill.assert_not_called()
+
+    def test_wedged_restarting_agent_force_killed_after_timeout(self):
+        """The payoff: because intent now PERSISTS as RESTARTING, the 60s
+        force-kill net finally engages for a wedged/non-cycling agent whose
+        same PID never reaches a cooperative cycle boundary. Old code reset
+        intent to RUNNING in the same poll, so this assertion would fail."""
+        from harness import AgentState, FORCE_KILL_TIMEOUT_SECONDS
+        hs, _ = self._make_state(AgentState.INTENT_RESTARTING, 1000.0)
+        kill = self._run_health(
+            hs, fake_now=1000.0 + FORCE_KILL_TIMEOUT_SECONDS + 1,
+            stored_pid_alive=True, read_pid_return=(None, False),
+        )
+        kill.assert_called_once_with(12345)
+        got = hs.get_agent("skill")
+        # Intent stays RESTARTING (no new PID yet); next poll sees the dead PID
+        # and runs the reboot path. intent_set_at cleared so the kill is not
+        # re-logged every poll.
+        self.assertEqual(got.intent, AgentState.INTENT_RESTARTING)
+        self.assertIsNone(got.intent_set_at)
+
+    def test_new_pid_not_force_killed_even_past_timeout(self):
+        """A restart that took >60s end-to-end must NOT have its freshly-booted
+        replacement force-killed: pid_changed proves the old process already
+        died, so the stale intent_set_at clock does not apply to the new PID."""
+        from harness import AgentState, FORCE_KILL_TIMEOUT_SECONDS
+        hs, _ = self._make_state(AgentState.INTENT_RESTARTING, 1000.0,
+                                 stored_pid=12345)
+        kill = self._run_health(
+            hs, fake_now=1000.0 + FORCE_KILL_TIMEOUT_SECONDS + 60,
+            stored_pid_alive=False, read_pid_return=(99999, True),
+        )
+        kill.assert_not_called()
+        got = hs.get_agent("skill")
+        self.assertEqual(got.intent, AgentState.INTENT_RUNNING)
+        self.assertIsNone(got.intent_set_at)
+        self.assertEqual(got.claude_pid, 99999)
+
+
 class TestIntentSetAtRepeatRequestIsIdempotent(unittest.TestCase):
     """#4792 Phase 1 iter-4: repeated stop/restart requests on an already
     -STOPPING/-RESTARTING agent must NOT reset intent_set_at — that would


### PR DESCRIPTION
## Summary
Fixes #11538 — `POST /agents/{role}/restart` returned success but did not restart a non-cycling agent.

## Root cause
`HarnessState.update_health` (harness.py) reset intent `RESTARTING→RUNNING` (and cleared `intent_set_at`) on **every** health poll where the agent's claude PID was merely alive — no `pid_changed` guard. With `HEALTH_POLL_INTERVAL=5s`, any restart of a still-alive (incl. wedged / non-cycling) agent was silently reverted within 5s. That also disarmed the 60s force-kill safety net (scoped to `STOPPING`/`RESTARTING`), so a wedged agent could never be restarted **or** force-killed. PM polled `/status` every 10s and never saw the 5s-lived `restarting` state.

## Fix (mirrors the existing STOPPING branch)
1. `RESTARTING→RUNNING` reset now requires `pid_changed` — a genuinely new claude PID = old process died and the agent rebooted. Intent persists as `RESTARTING` through the cooperative cycle-boundary exit OR the 60s force-kill → reboot → new PID → reset.
2. The force-kill net skips when `pid_changed`, so a freshly-rebooted replacement is never SIGKILLed for the prior process's stale `intent_set_at` (a latent edge this change would otherwise widen).

## Tests
- New `TestRestartLifecycle` (4 cases) drives `update_health` across the full restart lifecycle. Verified: **3 fail against the pre-fix code**, 1 locks the preserved happy path.
- Full `test_harness.py` (184) green; `run_tests.py` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)