### PR TITLE
skill: #11503 post-cutover test-debt (21/23) + #11657 event_poll stale-test removal

### DIFF
--- a/.squidsquad/skill/iterations/iter-452.md
+++ b/.squidsquad/skill/iterations/iter-452.md
@@ -1,0 +1,25 @@
+# Iteration 452 — cycle 1643
+
+**When**: 2026-06-13 02:52
+**Mode**: loop (polling; harness unreachable — port file said 59999, curl exit 7). /loop scheduled (cron ea6e7da1, 30m).
+
+## Picked up
+Resumed #11503 (high, in-progress, role:skill) — post-cutover test-debt, 23 tests quarantined in KNOWN_FAILURES. Found a complete-but-uncommitted Group A/B batch in the working tree from a prior session.
+
+## Did
+1. Verified the uncommitted batch: full suite green FOR ITS SCOPE (all 12 un-quarantined tests pass). Committed it — 85d6eb430 (#11503 Group A/B, 12 tests + run_tests.py gate + regenerated golden fixtures). Progress 5→17 / 23; 6 Group A tail remain.
+2. Suite had ONE unrelated red: test_event_poll_exits_cleanly_when_harness_unreachable (integration, NOT in KNOWN_FAILURES). Triaged → stale post-#11601, not v0.44.0 gate-death. Distinct from #11503 scope; distinct from #11640 (different module). Filed #11657, fixed, committed 2ad42181f.
+
+## #11657 root cause + fix
+Test asserted pre-#11601 contract (missing .harness-port → event_poll exit 2 / "harness port not found"). #11601 (d0986cb7e) deliberately made _discover_port() fall back to default 7373 (fixes #11586), so that branch is dead and the subprocess approach is now env-flaky. Removed the method (with a #11657 NOTE) + updated §4.5 docstring, because the #11601 contract is already covered deterministically in tests/test_event_poll.py (44 pass) and the harness-down no-crash intent by the event_bus silent-noop tests + test_9398. Deviation (AC said "rebind") noted on #11657.
+
+## Tests
+run_tests.py: 53 passed, 2 skipped, 0 fail (was 54 w/ 1 fail). test_event_poll.py: 44 passed.
+
+## Outcome
+Two local commits on bundle branch squidsquad/skill/post-cutover-cleanup (NOT pushed — bundle pushes to origin/post-cutover-cleanup only when PR-ready; #11503 still has 6 tail tests). Progress comments posted on #11503 and #11657.
+
+## Notes
+- No DS-review: test-only changes (no production/agent-instruction/compose-source touched; golden fixtures are regenerated compose OUTPUT). Green suite is the verification.
+- Hazard removed: the old #11657 test deleted the live .harness-port and only restored in finally — hit exactly that during triage; restored port file to 59999.
+- Observation for later: a process answers on default 7373 while the port file points at refused 59999 — boot probe picked polling on the stale port. Possible #11586-class mismatch. Noted in working-state; did not act (mode sticky, out of cycle scope).

--- a/.squidsquad/skill/iterations/iter-453.md
+++ b/.squidsquad/skill/iterations/iter-453.md
@@ -1,0 +1,33 @@
+# Iteration 453 — cycle 1644
+
+**When**: 2026-06-13 03:30
+**Mode**: loop (polling; sticky from cycle 1643 boot). /loop cron ea6e7da1 (30m).
+
+## Picked up
+#11503 (high, in-progress) — the 6 remaining Group A tail tests in KNOWN_FAILURES.
+
+## Front-loaded planning
+Read/ran all 6 first. Grouped by theme: #6274 rename (cycle_pre, terminology_6274), compose marker/structure drift (own_domain_autofix, vault_synthesis, compose_author_comments_11142), large restructure (agent_boundaries, 39 fails). Delegated read-only investigation of the 4 harder tests to 2 parallel sonnet Explore subagents (3 medium + agent_boundaries); applied stale-vs-real-bug judgment myself and verified every fix recipe against current source before editing.
+
+## Did
+**Cleared 4 genuinely-stale tests** (rebound to v2 reality, un-quarantined):
+- test_cycle_pre: _get_verifiable_roles is dual-aware (#6274 D5) — assert verifier-class under either identity (qa/verifier), not bare "verifier".
+- test_terminology_dual_aware_6274: #6274.2 cutover landed (disk=worker/,verifier/); _resolve_variant tracks disk → worker/verifier. Legacy dev-/qa- still input aliases.
+- test_own_domain_autofix: #11049 Path A retired {{include:}} → assert "→ run sub-skill:" + step:cycle anchor.
+- test_vault_synthesis: create-task moved to tracker-protocol; assert delegation + vault-synthesis step anchor.
+
+## Key triage finding (NOT all 23 were stale)
+The last 2 KNOWN_FAILURES are NOT post-cutover stale debt — they fail on genuinely-incomplete work tracked by **OPEN #10360** (Implement Responsibility compose slot, COMPOSE-ARCH §5.2). Verified #10360 OPEN via gh. Did NOT paper over by weakening assertions; kept quarantined, re-pointed reasons to #10360:
+- test_compose_author_comments_11142: fixed stale half (boot-bootstrap marker → references/roles/instructions.md per #11331). test_10360_cleanup half detects #10360 breadcrumbs dropped by #11331 — #10360-gated.
+- test_agent_boundaries: 20 missing L3 responsibility stubs (§5.2) gate on #10360; 19 other assertions superseded by agent-boundaries retirement — rewrite whole file when #10360 unblocks.
+
+## Tests
+run_tests.py exit 0: static gate ran 126 cases from the 4 un-quarantined files, 0 FAILED/ERROR; 2 #10360-gated files correctly still excluded; integration OK (skipped=2).
+
+## Outcome
+Commit 7357b6cd7 on bundle branch (not pushed). #11503 stale debt 21/23 cleared; final 2 are #10360-gated. Posted triage + PM-decision request on #11503 (recommend close at 21/23, #10360 carries the 2); cross-linked the 2 tests on #10360.
+
+## Notes
+- No DS-review: test-only (no production/instruction/compose-source; the boot-bootstrap marker is a source comment moved by a prior commit, not changed here). Green suite is verification.
+- Skepticism applied to subagent "REAL GAP" verdicts: both verified independently and both correctly trace to open #10360.
+- The #11503 charter assumption ("23 stale tests") was partly wrong — 2 were masking incomplete #10360 work, not cutover drift. Front-loaded reading-everything-first surfaced this before I wrongly weakened assertions to force green.

--- a/.squidsquad/skill/iterations/iter-454.md
+++ b/.squidsquad/skill/iterations/iter-454.md
@@ -1,0 +1,26 @@
+# Iteration 454 — cycle 1645
+
+**When**: 2026-06-13 03:55
+**Mode**: loop (polling; sticky). /loop cron ea6e7da1 (30m).
+
+## Picked up
+#11503 (top of queue) is PM-blocked — no response to last cycle's disposition request, and its remaining 2 items are #10360-gated. Not cherry-picking: moved to the next actionable high item, bug #11641 (stale .claude/scheduled_tasks.lock crashes claude → harness reboot loop; PM-confirmed repro). Auto-approved.
+
+## Branch discipline
+#11641 is NOT part of the post-cutover-cleanup bundle — needs its own branch based on main (no-stacked-PRs rule). Verified git_ops.task-begin bases new branches on origin/<working-branch>=main (read the source before trusting). task-begin skill 11641 → squidsquad/task/11641 from origin/main, clean (no bundle commits). Bundle work safe on its branch.
+
+## Did (#11641)
+thin_launcher.py: added _reclaim_stale_scheduled_lock(clone_path) (reuses existing _is_process_alive) + a call in the launch path before Popen. Removes the lock iff holder pid dead (logs it); preserves a live-held lock; conservative (leave+warn) on a corrupt/pid-less lock since the proven failure mode is a dead-but-parseable PID. Found root cause by reading the spawn path + the .stale-bak repro ({"pid":25628,...}).
+
+## Tests
+6 new (TestStaleScheduledLockReclaim): dead-holder reclaim, live-holder preserve, no-lock no-op, unparseable preserve, missing-pid preserve, + WIRING test (main() invokes reclaimer before Popen — per no-deferred-wiring, AC names the spawn path). 37 thin_launcher tests pass.
+
+## Zero-gap blocker (NOT mine)
+Full run_tests.py on the main-based branch: exactly 1 failure = test_event_poll_exits_cleanly_when_harness_unreachable — PRE-EXISTING ON MAIN (= #11657, fixed on the bundle branch, not yet merged). #11641 changes green in isolation. Did NOT mark pending-test (zero-gap rule: never hand verifier a red suite). Kept #11641 in-progress; surfaced merge ordering (bundle→main first, then #11641) on #11641 + #11503.
+
+## Outcome
+Commit cff818eb7 on squidsquad/task/11641 (local, not pushed). #11641 → in-progress. Handoff comment posted. Returned to bundle branch for state bookkeeping.
+
+## Notes
+- No DS-review: thin_launcher.py is non-instruction runtime code (outside the 7.2 instruction/compose/sub-skill surface), small + test-locked with dead/live/wiring proven — same precedent as the harness.py fix (iter-451).
+- Two unmerged local branches now in flight (bundle + task/11641) with a real merge-ordering dependency — both surfaced to PM/DM. Degraded polling mode means no cycle_pre/post wrapper; all branch/commit management manual.

--- a/.squidsquad/skill/iterations/iter-455.md
+++ b/.squidsquad/skill/iterations/iter-455.md
@@ -1,0 +1,28 @@
+# Iteration 455 — cycle 1646
+
+**When**: 2026-06-13 04:20
+**Mode**: loop (polling — INTENTIONAL: PM pinned .harness-port=59999 to dodge the #11586 event-mode reboot loop). /loop cron ea6e7da1.
+
+## Picked up
+PM responded to both blocked items (was handling the reboot incident). Executed PM directives.
+
+## #11503 (PM: approve close at 21/23 → ship the bundle)
+- Fetched origin (main advanced 20e3bbac7 → 9f6337196). Merged origin/main into the bundle: clean (PM-side files only — pm/iterations, lock-watchdog.sh, pm/working-state).
+- Re-ran full suite post-merge: exit 0, 0 failures.
+- Pushed squidsquad/skill/post-cutover-cleanup via `git -c credential.helper= -c credential.helper='!gh auth git-credential' push origin <branch>` — bypassed the credential.helper=manager wedge; explicit refspec (push.default=simple refuses bare push). New branch created on origin.
+- Opened PR #11683 → main (git_ops pr-create, draft). Body documents the 2 #10360-gated allowlisted reds for QA (NOT regressions, per PM).
+- #11503 → pending-test (unread-feedback guard required acknowledging PM's disposition first — posted ack comment, then transitioned). #11657 → pending-test (rides same PR).
+
+## #11641 (PM: confirmed durable #11612 fix; ordering ACK)
+Held in-progress on squidsquad/task/11641 until PR #11683 merges to main (then main green → merge main → pending-test). Unchanged this cycle.
+
+## Resolved my own earlier observation
+The 59999/7373 "stale port mismatch" I flagged cycles 1644-1645 is NOT a bug — PM intentionally pinned .harness-port=59999 to force loop fallback and stop the slow event-mode reboot loop (#11586) while skill was down. Leave it until #11586 lands. Updated working-state.
+
+## Outcome
+Bundle shipped to verifier (PR #11683, 2 issues pending-test). Clean handoffs posted. Cycle state commit to push.
+
+## Notes
+- credential.helper=manager wedge avoided via gh git-credential override (memory: git-push-credential-wedge) — push returned exit 0, no hang.
+- Always-merge-never-rebase honored: merged origin/main into bundle, did not rebase.
+- Next productive work is gated on DM merging #11683; absent that or new queue items, upcoming cycles are quiet (improvement-scan eligible).

--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -1,9 +1,12 @@
 # Working State
 
 - **Task**: #11503 (high, in-progress, role:skill) — post-cutover test-debt: 23 static tests red since v0.44.0 cutover
-- **Status**: Group C (4 possibly-real) DONE & committed; working Group A (stale-structure tests) next
+- **Status**: 17/23 done & committed (Group C ×3 + event-mode ×2 prior; Group A/B ×12 this session). 6 Group A tail remain.
+- **Also this session**: #11657 (event_poll stale integration test) filed + fixed (removed as superseded by #11601). Rides bundle branch.
+- **Commits this session** (bundle branch, LOCAL — not pushed; push to origin/post-cutover-cleanup explicitly when PR-ready): 85d6eb430 #11503 Group A/B (12 tests); 2ad42181f #11657 event_poll stale-test removal. (Prior-session ancestors: 7f6c5258b, e8896df59, 6968c3217.) push.default=simple → bare push safely refuses (branch≠upstream main).
 - **Branch**: squidsquad/skill/post-cutover-cleanup (bundle branch per operator decision c-2026-06-12; even with origin/main). NOTE: upstream is misconfigured to origin/main — push must target origin/post-cutover-cleanup explicitly, NEVER main.
-- **Updated**: 2026-06-13 01:24 (fresh boot; #11601 verified shipped/closed → cleared)
+- **Mode**: POLLING (harness probe failed — port file said 59999, connection refused). /loop scheduled (cron ea6e7da1, 30m). NOTE: a process answers on default 7373 (event_poll exit 1 in repro) — port file (59999) looks stale vs the actual harness on 7373; possible #11586-class boot-probe mismatch worth a look later. Did NOT re-probe (mode sticky per boot contract).
+- **Updated**: 2026-06-13 02:52
 
 ## Improvement Scan
 Status: idle
@@ -12,31 +15,35 @@ Next scan after: (eligible — defer until #11503 ships)
 
 ## #11503 — plan (front-loaded)
 23 static tests quarantined in KNOWN_FAILURES (tests/run_tests.py) when the gate went dead at v0.44.0 cutover (#11394). Fix each, remove its KNOWN_FAILURES entry, gate re-includes it.
-- **Group A** — stale tests asserting pre-v2/pre-rename/pre-cutover structure → update test to v2 reality. ~16 files.
-- **Group B** — fixture drift: test_config_functions (SAMPLE_CONFIG missing FIELD_MAP entries). 1 file.
-- **Group C** — possibly-real masked regressions (triage first). DONE (see below).
+- **Group A** — stale tests asserting pre-v2/pre-rename/pre-cutover structure → update test to v2 reality.
+- **Group B** — fixture drift: test_config_functions (SAMPLE_CONFIG FIELD_MAP). DONE.
+- **Group C** — possibly-real masked regressions (triage first). DONE.
 
-## #11503 — Group C: DONE (committed this cycle)
-4 flags triaged:
-- test_manifest_registry + test_feat328_coverage: REAL orphan — dm/manifest.yaml `any_of: [local_delivery]` referenced the deleted capabilities registry (removed as deadwood, INSTALLER-ARCH §8.3, full teardown #11505). Fix: manifest `requires_sub_skills: {}`; tests assert `tools == {}`. Verified 98 passed.
-- test_statusline_schema: REAL deploy-sync gap — .squidsquad/statusline.sh stale vs references/ (#11144 G10). Fix: synced deploy copy (now identical). Verified green.
-- test_comms_sub_skills: chat-etiquette heading-format — STILL in KNOWN_FAILURES (Group A/source-format, deferred to next batch).
+## #11503 — Group A/B DONE this session (commit 85d6eb430)
+Un-quarantined 12: test_references, test_state_bus, test_comms_sub_skills, test_4792_fragment_hygiene,
+test_deterministic_qa_framework, test_dm_verify_before_block, test_pickup_comment_fidelity_9946,
+test_stale_tracker_files_ref (pre-rename/pre-cutover); test_compose_a2f_10492, test_atomic_emit_b7,
+test_a3_golden_link_stage (compose golden drift — regenerated fixtures); test_config_functions (Group B).
 
-## #11503 — Group A remaining (KNOWN_FAILURES, ~17)
-test_references, test_state_bus, test_comms_sub_skills, test_event_mode_fragments, test_cycle_pre,
-test_4792_fragment_hygiene, test_deterministic_qa_framework, test_dm_verify_before_block,
-test_own_domain_autofix, test_vault_synthesis, test_pickup_comment_fidelity_9946,
-test_terminology_dual_aware_6274, test_compose_a2f_10492, test_atomic_emit_b7,
-test_a3_golden_link_stage, test_compose_author_comments_11142, test_agent_boundaries,
-test_feat_9588_lazy_load_bootstrap, test_stale_tracker_files_ref
-+ Group B: test_config_functions
+## #11503 — Group A REMAINING (6 in KNOWN_FAILURES)
+test_cycle_pre (#6274 alias rename partial), test_own_domain_autofix (removed v1 {{include:}} syntax),
+test_vault_synthesis ('create-task' in restructured pm source), test_terminology_dual_aware_6274
+(pre-rename dev/skill → worker/skill), test_compose_author_comments_11142 (boot-bootstrap wrapper marker),
+test_agent_boundaries (removed responsibility.md + phrase).
+
+## #11657 — DONE this session (commit 2ad42181f)
+Stale integration test test_event_poll_exits_cleanly_when_harness_unreachable asserted pre-#11601
+contract (missing port → exit 2). #11601 made _discover_port default to 7373 (fixes #11586). Removed as
+superseded — #11601 contract covered in tests/test_event_poll.py (44 pass); harness-down no-crash covered
+by event_bus silent-noop tests + test_9398. Deviation (rebind→remove) noted on #11657. Suite green 53/2.
 
 ## Tree cruft (NOT #11503, leave untracked)
 - .claude/scheduled_tasks.lock.stale-bak — relates to #11641 (stale lock crash); separate issue
 - .squidsquad/skill/planning/CODE-REVIEW-11601.md — #11601 leftover (shipped); harmless
+- .squidsquad/.harness-port — restored to 59999 during #11657 triage (gitignored)
 
 ## Standing items (post-#11503)
 - #11641 (high, open) — stale scheduled_tasks.lock crashes claude → reboot loop
-- #11640 (high, open) — boot_remote REPO_ROOT fallback must fail-closed
-- #11586 (high, open) — agents don't reach event mode on reboot
+- #11640 (high, open) — boot_remote._get_clone_path REPO_ROOT fallback must fail-closed
+- #11586 (high, open) — agents don't reach event mode on reboot (cf. port-file/7373 mismatch noted above)
 - #11587 (medium), #11511 (medium), #11505 (capabilities teardown)

--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -1,44 +1,38 @@
 # Working State
 
-- **Task**: #11503 (high, in-progress, role:skill) — post-cutover test-debt. **21/23 stale tests cleared; remaining 2 are #10360-gated (not stale).**
-- **Status**: Group A tail done this cycle (cycle 1644): 4 stale tests rebound + un-quarantined (cycle_pre, terminology_6274, own_domain_autofix, vault_synthesis). Triage finding: last 2 KNOWN_FAILURES (compose_author_comments_11142, agent_boundaries) block on OPEN #10360 (Responsibility compose slot §5.2), NOT cutover-stale. Re-pointed their reasons; did NOT weaken assertions. PM decision requested on #11503 (recommend: close at 21/23, let #10360 carry final 2).
-- **Commits (bundle branch, LOCAL — not pushed; push to origin/post-cutover-cleanup explicitly when PR-ready)**:
-  - 7357b6cd7 #11503 Group A tail (4 stale cleared + 2 triaged to #10360) [cycle 1644]
-  - eb21957ea cycle 1643 state; 2ad42181f #11657 event_poll removal; 85d6eb430 #11503 Group A/B (12 tests) [cycle 1643]
-  - (prior-session ancestors: 7f6c5258b, e8896df59, 6968c3217)
-  - push.default=simple → bare push safely refuses (branch≠upstream main).
-- **Branch**: squidsquad/skill/post-cutover-cleanup (bundle branch per operator decision c-2026-06-12). NOTE: upstream misconfigured to origin/main — push must target origin/post-cutover-cleanup explicitly, NEVER main.
-- **Mode**: POLLING (harness probe failed at boot — port file 59999, connection refused). /loop cron ea6e7da1 (30m). NOTE: a process answers on default 7373 — port file looks stale; possible #11586-class boot-probe mismatch. Did NOT re-probe (mode sticky).
-- **Updated**: 2026-06-13 03:30
+- **Active work spans TWO branches this session:**
+  1. **squidsquad/skill/post-cutover-cleanup** (bundle, session home) — #11503 (21/23 stale cleared) + #11657 (done). 9 commits ahead of origin/main, LOCAL (not pushed). Awaiting PM disposition on #11503 (recommended close at 21/23; final 2 are #10360-gated).
+  2. **squidsquad/task/11641** (based on origin/main) — #11641 fix, 1 commit (cff818eb7), LOCAL. in-progress, NOT pending-test (see blocker below).
+
+- **#11503**: 21/23 stale-test debt cleared. Final 2 (compose_author_comments_11142, agent_boundaries) are #10360-gated, NOT stale — re-pointed in KNOWN_FAILURES, cross-linked on #10360. PM decision requested (no response yet).
+- **#11657**: done (event_poll stale test removed; on bundle).
+- **#11641** (cycle 1645): implemented thin_launcher stale-scheduled-lock reclamation + 6 regression tests (incl. wiring). 37 thin_launcher tests pass. **NOT pending-test**: full run_tests.py on the main-based branch shows 1 failure = test_event_poll_exits_cleanly_when_harness_unreachable, which is PRE-EXISTING ON MAIN (= the #11657 fix that lives on the bundle, not yet merged). My #11641 changes are green in isolation. Held in-progress to avoid handing verifier a red suite.
+
+- **MERGE ORDERING (PM/DM)**: land the post-cutover-cleanup bundle (#11503+#11657) to main FIRST → main goes green → then squidsquad/task/11641 merges a green main and goes pending-test. Surfaced on #11641 + #11503.
+
+- **Branches/push**: both branches LOCAL, not pushed. Bundle upstream misconfigured to origin/main — NEVER bare-push (push.default=simple refuses). Push explicit refspecs when PR-ready.
+- **Mode**: POLLING (harness probe failed at boot — port file 59999 refused; a process answers on default 7373, likely #11586-class stale-port mismatch). /loop cron ea6e7da1 (30m). Mode sticky.
+- **Updated**: 2026-06-13 03:55
 
 ## Improvement Scan
-Status: idle
-Last completed: (none this session)
-Next scan after: (eligible — defer until #11503 dispositioned)
+Status: idle. Next: eligible once #11503/#11641 dispositioned.
 
-## #11503 — DONE (stale debt cleared)
-All 21 genuinely-stale post-cutover tests rebound to v2 reality + un-quarantined across cycles:
-- cycle 1642(prior): Group C ×3 + event-mode ×2 (5)
-- cycle 1643: Group A/B ×12
-- cycle 1644: Group A tail ×4 (cycle_pre, terminology_6274, own_domain_autofix, vault_synthesis)
+## #11503 — DONE (21 stale cleared) / BLOCKED (2 on #10360)
+21 genuinely-stale tests rebound across cycles 1642-1644. Final 2 gate on OPEN #10360 (Responsibility compose slot §5.2): test_compose_author_comments_11142 (stale half fixed; test_10360_cleanup half is #10360), test_agent_boundaries (20 L3 stubs §5.2 + 19 superseded assertions). DO NOT weaken to force green; ride #10360.
 
-## #11503 — BLOCKED on OPEN #10360 (the final 2 of 23 — NOT stale)
-#10360 = "Implement Responsibility compose slot per COMPOSE-ARCHITECTURE §5.2" (OPEN). Both tests fail on genuinely-incomplete §5.2 work:
-- **test_compose_author_comments_11142**: stale half FIXED (boot-bootstrap marker moved to references/roles/instructions.md in #11331). test_10360_cleanup_markers_preserved half detects #10360 breadcrumbs dropped by #11331 rewrite — gated on #10360.
-- **test_agent_boundaries**: 20 missing L3 variant responsibility.md stubs (§5.2) gate on #10360; 19 other assertions (ac4/ac6/ac11) superseded by agent-boundaries sub-skill retirement — rewrite whole file when #10360 unblocks.
-Cross-linked on #10360. KNOWN_FAILURES reasons re-pointed. DO NOT un-quarantine these by weakening assertions; they ride #10360.
+## #11641 — DONE on its branch (cycle 1645)
+thin_launcher._reclaim_stale_scheduled_lock(clone_path): removes .claude/scheduled_tasks.lock iff holder pid dead (reuses _is_process_alive), before Popen; live lock preserved; corrupt/pid-less lock left+warn. Wiring test confirms main() calls it. Root cause of #11612 reboot loop. Commit cff818eb7 on squidsquad/task/11641.
 
-## #11657 — DONE (cycle 1643, commit 2ad42181f)
-Stale event_poll integration test removed (superseded by #11601). Deviation noted on issue.
+## #11657 — DONE (cycle 1643, commit 2ad42181f on bundle)
 
-## Tree cruft (NOT tracked, leave untracked)
-- .claude/scheduled_tasks.lock.stale-bak — #11641 (stale lock crash)
-- .squidsquad/skill/planning/CODE-REVIEW-11601.md — #11601 leftover (shipped)
-- .squidsquad/.harness-port — restored to 59999 during #11657 triage (gitignored)
+## Tree cruft (untracked, leave)
+- .claude/scheduled_tasks.lock.stale-bak — #11641 repro backup (now travels with checkouts)
+- .squidsquad/skill/planning/CODE-REVIEW-11601.md — #11601 leftover
+- .squidsquad/.harness-port — restored 59999 during #11657 triage (gitignored)
 
 ## Standing items
-- #10360 (high, OPEN) — Responsibility compose slot §5.2; now also gates the final 2 #11503 tests
-- #11641 (high) — stale scheduled_tasks.lock crashes claude → reboot loop
-- #11640 (high) — boot_remote._get_clone_path REPO_ROOT fallback must fail-closed
-- #11586 (high) — agents don't reach event mode on reboot (cf. port-file/7373 mismatch)
+- #10360 (high, OPEN) — Responsibility compose slot §5.2; gates final 2 #11503 tests
+- #11641 (in-progress, this session) — verification-blocked on bundle→main merge
+- #11640 (high) — boot_remote REPO_ROOT fallback must fail-closed
+- #11586 (high) — agents don't reach event mode on reboot (cf. 7373/port-file mismatch)
 - #11587 (medium), #11511 (medium), #11505 (capabilities teardown)

--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -1,28 +1,42 @@
 # Working State
 
-- **Task**: none active — on main (#11538 fix shipped to pending-test, PR #11564)
-- **Status**: none (idle)
-- **Updated**: 2026-06-12 21:06
-- **Last Processed Event ID**: 9d7c2489
-- **Quiet Cycle Counter**: 0
+- **Task**: #11503 (high, in-progress, role:skill) — post-cutover test-debt: 23 static tests red since v0.44.0 cutover
+- **Status**: Group C (4 possibly-real) DONE & committed; working Group A (stale-structure tests) next
+- **Branch**: squidsquad/skill/post-cutover-cleanup (bundle branch per operator decision c-2026-06-12; even with origin/main). NOTE: upstream is misconfigured to origin/main — push must target origin/post-cutover-cleanup explicitly, NEVER main.
+- **Updated**: 2026-06-13 01:24 (fresh boot; #11601 verified shipped/closed → cleared)
 
-## ⚠️ Session note
-Booted PRE-v0.44.0; runs OLD composed CLAUDE.md (reboot pending per DM — do NOT self-reboot). Harness DOWN (port 7373 exit 7) — loop-mode this session.
+## Improvement Scan
+Status: idle
+Last completed: (none this session)
+Next scan after: (eligible — defer until #11503 ships)
 
-## Last cycle (1642, iter-451): fixed #11538 harness restart bug
-update_health reset RESTARTING→RUNNING on every poll where the same claude PID was alive (no pid_changed guard) → HEALTH_POLL_INTERVAL=5s silently reverted any restart of a still-alive/wedged agent AND disarmed the 60s force-kill net. Fix mirrors STOPPING branch: (1) RESTARTING→RUNNING reset gated on pid_changed; (2) force-kill skips when pid_changed. TestRestartLifecycle (4 cases) — 3 fail on pre-fix code, verified via git stash. 184 harness tests + run_tests.py green. → pending-test, PR #11564, back on main.
+## #11503 — plan (front-loaded)
+23 static tests quarantined in KNOWN_FAILURES (tests/run_tests.py) when the gate went dead at v0.44.0 cutover (#11394). Fix each, remove its KNOWN_FAILURES entry, gate re-includes it.
+- **Group A** — stale tests asserting pre-v2/pre-rename/pre-cutover structure → update test to v2 reality. ~16 files.
+- **Group B** — fixture drift: test_config_functions (SAMPLE_CONFIG missing FIELD_MAP entries). 1 file.
+- **Group C** — possibly-real masked regressions (triage first). DONE (see below).
 
-## Standing
-- **#11538 / PR #11564**: pending-test — verifier to verify (harness restart endpoint fix).
-- **#11512 / PR #11518**: pending-ship, MERGEABLE/CLEAN — DM to ship promptly (may re-stale).
-- **#11519 / PR #11530**: pending-ship — DM to ship.
-- **#11511 (medium)**: root cause = merge=ours not honored by GitHub server-side; recommendation posted (A=state-branch via state_bus [recommended]; B=stopgap merge=union). Awaiting PM/operator decision. NOT implementing (high blast radius).
+## #11503 — Group C: DONE (committed this cycle)
+4 flags triaged:
+- test_manifest_registry + test_feat328_coverage: REAL orphan — dm/manifest.yaml `any_of: [local_delivery]` referenced the deleted capabilities registry (removed as deadwood, INSTALLER-ARCH §8.3, full teardown #11505). Fix: manifest `requires_sub_skills: {}`; tests assert `tools == {}`. Verified 98 passed.
+- test_statusline_schema: REAL deploy-sync gap — .squidsquad/statusline.sh stale vs references/ (#11144 G10). Fix: synced deploy copy (now identical). Verified green.
+- test_comms_sub_skills: chat-etiquette heading-format — STILL in KNOWN_FAILURES (Group A/source-format, deferred to next batch).
 
-## Watch
-- **PR #11504 / #11394**: static-gate auto-discovery — MERGED into this branch base (5f6caffbf). On confirmed merge → #11503/#11505 ungated.
-- #11503 (high) / #11505 (low): gated on #11504 (now likely unblocked — re-check next cycle).
-- #10690 / #10686 (E7): operator-gated.
-- #11329 (approved): runtime per-event ack-cursor.
+## #11503 — Group A remaining (KNOWN_FAILURES, ~17)
+test_references, test_state_bus, test_comms_sub_skills, test_event_mode_fragments, test_cycle_pre,
+test_4792_fragment_hygiene, test_deterministic_qa_framework, test_dm_verify_before_block,
+test_own_domain_autofix, test_vault_synthesis, test_pickup_comment_fidelity_9946,
+test_terminology_dual_aware_6274, test_compose_a2f_10492, test_atomic_emit_b7,
+test_a3_golden_link_stage, test_compose_author_comments_11142, test_agent_boundaries,
+test_feat_9588_lazy_load_bootstrap, test_stale_tracker_files_ref
++ Group B: test_config_functions
 
-## ⚠️ Recurring conflict note
-PR CONFLICTING-while-locally-clean = merge=ours custom driver not honored by GitHub server-side (#11511). Verify real vs cosmetic with `git merge-tree --write-tree origin/main origin/<branch>` (exit 0 = cosmetic). Real fix = state-branch (state_bus, unwired). See [[learning-pr-conflicting-flag-can-be-cosmetic]].
+## Tree cruft (NOT #11503, leave untracked)
+- .claude/scheduled_tasks.lock.stale-bak — relates to #11641 (stale lock crash); separate issue
+- .squidsquad/skill/planning/CODE-REVIEW-11601.md — #11601 leftover (shipped); harmless
+
+## Standing items (post-#11503)
+- #11641 (high, open) — stale scheduled_tasks.lock crashes claude → reboot loop
+- #11640 (high, open) — boot_remote REPO_ROOT fallback must fail-closed
+- #11586 (high, open) — agents don't reach event mode on reboot
+- #11587 (medium), #11511 (medium), #11505 (capabilities teardown)

--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -1,38 +1,37 @@
 # Working State
 
-- **Active work spans TWO branches this session:**
-  1. **squidsquad/skill/post-cutover-cleanup** (bundle, session home) — #11503 (21/23 stale cleared) + #11657 (done). 9 commits ahead of origin/main, LOCAL (not pushed). Awaiting PM disposition on #11503 (recommended close at 21/23; final 2 are #10360-gated).
-  2. **squidsquad/task/11641** (based on origin/main) — #11641 fix, 1 commit (cff818eb7), LOCAL. in-progress, NOT pending-test (see blocker below).
+- **Cycle 1646: PM dispositioned both blocked items — executed.**
 
-- **#11503**: 21/23 stale-test debt cleared. Final 2 (compose_author_comments_11142, agent_boundaries) are #10360-gated, NOT stale — re-pointed in KNOWN_FAILURES, cross-linked on #10360. PM decision requested (no response yet).
-- **#11657**: done (event_poll stale test removed; on bundle).
-- **#11641** (cycle 1645): implemented thin_launcher stale-scheduled-lock reclamation + 6 regression tests (incl. wiring). 37 thin_launcher tests pass. **NOT pending-test**: full run_tests.py on the main-based branch shows 1 failure = test_event_poll_exits_cleanly_when_harness_unreachable, which is PRE-EXISTING ON MAIN (= the #11657 fix that lives on the bundle, not yet merged). My #11641 changes are green in isolation. Held in-progress to avoid handing verifier a red suite.
+## Shipped to verifier this cycle
+- **PR #11683** opened (squidsquad/skill/post-cutover-cleanup → main): #11503 (21/23) + #11657. Merged current origin/main (clean), pushed via gh credential bypass (credential.helper=manager would wedge a bare push), full suite green (exit 0).
+- **#11503 → pending-test** (PM approved close at 21/23). 2 remaining KNOWN_FAILURES (test_compose_author_comments_11142, test_agent_boundaries) are #10360-gated, allowlisted, NOT regressions — noted for QA in PR body + handoff.
+- **#11657 → pending-test** (rides PR #11683).
 
-- **MERGE ORDERING (PM/DM)**: land the post-cutover-cleanup bundle (#11503+#11657) to main FIRST → main goes green → then squidsquad/task/11641 merges a green main and goes pending-test. Surfaced on #11641 + #11503.
+## #11641 — DONE on squidsquad/task/11641 (commit cff818eb7), HELD in-progress
+Verification-blocked until PR #11683 merges to main (then main goes green; task/11641 merges green main → pending-test). PM ACK'd this ordering. NOT pushed yet. Once #11683 lands, next steps: checkout task/11641, merge main, run suite (expect green), push, PR, → pending-test.
 
-- **Branches/push**: both branches LOCAL, not pushed. Bundle upstream misconfigured to origin/main — NEVER bare-push (push.default=simple refuses). Push explicit refspecs when PR-ready.
-- **Mode**: POLLING (harness probe failed at boot — port file 59999 refused; a process answers on default 7373, likely #11586-class stale-port mismatch). /loop cron ea6e7da1 (30m). Mode sticky.
-- **Updated**: 2026-06-13 03:55
+## Open loops / next actions (in order)
+1. **Wait for DM to merge PR #11683 to main.** (verifier verifies #11503/#11657 first.)
+2. After #11683 merges → unblock #11641: merge main into task/11641, verify green, push, PR, → pending-test.
+3. #10360 (role:pm) lands later → final 2 #11503 tests un-quarantine (PM owns).
 
-## Improvement Scan
-Status: idle. Next: eligible once #11503/#11641 dispositioned.
+## Mode / environment
+- POLLING is INTENTIONAL: PM pinned .harness-port=59999 (probe fails → loop fallback) to stop the SLOW event-mode reboot loop (#11586) while skill was down. 59999 is intentional + gitignored — LEAVE IT. Revert to 7373 only after #11586 lands. (Resolves my earlier "stale port mismatch" note — it was deliberate.)
+- /loop cron ea6e7da1 (30m). Mode sticky.
+- **Updated**: 2026-06-13 04:20
 
-## #11503 — DONE (21 stale cleared) / BLOCKED (2 on #10360)
-21 genuinely-stale tests rebound across cycles 1642-1644. Final 2 gate on OPEN #10360 (Responsibility compose slot §5.2): test_compose_author_comments_11142 (stale half fixed; test_10360_cleanup half is #10360), test_agent_boundaries (20 L3 stubs §5.2 + 19 superseded assertions). DO NOT weaken to force green; ride #10360.
-
-## #11641 — DONE on its branch (cycle 1645)
-thin_launcher._reclaim_stale_scheduled_lock(clone_path): removes .claude/scheduled_tasks.lock iff holder pid dead (reuses _is_process_alive), before Popen; live lock preserved; corrupt/pid-less lock left+warn. Wiring test confirms main() calls it. Root cause of #11612 reboot loop. Commit cff818eb7 on squidsquad/task/11641.
-
-## #11657 — DONE (cycle 1643, commit 2ad42181f on bundle)
+## Branch state
+- squidsquad/skill/post-cutover-cleanup: pushed to origin, PR #11683 open. = origin/main + bundle work + merge.
+- squidsquad/task/11641: local only (1 commit cff818eb7), held.
 
 ## Tree cruft (untracked, leave)
-- .claude/scheduled_tasks.lock.stale-bak — #11641 repro backup (now travels with checkouts)
+- .claude/scheduled_tasks.lock.stale-bak — #11641 repro backup
 - .squidsquad/skill/planning/CODE-REVIEW-11601.md — #11601 leftover
-- .squidsquad/.harness-port — restored 59999 during #11657 triage (gitignored)
+- .squidsquad/.harness-port — 59999 (INTENTIONAL PM pin, gitignored)
 
 ## Standing items
-- #10360 (high, OPEN) — Responsibility compose slot §5.2; gates final 2 #11503 tests
-- #11641 (in-progress, this session) — verification-blocked on bundle→main merge
-- #11640 (high) — boot_remote REPO_ROOT fallback must fail-closed
-- #11586 (high) — agents don't reach event mode on reboot (cf. 7373/port-file mismatch)
+- #10360 (OPEN, role:pm) — Responsibility compose slot §5.2; gates final 2 #11503 tests (PM advancing)
+- #11641 (in-progress) — held pending #11683 merge
+- #11640 (high, open) — boot_remote REPO_ROOT fallback must fail-closed
+- #11586 (high, open) — agents don't reach event mode on reboot (why 59999 pin exists)
 - #11587 (medium), #11511 (medium), #11505 (capabilities teardown)

--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -1,49 +1,44 @@
 # Working State
 
-- **Task**: #11503 (high, in-progress, role:skill) — post-cutover test-debt: 23 static tests red since v0.44.0 cutover
-- **Status**: 17/23 done & committed (Group C ×3 + event-mode ×2 prior; Group A/B ×12 this session). 6 Group A tail remain.
-- **Also this session**: #11657 (event_poll stale integration test) filed + fixed (removed as superseded by #11601). Rides bundle branch.
-- **Commits this session** (bundle branch, LOCAL — not pushed; push to origin/post-cutover-cleanup explicitly when PR-ready): 85d6eb430 #11503 Group A/B (12 tests); 2ad42181f #11657 event_poll stale-test removal. (Prior-session ancestors: 7f6c5258b, e8896df59, 6968c3217.) push.default=simple → bare push safely refuses (branch≠upstream main).
-- **Branch**: squidsquad/skill/post-cutover-cleanup (bundle branch per operator decision c-2026-06-12; even with origin/main). NOTE: upstream is misconfigured to origin/main — push must target origin/post-cutover-cleanup explicitly, NEVER main.
-- **Mode**: POLLING (harness probe failed — port file said 59999, connection refused). /loop scheduled (cron ea6e7da1, 30m). NOTE: a process answers on default 7373 (event_poll exit 1 in repro) — port file (59999) looks stale vs the actual harness on 7373; possible #11586-class boot-probe mismatch worth a look later. Did NOT re-probe (mode sticky per boot contract).
-- **Updated**: 2026-06-13 02:52
+- **Task**: #11503 (high, in-progress, role:skill) — post-cutover test-debt. **21/23 stale tests cleared; remaining 2 are #10360-gated (not stale).**
+- **Status**: Group A tail done this cycle (cycle 1644): 4 stale tests rebound + un-quarantined (cycle_pre, terminology_6274, own_domain_autofix, vault_synthesis). Triage finding: last 2 KNOWN_FAILURES (compose_author_comments_11142, agent_boundaries) block on OPEN #10360 (Responsibility compose slot §5.2), NOT cutover-stale. Re-pointed their reasons; did NOT weaken assertions. PM decision requested on #11503 (recommend: close at 21/23, let #10360 carry final 2).
+- **Commits (bundle branch, LOCAL — not pushed; push to origin/post-cutover-cleanup explicitly when PR-ready)**:
+  - 7357b6cd7 #11503 Group A tail (4 stale cleared + 2 triaged to #10360) [cycle 1644]
+  - eb21957ea cycle 1643 state; 2ad42181f #11657 event_poll removal; 85d6eb430 #11503 Group A/B (12 tests) [cycle 1643]
+  - (prior-session ancestors: 7f6c5258b, e8896df59, 6968c3217)
+  - push.default=simple → bare push safely refuses (branch≠upstream main).
+- **Branch**: squidsquad/skill/post-cutover-cleanup (bundle branch per operator decision c-2026-06-12). NOTE: upstream misconfigured to origin/main — push must target origin/post-cutover-cleanup explicitly, NEVER main.
+- **Mode**: POLLING (harness probe failed at boot — port file 59999, connection refused). /loop cron ea6e7da1 (30m). NOTE: a process answers on default 7373 — port file looks stale; possible #11586-class boot-probe mismatch. Did NOT re-probe (mode sticky).
+- **Updated**: 2026-06-13 03:30
 
 ## Improvement Scan
 Status: idle
 Last completed: (none this session)
-Next scan after: (eligible — defer until #11503 ships)
+Next scan after: (eligible — defer until #11503 dispositioned)
 
-## #11503 — plan (front-loaded)
-23 static tests quarantined in KNOWN_FAILURES (tests/run_tests.py) when the gate went dead at v0.44.0 cutover (#11394). Fix each, remove its KNOWN_FAILURES entry, gate re-includes it.
-- **Group A** — stale tests asserting pre-v2/pre-rename/pre-cutover structure → update test to v2 reality.
-- **Group B** — fixture drift: test_config_functions (SAMPLE_CONFIG FIELD_MAP). DONE.
-- **Group C** — possibly-real masked regressions (triage first). DONE.
+## #11503 — DONE (stale debt cleared)
+All 21 genuinely-stale post-cutover tests rebound to v2 reality + un-quarantined across cycles:
+- cycle 1642(prior): Group C ×3 + event-mode ×2 (5)
+- cycle 1643: Group A/B ×12
+- cycle 1644: Group A tail ×4 (cycle_pre, terminology_6274, own_domain_autofix, vault_synthesis)
 
-## #11503 — Group A/B DONE this session (commit 85d6eb430)
-Un-quarantined 12: test_references, test_state_bus, test_comms_sub_skills, test_4792_fragment_hygiene,
-test_deterministic_qa_framework, test_dm_verify_before_block, test_pickup_comment_fidelity_9946,
-test_stale_tracker_files_ref (pre-rename/pre-cutover); test_compose_a2f_10492, test_atomic_emit_b7,
-test_a3_golden_link_stage (compose golden drift — regenerated fixtures); test_config_functions (Group B).
+## #11503 — BLOCKED on OPEN #10360 (the final 2 of 23 — NOT stale)
+#10360 = "Implement Responsibility compose slot per COMPOSE-ARCHITECTURE §5.2" (OPEN). Both tests fail on genuinely-incomplete §5.2 work:
+- **test_compose_author_comments_11142**: stale half FIXED (boot-bootstrap marker moved to references/roles/instructions.md in #11331). test_10360_cleanup_markers_preserved half detects #10360 breadcrumbs dropped by #11331 rewrite — gated on #10360.
+- **test_agent_boundaries**: 20 missing L3 variant responsibility.md stubs (§5.2) gate on #10360; 19 other assertions (ac4/ac6/ac11) superseded by agent-boundaries sub-skill retirement — rewrite whole file when #10360 unblocks.
+Cross-linked on #10360. KNOWN_FAILURES reasons re-pointed. DO NOT un-quarantine these by weakening assertions; they ride #10360.
 
-## #11503 — Group A REMAINING (6 in KNOWN_FAILURES)
-test_cycle_pre (#6274 alias rename partial), test_own_domain_autofix (removed v1 {{include:}} syntax),
-test_vault_synthesis ('create-task' in restructured pm source), test_terminology_dual_aware_6274
-(pre-rename dev/skill → worker/skill), test_compose_author_comments_11142 (boot-bootstrap wrapper marker),
-test_agent_boundaries (removed responsibility.md + phrase).
+## #11657 — DONE (cycle 1643, commit 2ad42181f)
+Stale event_poll integration test removed (superseded by #11601). Deviation noted on issue.
 
-## #11657 — DONE this session (commit 2ad42181f)
-Stale integration test test_event_poll_exits_cleanly_when_harness_unreachable asserted pre-#11601
-contract (missing port → exit 2). #11601 made _discover_port default to 7373 (fixes #11586). Removed as
-superseded — #11601 contract covered in tests/test_event_poll.py (44 pass); harness-down no-crash covered
-by event_bus silent-noop tests + test_9398. Deviation (rebind→remove) noted on #11657. Suite green 53/2.
-
-## Tree cruft (NOT #11503, leave untracked)
-- .claude/scheduled_tasks.lock.stale-bak — relates to #11641 (stale lock crash); separate issue
-- .squidsquad/skill/planning/CODE-REVIEW-11601.md — #11601 leftover (shipped); harmless
+## Tree cruft (NOT tracked, leave untracked)
+- .claude/scheduled_tasks.lock.stale-bak — #11641 (stale lock crash)
+- .squidsquad/skill/planning/CODE-REVIEW-11601.md — #11601 leftover (shipped)
 - .squidsquad/.harness-port — restored to 59999 during #11657 triage (gitignored)
 
-## Standing items (post-#11503)
-- #11641 (high, open) — stale scheduled_tasks.lock crashes claude → reboot loop
-- #11640 (high, open) — boot_remote._get_clone_path REPO_ROOT fallback must fail-closed
-- #11586 (high, open) — agents don't reach event mode on reboot (cf. port-file/7373 mismatch noted above)
+## Standing items
+- #10360 (high, OPEN) — Responsibility compose slot §5.2; now also gates the final 2 #11503 tests
+- #11641 (high) — stale scheduled_tasks.lock crashes claude → reboot loop
+- #11640 (high) — boot_remote._get_clone_path REPO_ROOT fallback must fail-closed
+- #11586 (high) — agents don't reach event mode on reboot (cf. port-file/7373 mismatch)
 - #11587 (medium), #11511 (medium), #11505 (capabilities teardown)

--- a/.squidsquad/statusline.sh
+++ b/.squidsquad/statusline.sh
@@ -162,16 +162,19 @@ if [ -n "$BEHIND" ] && [ "$BEHIND" -gt 0 ]; then
   GIT_SYNC="${GIT_SYNC}↓${BEHIND}"
 fi
 
-# Role label — use alias from config if available
+# Role label — alias is sole truth (#11144 G10).
+# Look up the alias from config; if it differs from $ROLE (which means
+# the caller passed a role-class name), use the alias. Otherwise $ROLE
+# is already the alias — use it raw. No hardcoded uppercase fallback.
+#
+# Defensive parse: `config.py alias` is contracted to print a single
+# kebab-case token to stdout (e.g. `qa`, `skill`, `frontend-1`). The
+# guard below rejects ALIAS if it isn't a single line matching that
+# shape — protects against future-stdout pollution (#11144 Iter 40 DS
+# F2). On reject, fall through to raw $ROLE.
 ALIAS=$(python references/scripts/config.py alias "$ROLE" 2>/dev/null) || true
-if [ -n "$ALIAS" ] && [ "$ALIAS" != "$ROLE" ]; then
+if echo "$ALIAS" | grep -Eq '^[a-z][a-z0-9-]*$' && [ "$ALIAS" != "$ROLE" ]; then
   ROLE_LABEL="$ALIAS"
-elif [ "$ROLE" = "pm" ]; then
-  ROLE_LABEL="PM"
-elif [ "$ROLE" = "qa" ]; then
-  ROLE_LABEL="QA"
-elif [ "$ROLE" = "dm" ]; then
-  ROLE_LABEL="DM"
 else
   ROLE_LABEL="$ROLE"
 fi

--- a/.squidsquad/vault/galaxy/learning-quarantine-clear-triage-stale-vs-blocked.md
+++ b/.squidsquad/vault/galaxy/learning-quarantine-clear-triage-stale-vs-blocked.md
@@ -1,0 +1,60 @@
+---
+type: learning
+tags: [skill, worker, testing, quarantine, known-failures, triage, scope-discipline]
+created: 2026-06-13
+updated: 2026-06-13
+owner: skill
+status: active
+confidence: high
+source: observation
+links: [learning-gate-collection-abort-masks-reds, decision-deterministic-testing]
+---
+
+## Context
+
+#11503 was chartered as "23 post-cutover stale tests red since the v0.44.0
+gate-death — rebind each to v2 reality and un-quarantine." That framing
+assumed every quarantined red was *stale* (test asserts old structure that
+legitimately changed). Working the tail (cycle 1644), 2 of the 23 turned out
+NOT to be stale: `test_agent_boundaries` (20 missing L3 responsibility stubs)
+and `test_compose_author_comments_11142::test_10360_cleanup_markers_preserved`
+were failing because they correctly demand work that is **genuinely
+incomplete** — the Responsibility compose slot tracked by still-OPEN #10360
+(COMPOSE-ARCHITECTURE §5.2). The gate-death had masked them too, so they sat
+in the same quarantine bucket as the stale ones and looked identical.
+
+## Lesson
+
+**A quarantine list mixes two species of red, and they need opposite
+treatment. Triage each before un-quarantining:**
+
+- **Stale test** — source legitimately restructured; the assertion describes
+  a world that no longer exists. → Rebind the assertion to current reality,
+  un-quarantine. (This is the expected #11503 work.)
+- **Blocked-on-open-work test** — the assertion is *correct*; the source is
+  genuinely missing something an OPEN issue is chartered to deliver. → Do NOT
+  weaken or delete the assertion to force the gate green. Keep it quarantined,
+  re-point its KNOWN_FAILURES reason to the blocking issue, and cross-link the
+  test on that issue so it un-quarantines when the work lands.
+
+The tell: when a "stale test" fix would require you to *delete a real
+assertion* or *create the missing thing yourself*, stop — you've crossed from
+stale-test-rebind into the blocking issue's scope. Check `gh issue view` on
+any issue the test/source references before deciding. Front-loaded
+reading-everything-first (not skim-then-fix) is what surfaces this before you
+wrongly paper over a real gap.
+
+This is the same shape as the recurring "shipped-but-unwired" audit pattern —
+a surface that *looks* complete (here: a quarantine framed as pure stale-debt)
+hiding an unfinished one. And it complements
+[[learning-gate-collection-abort-masks-reds]]: that one is how the gate should
+be *built*; this one is how to *work the backlog* the gate exposed.
+
+## How to apply
+
+When clearing any quarantine / KNOWN_FAILURES / xfail backlog: for each entry,
+classify stale vs blocked-on-open-work BEFORE editing. Verify the issue state
+of anything the failing assertion references. Un-quarantine only the stale
+ones; route the blocked ones to their owning issue with a re-pointed reason
+and a cross-link. Surface the re-scoping to PM — an umbrella chartered as "N
+stale tests" that contains M blocked-on-other-work tests cannot reach N/N.

--- a/references/roles/dm/manifest.yaml
+++ b/references/roles/dm/manifest.yaml
@@ -29,10 +29,11 @@ claude_template: instructions.md
 # Terminal node — DM is where every path ends.
 routes_to: []
 
-# DM needs exactly one delivery tool. `local_delivery` is the always-available
-# fallback; richer delivery channels (email, Slack, Drive, etc.) are added to
-# this list as tools ship in future registries.
-requires_sub_skills:
-  any_of: [local_delivery]
+# No capability requirements. The capability mechanism (capabilities/ dir) was
+# removed as deadwood (INSTALLER-ARCH §8.3) and superseded by per-agent L4 tool
+# config, so the registry now loads zero capabilities. The former
+# `any_of: [local_delivery]` was an orphan reference into that deleted registry
+# (#11503). Matches the empty form used by pm/verifier/worker manifests.
+requires_sub_skills: {}
 
 setup_requirements: []

--- a/tests/compose-fixtures/pm/CLAUDE.linked.golden.md
+++ b/tests/compose-fixtures/pm/CLAUDE.linked.golden.md
@@ -1,6 +1,7 @@
 ## Identity
 
 You are a SquidSquad PM agent. You coordinate the team, talk to the human, and orchestrate work.
+
 → run sub-skill: project-context-load
 
 Project Acme PM: deeply familiar with the Acme team's cadences and incident-response rituals.
@@ -8,6 +9,8 @@ Project Acme PM: deeply familiar with the Acme team's cadences and incident-resp
 ## Responsibility
 
 PM coordinates the team, shapes incoming work into concrete plans, and assigns it to the right specialist.
+
+## Project Context
 
 ## Soul
 
@@ -27,19 +30,20 @@ Do the unit of work for the current cycle. Vary by role.
 → run sub-skill: vault-consult
 
 Consult the vault for active priorities before triage.
+
 → run sub-skill: post-cycle-checkpoint
 
 Checkpoint cycle state into the working-state file.
+
 ### step:cycle/triage
 
 → run sub-skill: task-pickup
 
 Triage approved tasks; assign each to the role best suited to deliver.
+
 → run sub-skill: human-status-update
 
 End each cycle with a short status update to the human.
-
-## Project Context
 
 ## Vault
 

--- a/tests/compose-fixtures/worker-fe/CLAUDE.linked.golden.md
+++ b/tests/compose-fixtures/worker-fe/CLAUDE.linked.golden.md
@@ -6,6 +6,8 @@ You are a SquidSquad agent. You execute discrete units of work and report back t
 
 Worker implements approved tasks, fixes bugs filed to its tracker, and lands regression tests for every fix.
 
+## Project Context
+
 ## Soul
 
 Pragmatic. Implementation-focused. Honest about tradeoffs.
@@ -27,6 +29,7 @@ Pick up the highest-priority approved item from the deterministic queue.
 → run sub-skill: design-context-load
 
 Load the project's design system tokens into the working state.
+
 ### step:cycle/implement
 
 → run sub-skill: implement-tasks
@@ -35,16 +38,16 @@ Implement the approved task; in this project, ALSO run `npm run typecheck` befor
 → run sub-skill: design-review
 
 Pull the Figma frame for the change and confirm visual parity before building.
+
 ### step:cycle/fe-build
 
 → run sub-skill: fe-build-and-snapshot
 
 Run the FE build pipeline; capture visual snapshots for changed components.
+
 → run sub-skill: commit-with-design-tag
 
 Tag each implementation commit with the Figma frame ID for traceability.
-
-## Project Context
 
 ## Vault
 

--- a/tests/integration/test_event_mode_agent_subprocess.py
+++ b/tests/integration/test_event_mode_agent_subprocess.py
@@ -18,10 +18,12 @@ Scope this file:
   "agent picks up real work" half is agent-decision territory
   (covered by ``8694_spec.json`` Q1 — boot-path resume logic).
 - §4.5 Harness-down boot — event_bus.emit() is silent no-op when
-  the harness port is missing; event_poll exits with the
-  no-events code without crashing when the harness is unreachable.
-  Together these prove the agent's boot path doesn't crash when
-  harness is down (AC-2 M-2.1/M-2.2).
+  the harness port is missing or the harness refuses the connection.
+  (Post-#11601, a missing .harness-port no longer fails event_poll —
+  _discover_port falls back to default port 7373; that resolution
+  contract is covered in tests/test_event_poll.py, not here.) These
+  prove the agent's boot path doesn't crash when harness is down
+  (AC-2 M-2.1/M-2.2).
 
 Scope deliberately NOT in this file yet (PR3 follow-up cycles):
 
@@ -518,54 +520,26 @@ class TestHarnessDownBoot(unittest.TestCase):
                     f"the 500ms cap so boot path doesn't stall.",
             )
 
-    def test_event_poll_exits_cleanly_when_harness_unreachable(self):
-        """event_poll.py with no .harness-port at all must exit
-        non-zero with an ERROR to stderr but not crash with a
-        traceback. The agent's wrapper script reads stderr and
-        decides whether to retry (handled by the retry-backoff
-        path already in event_poll's --wait loop)."""
-        import subprocess
-        import tempfile
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Run event_poll with a SQUID_DIR override via env var if
-            # supported; otherwise use the role-specific isolation
-            # pattern from test_event_mode_e2e.py — but we want NO
-            # port file at all. Easiest: use a unique role name whose
-            # working-state lives in the real .squidsquad/ but
-            # temporarily mask out .harness-port via a backup.
-            squid_dir = REPO_ROOT / ".squidsquad"
-            port_file = squid_dir / ".harness-port"
-            backup = port_file.read_bytes() if port_file.exists() else None
-            try:
-                if port_file.exists():
-                    port_file.unlink()
-                result = subprocess.run(
-                    [
-                        __import__("sys").executable,
-                        str(SCRIPTS / "event_poll.py"),
-                        "test-harness-down-role",
-                    ],
-                    capture_output=True, text=True,
-                    cwd=str(REPO_ROOT), timeout=15,
-                )
-            finally:
-                if backup is not None:
-                    port_file.write_bytes(backup)
-
-            # Spec: non-zero exit (fatal/no-port branch).
-            self.assertEqual(
-                result.returncode, 2,
-                msg=f"event_poll should exit 2 when port file is "
-                    f"missing. stderr={result.stderr!r}",
-            )
-            self.assertIn("harness port not found", result.stderr)
-            # Crucially: no Python traceback in stderr.
-            self.assertNotIn(
-                "Traceback", result.stderr,
-                msg="event_poll must not crash with a traceback when "
-                    "the harness is down — the agent's wrapper "
-                    "interprets the exit code, not the stack trace.",
-            )
+    # NOTE (#11657): the former ``test_event_poll_exits_cleanly_when_
+    # harness_unreachable`` was removed here. It asserted the pre-#11601
+    # contract — missing ``.harness-port`` -> event_poll exits 2 with
+    # "harness port not found". #11601 (d0986cb7e) deliberately changed
+    # ``_discover_port()`` to fall back to the default port 7373 (+ a
+    # parent-dir walk) instead of returning None, fixing #11586 (agents
+    # could not sustain event mode in clones lacking the gitignored
+    # port file). That made the old assertion impossible and the
+    # subprocess approach flaky: with no port file, single-shot
+    # event_poll resolves 7373 and either polls a live default-port
+    # harness (exit 1, no events) or retries a refused port forever.
+    # The surviving #11601 contract is covered deterministically in
+    # tests/test_event_poll.py (``test_defaults_to_7373_when_file_absent``,
+    # ``test_garbage_content_defaults_to_7373``,
+    # ``test_poll_returns_none_when_discover_port_returns_none``); the
+    # harness-down-boot no-crash intent is covered by the two
+    # ``test_event_bus_emit_silent_noop_*`` tests above and by
+    # test_9398_real_agent_subprocess.py. The old test also deleted the
+    # live ``.harness-port`` and only restored it in a ``finally`` — a
+    # killed run left the file gone.
 
 
 if __name__ == "__main__":

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -82,7 +82,6 @@ KNOWN_FAILURES = {
     "test_references": "asserts removed v1 references/agent-instructions.md — #11503",
     "test_state_bus": "asserts git pull --rebase; code is --no-rebase per never-rebase rule — #11503",
     "test_comms_sub_skills": "chat-etiquette.md heading-format assertion (possibly real) — #11503",
-    "test_event_mode_fragments": "expects includes.yml to list common/boot-bootstrap (v2 changed includes) — #11503",
     "test_cycle_pre": "asserts 'verifier' in alias set; #6274 rename partial — #11503 / #6274",
     "test_4792_fragment_hygiene": "asserts removed 'sole liveness signal' phrase in composed skill — #11503",
     "test_deterministic_qa_framework": "asserts '\"Deferred\"' in composed QA (drifted) — #11503",

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -80,9 +80,6 @@ KNOWN_NON_STATIC = {
 # first-failure cause; full detail in .squidsquad/skill/planning/11394-reasons.txt.
 KNOWN_FAILURES = {
     "test_references": "asserts removed v1 references/agent-instructions.md — #11503",
-    "test_manifest_registry": "shipped registry validation error (possibly real) — #11503",
-    "test_statusline_schema": "references/ vs .squidsquad/ statusline.sh out of sync (possibly real) — #11503",
-    "test_feat328_coverage": "capability registry empty: known capabilities [] (possibly real) — #11503",
     "test_state_bus": "asserts git pull --rebase; code is --no-rebase per never-rebase rule — #11503",
     "test_comms_sub_skills": "chat-etiquette.md heading-format assertion (possibly real) — #11503",
     "test_event_mode_fragments": "expects includes.yml to list common/boot-bootstrap (v2 changed includes) — #11503",

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -79,24 +79,12 @@ KNOWN_NON_STATIC = {
 # (gate went dead at the v0.44.0 cutover, masking these). Reasons are the
 # first-failure cause; full detail in .squidsquad/skill/planning/11394-reasons.txt.
 KNOWN_FAILURES = {
-    "test_references": "asserts removed v1 references/agent-instructions.md — #11503",
-    "test_state_bus": "asserts git pull --rebase; code is --no-rebase per never-rebase rule — #11503",
-    "test_comms_sub_skills": "chat-etiquette.md heading-format assertion (possibly real) — #11503",
     "test_cycle_pre": "asserts 'verifier' in alias set; #6274 rename partial — #11503 / #6274",
-    "test_4792_fragment_hygiene": "asserts removed 'sole liveness signal' phrase in composed skill — #11503",
-    "test_deterministic_qa_framework": "asserts '\"Deferred\"' in composed QA (drifted) — #11503",
-    "test_dm_verify_before_block": "reads removed references/sub-skills/roles/dm/prohibitions.md — #11503",
     "test_own_domain_autofix": "asserts removed v1 {{include:}} directive syntax (#11049 Path A) — #11503",
     "test_vault_synthesis": "asserts 'create-task' in restructured pm source (drifted) — #11503",
-    "test_pickup_comment_fidelity_9946": "reads removed references/roles/dev/includes.yml (pre-rename) — #11503",
     "test_terminology_dual_aware_6274": "asserts pre-rename ('dev','skill'); #6274 landed → ('worker','skill') — #11503",
-    "test_compose_a2f_10492": "compose section-list golden drifted — #11503",
-    "test_atomic_emit_b7": "compose section-list golden drifted — #11503",
-    "test_a3_golden_link_stage": "compose golden drifted — #11503",
     "test_compose_author_comments_11142": "asserts boot-bootstrap wrapper marker in restructured worker/instructions.md — #11503",
-    "test_config_functions": "SAMPLE_CONFIG fixture missing new FIELD_MAP entries (code-review-model, effort-*, event-driven) — #11503",
     "test_agent_boundaries": "asserts removed responsibility.md + 'Know each other's responsibilities' phrase — #11503",
-    "test_stale_tracker_files_ref": "reads removed references/sub-skills/roles/pm/prohibitions.md — #11503",
 }
 
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -75,16 +75,17 @@ KNOWN_NON_STATIC = {
     "test_feat_6581_wizard_reframing": "test_tc_10b recursively invokes run_tests.py (full suite incl integration) — unsuitable for static gate; #11503",
 }
 
-# Currently-red files quarantined out of the gate. Triage/fix tracked in #11503
-# (gate went dead at the v0.44.0 cutover, masking these). Reasons are the
-# first-failure cause; full detail in .squidsquad/skill/planning/11394-reasons.txt.
+# Currently-red files quarantined out of the gate. The post-cutover stale-test
+# debt (gate went dead at the v0.44.0 cutover, masking these; full detail in
+# .squidsquad/skill/planning/11394-reasons.txt) has been worked down under
+# #11503. The REMAINING two entries are NOT stale-test debt: they are tests
+# that correctly fail on genuinely-incomplete work tracked by OPEN #10360
+# (Implement Responsibility compose slot per COMPOSE-ARCHITECTURE §5.2). They
+# clear only once #10360 lands the Responsibility slot — do NOT paper over by
+# weakening assertions. See the #11503 comment for the full triage.
 KNOWN_FAILURES = {
-    "test_cycle_pre": "asserts 'verifier' in alias set; #6274 rename partial — #11503 / #6274",
-    "test_own_domain_autofix": "asserts removed v1 {{include:}} directive syntax (#11049 Path A) — #11503",
-    "test_vault_synthesis": "asserts 'create-task' in restructured pm source (drifted) — #11503",
-    "test_terminology_dual_aware_6274": "asserts pre-rename ('dev','skill'); #6274 landed → ('worker','skill') — #11503",
-    "test_compose_author_comments_11142": "asserts boot-bootstrap wrapper marker in restructured worker/instructions.md — #11503",
-    "test_agent_boundaries": "asserts removed responsibility.md + 'Know each other's responsibilities' phrase — #11503",
+    "test_compose_author_comments_11142": "test_10360_cleanup_markers_preserved: #10360-cleanup breadcrumbs (future-work pointers for OPEN #10360) dropped by #11331 rewrite — blocked on #10360 (the stale boot-bootstrap-marker half is fixed)",
+    "test_agent_boundaries": "test_ac7: 20 L3 variant responsibility stubs missing (COMPOSE-ARCH §5.2) — blocked on OPEN #10360. The other 19 assertions (ac4/ac6/ac11) are superseded by the agent-boundaries sub-skill retirement; rewrite the file together once #10360 unblocks it",
 }
 
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -96,7 +96,6 @@ KNOWN_FAILURES = {
     "test_compose_author_comments_11142": "asserts boot-bootstrap wrapper marker in restructured worker/instructions.md — #11503",
     "test_config_functions": "SAMPLE_CONFIG fixture missing new FIELD_MAP entries (code-review-model, effort-*, event-driven) — #11503",
     "test_agent_boundaries": "asserts removed responsibility.md + 'Know each other's responsibilities' phrase — #11503",
-    "test_feat_9588_lazy_load_bootstrap": "asserts removed '## Boot — Mode Detection (#9588)' heading — #11503",
     "test_stale_tracker_files_ref": "reads removed references/sub-skills/roles/pm/prohibitions.md — #11503",
 }
 

--- a/tests/test_4792_fragment_hygiene.py
+++ b/tests/test_4792_fragment_hygiene.py
@@ -88,7 +88,15 @@ class TestSharedInstructions:
 
 
 class TestComposedClaudeMd:
-    """Composed CLAUDE.md files must mirror the cleaned fragments."""
+    """Composed CLAUDE.md files must wire the agent-lifecycle sub-skill.
+
+    Post-v0.44.0 cutover: agent-lifecycle is no longer inlined into CLAUDE.md
+    at compose time — it is invoked at runtime via ``→ run sub-skill:``.
+    The lifecycle phrases ("sole liveness signal", "squidsquad_cli.py start")
+    live in the sub-skill source and in shared-instructions.md (tested
+    separately by TestSharedInstructions).  What the composed CLAUDE.md MUST
+    do is reference the sub-skill so the agent picks it up at runtime.
+    """
 
     @pytest.mark.parametrize("composed", COMPOSED_CLAUDE_MD,
                              ids=lambda p: p.parent.name)
@@ -99,17 +107,31 @@ class TestComposedClaudeMd:
             "recompose pass is incomplete"
         )
 
-    @pytest.mark.parametrize("composed", COMPOSED_CLAUDE_MD,
-                             ids=lambda p: p.parent.name)
-    def test_sole_liveness_signal_present(self, composed):
-        text = composed.read_text(encoding="utf-8")
-        assert "sole liveness signal" in text
+    def test_sole_liveness_signal_present(self):
+        # v2: lifecycle info lives in shared-instructions.md (always merged
+        # into agent context) and in the agent-lifecycle sub-skill source.
+        # Verify that shared-instructions carries the canonical phrase so the
+        # agent definitely reads it — the sub-skill itself is tested by
+        # TestLifecycleFragment.test_canonical_liveness_phrase_present.
+        shared = SHARED_INSTRUCTIONS.read_text(encoding="utf-8")
+        assert "sole liveness signal" in shared, (
+            "sole liveness signal must be present in shared-instructions.md "
+            "— agents read this file every cycle."
+        )
 
     @pytest.mark.parametrize("composed", COMPOSED_CLAUDE_MD,
                              ids=lambda p: p.parent.name)
     def test_squidsquad_cli_canonical(self, composed):
+        # v2: squidsquad_cli.py is referenced in shared-instructions.md and
+        # in the agent-lifecycle sub-skill source (tested by
+        # TestLifecycleFragment.test_lifecycle_interface_uses_squidsquad_cli).
+        # The composed CLAUDE.md wires the sub-skill via a runtime reference.
         text = composed.read_text(encoding="utf-8")
-        assert "squidsquad_cli.py start" in text
+        assert "agent-lifecycle" in text, (
+            f"{composed.parent.name}/CLAUDE.md must reference the "
+            "agent-lifecycle sub-skill so the agent can access the "
+            "squidsquad_cli.py lifecycle interface at runtime."
+        )
 
 
 class TestComprehensionSpecExists:

--- a/tests/test_atomic_emit_b7.py
+++ b/tests/test_atomic_emit_b7.py
@@ -75,9 +75,9 @@ def test_success_claude_md_contains_six_h2_sections_in_order(tmp_path):
     assert h2 == [
         "## Identity",
         "## Responsibility",
+        "## Project Context",
         "## Soul",
         "## Agent Functions",
-        "## Project Context",
         "## Vault",
     ]
 

--- a/tests/test_comms_sub_skills.py
+++ b/tests/test_comms_sub_skills.py
@@ -29,9 +29,21 @@ class TestSubSkillFiles:
         "consensus-protocol",
     ])
     def test_sub_skill_has_heading(self, name):
-        """Each sub-skill starts with a ## heading."""
+        """Each sub-skill has a ## heading as its first non-frontmatter line.
+
+        v2 sub-skill files use YAML frontmatter (--- ... ---) before the
+        heading. Strip the frontmatter block (if present) before checking
+        for the ## heading.
+        """
         content = (SUB_SKILLS_DIR / f"{name}.md").read_text(encoding="utf-8")
-        assert content.startswith("## "), f"{name}.md must start with ## heading"
+        # Strip YAML frontmatter (--- ... ---) if present
+        if content.startswith("---"):
+            end = content.find("\n---\n", 3)
+            if end != -1:
+                content = content[end + 5:]  # skip past closing ---\n
+        assert content.lstrip("\n").startswith("## "), (
+            f"{name}.md must have a ## heading (after optional frontmatter)"
+        )
 
     @pytest.mark.parametrize("name", [
         "chat-etiquette",

--- a/tests/test_compose_a2f_10492.py
+++ b/tests/test_compose_a2f_10492.py
@@ -161,9 +161,9 @@ def test_deploy_alias_v2_output_contains_six_canonical_h2_sections(tmp_path):
     assert h2_lines == [
         "## Identity",
         "## Responsibility",
+        "## Project Context",
         "## Soul",
         "## Agent Functions",
-        "## Project Context",
         "## Vault",
     ]
 

--- a/tests/test_compose_author_comments_11142.py
+++ b/tests/test_compose_author_comments_11142.py
@@ -124,13 +124,19 @@ def test_sub_skill_wrapper_markers_preserved(_deploy_all):
     """``<!-- sub-skill: NAME -->`` / ``<!-- /sub-skill: NAME -->`` wrapper
     markers around inlined sub-skill bodies (preserved through #11137)
     must survive the #11142 cleanup — they're not author commentary,
-    they're inlined-block boundary markers."""
-    path = REPO_ROOT / "references" / "roles" / "worker" / "instructions.md"
+    they're inlined-block boundary markers.
+
+    (#11331 compose-polish centralised the boot-bootstrap inline into the
+    shared L1 base ``references/roles/instructions.md`` rather than the
+    role-specific ``worker/instructions.md`` — the wrapper marker moved
+    with it. This test now asserts the marker survives in its current,
+    correct home.)"""
+    path = REPO_ROOT / "references" / "roles" / "instructions.md"
     text = path.read_text(encoding="utf-8")
     # boot-bootstrap is the one mandatory-inline that #11137 kept
     assert "<!-- sub-skill: boot-bootstrap -->" in text, (
-        "boot-bootstrap wrapper marker missing from worker/instructions.md "
-        "— #11142 strip should not touch sub-skill wrappers."
+        "boot-bootstrap wrapper marker missing from references/roles/"
+        "instructions.md — the strip must not touch sub-skill wrappers."
     )
 
 

--- a/tests/test_config_functions.py
+++ b/tests/test_config_functions.py
@@ -20,6 +20,7 @@ SAMPLE_CONFIG = """# SquidSquad Config
 ## Agents
 
 - **Dev Agents**: qa, skill
+- **Workers**: qa, skill
 - **PM**: always present
 - **QA**: always present
 - **DM**: present
@@ -68,6 +69,7 @@ SAMPLE_CONFIG = """# SquidSquad Config
 ## Improvement Scanning
 
 - **Enabled**: yes
+- **Improvement Scan Cool-Down**: 30
 
 ## Vault Optimize
 
@@ -103,6 +105,7 @@ SAMPLE_CONFIG = """# SquidSquad Config
 - **QA Execution Model**: claude
 - **Comprehension Model**: claude
 - **Improvement Scan Model**: claude
+- **Code Review Model**: deepseek-v4-pro
 - **Fallback Model**: claude
 - **API Timeout Seconds**: 120
 
@@ -116,6 +119,23 @@ SAMPLE_CONFIG = """# SquidSquad Config
 ## Mandatory Human Approval
 
 - **Enabled**: yes
+
+## Event Driven
+
+- **Enabled**: no
+- **Scan Idle Timeout**: 300
+- **Timeout Minutes**: 5
+- **Max Retries**: 3
+- **Poll Interval**: 30
+- **Queue Cap**: 100
+- **Scan Cooldown**: 60
+
+## Agent Effort
+
+- **pm**: high
+- **skill**: high
+- **qa**: high
+- **dm**: high
 
 ## Auto Versioning
 

--- a/tests/test_cycle_pre.py
+++ b/tests/test_cycle_pre.py
@@ -988,17 +988,22 @@ class TestGetVerifiableRoles:
         roles = cycle_pre._get_verifiable_roles()
         assert "dm" in roles
         assert "pm" in roles
-        assert "verifier" in roles
+        # #6274 D5 dual-aware: the verifier class is mandatory under whichever
+        # install identity exists on disk — "qa" pre-wizard-D4 (qa/ dir), and
+        # "verifier" once D4 renames the install dir. _get_verifiable_roles
+        # adds exactly one of {qa, verifier} per the on-disk check.
+        assert "verifier" in roles or "qa" in roles
 
     def test_fallback_when_config_empty(self, monkeypatch):
         """If config returns empty, at least skill is present."""
         monkeypatch.setattr(cycle_pre, "_config_get", lambda f: "")
         roles = cycle_pre._get_verifiable_roles()
         assert "skill" in roles
-        # mandatory roles always added (pm, verifier, dm — #9318 / #6274.2)
+        # mandatory roles always added (pm, verifier-class, dm — #9318 / #6274.2)
         assert "dm" in roles
         assert "pm" in roles
-        assert "verifier" in roles
+        # #6274 D5 dual-aware (see test_always_includes_mandatory_roles).
+        assert "verifier" in roles or "qa" in roles
 
     def test_deduplicates(self, monkeypatch):
         """Roles are not duplicated even if they appear in config and hardcoded."""

--- a/tests/test_deterministic_qa_framework.py
+++ b/tests/test_deterministic_qa_framework.py
@@ -73,7 +73,14 @@ class TestDeployedQAClaude:
         return (REPO / ".squidsquad/qa/CLAUDE.md").read_text(encoding="utf-8")
 
     def test_deferred_rejection_deployed(self, qa_claude):
-        assert '"Deferred"' in qa_claude and "NOT valid" in qa_claude
+        # v2 composed CLAUDE.md paraphrases the source phrase; verify the
+        # semantic contract (no deferred/skipped results) is still present.
+        lower = qa_claude.lower()
+        assert "deferred" in lower and "skipped" in lower, (
+            "qa/CLAUDE.md must forbid deferred and skipped TC results — "
+            "the v2 compose output paraphrases the verification.md phrase "
+            "but the contract must still be explicit."
+        )
 
     def test_human_required_gate_deployed(self, qa_claude):
         assert "HUMAN-REQUIRED gate" in qa_claude

--- a/tests/test_dm_verify_before_block.py
+++ b/tests/test_dm_verify_before_block.py
@@ -13,8 +13,15 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 class TestDmVerifyBeforeBlock:
     def test_prohibitions_has_verify_requirement(self):
-        """DM prohibitions sub-skill must require verification before human-block."""
-        path = REPO_ROOT / "references" / "sub-skills" / "roles" / "dm" / "prohibitions.md"
+        """DM prohibitions content must require verification before human-block.
+
+        #11503 rebind: references/sub-skills/roles/dm/prohibitions.md was
+        retired in #11087 (prohibitions inlined into each role's instructions.md
+        per #11049 Path A D1 with <!-- sub-skill: prohibitions --> markers).
+        The guarantee — DM must verify before declaring human-blocked — now
+        lives in references/roles/dm/instructions.md.
+        """
+        path = REPO_ROOT / "references" / "roles" / "dm" / "instructions.md"
         content = path.read_text(encoding="utf-8")
         assert "verify" in content.lower()
         assert "pending-human-setup" in content

--- a/tests/test_event_mode_fragments.py
+++ b/tests/test_event_mode_fragments.py
@@ -169,94 +169,96 @@ class TestAc7TopicCoverage:
 
 
 class TestAc6M62ManifestWiring:
-    """AC-6 M-6.2 (post-#9588 + post-E6 cutover #10999): the event-mode L1
-    base fragment + its four supporting common-events fragments must reach
-    the agent at runtime via the boot bootstrap, NOT via compose-time
-    inlining.
+    """AC-6 M-6.2 (v2 wiring, rebound at #11503): the event-mode L1 base
+    fragment + its supporting common-events fragments must reach the agent
+    at runtime via the boot bootstrap, NOT via compose-time inlining.
 
-    #9588 swapped the wiring mechanism: instead of every event-mode manifest
-    listing all six common-events fragments and the template having matching
-    `{{include:}}` directives, the manifest now contains `common/boot-bootstrap`
-    only, and the bootstrap's content carries `Read references/sub-skills/
-    common-events/<name>.md` directives that fire when the agent boots in
-    event mode.
+    History of the wiring mechanism:
+    - #9588 swapped per-manifest fragment lists for a single
+      ``common/boot-bootstrap`` loader carrying runtime-load directives.
+    - #11046 consolidated the v1 polling/event manifest split
+      (``includes.yml`` + ``includes-events.yml``) into one mode-agnostic
+      ``includes.yml`` per role.
+    - v0.44.0 / v2 cutover (#11394) moved the boot-bootstrap body OUT of a
+      standalone ``common/boot-bootstrap.md`` AND out of per-role
+      ``includes.yml`` entirely: it is now authored in the shared base
+      ``references/roles/instructions.md`` (composed into every role via
+      the ``<!-- sub-skill: boot-bootstrap -->`` markers) and references
+      each runtime fragment with a ``→ run sub-skill: <name>`` marker
+      (catalog-resolved to ``common-events/<name>.md``) instead of a
+      literal ``Read .../common-events/X.md`` path.
 
-    #11046: post-E6 cutover (#10999, commit 1050bfe0) consolidated the v1
-    polling/event manifest split (``includes.yml`` + ``includes-events.yml``)
-    into a single mode-agnostic ``includes.yml`` per role. The per-role
-    ``includes-events.yml`` files are GONE — wake mode is a runtime
-    concern handled by ``common/boot-bootstrap`` at session start. This
-    fixture and the manifest test rebind from the retired file to the
-    surviving unified manifest. The wiring contract is unchanged.
+    This test rebinds to that v2 source + reference syntax (#11503 Group A).
+    The wiring contract is unchanged: every role reaches event mode, and the
+    bootstrap loads the full event contract at boot.
     """
 
+    # Bare catalog names (v2): the boot block references these via
+    # `→ run sub-skill: <name>` markers; the catalog resolves each to
+    # references/sub-skills/common-events/<name>.md.
     REQUIRED_COMMON_EVENTS = [
-        "common-events/event-mode-contract",
-        "common-events/cursor-management",
-        "common-events/forge-read-pattern",
-        "common-events/idle-cooldown-loop",
-        "common-events/comment-handling",
+        "event-mode-contract",
+        "cursor-management",
+        "forge-read-pattern",
+        "idle-cooldown-loop",
+        "comment-handling",
     ]
-    # #10156: post-#6274.2 rename — dev→worker, qa→verifier. Directories
-    # on disk are references/roles/{worker,pm,verifier,dm}/.
-    ROLES = ["worker", "pm", "verifier", "dm"]
+
+    SHARED_BASE = REPO_ROOT / "references" / "roles" / "instructions.md"
 
     @pytest.fixture(scope="class")
-    def includes_by_role(self):
-        """#11046: switched from the retired ``includes-events.yml`` to the
-        post-cutover unified ``includes.yml``."""
-        import yaml
-        roles_dir = REPO_ROOT / "references" / "roles"
-        out = {}
-        for role in self.ROLES:
-            path = roles_dir / role / "includes.yml"
-            assert path.exists(), f"missing manifest: {path}"
-            data = yaml.safe_load(path.read_text(encoding="utf-8"))
-            out[role] = data.get("includes", [])
-        return out
-
-    @pytest.fixture(scope="class")
-    def bootstrap_text(self):
-        path = SUB_SKILLS / "common" / "boot-bootstrap.md"
-        assert path.exists(), (
-            "common/boot-bootstrap.md must exist — #9588 made it the single "
-            "loader for both polling and event-mode entry fragments."
+    def bootstrap_block(self):
+        """The boot-bootstrap body lives in the shared base instructions
+        (composed into every role), delimited by the sub-skill markers.
+        Extract that block so the reference checks target bootstrap content,
+        not the whole file."""
+        assert self.SHARED_BASE.exists(), (
+            f"shared base instructions missing: {self.SHARED_BASE}"
         )
-        return path.read_text(encoding="utf-8")
+        text = self.SHARED_BASE.read_text(encoding="utf-8")
+        m = re.search(
+            r"<!-- sub-skill: boot-bootstrap -->(.*?)"
+            r"<!-- /sub-skill: boot-bootstrap -->",
+            text, re.DOTALL,
+        )
+        assert m, (
+            "references/roles/instructions.md must contain a "
+            "`<!-- sub-skill: boot-bootstrap -->` block — it is the v2 home "
+            "of the boot sequence that gets every role into event mode "
+            "(or fallback polling)."
+        )
+        return m.group(1)
 
-    @pytest.mark.parametrize("role", ROLES)
-    def test_role_manifest_includes_boot_bootstrap(
-        self, includes_by_role, role,
-    ):
-        """Manifests reference `common/boot-bootstrap` as the loader. The
-        six legacy `common-events/*` entries are no longer present — they
-        are Read at runtime by the bootstrap instead."""
-        includes = includes_by_role[role]
-        assert "common/boot-bootstrap" in includes, (
-            f"references/roles/{role}/includes.yml must list "
-            f"`common/boot-bootstrap` — #9588 made it the manifest entry "
-            f"that gets the agent into event mode (or fallback polling)."
+    def test_boot_bootstrap_authored_in_shared_base(self, bootstrap_block):
+        """The boot-bootstrap block composes into every role from the shared
+        base, so one presence check covers all roles (replaces the retired
+        per-role includes.yml entry check)."""
+        assert "step:cycle/boot" in bootstrap_block, (
+            "boot-bootstrap block must define the step:cycle/boot sequence."
         )
 
     @pytest.mark.parametrize("required", REQUIRED_COMMON_EVENTS)
     def test_bootstrap_references_common_events_fragment(
-        self, bootstrap_text, required,
+        self, bootstrap_block, required,
     ):
-        """The bootstrap fragment must Read each common-events fragment at
-        runtime so a fresh event-mode agent loads the full event contract."""
-        rel = f"references/sub-skills/{required}.md"
-        assert rel in bootstrap_text, (
-            f"boot-bootstrap.md must reference `{rel}` so event-mode agents "
-            f"Read it at boot. Removing the runtime Read here breaks the "
-            f"same wiring AC-6 M-6.2 was originally written to enforce."
+        """The bootstrap block must load each common-events fragment at
+        runtime via a `→ run sub-skill: <name>` marker so a fresh event-mode
+        agent loads the full event contract at boot."""
+        pat = re.compile(r"run sub-skill:\s*`?" + re.escape(required) + r"`?")
+        assert pat.search(bootstrap_block), (
+            f"boot-bootstrap block must reference `{required}` via a "
+            f"`→ run sub-skill: {required}` marker so event-mode agents Read "
+            f"it at boot. Removing it breaks the wiring AC-6 M-6.2 enforces."
         )
 
-    def test_bootstrap_references_pr_merge_wait_for_dm(self, bootstrap_text):
-        """DM's role-specific events extra is loaded by the bootstrap too."""
-        rel = "references/sub-skills/roles/dm/events/pr-merge-wait.md"
-        assert rel in bootstrap_text, (
-            f"boot-bootstrap.md must reference `{rel}` in its DM-only "
-            f"branch — it is the sole loader for the per-role events extra."
+    def test_bootstrap_references_pr_merge_wait(self, bootstrap_block):
+        """DM's role-specific events extra is loaded by the bootstrap too
+        (referenced in the shared block in v2)."""
+        pat = re.compile(r"run sub-skill:\s*`?roles/dm/events/pr-merge-wait`?")
+        assert pat.search(bootstrap_block), (
+            "boot-bootstrap block must reference "
+            "`roles/dm/events/pr-merge-wait` via a `→ run sub-skill:` marker "
+            "— it is the sole loader for the per-role events extra."
         )
 
 

--- a/tests/test_feat328_coverage.py
+++ b/tests/test_feat328_coverage.py
@@ -242,10 +242,11 @@ class TestSmokeManifestValidation:
         assert set(roles.keys()) >= {"pm", "dm", "worker", "verifier"}
 
     def test_st2_tool_manifests_load_cleanly(self):
+        # capabilities/ removed as deadwood (INSTALLER-ARCH §8.3, superseded by
+        # per-agent L4 tool config) → the registry now loads zero tools, cleanly.
+        # Full capability-mechanism teardown tracked in #11505. (#11503)
         _, _, tools, _ = manifest.validate_registry()
-        assert set(tools.keys()) >= {
-            "figma", "google_stitch", "local_html", "local_delivery",
-        }
+        assert tools == {}
 
     def test_st3_preset_manifests_load_cleanly(self):
         _, _, _, presets = manifest.validate_registry()

--- a/tests/test_feat_9588_lazy_load_bootstrap.py
+++ b/tests/test_feat_9588_lazy_load_bootstrap.py
@@ -86,7 +86,11 @@ def test_tc_01_no_mode_specific_markers_inlined(role, marker):
 def test_tc_02_bootstrap_present(role):
     text = _composed(role)
     assert "<!-- sub-skill: boot-bootstrap -->" in text
-    assert "## Boot — Mode Detection (#9588)" in text
+    # v2 cutover (#11394): the boot section heading "## Boot — Mode Detection
+    # (#9588)" was restructured into the canonical step anchor
+    # `### Step 1 — step:cycle/boot`. The contract (a boot/mode-detection
+    # section exists in the bootstrap) is unchanged. (#11503 Group A)
+    assert "step:cycle/boot" in text
 
 
 # TC-3
@@ -106,39 +110,51 @@ def test_tc_03_polling_fragment_substituted_per_role(role, entry):
 # TC-4
 @pytest.mark.parametrize("role", ROLES)
 def test_tc_04_event_fragments_referenced_in_bootstrap(role):
+    # v2 cutover (#11394): event fragments are wired via `→ run sub-skill:
+    # <bare-name>` markers (catalog-resolved to common-events/<name>.md), not
+    # literal `Read .../common-events/X.md` paths. The contract (a fresh
+    # event-mode agent loads the full event contract at boot) is unchanged.
+    # (#11503 Group A)
     block = _bootstrap_block(_composed(role))
     for frag in EVENT_FRAGMENTS:
-        path = f"references/sub-skills/{frag}.md"
-        assert path in block, (
-            f"{role}: bootstrap missing reference to {path}"
+        name = frag.split("/")[-1]  # bare catalog name used by the marker
+        pat = re.compile(r"run sub-skill:\s*`?" + re.escape(name) + r"`?")
+        assert pat.search(block), (
+            f"{role}: bootstrap missing `→ run sub-skill: {name}` marker"
         )
-        assert (REPO_ROOT / path).exists(), (
-            f"{role}: event fragment {path} does not exist on disk"
+        assert (REPO_ROOT / f"references/sub-skills/{frag}.md").exists(), (
+            f"{role}: event fragment {frag}.md does not exist on disk"
         )
 
 
 def test_tc_04_dm_pr_merge_wait_present_only_in_dm():
+    # v2 cutover (#11394): pr-merge-wait is referenced via a `→ run sub-skill:
+    # roles/dm/events/pr-merge-wait` marker, and compose role-scopes
+    # `roles/dm/*` references so only DM's composed bootstrap carries it.
+    # (#11503 Group A)
     dm_block = _bootstrap_block(_composed("dm"))
-    assert "roles/dm/events/pr-merge-wait.md" in dm_block
+    pat = re.compile(r"run sub-skill:\s*`?roles/dm/events/pr-merge-wait`?")
+    assert pat.search(dm_block), (
+        "dm bootstrap must reference roles/dm/events/pr-merge-wait via a "
+        "`→ run sub-skill:` marker"
+    )
     assert (REPO_ROOT / "references/sub-skills/roles/dm/events/pr-merge-wait.md").exists()
+    # Non-DM roles must NOT carry the DM-only fragment (compose role-scoping).
     for r in ("skill", "pm", "qa"):
         block = _bootstrap_block(_composed(r))
-        # Non-DM roles still mention "role is dm" in conditional text, but should
-        # not be telling themselves to Read the file. Check the file path appears
-        # only inside a conditional pointing at dm role.
-        # The bootstrap text says: "if your role is `dm`, ALSO Read ... pr-merge-wait.md"
-        # Non-DM roles inherit this conditional verbatim, which is fine — the
-        # check that matters is they do not unconditionally Read it. We verify by
-        # confirming the conditional wording is preserved.
-        if "pr-merge-wait.md" in block:
-            assert "if your role is `dm`" in block.lower() or "role is `dm`" in block, (
-                f"{r}: pr-merge-wait.md mentioned without DM conditional"
-            )
+        assert "pr-merge-wait" not in block, (
+            f"{r}: pr-merge-wait must not appear in a non-DM bootstrap "
+            f"(v2 compose role-scopes roles/dm/* references)"
+        )
 
 
 # TC-5
 def test_tc_05_bootstrap_uses_127_0_0_1_and_no_dev_null():
-    src = (SUB_SKILLS / "common" / "boot-bootstrap.md").read_text(encoding="utf-8")
+    # v2 cutover (#11394): the boot-bootstrap body is authored in the shared
+    # base references/roles/instructions.md and composed into each role; the
+    # standalone common/boot-bootstrap.md is gone. Read the probe instruction
+    # from the composed boot block instead. (#11503 Group A)
+    src = _bootstrap_block(_composed("skill"))
     assert "127.0.0.1" in src, "Bootstrap must probe 127.0.0.1 (not localhost)"
     assert "/status" in src
     assert "--max-time 5" in src
@@ -161,11 +177,14 @@ def test_tc_06_event_mode_contract_degraded_branch_removed():
 
 # TC-7
 @pytest.mark.parametrize("role", ROLES)
-def test_tc_07_bootstrap_reads_config_at_runtime(role):
+def test_tc_07_bootstrap_mode_is_sticky(role):
+    # v2 cutover (#11394): wake mode is decided by the harness curl probe
+    # (TC-5) and the /loop interval is substituted at compose time (TC-8), so
+    # the bootstrap no longer Reads config.md at runtime — the original
+    # `Read config.md` assertion was dropped. The surviving, still-load-bearing
+    # contract is loaded-mode stickiness: mode is fixed for the session and
+    # flips only take effect on the next restart. (#11503 Group A)
     block = _bootstrap_block(_composed(role))
-    assert "Read `.squidsquad/config.md`" in block, (
-        f"{role}: bootstrap must instruct agent to Read config.md at runtime"
-    )
     assert "Loaded mode is sticky" in block, (
         f"{role}: bootstrap must declare the loaded-mode-is-sticky contract"
     )
@@ -308,9 +327,12 @@ def test_tc_13_manifest_no_runtime_read_entries(role, manifest_file):
     assert isinstance(data, dict)
     includes = data.get("includes", [])
     assert includes, f"{manifest_path}: empty includes list"
-    assert includes[0] == "common/boot-bootstrap", (
-        f"{manifest_path}: boot-bootstrap must be the first include"
-    )
+    # v2 cutover (#11394): boot-bootstrap is no longer an includes.yml entry —
+    # it is authored in the shared base references/roles/instructions.md and
+    # composed into every role, so the includes.yml first entry is now an
+    # ordinary cycle sub-skill (cycle-runner / capability-check). The contract
+    # this TC still enforces is unchanged: runtime-Read fragments must NOT be
+    # inlined via includes. (#11503 Group A)
     forbidden = {
         f"roles/{entry}/ralph-loop-overview",
         *EVENT_FRAGMENTS,

--- a/tests/test_manifest_registry.py
+++ b/tests/test_manifest_registry.py
@@ -191,7 +191,10 @@ class TestShippedRegistry:
         )
         # v2 shape guarantee (post-#6274.2: dev→worker, qa→verifier)
         assert set(roles) >= {"pm", "dm", "worker", "verifier"}
-        assert set(tools) >= {"figma", "google_stitch", "local_html", "local_delivery"}
+        # capabilities/ removed as deadwood (INSTALLER-ARCH §8.3, superseded by
+        # per-agent L4 tool config) → the shipped registry now loads zero tools.
+        # Full capability-mechanism teardown tracked in #11505. (#11503)
+        assert tools == {}
         assert set(presets) >= {"software-dev", "design"}
 
     def test_shipped_pipelines_match_spec(self):

--- a/tests/test_own_domain_autofix.py
+++ b/tests/test_own_domain_autofix.py
@@ -39,18 +39,23 @@ class TestOwnDomainAutofix:
         assert "roles/pm/own-domain-autofix" in data["includes"]
 
     def test_included_in_pm_template(self):
-        """PM CLAUDE.md template has the include directive."""
+        """PM instructions.md wires the sub-skill via a v2 run-marker.
+        (#11049 Path A retired the v1 `{{include:}}` directive syntax —
+        sub-skills are now invoked by `→ run sub-skill:` markers.)"""
         tmpl_path = REFERENCES_DIR / "roles" / "pm" / "instructions.md"
         text = tmpl_path.read_text(encoding="utf-8")
-        assert "{{include: roles/pm/own-domain-autofix}}" in text
+        assert "→ run sub-skill: own-domain-autofix" in text
 
     def test_composed_pm_has_autofix_section(self):
-        """Composed PM CLAUDE.md contains the Own-Domain Auto-Fix section."""
+        """Composed PM CLAUDE.md references the own-domain-autofix step.
+        (Sub-skill bodies are loaded at runtime via the run-marker, not
+        inlined — the composed output carries the step anchor, not the
+        sub-skill heading.)"""
         path = SQUIDSQUAD_DIR / "pm" / "CLAUDE.md"
         if not path.exists():
             pytest.skip("Composed PM CLAUDE.md not deployed")
         text = path.read_text(encoding="utf-8")
-        assert "Own-Domain Auto-Fix" in text
+        assert "step:cycle/own-domain-autofix" in text
 
     def test_autofix_after_pipeline_sentinel(self):
         """own-domain-autofix appears after pipeline-sentinel in includes."""

--- a/tests/test_pickup_comment_fidelity_9946.py
+++ b/tests/test_pickup_comment_fidelity_9946.py
@@ -29,11 +29,13 @@ import compose  # noqa: E402
 from _v2_test_helpers import v2_compose_for as _v2_compose_for  # noqa: E402
 
 FRAGMENT = REPO / "references" / "sub-skills" / "common" / "pickup-comment-fidelity.md"
-DEV_TEMPLATE = REPO / "references" / "roles" / "dev" / "instructions.md"
-DEV_POLL_MANIFEST = REPO / "references" / "roles" / "dev" / "includes.yml"
-DEV_EVENT_MANIFEST = REPO / "references" / "roles" / "dev" / "includes-events.yml"
-IMPLEMENT_TASKS = REPO / "references" / "sub-skills" / "roles" / "dev" / "implement-tasks.md"
-TRIAGE_ISSUES = REPO / "references" / "sub-skills" / "roles" / "dev" / "triage-issues.md"
+# #11503 rebind: role `dev` was renamed to `worker` in #6274; paths updated accordingly.
+WORKER_TEMPLATE = REPO / "references" / "roles" / "worker" / "instructions.md"
+# #11503 rebind: v2 (E6 #10685) merged includes.yml + includes-events.yml into a
+# single unified includes.yml; includes-events.yml no longer exists.
+WORKER_MANIFEST = REPO / "references" / "roles" / "worker" / "includes.yml"
+IMPLEMENT_TASKS = REPO / "references" / "sub-skills" / "roles" / "worker" / "implement-tasks.md"
+TRIAGE_ISSUES = REPO / "references" / "sub-skills" / "roles" / "worker" / "triage-issues.md"
 
 
 def test_fragment_file_exists():
@@ -57,26 +59,36 @@ def test_fragment_covers_both_failure_modes():
     )
 
 
-def test_fragment_in_dev_polling_manifest():
-    manifest = yaml.safe_load(DEV_POLL_MANIFEST.read_text(encoding="utf-8"))
+def test_fragment_in_worker_manifest():
+    """pickup-comment-fidelity must be in the unified worker manifest.
+
+    #11503 rebind: role `dev` renamed to `worker` (#6274); split poll/event
+    manifests merged into a single includes.yml in E6 (#10685).  Both the
+    old polling-manifest and event-manifest guarantees are now covered by
+    the single WORKER_MANIFEST check.
+    """
+    manifest = yaml.safe_load(WORKER_MANIFEST.read_text(encoding="utf-8"))
     assert "common/pickup-comment-fidelity" in manifest["includes"], (
-        "common/pickup-comment-fidelity missing from dev polling manifest"
+        "common/pickup-comment-fidelity missing from worker unified manifest"
     )
 
 
-def test_fragment_in_dev_events_manifest():
-    manifest = yaml.safe_load(DEV_EVENT_MANIFEST.read_text(encoding="utf-8"))
-    assert "common/pickup-comment-fidelity" in manifest["includes"], (
-        "common/pickup-comment-fidelity missing from dev events manifest"
+def test_fragment_referenced_in_worker_template():
+    """The worker instructions.md must wire the pickup-comment-fidelity step.
+
+    #11503 rebind: role `dev` renamed to `worker` (#6274).  In v2 the
+    instructions.md uses a runtime ``→ run sub-skill:`` marker at a named
+    step anchor (step:cycle/pickup-comment-fidelity), not the v1-style
+    ``{{include:}}`` compile-time directive.  Assert the runtime wiring
+    exists and the step ID is present — the manifest entry alone is
+    insufficient without the step anchor in the template.
+    """
+    template = WORKER_TEMPLATE.read_text(encoding="utf-8")
+    assert "→ run sub-skill: pickup-comment-fidelity" in template, (
+        "→ run sub-skill: pickup-comment-fidelity missing from worker instructions.md"
     )
-
-
-def test_fragment_referenced_in_dev_template():
-    """The dev instructions.md template must have the include directive — without it,
-    the manifest entry is dead weight (compose only inlines what the template requests)."""
-    template = DEV_TEMPLATE.read_text(encoding="utf-8")
-    assert "{{include: common/pickup-comment-fidelity}}" in template, (
-        "{{include: common/pickup-comment-fidelity}} missing from dev template"
+    assert "step:cycle/pickup-comment-fidelity" in template, (
+        "step:cycle/pickup-comment-fidelity step anchor missing from worker instructions.md"
     )
 
 
@@ -113,26 +125,27 @@ def test_triage_issues_crossref_to_implement_tasks_not_off_by_one():
 
 
 @pytest.mark.parametrize("role", ["skill"])
-def test_fragment_renders_in_composed_dev_variant_claude_md(role):
-    """End-to-end: composing the dev variant CLAUDE.md must inline the full
-    fragment, not just the 8b-bis / 7b-bis pointer lines.
+def test_fragment_renders_in_composed_worker_variant_claude_md(role):
+    """End-to-end: composing the worker (skill) variant CLAUDE.md must wire
+    the pickup-comment-fidelity runtime marker and its step anchor.
 
-    Post-E6 (#10685) this uses ``_v2_compose_for`` — v2 link stage +
-    the deterministic ``expand_v2_includes`` helper that gives the
-    test the same expanded ``<!-- sub-skill: X --> body -->`` shape
-    v1's ``compose_role`` produced. The invariant set is identical
-    to the pre-cutover version (marker + three body-text checks).
+    #11503 rebind: role `dev` renamed to `worker` (#6274).  In v2
+    (post-E6 #10685) sub-skill bodies are NOT inlined at compose time —
+    they are loaded at runtime via ``→ run sub-skill:`` markers.  The
+    old assertions for ``<!-- sub-skill: pickup-comment-fidelity -->`` and
+    body-text fragments (State-file filter, Test-result fidelity,
+    Prior-cycle phantoms) no longer apply.
+
+    The v2 invariant: the composed CLAUDE.md must contain both the
+    step-anchor line (``step:cycle/pickup-comment-fidelity``) and the
+    runtime ``→ run sub-skill: pickup-comment-fidelity`` marker — these
+    confirm the fragment is wired into the agent's cycle, not merely listed
+    in the manifest as dead weight.
     """
     composed = _v2_compose_for(role)
-    assert "<!-- sub-skill: pickup-comment-fidelity -->" in composed, (
-        f"sub-skill marker for pickup-comment-fidelity missing from {role}"
+    assert "step:cycle/pickup-comment-fidelity" in composed, (
+        f"step anchor step:cycle/pickup-comment-fidelity missing from composed {role}"
     )
-    assert "State-file filter" in composed, (
-        f"fragment content (State-file filter) missing from composed {role}"
-    )
-    assert "Test-result fidelity" in composed, (
-        f"fragment content (Test-result fidelity) missing from composed {role}"
-    )
-    assert "Prior-cycle phantoms" in composed, (
-        f"fragment content (Prior-cycle phantoms) missing from composed {role}"
+    assert "→ run sub-skill: pickup-comment-fidelity" in composed, (
+        f"runtime sub-skill marker for pickup-comment-fidelity missing from composed {role}"
     )

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -54,17 +54,28 @@ class TestStatusline:
 
 
 class TestAgentInstructions:
-    """Verify agent-instructions.md exists and has sub-skill markers."""
+    """Verify the v2 shared instructions base exists and has sub-skill markers.
+
+    #11503 rebind: v1 references/agent-instructions.md was removed in the
+    L1-L4 compose migration.  The v2 equivalent is the shared base layer at
+    references/roles/instructions.md, which carries the boot-bootstrap
+    <!-- sub-skill: --> marker and is the common foundation assembled into
+    every role's composed CLAUDE.md.
+    """
 
     def test_agent_instructions_exists(self):
-        path = REFERENCES_DIR / "agent-instructions.md"
-        assert path.exists(), "Missing agent-instructions.md in references/"
+        # v2: monolithic agent-instructions.md was split; shared base is here.
+        path = REFERENCES_DIR / "roles" / "instructions.md"
+        assert path.exists(), (
+            "Missing v2 shared base instructions at references/roles/instructions.md"
+        )
 
     def test_has_sub_skill_markers(self):
-        content = (REFERENCES_DIR / "agent-instructions.md").read_text(encoding="utf-8")
+        # v2: sub-skill markers live in per-layer instructions.md files.
+        content = (REFERENCES_DIR / "roles" / "instructions.md").read_text(encoding="utf-8")
         assert "<!-- sub-skill:" in content, (
-            "agent-instructions.md has no sub-skill markers — "
-            "may not be composed from sub-skills"
+            "references/roles/instructions.md has no sub-skill markers — "
+            "v2 shared base must contain at least one <!-- sub-skill: --> block"
         )
 
 

--- a/tests/test_stale_tracker_files_ref.py
+++ b/tests/test_stale_tracker_files_ref.py
@@ -9,30 +9,46 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-PROHIBITIONS_DIR = REPO_ROOT / "references" / "sub-skills" / "roles"
+# #11503 rebind: per-role prohibitions.md files were retired in #11087
+# (content inlined into each role's instructions.md per #11049 Path A D1
+# with <!-- sub-skill: prohibitions --> markers).  Point checks at the
+# instructions.md files where the content now lives.
+INSTRUCTIONS_DIR = REPO_ROOT / "references" / "roles"
 
 
 class TestNoStaleTrackerFilesRef:
-    """Prohibitions must not reference the obsolete 'tracker files' concept."""
+    """Prohibitions content must not reference the obsolete 'tracker files' concept."""
 
     @pytest.mark.parametrize("role", ["pm", "dm"])
     def test_prohibitions_no_stale_tracker_files(self, role):
-        """Prohibition 'Never delete entries from tracker files' must not exist."""
-        path = PROHIBITIONS_DIR / role / "prohibitions.md"
+        """Prohibition 'Never delete entries from tracker files' must not exist.
+
+        #11503 rebind: prohibitions.md retired; content lives in
+        references/roles/<role>/instructions.md.
+        """
+        path = INSTRUCTIONS_DIR / role / "instructions.md"
         content = path.read_text(encoding="utf-8")
         assert "from tracker files" not in content
 
     def test_pm_prohibitions_names_actual_files(self):
-        """PM prohibitions must name qa-log.md and enhancements.md."""
-        path = PROHIBITIONS_DIR / "pm" / "prohibitions.md"
+        """PM prohibitions must name qa-log.md and enhancements.md.
+
+        #11503 rebind: prohibitions.md retired; content lives in
+        references/roles/pm/instructions.md.
+        """
+        path = INSTRUCTIONS_DIR / "pm" / "instructions.md"
         content = path.read_text(encoding="utf-8")
         assert "qa-log.md" in content
         assert "enhancements.md" in content
         assert "GitHub Issue comments" in content
 
     def test_dm_prohibitions_names_actual_files(self):
-        """DM prohibitions must name actual append-only files."""
-        path = PROHIBITIONS_DIR / "dm" / "prohibitions.md"
+        """DM prohibitions must name actual append-only files.
+
+        #11503 rebind: prohibitions.md retired; content lives in
+        references/roles/dm/instructions.md.
+        """
+        path = INSTRUCTIONS_DIR / "dm" / "instructions.md"
         content = path.read_text(encoding="utf-8")
         assert "append-only" in content.lower() or "append only" in content.lower()
         assert "GitHub Issue comments" in content

--- a/tests/test_state_bus.py
+++ b/tests/test_state_bus.py
@@ -313,8 +313,10 @@ class TestCommitAndPushFailedCommit:
 class TestPushHardening9930:
     """#9930: commit_and_push must (a) bypass credential.helper=manager
     via `gh auth git-credential`, (b) bound every git op with a timeout
-    so a wedged helper can't hang the cycle, and (c) use `pull --rebase`
-    instead of default-merge so retry divergence keeps history linear.
+    so a wedged helper can't hang the cycle, and (c) use `pull --no-rebase`
+    (explicit merge strategy) per the standing "always merge, never rebase"
+    operator rule — history linearity is less important than safety on
+    Windows/MSYS2.
     """
 
     def test_default_git_timeout_is_bounded(self):
@@ -407,25 +409,27 @@ class TestPushHardening9930:
     @patch("state_bus._worktree_exists", return_value=True)
     @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
     @patch("state_bus._run")
-    def test_retry_pull_uses_rebase(self, mock_run, mock_config, mock_wt):
-        """On push failure, the retry pull must use `--rebase` (not the
-        default merge) so divergent state-branch history stays linear
-        instead of accumulating `Merge branch 'squid-squad'` commits.
+    def test_retry_pull_uses_no_rebase(self, mock_run, mock_config, mock_wt):
+        """On push failure, the retry pull must use `--no-rebase` (explicit
+        merge strategy) per the standing "always merge, never rebase" rule.
+        State-branch history accumulates `Merge branch 'squid-squad'` commits;
+        that is accepted because merge is safer than rebase (no history
+        rewrite, less fragile on Windows/MSYS2).
         """
         mock_run.side_effect = [
             MagicMock(stdout="", returncode=0),                 # add -A
             MagicMock(stdout=" M file.md\n", returncode=0),     # status
             MagicMock(stdout="", stderr="", returncode=0),      # commit
             MagicMock(stdout="", returncode=1),                 # push FAILS
-            MagicMock(stdout="", returncode=0),                 # pull --rebase
+            MagicMock(stdout="", returncode=0),                 # pull --no-rebase
             MagicMock(stdout="", returncode=0),                 # push retry SUCCEEDS
         ]
         state_bus.commit_and_push("msg", role="skill")
-        # 5th call should be the pull --rebase.
+        # 5th call should be the pull --no-rebase.
         pull_call = mock_run.call_args_list[4]
         cmd = pull_call.args[0]
         assert "pull" in cmd
-        assert "--rebase" in cmd, f"retry pull missing --rebase: {cmd}"
+        assert "--no-rebase" in cmd, f"retry pull missing --no-rebase: {cmd}"
 
     @patch("state_bus._worktree_exists", return_value=True)
     @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
@@ -540,31 +544,33 @@ class TestPushHardening9930:
     @patch("state_bus._worktree_exists", return_value=True)
     @patch("state_bus._read_branch_config", return_value=("main", "squid-squad"))
     @patch("state_bus._run")
-    def test_rebase_abort_on_pull_failure(self, mock_run, mock_config, mock_wt):
-        """If the retry `pull --rebase` itself fails (e.g., real
-        conflict), the loop must `git rebase --abort` so the worktree
-        is left clean for the next attempt — leaving a half-rebased
+    def test_merge_abort_on_pull_failure(self, mock_run, mock_config, mock_wt):
+        """If the retry `pull --no-rebase` itself fails (e.g., real
+        conflict), the loop must `git merge --abort` so the worktree
+        is left clean for the next attempt — leaving a half-merged
         state was part of the #9930 'leaked state across attempts' bug.
+        The code uses merge (not rebase) per the standing "always merge,
+        never rebase" rule.
         """
         mock_run.side_effect = [
             MagicMock(stdout="", returncode=0),                 # add -A
             MagicMock(stdout=" M file.md\n", returncode=0),     # status
             MagicMock(stdout="", stderr="", returncode=0),      # commit
             MagicMock(stdout="", returncode=1),                 # push FAILS (1)
-            MagicMock(stdout="", returncode=1),                 # pull --rebase FAILS
-            MagicMock(stdout="", returncode=0),                 # rebase --abort
+            MagicMock(stdout="", returncode=1),                 # pull --no-rebase FAILS
+            MagicMock(stdout="", returncode=0),                 # merge --abort
             MagicMock(stdout="", returncode=0),                 # push retry SUCCEEDS (2)
         ]
         state_bus.commit_and_push("msg", role="skill")
-        # Check that one of the calls is `git rebase --abort`.
+        # Check that one of the calls is `git merge --abort`.
         abort_seen = any(
-            (lambda cmd: "--abort" in cmd and "rebase" in cmd)(
+            (lambda cmd: "--abort" in cmd and "merge" in cmd)(
                 c.args[0] if c.args else []
             )
             for c in mock_run.call_args_list
         )
         assert abort_seen, (
-            f"Expected `git rebase --abort` after failed pull --rebase, "
+            f"Expected `git merge --abort` after failed pull --no-rebase, "
             f"saw: {[c.args[0] for c in mock_run.call_args_list]}"
         )
 

--- a/tests/test_terminology_dual_aware_6274.py
+++ b/tests/test_terminology_dual_aware_6274.py
@@ -78,21 +78,24 @@ def test_ac1_1_dual_aware_constant_is_frozenset():
 
 
 def test_ac1_2_dev_skill_resolves_pre_rename():
-    """Pre-6274.2 state: `references/roles/dev/skill/` exists. The
-    canonical form resolves directly."""
+    """#6274.2 cutover landed: the on-disk dir is now
+    `references/roles/worker/skill/` (no `dev/`). The legacy `dev-`
+    prefix is still accepted as a dual-aware INPUT alias, but the
+    return tracks disk (F3 contract) → ('worker', 'skill')."""
     result = compose._resolve_variant("dev-skill")
-    assert result == ("dev", "skill"), (
-        f"dev-skill should resolve to ('dev', 'skill') pre-rename; got {result}"
+    assert result == ("worker", "skill"), (
+        f"dev-skill should resolve to ('worker', 'skill') post-cutover "
+        f"(return tracks disk per F3); got {result}"
     )
 
 
 def test_ac1_2_worker_skill_resolves_pre_rename_via_alias():
-    """Pre-6274.2 state: `worker-skill` is input-normalized to the
-    on-disk `dev/skill/` directory via the dual-aware alias. F3
-    contract: input independent of disk; return tracks disk."""
+    """Post-6274.2 cutover: `worker-skill` resolves directly to the
+    on-disk `worker/skill/` directory. F3 contract: input independent
+    of disk; return tracks disk."""
     result = compose._resolve_variant("worker-skill")
-    assert result == ("dev", "skill"), (
-        f"worker-skill should resolve to ('dev', 'skill') pre-rename "
+    assert result == ("worker", "skill"), (
+        f"worker-skill should resolve to ('worker', 'skill') post-cutover "
         f"(return tracks disk per F3); got {result}"
     )
 
@@ -108,9 +111,9 @@ def test_ac1_2_qa_and_verifier_resolve_identically():
         f"qa-skill and verifier-skill must resolve identically; "
         f"got qa={qa_result}, verifier={verifier_result}"
     )
-    # Both should resolve to a qa-rooted tuple pre-rename
+    # Post-6274.2 cutover: on-disk dir is verifier/ → return tracks disk.
     assert qa_result is not None
-    assert qa_result[0] == "qa"
+    assert qa_result[0] == "verifier"
 
 
 def test_ac1_2_non_variant_inputs_return_none():

--- a/tests/test_vault_synthesis.py
+++ b/tests/test_vault_synthesis.py
@@ -65,9 +65,12 @@ class TestVaultSynthesisStructure:
         assert re.search(r'\*\*Tags\*\*.*posture', synthesis_text)
 
     def test_human_approval_task(self, synthesis_text):
-        """#3139: Each posture files a pending task for human review."""
-        assert "create-task" in synthesis_text
-        assert "pending" in synthesis_text.lower() or "human" in synthesis_text.lower()
+        """#3139: Each posture files a pending task for human review.
+        (The `create-task` CLI one-liner now lives in tracker-protocol;
+        vault-synthesis delegates to it by reference rather than
+        inlining the command.)"""
+        assert "File a pending task for human review" in synthesis_text
+        assert "tracker-protocol" in synthesis_text
 
     def test_max_one_posture_per_cycle(self, synthesis_text):
         """#3139: Max 1 posture per synthesis cycle."""
@@ -98,8 +101,11 @@ class TestVaultSynthesisComposed:
     """Verify the sub-skill is properly composed into PM's CLAUDE.md."""
 
     def test_synthesis_in_composed_output(self, composed_pm):
-        """#3139: vault-synthesis appears in composed PM CLAUDE.md."""
-        assert "Vault Synthesis" in composed_pm
+        """#3139: vault-synthesis appears in composed PM CLAUDE.md.
+        (Composed via the `→ run sub-skill:` step marker — the step
+        anchor `step:cycle/vault-synthesis` is the inlined trace, not
+        the sub-skill's title-case heading.)"""
+        assert "vault-synthesis" in composed_pm
 
     def test_synthesis_after_vault_optimize(self, composed_pm):
         """#3139: vault-synthesis appears after vault-optimize in compose order."""


### PR DESCRIPTION
## Post-cutover test-debt cleanup — #11503 (21/23) + #11657

Closes #11657. Advances #11503 (PM-approved to close at 21/23 — see #11503 disposition).

### What this does
The static test gate went dead at the v0.44.0 cutover (#11394), masking 23 red test files. This bundle works that debt down:

- **#11503 — 21 genuinely-stale tests rebound to v2 reality + un-quarantined** across groups:
  - Group C (4 possibly-real masked regressions, triaged + fixed): manifest registry orphan, statusline deploy-sync.
  - Group A/B (12): pre-rename/pre-cutover structure, compose section-list/golden drift (regenerated golden fixtures), `test_config_functions` FIELD_MAP.
  - Group A tail (4): `test_cycle_pre` (dual-aware verifier-class), `test_terminology_dual_aware_6274` (#6274.2 cutover landed → worker/verifier), `test_own_domain_autofix` (#11049 retired `{{include:}}`), `test_vault_synthesis` (create-task → tracker-protocol).
  - event-mode fragment tests rebound to v2 boot wiring.
- **#11657 — removed a stale `event_poll` integration test** (`test_event_poll_exits_cleanly_when_harness_unreachable`) superseded by #11601's default-7373 port fallback; coverage retained in `tests/test_event_poll.py`.

### ⚠️ For QA — 2 expected allowlisted reds (NOT regressions)
Per PM disposition, **2 tests remain in `KNOWN_FAILURES`** and are intentionally allowlisted (the `run_tests.py` gate stays green):

- `test_compose_author_comments_11142` (the `test_10360_cleanup` half)
- `test_agent_boundaries`

These are **NOT stale debt** — they correctly fail on genuinely-incomplete work tracked by **OPEN #10360** (Implement Responsibility compose slot, COMPOSE-ARCHITECTURE §5.2). They are cross-linked on #10360 and will un-quarantine when it lands. Their `KNOWN_FAILURES` reasons are re-pointed to #10360. **Do not treat them as regressions.** `python tests/run_tests.py` exits 0 (static gate + integration green; the 2 are allowlisted out).

### Merge ordering
This PR merging to main unblocks **#11641** (stale scheduled_tasks.lock fix on `squidsquad/task/11641`), which is held in-progress until main is green (it currently inherits main's pre-#11657 `event_poll` red).

### Verification
`python tests/run_tests.py` → exit 0, `OK (skipped=2)`, 0 failures. Merged current origin/main (clean, PM-side files only).