### PR TITLE
skill: #11640 — _get_clone_path refuses REPO_ROOT fallback; spawn paths fail safe

### DIFF
--- a/.squidsquad/skill/iterations/iter-452.md
+++ b/.squidsquad/skill/iterations/iter-452.md
@@ -1,0 +1,20 @@
+# Iteration 452 — resumed + landed #11640 (clone-resolution refuse)
+
+**Mode**: loop (harness DOWN, port 59999 curl exit 7). `/loop 30m` scheduled (cron c8644353). Manual commit/push/PR (cycle_pre/post wrappers don't fire with harness down).
+
+## What happened
+- Boot probe: check-gh OK; harness unreachable → POLLING mode (pinned-stable per #11586 workaround).
+- Resume found drift: working-state said "none active / on main", but git was on `squidsquad/task/11640` with **uncommitted** WIP (boot_remote.py + harness.py + tests). The #11640 implementation was complete but never committed or recorded.
+- Verified #11640 WIP against ACs — comprehensive:
+  - `_get_clone_path` raises `CloneResolutionError` for unregistered role + registered-but-missing path (no REPO_ROOT fallback); explicit `pm->.` still resolves.
+  - Refusal wired through every spawn/resolution path: boot_agent (zero spawn, covers manual + auto-reboot + /start), auto-reboot loop (status=error), /start + /restart (refuse before mutating intent), stop_all + shutdown (skip, don't 500).
+  - 9 new tests; 237 passed in the two touched test files.
+- Full suite: 1 red = `test_event_poll_exits_cleanly_when_harness_unreachable`. Isolated via stash → **pre-existing on origin/main**, NOT from #11640. Root cause: #11601 (commit d0986cb7e) made `_discover_port` always-return-int (default 7373) but didn't update the stale pre-#11601 test. Already tracked as **#11657**, verified + pending-ship on **PR #11683**.
+- Committed #11640 (481cd4414), merged origin/main (clean), pushed, opened **PR #11709**.
+- Posted status on #11640; held at in-progress (can't honestly mark pending-test with red full suite). DM flagged: shipping #11683 unblocks handoff.
+- Spawned background DS review (bbz33qa9s) on the boot_remote/harness diff.
+
+## Next cycle
+- If #11683 shipped → merge origin/main → run full suite → if green, #11640 → pending-test (PR #11709). Else keep holding.
+- Read DS review output; address real findings on PR #11709 pre-handoff.
+- Re-verify standing items (#11641, #11538).

--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -9,12 +9,11 @@
 Harness DOWN (port 59999, curl exit 7) — loop-mode this session (skill pinned to stable loop per #11586 workaround). `/loop 30m` scheduled (cron c8644353). cycle_pre/post wrappers do NOT fire (harness down) — I commit/push/PR manually.
 
 ## Last cycle (resumed WIP for #11640)
-Resumed uncommitted #11640 WIP (boot_remote.py + harness.py + tests) that working-state had not recorded. Verified complete: _get_clone_path raises CloneResolutionError on unregistered role + registered-but-missing path (no REPO_ROOT fallback); boot_agent + auto-reboot loop + /start + /restart + stop_all + shutdown all refuse/skip safely. 9 new tests, all ACs covered, 237 passed in touched files. Committed 481cd4414, merged origin/main (clean), pushed, PR #11709. DS review running (bg bbz33qa9s) on the boot_remote/harness diff.
+Resumed uncommitted #11640 WIP (boot_remote.py + harness.py + tests) that working-state had not recorded. Verified complete: _get_clone_path raises CloneResolutionError on unregistered role + registered-but-missing path (no REPO_ROOT fallback); boot_agent + auto-reboot loop + /start + /restart + stop_all + shutdown all refuse/skip safely. 9 new tests, all ACs covered, 237 passed in touched files. Committed 481cd4414, merged origin/main (clean), pushed, PR #11709. **DS review (bbz33qa9s) DONE → NO_FINDINGS** (verified all 8 spawn paths + 3 unprotected call sites safe). PR #11709 implementation-clean.
 
 ## ⚠️ #11640 handoff is GATED
 Full repo suite has ONE red: test_event_poll_exits_cleanly_when_harness_unreachable = pre-existing #11601 regression, already fixed + verified + pending-ship on **PR #11683** (#11657, also bundles #11503). NOT mine. #11640 cannot reach a green full suite (→ pending-test) until #11683 ships to main + I merge main.
-- **Next cycle**: check if #11683 shipped → if yes, merge origin/main into task/11640, run full suite, confirm green, transition #11640 → pending-test on PR #11709. If still pending-ship, keep holding; consider nudging DM.
-- Check DS review output (.squidsquad/skill/planning/CODE-REVIEW-11640.md) — address any real findings on PR #11709 before pending-test.
+- **Next cycle**: check if #11683 shipped → if yes, merge origin/main into task/11640, run full suite, confirm green, transition #11640 → pending-test on PR #11709. If still pending-ship, keep holding; consider nudging DM. (DS review already done + clean — no findings to address.)
 
 ## Standing (from prior session, re-verify)
 - **#11641**: stale scheduled_tasks.lock reclaim — was implemented on branch task/11641 (commit cff818eb7), thin_launcher._reclaim_stale_scheduled_lock. PM confirmed as durable #11612 fix. Re-check its PR/ship status next cycle.

--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -1,28 +1,29 @@
 # Working State
 
-- **Task**: none active — on main (#11538 fix shipped to pending-test, PR #11564)
-- **Status**: none (idle)
-- **Updated**: 2026-06-12 21:06
-- **Last Processed Event ID**: 9d7c2489
+- **Task**: #11640 — clone-resolution refuse (COMPLETE, committed 481cd4414, PR #11709)
+- **Status**: in-progress — HELD pre-pending-test, gated on #11683 shipping (full-suite green)
+- **Updated**: 2026-06-13 05:19
 - **Quiet Cycle Counter**: 0
 
 ## ⚠️ Session note
-Booted PRE-v0.44.0; runs OLD composed CLAUDE.md (reboot pending per DM — do NOT self-reboot). Harness DOWN (port 7373 exit 7) — loop-mode this session.
+Harness DOWN (port 59999, curl exit 7) — loop-mode this session (skill pinned to stable loop per #11586 workaround). `/loop 30m` scheduled (cron c8644353). cycle_pre/post wrappers do NOT fire (harness down) — I commit/push/PR manually.
 
-## Last cycle (1642, iter-451): fixed #11538 harness restart bug
-update_health reset RESTARTING→RUNNING on every poll where the same claude PID was alive (no pid_changed guard) → HEALTH_POLL_INTERVAL=5s silently reverted any restart of a still-alive/wedged agent AND disarmed the 60s force-kill net. Fix mirrors STOPPING branch: (1) RESTARTING→RUNNING reset gated on pid_changed; (2) force-kill skips when pid_changed. TestRestartLifecycle (4 cases) — 3 fail on pre-fix code, verified via git stash. 184 harness tests + run_tests.py green. → pending-test, PR #11564, back on main.
+## Last cycle (resumed WIP for #11640)
+Resumed uncommitted #11640 WIP (boot_remote.py + harness.py + tests) that working-state had not recorded. Verified complete: _get_clone_path raises CloneResolutionError on unregistered role + registered-but-missing path (no REPO_ROOT fallback); boot_agent + auto-reboot loop + /start + /restart + stop_all + shutdown all refuse/skip safely. 9 new tests, all ACs covered, 237 passed in touched files. Committed 481cd4414, merged origin/main (clean), pushed, PR #11709. DS review running (bg bbz33qa9s) on the boot_remote/harness diff.
 
-## Standing
-- **#11538 / PR #11564**: pending-test — verifier to verify (harness restart endpoint fix).
-- **#11512 / PR #11518**: pending-ship, MERGEABLE/CLEAN — DM to ship promptly (may re-stale).
-- **#11519 / PR #11530**: pending-ship — DM to ship.
-- **#11511 (medium)**: root cause = merge=ours not honored by GitHub server-side; recommendation posted (A=state-branch via state_bus [recommended]; B=stopgap merge=union). Awaiting PM/operator decision. NOT implementing (high blast radius).
+## ⚠️ #11640 handoff is GATED
+Full repo suite has ONE red: test_event_poll_exits_cleanly_when_harness_unreachable = pre-existing #11601 regression, already fixed + verified + pending-ship on **PR #11683** (#11657, also bundles #11503). NOT mine. #11640 cannot reach a green full suite (→ pending-test) until #11683 ships to main + I merge main.
+- **Next cycle**: check if #11683 shipped → if yes, merge origin/main into task/11640, run full suite, confirm green, transition #11640 → pending-test on PR #11709. If still pending-ship, keep holding; consider nudging DM.
+- Check DS review output (.squidsquad/skill/planning/CODE-REVIEW-11640.md) — address any real findings on PR #11709 before pending-test.
 
-## Watch
-- **PR #11504 / #11394**: static-gate auto-discovery — MERGED into this branch base (5f6caffbf). On confirmed merge → #11503/#11505 ungated.
-- #11503 (high) / #11505 (low): gated on #11504 (now likely unblocked — re-check next cycle).
-- #10690 / #10686 (E7): operator-gated.
-- #11329 (approved): runtime per-event ack-cursor.
+## Standing (from prior session, re-verify)
+- **#11641**: stale scheduled_tasks.lock reclaim — was implemented on branch task/11641 (commit cff818eb7), thin_launcher._reclaim_stale_scheduled_lock. PM confirmed as durable #11612 fix. Re-check its PR/ship status next cycle.
+- **#11538 / PR #11564**: harness restart bug fix — was pending-test last session; re-check.
+- **#11511 (medium)**: PR mergeability flaps from transient-state commits — merge=ours not honored server-side; recommendation posted, awaiting PM/operator. NOT implementing (high blast radius).
+
+## Untracked files (leave; not part of #11640 PR)
+- `.claude/scheduled_tasks.lock.stale-bak` — #11641 manual-fix backup, do NOT commit.
+- `.squidsquad/skill/planning/CODE-REVIEW-11601.md`, `DIFF-11640.patch` — local planning scratch.
 
 ## ⚠️ Recurring conflict note
-PR CONFLICTING-while-locally-clean = merge=ours custom driver not honored by GitHub server-side (#11511). Verify real vs cosmetic with `git merge-tree --write-tree origin/main origin/<branch>` (exit 0 = cosmetic). Real fix = state-branch (state_bus, unwired). See [[learning-pr-conflicting-flag-can-be-cosmetic]].
+PR CONFLICTING-while-locally-clean = merge=ours custom driver not honored by GitHub server-side (#11511). Verify real vs cosmetic with `git merge-tree --write-tree origin/main origin/<branch>` (exit 0 = cosmetic). See [[learning-pr-conflicting-flag-can-be-cosmetic]].

--- a/.squidsquad/vault/galaxy/learning-resume-git-tree-is-truth.md
+++ b/.squidsquad/vault/galaxy/learning-resume-git-tree-is-truth.md
@@ -1,0 +1,24 @@
+---
+type: learning
+tags: [resume, working-state, loop-mode, harness-down, cycle-post, git, 11640]
+created: 2026-06-13
+updated: 2026-06-13
+owner: skill-lead
+status: active
+confidence: high
+source: observation
+links: [learning-pr-conflicting-flag-can-be-cosmetic, decision-branch-per-feature-workflow]
+---
+
+# On resume, the git working tree is truth — not working-state.md
+
+**Observed (#11640, cycle 452):** booted into loop-mode (harness down). `working-state.md` said "none active — on main", but the git tree was on `squidsquad/task/11640` with **complete, uncommitted** WIP (boot_remote.py + harness.py + 9 tests) for an in-progress issue. The prior session had finished the implementation but never committed it.
+
+**Root cause:** in loop-mode with the harness down, the `cycle_post.py` wrapper (which normally commits/pushes/writes working-state at cycle end) **does not fire** — there is no scheduler driving it. So a session can end with finished work uncommitted AND working-state un-updated. Both the commit and the state-write are wrapper responsibilities that silently no-op.
+
+**Why it matters:** trusting working-state.md on resume would have missed shipped-but-uncommitted work, risking re-implementation or loss. The forge/issue status (in-progress) + the git tree together are the real state; working-state is a hint that may be stale.
+
+**How to apply:**
+- On every resume, reconcile `git branch --show-current` + `git status --short` against working-state.md. If they disagree, the **git tree wins** — investigate the diff before acting.
+- In any harness-down / loop-mode session, do the commit + push + working-state write **manually** at cycle end; do not assume the wrapper ran.
+- Before attributing a red full-suite test to your own change, isolate it (`git stash` your WIP, re-run) and grep the tracker for an existing issue — the failure may be pre-existing and already fixed/pending-ship elsewhere (here: #11657/PR #11683). See [[learning-pr-conflicting-flag-can-be-cosmetic]] for the sibling "the obvious-looking failure isn't yours" pattern.

--- a/references/scripts/boot_remote.py
+++ b/references/scripts/boot_remote.py
@@ -153,14 +153,50 @@ def _get_all_roles():
     return sorted(roles)
 
 
-def _get_clone_path(role):
-    """Get the clone root path for a role. Falls back to REPO_ROOT.
+class CloneResolutionError(Exception):
+    """Raised when a role's clone path cannot be safely resolved (#11640).
 
-    Returns str (not Path) so the value is JSON-serializable when stored
-    in AgentState and written to .harness-state.json.
+    A missing or misregistered clone must NEVER fall back to REPO_ROOT.
+    Spawning an agent in the wrong realm corrupts another agent's working
+    checkout — exactly the incident in #11600, where `qa` (absent from
+    `.local-config`, which registers `verifier`) silently resolved to
+    REPO_ROOT and clobbered PM's clone. A loud failure is correct; a
+    wrong-realm boot is data corruption. Spawn paths catch this and REFUSE
+    to spawn.
+    """
+
+
+def _get_clone_path(role):
+    """Get the clone root path for a role. Raises on unsafe resolution.
+
+    Raises CloneResolutionError when:
+      - `role` is not registered in .local-config (no silent REPO_ROOT
+        fallback — #11640), or
+      - the registered path does not exist on disk.
+
+    An explicitly registered repo-root (`- **pm**: .`) is valid and
+    resolves normally; only an UNregistered role defaulting to repo-root
+    was the bug. Returns str (not Path) so the value is JSON-serializable
+    when stored in AgentState and written to .harness-state.json.
     """
     local = _parse_local_config()
-    return str(local.get(role, REPO_ROOT))
+    if role not in local:
+        raise CloneResolutionError(
+            f"role '{role}' is not registered in {LOCAL_CONFIG} "
+            f"(registered roles: {sorted(local)}). Refusing to fall back "
+            f"to REPO_ROOT ({REPO_ROOT}) — a wrong-realm boot corrupts "
+            f"another agent's clone (#11640). Register '{role}' in "
+            f".local-config before spawning it."
+        )
+    path = local[role]
+    if not Path(path).exists():
+        raise CloneResolutionError(
+            f"role '{role}' is registered to '{path}' in {LOCAL_CONFIG} "
+            f"but that path does not exist on disk. Refusing to spawn "
+            f"against a missing clone (#11640) — fix .local-config or "
+            f"create the clone."
+        )
+    return str(path)
 
 
 # ---------------------------------------------------------------------------
@@ -516,8 +552,23 @@ def boot_agent(role, dry_run=False):
         "timestamp": time.time(),
     }
 
+    # Clone resolution is the first gate (#11640). `_needs_boot` calls
+    # `_get_clone_path`, which now raises rather than silently falling back
+    # to REPO_ROOT for an unregistered / missing clone. Catch it here and
+    # REFUSE to spawn — never reach the orphan sweep, the boot sentinel, or
+    # the terminal spawn, all of which would otherwise operate in the wrong
+    # realm. This single guard covers every spawn path that routes through
+    # boot_agent: manual boot (start_team.py), the harness auto-reboot loop
+    # (harness.py), and POST /agents/{role}/start.
+    try:
+        needs, reason, clone_path = _needs_boot(role)
+    except CloneResolutionError as e:
+        result["action"] = "error"
+        result["success"] = False
+        result["message"] = f"clone resolution failed — refusing to spawn: {e}"
+        return result
+
     # PID-based detection
-    needs, reason, clone_path = _needs_boot(role)
     if not needs:
         result["action"] = "skip"
         result["success"] = True

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -478,6 +478,16 @@ class HarnessState:
                         agent = self.agents.get(role)
                         if agent:
                             agent.terminal_pid = result["terminal_pid"]
+                elif result.get("action") == "error":
+                    # #11640: boot_agent refused (e.g. unregistered/missing
+                    # clone). Never spawned in REPO_ROOT — surface the refusal
+                    # and mark the agent error so the operator sees it instead
+                    # of an endlessly re-attempting silent reboot.
+                    _log(f"Auto-reboot of {role} REFUSED: {result.get('message')}")
+                    with self._lock:
+                        agent = self.agents.get(role)
+                        if agent:
+                            agent.status = "error"
                 self.save_state()
             except Exception as e:
                 _log(f"Auto-reboot of {role} failed: {e}")
@@ -1599,7 +1609,17 @@ async def stop_all():
 
     results = []
     for role in roles:
-        clone_path = boot_remote._get_clone_path(role)
+        # #11640: an unregistered / missing clone now raises rather than
+        # resolving to REPO_ROOT. Stopping such a role is a no-op (it can't
+        # be running in a clone we refuse to resolve) — skip it instead of
+        # 500-ing the whole endpoint.
+        try:
+            clone_path = boot_remote._get_clone_path(role)
+        except boot_remote.CloneResolutionError as e:
+            results.append({"role": role, "action": "skip", "success": True,
+                            "message": f"skip (clone unresolved: {e})"})
+            _log(f"  {role}: skip (clone unresolved — {e})")
+            continue
 
         # Check if agent is already stopped (intent or health)
         agent_state = state.get_agent(role)
@@ -1690,6 +1710,14 @@ async def start_agent(role: str):
             agent_state.bootup_complete = False
         state.set_agent(role, agent_state)
         # #9242: disk write off the asyncio event loop.
+        await asyncio.to_thread(state.save_state)
+    elif result.get("action") == "error":
+        # #11640: boot_agent refused to spawn (e.g. unregistered/missing
+        # clone). No process started in REPO_ROOT — mark the agent error so
+        # the failed start is visible, not silently retried.
+        agent_state = state.get_agent(role) or AgentState(role)
+        agent_state.status = "error"
+        state.set_agent(role, agent_state)
         await asyncio.to_thread(state.save_state)
 
     status_code = 200 if result["success"] else 500
@@ -2350,6 +2378,23 @@ async def restart_agent(role: str):
 
     _log(f"Restarting {role}...")
 
+    # #11640: resolve the clone path BEFORE mutating any state. An
+    # unregistered / missing clone now raises rather than resolving to
+    # REPO_ROOT — refuse the restart up front so we never set
+    # intent=restarting (which would arm the auto-reboot loop to refuse
+    # spawn anyway) for a role we can't safely place.
+    try:
+        clone_path = boot_remote._get_clone_path(role)
+    except boot_remote.CloneResolutionError as e:
+        _log(f"  {role}: restart refused — clone resolution failed: {e}")
+        return JSONResponse(
+            status_code=500,
+            content={"role": role, "action": "restart", "success": False,
+                     "message": f"clone resolution failed — refusing to "
+                                f"restart: {e}"},
+        )
+    clone_path_p = Path(clone_path)
+
     # Set intent — harness will auto-reboot when agent exits
     # cycle_post.py queries GET /agents/{role} and reads intent (#4966).
     # Only record `intent_set_at` on the transition INTO RESTARTING; a repeat
@@ -2367,8 +2412,6 @@ async def restart_agent(role: str):
     await asyncio.to_thread(state.save_state)
 
     # #4792: stop is now expressed via harness intent — no sentinel to clean.
-    clone_path = boot_remote._get_clone_path(role)
-    clone_path_p = Path(clone_path)
 
     # #8689: if the agent is idle between cycles, kill the claude process
     # right now so the auto-reboot path (running periodic health-poll already
@@ -2439,7 +2482,15 @@ async def shutdown():
             if agent and agent.intent == AgentState.INTENT_STOPPING:
                 _log(f"  {role}: skip (already stopping)")
                 continue
-            needs_boot, _, _ = boot_remote._needs_boot(role)
+            # #11640: _needs_boot resolves the clone and now raises for an
+            # unregistered / missing one. Such a role cannot be running in a
+            # clone we refuse to resolve — skip it rather than crashing the
+            # shutdown thread.
+            try:
+                needs_boot, _, _ = boot_remote._needs_boot(role)
+            except boot_remote.CloneResolutionError as e:
+                _log(f"  {role}: skip (clone unresolved — {e})")
+                continue
             if needs_boot:
                 _log(f"  {role}: skip (not running)")
                 continue

--- a/tests/test_boot_remote.py
+++ b/tests/test_boot_remote.py
@@ -130,12 +130,15 @@ class TestParseLocalConfigMandatory:
 
 
 class TestGetClonePath:
-    """Regression tests for _get_clone_path() JSON serialization (#5915)."""
+    """_get_clone_path() resolution: JSON-serializable str (#5915) and
+    fail-closed on unsafe resolution (#11640)."""
 
     def test_returns_str_not_path(self, tmp_path):
         """_get_clone_path must return str so AgentState is JSON-serializable."""
+        skill_clone = tmp_path / "skill-clone"
+        skill_clone.mkdir()
         config = tmp_path / ".local-config"
-        config.write_text(f"- **skill**: {tmp_path / 'skill-clone'}\n")
+        config.write_text(f"- **skill**: {skill_clone}\n")
 
         with patch.object(boot_remote, "LOCAL_CONFIG", config):
             result = boot_remote._get_clone_path("skill")
@@ -147,15 +150,59 @@ class TestGetClonePath:
         import json
         json.dumps({"clone_path": result})  # Should not raise
 
-    def test_fallback_returns_str(self, tmp_path):
-        """Fallback to REPO_ROOT also returns str."""
+    def test_unregistered_role_raises(self, tmp_path):
+        """#11640 AC1: an unregistered role must raise, NOT fall back to
+        REPO_ROOT. The incident: `qa` absent from .local-config silently
+        resolved to PM's clone and clobbered it."""
+        pm_clone = tmp_path / "pm-clone"
+        pm_clone.mkdir()
         config = tmp_path / ".local-config"
-        config.write_text(f"- **pm**: {tmp_path / 'pm-clone'}\n")
+        config.write_text(f"- **pm**: {pm_clone}\n")
 
         with patch.object(boot_remote, "LOCAL_CONFIG", config):
-            result = boot_remote._get_clone_path("skill")  # not in config
+            with pytest.raises(boot_remote.CloneResolutionError) as exc:
+                boot_remote._get_clone_path("qa")  # not in config
+        # Error names the offending role and refuses REPO_ROOT
+        assert "qa" in str(exc.value)
+        assert "REPO_ROOT" in str(exc.value)
 
-        assert isinstance(result, str)
+    def test_registered_nonexistent_path_raises(self, tmp_path):
+        """#11640 AC2: a role registered to a path that does not exist on
+        disk must raise (e.g. verifier -> ../SquidSquad-verifier missing)."""
+        config = tmp_path / ".local-config"
+        missing = tmp_path / "does-not-exist"
+        config.write_text(f"- **verifier**: {missing}\n")
+
+        with patch.object(boot_remote, "LOCAL_CONFIG", config):
+            with pytest.raises(boot_remote.CloneResolutionError) as exc:
+                boot_remote._get_clone_path("verifier")
+        assert "does not exist" in str(exc.value)
+
+    def test_registered_existing_path_resolves(self, tmp_path):
+        """#11640 AC4: a legit registered role still resolves to its clone."""
+        skill_clone = tmp_path / "skill-clone"
+        skill_clone.mkdir()
+        config = tmp_path / ".local-config"
+        config.write_text(f"- **skill**: {skill_clone}\n")
+
+        with patch.object(boot_remote, "LOCAL_CONFIG", config):
+            result = boot_remote._get_clone_path("skill")
+        assert result == str(skill_clone)
+
+    def test_explicit_repo_root_registration_resolves(self, tmp_path):
+        """#11640 AC4: an EXPLICIT repo-root registration (`- **pm**: .`)
+        is valid and resolves — only an UNregistered role defaulting to
+        repo-root was the bug. Here pm is registered to an existing dir
+        that doubles as REPO_ROOT."""
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        config = tmp_path / ".local-config"
+        config.write_text(f"- **pm**: {repo_root}\n")
+
+        with patch.object(boot_remote, "LOCAL_CONFIG", config), \
+             patch.object(boot_remote, "REPO_ROOT", repo_root):
+            result = boot_remote._get_clone_path("pm")
+        assert result == str(repo_root)
 
 
 class TestIsProcessAlive:
@@ -252,6 +299,37 @@ class TestBootAgentSkip:
         result = boot_remote.boot_agent("skill")
         assert result["action"] == "skip"
         assert result["success"] is True
+
+
+class TestBootAgentCloneResolutionRefusal:
+    """#11640: boot_agent must REFUSE to spawn when clone resolution fails —
+    no orphan sweep, no boot sentinel, no terminal spawn. A wrong-realm boot
+    is data corruption (#11600), so a loud refusal is the correct outcome."""
+
+    @patch("boot_remote._spawn_terminal")
+    @patch("boot_remote._write_booting_sentinel")
+    @patch("boot_remote._get_clone_path",
+           side_effect=boot_remote.CloneResolutionError("role 'qa' not registered; REPO_ROOT refused"))
+    def test_unregistered_role_refuses_spawn(self, mock_clone, mock_sentinel, mock_spawn):
+        result = boot_remote.boot_agent("qa")
+        assert result["success"] is False
+        assert result["action"] == "error"
+        assert "clone resolution failed" in result["message"]
+        # Zero spawn: never reached the sentinel claim or terminal spawn
+        mock_sentinel.assert_not_called()
+        mock_spawn.assert_not_called()
+
+    @patch("boot_remote._spawn_terminal")
+    @patch("boot_remote._get_clone_path",
+           side_effect=boot_remote.CloneResolutionError("missing clone"))
+    def test_dry_run_also_refuses(self, mock_clone, mock_spawn):
+        """Even a dry-run must refuse — the resolution gate precedes the
+        dry-run short-circuit, so an unresolvable role never reports
+        'would boot'."""
+        result = boot_remote.boot_agent("qa", dry_run=True)
+        assert result["success"] is False
+        assert result["action"] == "error"
+        mock_spawn.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_feat_1496_shared_fs_fallback.py
+++ b/tests/test_feat_1496_shared_fs_fallback.py
@@ -4,6 +4,11 @@ Originally verified that _parse_local_config reads clone paths from the shared
 filesystem (~/.squidsquad/clones/) as a fallback. The global fallback was removed
 in #3100 — .local-config is now mandatory. Tests updated to reflect the new
 behavior: missing .local-config exits with code 2.
+
+#11640: the remaining per-role REPO_ROOT fallback in _get_clone_path was also
+removed — an unregistered role now raises CloneResolutionError instead of
+silently resolving to REPO_ROOT (which corrupts another agent's clone on a
+wrong-realm boot).
 """
 
 import sys
@@ -86,8 +91,12 @@ class TestSharedFsFallback:
                 boot_remote._parse_local_config()
         assert exc_info.value.code == 2
 
-    def test_get_clone_path_falls_back_to_repo_root(self):
-        """#1496: _get_clone_path returns REPO_ROOT (as str) when role not in config."""
+    def test_get_clone_path_raises_when_role_not_in_config(self):
+        """#11640: the #1496 REPO_ROOT fallback was removed — an unregistered role
+        now raises CloneResolutionError rather than silently resolving to REPO_ROOT
+        (a wrong-realm boot corrupts another agent's clone). Comprehensive coverage
+        of the new behavior lives in test_boot_remote.py; this asserts the reversal
+        of the historical #1496 fallback at its original site."""
         with patch.object(boot_remote, "_parse_local_config", return_value={}):
-            result = boot_remote._get_clone_path("unknown_role")
-        assert result == str(boot_remote.REPO_ROOT)
+            with pytest.raises(boot_remote.CloneResolutionError):
+                boot_remote._get_clone_path("unknown_role")

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -3280,5 +3280,77 @@ class TestCleanupLegacySentinels(unittest.TestCase):
         )
 
 
+class TestCloneResolutionRefusal(unittest.TestCase):
+    """#11640: every spawn path must REFUSE when clone resolution fails,
+    never spawning in REPO_ROOT. Covers the /start endpoint, the /restart
+    endpoint, and the harness auto-reboot loop."""
+
+    def setUp(self):
+        import harness
+        self.harness = harness
+        # Isolate from any state other tests left behind.
+        harness.state.agents.pop("qa", None)
+        harness.state.compose_freshness_failed = False
+
+    def test_start_endpoint_refuses_and_marks_error(self):
+        """POST /agents/{role}/start refuses (500) and marks the agent error
+        when boot_agent reports a clone-resolution failure — no spawn."""
+        from fastapi.testclient import TestClient
+        err = {"role": "qa", "action": "error", "success": False,
+               "message": "clone resolution failed — refusing to spawn"}
+        with patch.object(self.harness.boot_remote, "boot_agent", return_value=err) as mock_boot:
+            client = TestClient(self.harness.app)
+            resp = client.post("/agents/qa/start")
+        self.assertEqual(resp.status_code, 500)
+        self.assertFalse(resp.json()["success"])
+        mock_boot.assert_called_once_with("qa")
+        agent = self.harness.state.get_agent("qa")
+        self.assertIsNotNone(agent)
+        self.assertEqual(agent.status, "error")
+
+    def test_restart_endpoint_refuses_before_mutating_intent(self):
+        """POST /agents/{role}/restart resolves the clone BEFORE setting
+        intent=restarting, so an unregistered role is refused (500) and is
+        NOT left in a restarting state. `qa` is unregistered in this clone's
+        .local-config, so this exercises the real _get_clone_path raise."""
+        from fastapi.testclient import TestClient
+        client = TestClient(self.harness.app)
+        resp = client.post("/agents/qa/restart")
+        self.assertEqual(resp.status_code, 500)
+        self.assertIn("clone resolution failed", resp.json()["message"])
+        # No restarting state was created for the refused role.
+        agent = self.harness.state.get_agent("qa")
+        if agent is not None:
+            self.assertNotEqual(agent.intent, self.harness.AgentState.INTENT_RESTARTING)
+
+    def test_auto_reboot_loop_refuses_and_marks_error(self):
+        """The harness auto-reboot loop marks the agent error (and does not
+        retain a spawn) when boot_agent refuses on clone resolution."""
+        from harness import HarnessState, AgentState
+        st = HarnessState()
+        # A dead agent that was running and should reboot.
+        agent = AgentState("skill", "/tmp/skill-clone")
+        agent.status = "running"  # prev_status seen by the loop
+        agent.intent = AgentState.INTENT_RUNNING
+        agent.claude_pid = 99999999  # a dead pid
+        st.agents["skill"] = agent
+
+        err = {"role": "skill", "action": "error", "success": False,
+               "message": "clone resolution failed — refusing to spawn"}
+        with patch.object(self.harness.boot_remote, "_get_all_roles", return_value=["skill"]), \
+             patch.object(self.harness.boot_remote, "_get_clone_path", return_value="/tmp/skill-clone"), \
+             patch.object(self.harness.boot_remote, "_is_process_alive", return_value=False), \
+             patch.object(self.harness.reboot_agent, "_read_claude_pid", return_value=(None, False)), \
+             patch.object(self.harness.boot_remote, "boot_agent", return_value=err) as mock_boot, \
+             patch.object(self.harness, "_NO_AUTO_REBOOT", False), \
+             patch.object(st, "save_state"):
+            st.update_health()
+
+        mock_boot.assert_called_once_with("skill")
+        self.assertEqual(st.agents["skill"].status, "error")
+        # Refused boot left no terminal pid behind.
+        self.assertIsNone(st.agents["skill"].terminal_pid)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## #11640 — `_get_clone_path` must FAIL, never fall back to REPO_ROOT

Defensive half of the #11600 incident: agent `qa` (absent from `.local-config`, which registers `verifier`) silently resolved to `REPO_ROOT` and clobbered PM's clone. A wrong-realm boot is data corruption — it must fail loudly and refuse to spawn.

### Changes
- **`boot_remote._get_clone_path`**: raises `CloneResolutionError` when the role is unregistered in `.local-config`, or registered to a path that doesn't exist on disk. No silent `REPO_ROOT` fallback. Explicit repo-root registration (`pm -> .`) still resolves normally.
- **`boot_agent`**: catches at the `_needs_boot` gate → `action=error`, `success=False`, **zero spawn**. This single guard covers every spawn path that routes through `boot_agent`: manual boot (`start_team.py`), the harness auto-reboot loop, and `POST /agents/{role}/start`.
- **harness auto-reboot loop**: marks agent `status=error` on refusal instead of silently re-attempting.
- **`start_agent` / `restart_agent` endpoints**: mark error / refuse before mutating `intent`.
- **`stop_all` / `shutdown`**: skip unresolvable roles instead of 500-ing the whole endpoint.

### Tests (all green: 237 passed in the two touched test files)
- `TestGetClonePath` (4): unregistered raises, registered-but-missing raises, registered-existing resolves, explicit-repo-root resolves.
- `TestBootAgentCloneResolutionRefusal` (2): unregistered role refuses spawn (zero spawn asserted), dry-run also refuses.
- `TestCloneResolutionRefusal` (3): `/start` refuses + marks error, `/restart` refuses before mutating intent, auto-reboot loop refuses + marks error.

### AC coverage
- [x] `_get_clone_path('unregistered-role')` raises (unit)
- [x] registered-but-nonexistent path raises (unit)
- [x] boot path for unregistered role: `success=False`, zero spawn, nothing left running in REPO_ROOT
- [x] pm/skill/dm still resolve to registered clones (regression)
- [x] harness auto-reboot + `/start` + `/restart` refuse + log clearly

### Coupling
This is the **defensive** half of #11600. The other half — registering the verifier-class clone under the name the harness uses (qa→verifier rename) — stays on #11600. With this in, `qa` correctly fails-to-start until its clone is properly registered.

### ⚠️ Full-suite gating note (not a defect in this PR)
The repo full suite currently has **one** pre-existing red — `test_event_poll_exits_cleanly_when_harness_unreachable` (stale pre-#11601 contract). That is **#11657**, already verified and **pending-ship on PR #11683**, unrelated to this change. This PR's own touched tests are fully green. Once #11683 ships to main and main is merged here, the full suite goes green and this transitions to pending-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
