### PR TITLE
skill: #11641 — reclaim stale scheduled_tasks.lock before launch (durable #11612 reboot-loop fix)

### DIFF
--- a/.squidsquad/skill/iterations/iter-453.md
+++ b/.squidsquad/skill/iterations/iter-453.md
@@ -1,0 +1,22 @@
+# Iteration 453 — landed #11641 (stale-lock reclaim) into pipeline
+
+**Mode**: loop (harness DOWN, port 59999 exit 7). Manual commit/push/PR.
+
+## What happened
+- Cycle pickup: re-checked the #11640 gate — **#11683 still OPEN** (mergedAt null, stale event_poll test still on main). #11640 stays gated; nothing to advance there.
+- Work queue top = **#11641** (in-progress). Investigated: implemented last session (commit cff818eb7 on branch task/11641, thin_launcher reclaim + 37 tests) but **never pushed, no PR, still in-progress** — stranded, same resume-gap as #11640. PM had already confirmed it as the durable #11612 fix.
+- Switched to task/11641 (28 behind main), merged origin/main (clean, no conflicts).
+- Verified: test_thin_launcher.py 37 pass. Full suite: only red = the same #11683-gated event_poll test. So #11641 is complete + own-tests green, identical gate to #11640.
+- Reviewed the reclaim fix — solid: dead-holder remove+log, live-holder preserve, no-lock no-op, unparseable leave+warn, unlink-race handled, wired before Popen.
+- Pushed task/11641, opened **PR #11715**. Posted status on #11641 (held in-progress, gated on #11683). Flagged DM that #11683 unblocks BOTH #11709 and #11715.
+- Spawned background DS review on the thin_launcher diff (bxas30jg8).
+
+## Net
+Both durable reboot-loop fixes are now in the pipeline as PRs, both gated only on #11683 shipping:
+- #11640 → PR #11709 (DS NO_FINDINGS)
+- #11641 → PR #11715 (DS running)
+
+## Next cycle
+- Check #11683 mergedAt. If shipped → merge main into each branch, run full suite, confirm green, transition both → pending-test.
+- Read #11641 DS output (bxas30jg8); address real findings on PR #11715.
+- Re-verify standing #11538.

--- a/.squidsquad/skill/iterations/iter-454.md
+++ b/.squidsquad/skill/iterations/iter-454.md
@@ -1,0 +1,17 @@
+# Iteration 454 — quiet cycle (primary gated); improvement scan
+
+**Mode**: loop (harness DOWN). Manual ops.
+
+## What happened
+- Gate re-check: **#11683 still OPEN** (now MERGEABLE, mergedAt null). Both #11640 (PR #11709) and #11641 (PR #11715) stay gated — can't advance.
+- Standing sweep: **#11538 / PR #11564 SHIPPED** (merged 03:49Z, issue closed) — resolved, dropped from standing.
+- PR health check (guards against #11511 conflict-flap): #11715 CLEAN/MERGEABLE; #11709 mergeable UNKNOWN (transient GitHub compute, not CONFLICTING — recheck next cycle). No conflict work needed.
+- Triaged remaining queue: #10690/#10686 still E6/E7/operator-gated; #11586/#11587 are a live multi-party harness event-mode investigation, partly operator-gated (harness down) — watch, not a clean skill fix; #11511 explicitly not-implementing; #11505 low deadwood.
+- Genuinely quiet cycle → ran improvement scan (policy: every quiet cycle, target references/scripts/ + tests/, file don't fix, cap 2). Scanned tests/run_tests.py.
+
+## Finding filed: #11716 (improvement-scan, low)
+`main()`'s `integration_only` tuple (run_tests.py:235-237) lists 4 targets but `run_integration_tests` dispatches 6 (also real_agent_subprocess, gh_shim_tracker). So `run_tests.py real_agent_subprocess` runs the full static suite first, contrary to single-target intent. Same hand-maintained-list-drift class #11394 killed for static discovery. Suggested: single source of truth for the integration target set + refresh usage docstring. NOT auto-fixed (PM/human triage). Recorded in scan_index.
+
+## Next cycle
+- Check #11683 mergedAt → if shipped, land both gated PRs to pending-test (merge main, run suite, confirm green, transition).
+- Recheck #11709 mergeability (was UNKNOWN).

--- a/.squidsquad/skill/iterations/iter-455.md
+++ b/.squidsquad/skill/iterations/iter-455.md
@@ -1,0 +1,16 @@
+# Iteration 455 — still gated; escalated the #11683 ship-stall
+
+**Mode**: loop (harness DOWN). Manual ops.
+
+## What happened
+- Gate re-check: **#11683 still OPEN/unshipped — 3rd consecutive gated cycle** (~05:08→06:44Z). Both #11640 (PR #11709) and #11641 (PR #11715) remain blocked from pending-test.
+- Diagnosed WHY #11683 isn't moving: the entire pending-ship queue is just the #11683 bundle (#11657 + #11503), it's MERGEABLE, and there's ZERO DM activity on it for ~90+ min. This is the DM-starvation symptom PM flagged on #11586 — DM is in event mode but the harness is down, so it isn't waking to ship pending-ship items.
+- **Escalated** on #11586 (the issue that owns DM-starvation, PM-tracked) with concrete cross-cycle blast-radius: #11683 carries the only red on main (#11657 event_poll stale test), which gates both durable reboot-loop fixes. Recommended operator manually ship #11683 (or wake DM); dependency chain = ship #11683 → main green → I merge → both PRs → pending-test.
+- Routed the escalation to PM (coordinator) rather than re-flagging the starved DM a third time.
+- Improvement scan: reviewed suggest-targets; SKILL.md is doc (out of code-scan scope), and I filed a solid finding (#11716) last cycle. Deferred a forced 2nd finding — situationally-aware restraint during the ship-stall firefight (avoid backlog noise). Zero new findings.
+
+## ⚠️ Operator action needed
+Manually ship PR #11683 (verified + MERGEABLE) to break the stall and unblock #11640 + #11641. Underlying fix = get DM into working event mode (#11586) or run a manual DM cycle.
+
+## Next cycle
+- Re-check #11683 mergedAt → if shipped, land both PRs (merge main, run suite, confirm green, transition to pending-test). Recheck #11709 mergeability.

--- a/.squidsquad/skill/iterations/iter-456.md
+++ b/.squidsquad/skill/iterations/iter-456.md
@@ -1,0 +1,17 @@
+# Iteration 456 — pivoted to #11586 root cause; resolved verifier's split question
+
+**Mode**: loop (harness DOWN, port 59999 exit 7). Manual ops.
+
+## What happened
+- Gate re-check: #11683 still OPEN/unshipped (4th gated cycle). Both PRs (#11709/#11715) still blocked.
+- Decided NOT to re-escalate the ship-stall a 4th time (diminishing value / noise) and instead engaged the actual root-cause issue I own: **#11586** (high, role:skill — the DM-starvation / event-mode-not-sustaining cluster that is itself why #11683 isn't shipping).
+- Read the full #11586 thread. Untangled the sub-problems:
+  - **(A)** reboot/respawn lands in loop mode (boot_agent path never arms Monitor) — the open core. Currently undiagnosable from worker clone because the harness is genuinely down (59999, exit 7) → agents correctly fall to loop mode per boot Step 1. Operator/harness territory (prior analysis: boot-prompt mode-injection + stale harness process).
+  - **(B)** verifier's 03:33 observation: armed Monitor died `exit 2 'harness port not found'` after running the full suite in a worktree. Verifier asked skill to decide whether to split it.
+- **Resolved (B)** (the concrete skill action item): verified PR #11683 DELETES `test_event_poll_exits_cleanly_when_harness_unreachable`, which did `port_file.unlink()` on the SHARED `.harness-port` mid-test — sabotaging any live Monitor. Combined with #11601 (live: `_discover_port` defaults to 7373, never exits "port not found"), (B) is fully covered by tracked work. **Decision: no new issue**; fold into the #11683 chain. Posted on #11586.
+- Key reframe: shipping #11683 isn't just unblocking my 2 PRs — it removes a test that kills live Monitors during full-suite runs, a real contributor to event mode not sustaining (#11586).
+- Vault note: [[learning-tests-must-not-mutate-shared-live-state]] (tests must not mutate shared live runtime files; source-resilience + test-isolation are both needed).
+
+## Next cycle
+- Re-check #11683 mergedAt → if shipped, land both PRs to pending-test. Recheck #11709 mergeability.
+- If harness comes back up: (A) becomes diagnosable — trace a boot_agent reboot to see if it arms Monitor.

--- a/.squidsquad/skill/planning/CODE-REVIEW-11601.md
+++ b/.squidsquad/skill/planning/CODE-REVIEW-11601.md
@@ -1,0 +1,8 @@
+After a thorough review of both files — tracing every code path, comparing against `cycle_post._discover_harness_port()` and `cycle_pre._discover_harness_port()`, verifying error handling, retry logic, test coverage, and edge cases — I find no correctness issues, regressions, or philosophy violations.
+
+- **`_discover_port()`** (event_poll.py:92-125) is byte-for-byte identical in logic to `cycle_post._discover_harness_port()` (cycle_post.py:764-788) and `cycle_pre._discover_harness_port()` (cycle_pre.py:282-302): SQUID_DIR check → 5-level parent walk → default 7373. The "always returns int" contract is verified.
+- **File-present path**: Same as before — `int(port_file.read_text(...).strip())` — no regression.
+- **Defensive `if port is None` guard** (event_poll.py:186-188) is never reached post-fix but is exercised via stub in `test_poll_returns_none_when_discover_port_returns_none` (test_event_poll.py:447-456).
+- **Tests** cover: file-present, file-absent→7373, parent-walk inheritance, garbage→7373, never-None contract, eviction, retry/backoff, timeout, since-seeding, URL building, malformed payloads, connection drops, exit codes, and wait-loop advancement.
+
+NO_FINDINGS

--- a/.squidsquad/skill/planning/CODE-REVIEW-11640.md
+++ b/.squidsquad/skill/planning/CODE-REVIEW-11640.md
@@ -1,0 +1,27 @@
+I've completed a thorough analysis of the diff, all changed code paths, and all integration points. Here are my conclusions:
+
+**Covered spawn paths:**
+- `boot_agent` — catches `CloneResolutionError` at the `_needs_boot` gate, returns `action="error"` / `success=False`, zero spawn. ✅
+- Harness auto-reboot loop — handles `action="error"` from `boot_agent`, marks `agent.status = "error"`. ✅
+- `POST /agents/{role}/start` (`start_agent`) — handles `action="error"`, marks agent error. ✅
+- `POST /agents/{role}/restart` (`restart_agent`) — resolves clone before intent mutation, refuses on failure. ✅
+- `POST /agents/all/stop` (`stop_all`) — skips unresolvable roles. ✅
+- `POST /shutdown` — skips unresolvable roles. ✅
+- `POST /agents/all/start` (`start_all`) — goes through `boot_agent` which refuses internally. ✅
+- CLI paths (`start_team.py` → `squidsquad_cli.py` → harness HTTP API) — all go through protected endpoints. ✅
+
+**Unprotected `_get_clone_path` / `_needs_boot` call sites verified:**
+- Health poller (line 291) — pre-existing `except Exception: continue` catches `CloneResolutionError`. ✅
+- `shutdown` lines 2502, 2534 — only reached for roles that already passed the `_needs_boot` filter, which internally resolved the clone. ✅
+- `stop_all` line 1633 (`_needs_boot`) — only reached after `_get_clone_path` already succeeded for the same role. ✅
+
+**Behavioral spec verified:**
+- Unregistered role → `CloneResolutionError` raised. ✅
+- Registered-but-missing path → `CloneResolutionError` raised. ✅
+- Explicit `pm -> .` → resolves normally (path exists, returns str). ✅
+- Refusal produces zero spawn (caught before orphan sweep, boot sentinel, terminal spawn). ✅
+- Refusal marks agent error. ✅
+
+No regressions, no swallowed exceptions, no path that resolves to REPO_ROOT, no unintended state mutation before clone-resolution gate.
+
+NO_FINDINGS

--- a/.squidsquad/skill/planning/CODE-REVIEW-11641.md
+++ b/.squidsquad/skill/planning/CODE-REVIEW-11641.md
@@ -1,0 +1,12 @@
+NO_FINDINGS
+
+The implementation correctly satisfies all acceptance criteria:
+
+- **Dead holder → remove+log**: Lines 229-239 unlink the lock and print a reclaim message when `_is_process_alive` returns `False`.
+- **Live holder → preserve**: Line 227-228 returns `False` without touching the lock when the holder PID is alive.
+- **No lock → no-op**: Line 215-216 returns `False` immediately when the lock file doesn't exist.
+- **Unparseable → preserve+warn**: Lines 217-226 catch both `ValueError` (malformed JSON) and `OSError` (I/O failure), fall back to `holder_pid = None`, and emit a stderr warning. Non-integer `pid` values (missing key, wrong type) trigger the same warn-and-preserve path.
+- **Unlink race → treat as gone**: Lines 231-232 catch `FileNotFoundError` specifically (another reclaimer or process already removed it) and return `False` as a no-op.
+- **Runs before Popen**: The call is at line 524, while `subprocess.Popen` is at line 561 — strictly before.
+- **No unhandled exceptions**: Every operation that could raise (`json.loads`, `read_text`, `unlink`, `_is_process_alive`) is guarded by an appropriate `try/except` block.
+- **No silent swallow of a reclaimable stale lock**: The only error path that leaves a known-stale lock in place (OSError on unlink, line 233) emits an explicit stderr warning, conforming to the "conservative (leave+warn)" directive.

--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -13,14 +13,14 @@ Harness DOWN (port 59999, curl exit 7) — loop-mode (skill pinned stable per #1
 | Issue | Fix | Branch | PR | Tests | State |
 |---|---|---|---|---|---|
 | #11640 | _get_clone_path raises (no REPO_ROOT fallback); all spawn paths refuse | task/11640 | #11709 | 237 pass; DS NO_FINDINGS | in-progress, gated |
-| #11641 | thin_launcher reclaims stale scheduled_tasks.lock before Popen | task/11641 | #11715 | 37 pass; DS running (bxas30jg8) | in-progress, gated |
+| #11641 | thin_launcher reclaims stale scheduled_tasks.lock before Popen | task/11641 | #11715 | 37 pass; DS NO_FINDINGS | in-progress, gated |
 
 Both PR'd this/last cycle from prior-session WIP that was implemented but never committed/pushed (the resume-gap pattern). PM confirmed #11641 = durable #11612 fix.
 
 ## ⚠️ The shared gate: #11683 / #11657
 Full suite has ONE red on every branch that has current main: `test_event_poll_exits_cleanly_when_harness_unreachable` — stale pre-#11601 contract. Fixed + verified + **pending-ship on PR #11683** (#11657, bundles #11503). NOT mine, NOT a regression in either of my PRs.
 - **Next cycle**: check #11683 mergedAt. If shipped → for EACH of task/11640 & task/11641: merge origin/main, run `python tests/run_tests.py`, confirm green, transition → pending-test (PR #11709 / #11715). If still open, keep holding; nudge DM again if stale.
-- DS reviews: #11640 = NO_FINDINGS (done). #11641 = bxas30jg8 running — read output, address real findings on PR #11715 before handoff.
+- DS reviews: #11640 = NO_FINDINGS (done). #11641 = NO_FINDINGS (done). Both PRs implementation-clean; no findings to address.
 
 ## Standing (re-verify next cycle)
 - **#11538 / PR #11564**: harness restart fix — was pending-test. Re-check ship/verify status.

--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -2,9 +2,9 @@
 
 - **Task**: #11641 — stale scheduled_tasks.lock reclaim (COMPLETE, PR #11715) + #11640 (PR #11709)
 - **Status**: in-progress (BOTH) — HELD pre-pending-test, gated on #11683 shipping (full-suite green)
-- **Updated**: 2026-06-13 05:48
+- **Updated**: 2026-06-13 06:14
 - **Branch**: squidsquad/task/11641 (current); #11640 work on squidsquad/task/11640
-- **Quiet Cycle Counter**: 0
+- **Quiet Cycle Counter**: 1 (iter-454: primary work done+gated; ran improvement scan)
 
 ## ⚠️ Session note
 Harness DOWN (port 59999, curl exit 7) — loop-mode (skill pinned stable per #11586). `/loop 30m` cron c8644353. cycle_pre/post wrappers DON'T fire — commit/push/PR MANUALLY. NOTE: working-state.md is per-branch in git — switching branches swaps it; this file on task/11640 vs task/11641 will differ. Git tree + issue status is truth (see [[learning-resume-git-tree-is-truth]]).
@@ -19,13 +19,14 @@ Both PR'd this/last cycle from prior-session WIP that was implemented but never 
 
 ## ⚠️ The shared gate: #11683 / #11657
 Full suite has ONE red on every branch that has current main: `test_event_poll_exits_cleanly_when_harness_unreachable` — stale pre-#11601 contract. Fixed + verified + **pending-ship on PR #11683** (#11657, bundles #11503). NOT mine, NOT a regression in either of my PRs.
+- **iter-454 (06:14) re-check**: #11683 still OPEN (now MERGEABLE, mergedAt null) — both PRs still gated. PR health: #11715 CLEAN, #11709 mergeable UNKNOWN (transient compute, NOT conflicting — recheck). DS both NO_FINDINGS. Nothing to advance; ran quiet-cycle improvement scan → filed #11716.
 - **Next cycle**: check #11683 mergedAt. If shipped → for EACH of task/11640 & task/11641: merge origin/main, run `python tests/run_tests.py`, confirm green, transition → pending-test (PR #11709 / #11715). If still open, keep holding; nudge DM again if stale.
-- DS reviews: #11640 = NO_FINDINGS (done). #11641 = NO_FINDINGS (done). Both PRs implementation-clean; no findings to address.
 
 ## Standing (re-verify next cycle)
-- **#11538 / PR #11564**: harness restart fix — was pending-test. Re-check ship/verify status.
+- **#11538 / PR #11564**: ✅ SHIPPED (merged 03:49Z, issue closed). Resolved — drop.
+- **#11716 (low, NEW this cycle)**: improvement-scan — run_tests.py integration_only target list drifted (4 vs 6); filed, awaiting PM/human triage. Do NOT auto-fix.
 - **#11511 (medium)**: PR mergeability flaps from transient-state commits (merge=ours not server-honored). Recommendation posted; awaiting PM/operator. NOT implementing (high blast radius).
-- #10690 / #10686: operator/E6-E7 gated. #11586/#11587: harness event-mode bugs (open). #11505 (low): deadwood removal.
+- #10690 / #10686: operator/E6-E7 gated (E7=#10686 operator manual smoke, not done → #10690 stays gated). #11586 (high)/#11587 (medium): live harness event-mode investigation, multi-party, partly operator-gated (harness down) — watch, not a clean skill fix. #11505 (low): deadwood removal.
 
 ## Untracked scratch (leave; not part of any PR)
 .claude/scheduled_tasks.lock.stale-bak (#11641 manual backup); .squidsquad/skill/planning/CODE-REVIEW-11601/11640/11641.md, DIFF-11641.patch.

--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -1,28 +1,34 @@
 # Working State
 
-- **Task**: none active — on main (#11538 fix shipped to pending-test, PR #11564)
-- **Status**: none (idle)
-- **Updated**: 2026-06-12 21:06
-- **Last Processed Event ID**: 9d7c2489
+- **Task**: #11641 — stale scheduled_tasks.lock reclaim (COMPLETE, PR #11715) + #11640 (PR #11709)
+- **Status**: in-progress (BOTH) — HELD pre-pending-test, gated on #11683 shipping (full-suite green)
+- **Updated**: 2026-06-13 05:48
+- **Branch**: squidsquad/task/11641 (current); #11640 work on squidsquad/task/11640
 - **Quiet Cycle Counter**: 0
 
 ## ⚠️ Session note
-Booted PRE-v0.44.0; runs OLD composed CLAUDE.md (reboot pending per DM — do NOT self-reboot). Harness DOWN (port 7373 exit 7) — loop-mode this session.
+Harness DOWN (port 59999, curl exit 7) — loop-mode (skill pinned stable per #11586). `/loop 30m` cron c8644353. cycle_pre/post wrappers DON'T fire — commit/push/PR MANUALLY. NOTE: working-state.md is per-branch in git — switching branches swaps it; this file on task/11640 vs task/11641 will differ. Git tree + issue status is truth (see [[learning-resume-git-tree-is-truth]]).
 
-## Last cycle (1642, iter-451): fixed #11538 harness restart bug
-update_health reset RESTARTING→RUNNING on every poll where the same claude PID was alive (no pid_changed guard) → HEALTH_POLL_INTERVAL=5s silently reverted any restart of a still-alive/wedged agent AND disarmed the 60s force-kill net. Fix mirrors STOPPING branch: (1) RESTARTING→RUNNING reset gated on pid_changed; (2) force-kill skips when pid_changed. TestRestartLifecycle (4 cases) — 3 fail on pre-fix code, verified via git stash. 184 harness tests + run_tests.py green. → pending-test, PR #11564, back on main.
+## TWO durable reboot-loop fixes — both DONE, both gated on #11683
+| Issue | Fix | Branch | PR | Tests | State |
+|---|---|---|---|---|---|
+| #11640 | _get_clone_path raises (no REPO_ROOT fallback); all spawn paths refuse | task/11640 | #11709 | 237 pass; DS NO_FINDINGS | in-progress, gated |
+| #11641 | thin_launcher reclaims stale scheduled_tasks.lock before Popen | task/11641 | #11715 | 37 pass; DS running (bxas30jg8) | in-progress, gated |
 
-## Standing
-- **#11538 / PR #11564**: pending-test — verifier to verify (harness restart endpoint fix).
-- **#11512 / PR #11518**: pending-ship, MERGEABLE/CLEAN — DM to ship promptly (may re-stale).
-- **#11519 / PR #11530**: pending-ship — DM to ship.
-- **#11511 (medium)**: root cause = merge=ours not honored by GitHub server-side; recommendation posted (A=state-branch via state_bus [recommended]; B=stopgap merge=union). Awaiting PM/operator decision. NOT implementing (high blast radius).
+Both PR'd this/last cycle from prior-session WIP that was implemented but never committed/pushed (the resume-gap pattern). PM confirmed #11641 = durable #11612 fix.
 
-## Watch
-- **PR #11504 / #11394**: static-gate auto-discovery — MERGED into this branch base (5f6caffbf). On confirmed merge → #11503/#11505 ungated.
-- #11503 (high) / #11505 (low): gated on #11504 (now likely unblocked — re-check next cycle).
-- #10690 / #10686 (E7): operator-gated.
-- #11329 (approved): runtime per-event ack-cursor.
+## ⚠️ The shared gate: #11683 / #11657
+Full suite has ONE red on every branch that has current main: `test_event_poll_exits_cleanly_when_harness_unreachable` — stale pre-#11601 contract. Fixed + verified + **pending-ship on PR #11683** (#11657, bundles #11503). NOT mine, NOT a regression in either of my PRs.
+- **Next cycle**: check #11683 mergedAt. If shipped → for EACH of task/11640 & task/11641: merge origin/main, run `python tests/run_tests.py`, confirm green, transition → pending-test (PR #11709 / #11715). If still open, keep holding; nudge DM again if stale.
+- DS reviews: #11640 = NO_FINDINGS (done). #11641 = bxas30jg8 running — read output, address real findings on PR #11715 before handoff.
+
+## Standing (re-verify next cycle)
+- **#11538 / PR #11564**: harness restart fix — was pending-test. Re-check ship/verify status.
+- **#11511 (medium)**: PR mergeability flaps from transient-state commits (merge=ours not server-honored). Recommendation posted; awaiting PM/operator. NOT implementing (high blast radius).
+- #10690 / #10686: operator/E6-E7 gated. #11586/#11587: harness event-mode bugs (open). #11505 (low): deadwood removal.
+
+## Untracked scratch (leave; not part of any PR)
+.claude/scheduled_tasks.lock.stale-bak (#11641 manual backup); .squidsquad/skill/planning/CODE-REVIEW-11601/11640/11641.md, DIFF-11641.patch.
 
 ## ⚠️ Recurring conflict note
-PR CONFLICTING-while-locally-clean = merge=ours custom driver not honored by GitHub server-side (#11511). Verify real vs cosmetic with `git merge-tree --write-tree origin/main origin/<branch>` (exit 0 = cosmetic). Real fix = state-branch (state_bus, unwired). See [[learning-pr-conflicting-flag-can-be-cosmetic]].
+PR CONFLICTING-while-locally-clean = merge=ours not honored server-side (#11511). Verify with `git merge-tree --write-tree origin/main origin/<branch>` (exit 0 = cosmetic). See [[learning-pr-conflicting-flag-can-be-cosmetic]].

--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -2,9 +2,9 @@
 
 - **Task**: #11641 — stale scheduled_tasks.lock reclaim (COMPLETE, PR #11715) + #11640 (PR #11709)
 - **Status**: in-progress (BOTH) — HELD pre-pending-test, gated on #11683 shipping (full-suite green)
-- **Updated**: 2026-06-13 06:44
+- **Updated**: 2026-06-13 07:13
 - **Branch**: squidsquad/task/11641 (current); #11640 work on squidsquad/task/11640
-- **Quiet Cycle Counter**: 2 (iter-455: still gated; escalated the #11683 ship-stall to PM on #11586)
+- **Quiet Cycle Counter**: 0 (iter-456: did real #11586 triage — not a quiet cycle)
 
 ## ⚠️ Session note
 Harness DOWN (port 59999, curl exit 7) — loop-mode (skill pinned stable per #11586). `/loop 30m` cron c8644353. cycle_pre/post wrappers DON'T fire — commit/push/PR MANUALLY. NOTE: working-state.md is per-branch in git — switching branches swaps it; this file on task/11640 vs task/11641 will differ. Git tree + issue status is truth (see [[learning-resume-git-tree-is-truth]]).
@@ -19,6 +19,7 @@ Both PR'd this/last cycle from prior-session WIP that was implemented but never 
 
 ## ⚠️ The shared gate: #11683 / #11657
 Full suite has ONE red on every branch that has current main: `test_event_poll_exits_cleanly_when_harness_unreachable` — stale pre-#11601 contract. Fixed + verified + **pending-ship on PR #11683** (#11657, bundles #11503). NOT mine, NOT a regression in either of my PRs.
+- **iter-456 (07:13)**: #11683 still unshipped (4th gated cycle). Stopped re-escalating (noise); pivoted to the #11586 root cause instead. Made the verifier's requested split-decision: the 03:33 qa "Monitor died — harness port not found" symptom (B) is NOT a new issue — it's the event_poll port-discovery failure already fixed by #11601 (live) + #11657's removal of the self-sabotaging test (port_file.unlink on shared .harness-port) in PR #11683. Strengthens #11683 priority: shipping it removes a test that kills live Monitors during any full-suite run (a real #11586 contributor). Posted decision on #11586. Vault: [[learning-tests-must-not-mutate-shared-live-state]]. (A) reboot→loop-mode remains the #11586 core; only diagnosable while harness is up (currently down on 59999) — operator/harness territory.
 - **iter-455 (06:44)**: #11683 STILL OPEN/unshipped (3rd consecutive gated cycle). Confirmed systemic: entire pending-ship queue = just the #11683 bundle (#11657+#11503), MERGEABLE, ZERO DM activity ~90+ min → DM-starvation (harness down, DM not waking). ESCALATED to PM on #11586 with cross-cycle data + recommended operator manually ship #11683. ⚠️ NEEDS OPERATOR ACTION: manually ship #11683 (or wake DM) to unblock #11640+#11641. No new improvement finding (SKILL.md is doc/out-of-scope; avoiding backlog noise during firefight — #11716 filed last cycle).
 - **iter-454 (06:14) re-check**: #11683 still OPEN (now MERGEABLE, mergedAt null) — both PRs still gated. PR health: #11715 CLEAN, #11709 mergeable UNKNOWN (transient compute, NOT conflicting — recheck). DS both NO_FINDINGS. Nothing to advance; ran quiet-cycle improvement scan → filed #11716.
 - **Next cycle**: check #11683 mergedAt. If shipped → for EACH of task/11640 & task/11641: merge origin/main, run `python tests/run_tests.py`, confirm green, transition → pending-test (PR #11709 / #11715). If still open, keep holding; nudge DM again if stale.

--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -2,9 +2,9 @@
 
 - **Task**: #11641 — stale scheduled_tasks.lock reclaim (COMPLETE, PR #11715) + #11640 (PR #11709)
 - **Status**: in-progress (BOTH) — HELD pre-pending-test, gated on #11683 shipping (full-suite green)
-- **Updated**: 2026-06-13 06:14
+- **Updated**: 2026-06-13 06:44
 - **Branch**: squidsquad/task/11641 (current); #11640 work on squidsquad/task/11640
-- **Quiet Cycle Counter**: 1 (iter-454: primary work done+gated; ran improvement scan)
+- **Quiet Cycle Counter**: 2 (iter-455: still gated; escalated the #11683 ship-stall to PM on #11586)
 
 ## ⚠️ Session note
 Harness DOWN (port 59999, curl exit 7) — loop-mode (skill pinned stable per #11586). `/loop 30m` cron c8644353. cycle_pre/post wrappers DON'T fire — commit/push/PR MANUALLY. NOTE: working-state.md is per-branch in git — switching branches swaps it; this file on task/11640 vs task/11641 will differ. Git tree + issue status is truth (see [[learning-resume-git-tree-is-truth]]).
@@ -19,6 +19,7 @@ Both PR'd this/last cycle from prior-session WIP that was implemented but never 
 
 ## ⚠️ The shared gate: #11683 / #11657
 Full suite has ONE red on every branch that has current main: `test_event_poll_exits_cleanly_when_harness_unreachable` — stale pre-#11601 contract. Fixed + verified + **pending-ship on PR #11683** (#11657, bundles #11503). NOT mine, NOT a regression in either of my PRs.
+- **iter-455 (06:44)**: #11683 STILL OPEN/unshipped (3rd consecutive gated cycle). Confirmed systemic: entire pending-ship queue = just the #11683 bundle (#11657+#11503), MERGEABLE, ZERO DM activity ~90+ min → DM-starvation (harness down, DM not waking). ESCALATED to PM on #11586 with cross-cycle data + recommended operator manually ship #11683. ⚠️ NEEDS OPERATOR ACTION: manually ship #11683 (or wake DM) to unblock #11640+#11641. No new improvement finding (SKILL.md is doc/out-of-scope; avoiding backlog noise during firefight — #11716 filed last cycle).
 - **iter-454 (06:14) re-check**: #11683 still OPEN (now MERGEABLE, mergedAt null) — both PRs still gated. PR health: #11715 CLEAN, #11709 mergeable UNKNOWN (transient compute, NOT conflicting — recheck). DS both NO_FINDINGS. Nothing to advance; ran quiet-cycle improvement scan → filed #11716.
 - **Next cycle**: check #11683 mergedAt. If shipped → for EACH of task/11640 & task/11641: merge origin/main, run `python tests/run_tests.py`, confirm green, transition → pending-test (PR #11709 / #11715). If still open, keep holding; nudge DM again if stale.
 

--- a/.squidsquad/vault/galaxy/learning-tests-must-not-mutate-shared-live-state.md
+++ b/.squidsquad/vault/galaxy/learning-tests-must-not-mutate-shared-live-state.md
@@ -1,0 +1,22 @@
+---
+type: learning
+tags: [testing, isolation, harness, event-mode, monitor, 11586, 11657, 11601]
+created: 2026-06-13
+updated: 2026-06-13
+owner: skill-lead
+status: active
+confidence: high
+source: observation
+links: [learning-resume-git-tree-is-truth, decision-clone-isolation-architecture]
+---
+
+# Tests must not mutate SHARED live runtime state — it sabotages concurrent agents
+
+**Observed (#11586 triage, #11657):** the verifier ran `python tests/run_tests.py` while its own event-mode Monitor was armed. The Monitor died (`exit 2, "harness port not found"`) and the agent session ended. Root cause: `test_event_poll_exits_cleanly_when_harness_unreachable` called `port_file.unlink()` on the **shared** `REPO_ROOT/.squidsquad/.harness-port` mid-test (restoring it in `finally`). During that window, the live `event_poll.py` sidecar read a missing port file and, on pre-#11601 code, exited 2 → Monitor died → session ended.
+
+**Why it matters:** in SquidSquad, tests run inside live agent clones while agents are actively cycling. A test that deletes/edits a shared runtime file (`.harness-port`, `.event-state.json`, `.claude-pid`, `current-state`, lock files) is not isolated — it reaches outside the test and can kill a live agent. "Passes in isolation" hides this; the damage only shows when something else is running concurrently.
+
+**How to apply:**
+- A test that needs to simulate "file absent / corrupt" must operate on a **temp copy / `tmp_path` / monkeypatched path**, never the real shared file. If a function reads a hard-coded shared path, inject the path (or patch the module global) rather than mutating the real file.
+- Two independent defenses are both correct and belong together: (1) make the *consumer* resilient to the missing file (#11601 — `event_poll._discover_port` defaults to 7373 instead of exiting), AND (2) remove/sandbox the *test* that yanks the shared file (#11657). Source-resilience + test-isolation, not either alone.
+- When triaging a "live agent died mid-session" report, check whether a test run touched shared state in that window before opening a new root-cause issue — it may already be covered by source-hardening + test-removal work. See [[learning-resume-git-tree-is-truth]] for the sibling "the failure may already be tracked elsewhere" reflex.

--- a/references/scripts/thin_launcher.py
+++ b/references/scripts/thin_launcher.py
@@ -20,6 +20,7 @@ Exit codes:
     3  — refused: another agent of this role is already running in this clone (#8692)
 """
 
+import json
 import os
 import shutil
 import subprocess
@@ -185,6 +186,57 @@ def _check_singleton(clone_path, role):
         # Defensive: our own PID shouldn't be there, but if it is, treat as stale.
         return None
     return pid if _is_process_alive(pid) else None
+
+
+def _reclaim_stale_scheduled_lock(clone_path):
+    """#11641: reclaim a stale ``.claude/scheduled_tasks.lock`` before launch.
+
+    claude-code's scheduler writes ``.claude/scheduled_tasks.lock`` (JSON with
+    a ``pid`` holder) when a session schedules a task — e.g. an agent that ran
+    ``/loop`` in polling mode. If that session dies UNcleanly the lock is left
+    behind, and claude-code does NOT reclaim a dead-holder lock: it aborts
+    startup with exit 1, BEFORE any session transcript. Under the harness
+    auto-reboot loop (#4949) that becomes a crash loop — every respawn hits the
+    same stale lock and the crashed startup never cleans it (root cause of the
+    #11612 reboot loop; confirmed by PM repro on 2026-06-13).
+
+    Contract (AC #11641):
+      - lock exists + holder PID not alive  -> remove it, log the reclamation.
+      - lock exists + holder PID IS alive   -> leave it (never stomp a live lock).
+      - no lock                              -> no-op.
+      - lock present but pid unreadable      -> leave it + warn. We cannot prove
+        the holder dead, and the proven failure mode is a dead-but-parseable
+        PID; clearing an unparseable lock risks stomping a live holder, so we
+        stay conservative and surface it instead.
+
+    Returns True iff a stale lock was reclaimed.
+    """
+    lock_path = Path(clone_path) / ".claude" / "scheduled_tasks.lock"
+    if not lock_path.exists():
+        return False
+    try:
+        data = json.loads(lock_path.read_text(encoding="utf-8"))
+        holder_pid = data.get("pid") if isinstance(data, dict) else None
+    except (ValueError, OSError):
+        holder_pid = None
+    if not isinstance(holder_pid, int):
+        print(f"[thin-launcher] WARNING: scheduled-tasks lock {lock_path} has no "
+              f"readable holder pid; leaving it in place (cannot prove it stale)",
+              file=sys.stderr)
+        return False
+    if _is_process_alive(holder_pid):
+        return False  # live holder — never stomp
+    try:
+        lock_path.unlink()
+    except FileNotFoundError:
+        return False  # raced with another reclaimer — already gone, fine
+    except OSError as e:
+        print(f"[thin-launcher] WARNING: could not remove stale scheduled-tasks "
+              f"lock {lock_path}: {e}", file=sys.stderr)
+        return False
+    print(f"[thin-launcher] reclaimed stale scheduled-tasks lock {lock_path} "
+          f"(holder pid {holder_pid} not alive) — #11641")
+    return True
 
 
 def _resolve_claude_exe_pid(wrapper_pid, claude_exe_used,
@@ -464,6 +516,12 @@ def main():
             file=sys.stderr,
         )
         return 3
+
+    # #11641: clear a stale claude-code scheduler lock left by a previous
+    # session that died uncleanly — otherwise claude aborts startup with exit 1
+    # and the harness auto-reboot turns it into a crash loop. Only reclaims a
+    # dead-holder lock; a live-held lock is left untouched.
+    _reclaim_stale_scheduled_lock(clone_path)
 
     # Set environment
     env = os.environ.copy()

--- a/tests/test_thin_launcher.py
+++ b/tests/test_thin_launcher.py
@@ -1,5 +1,6 @@
 """Tests for references/scripts/thin_launcher.py (#4966)."""
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -408,3 +409,79 @@ class TestWritePidFailure:
         err = capsys.readouterr().err
         assert "WARNING" in err and "pid file" in err
         assert str(tmp_path / ".squidsquad" / "skill" / ".claude-pid") in err
+
+
+class TestStaleScheduledLockReclaim:
+    """#11641: before launch, thin_launcher clears a stale claude-code
+    scheduler lock (.claude/scheduled_tasks.lock with a DEAD holder PID) so a
+    crashed-startup loop can't persist — but never stomps a LIVE-held lock."""
+
+    def _write_lock(self, clone_path, pid):
+        lock = Path(clone_path) / ".claude" / "scheduled_tasks.lock"
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        # Mirror the real claude-code lock shape (see #11641 repro backup).
+        body = {"sessionId": "abc", "pid": pid,
+                "procStart": "639168942179987460", "acquiredAt": 1781312891613}
+        lock.write_text(json.dumps(body), encoding="utf-8")
+        return lock
+
+    def test_dead_holder_lock_reclaimed(self, tmp_path, capsys):
+        """Dead holder PID -> lock removed, reclamation logged."""
+        lock = self._write_lock(tmp_path, 25628)
+        with patch("thin_launcher._is_process_alive", return_value=False):
+            reclaimed = thin_launcher._reclaim_stale_scheduled_lock(str(tmp_path))
+        assert reclaimed is True
+        assert not lock.exists()
+        assert "reclaimed stale scheduled-tasks lock" in capsys.readouterr().out
+
+    def test_live_holder_lock_preserved(self, tmp_path):
+        """Live holder PID -> lock left untouched (never stomp a live lock)."""
+        lock = self._write_lock(tmp_path, 4242)
+        with patch("thin_launcher._is_process_alive", return_value=True):
+            reclaimed = thin_launcher._reclaim_stale_scheduled_lock(str(tmp_path))
+        assert reclaimed is False
+        assert lock.exists()
+
+    def test_no_lock_is_noop(self, tmp_path):
+        """No lock file (no .claude dir) -> no error, nothing reclaimed."""
+        assert thin_launcher._reclaim_stale_scheduled_lock(str(tmp_path)) is False
+
+    def test_unparseable_lock_preserved(self, tmp_path, capsys):
+        """Corrupt lock (no readable pid) -> conservative: leave it + warn.
+        We cannot prove the holder dead, and the proven #11641 failure mode is
+        a dead-but-parseable PID; clearing risks stomping a live holder."""
+        lock = Path(tmp_path) / ".claude" / "scheduled_tasks.lock"
+        lock.parent.mkdir(parents=True)
+        lock.write_text("}{ not json", encoding="utf-8")
+        with patch("thin_launcher._is_process_alive", return_value=False):
+            reclaimed = thin_launcher._reclaim_stale_scheduled_lock(str(tmp_path))
+        assert reclaimed is False
+        assert lock.exists()
+        assert "WARNING" in capsys.readouterr().err
+
+    def test_missing_pid_field_preserved(self, tmp_path):
+        """Valid JSON but no `pid` key -> cannot prove dead -> leave it."""
+        lock = Path(tmp_path) / ".claude" / "scheduled_tasks.lock"
+        lock.parent.mkdir(parents=True)
+        lock.write_text(json.dumps({"sessionId": "abc"}), encoding="utf-8")
+        assert thin_launcher._reclaim_stale_scheduled_lock(str(tmp_path)) is False
+        assert lock.exists()
+
+    def test_main_launch_path_invokes_reclaim(self, tmp_path):
+        """Wiring: the spawn path actually calls the reclaimer before Popen —
+        the fix is worthless if it ships unwired (#11641 names the spawn path
+        as the runtime actor)."""
+        (tmp_path / ".squidsquad" / "skill").mkdir(parents=True)
+        proc = MagicMock()
+        proc.pid = 11111
+        proc.wait.return_value = 0
+        with patch("thin_launcher.os.getcwd", return_value=str(tmp_path)), \
+             patch("thin_launcher.subprocess.Popen", return_value=proc), \
+             patch("thin_launcher._get_effort_level", return_value="high"), \
+             patch("thin_launcher._resolve_claude_exe_pid", return_value=11111), \
+             patch("thin_launcher.shutil.which", return_value="/usr/bin/claude"), \
+             patch("thin_launcher._reclaim_stale_scheduled_lock") as mock_reclaim, \
+             patch("sys.argv", ["thin_launcher.py", "skill"]):
+            rc = thin_launcher.main()
+        assert rc == 0
+        mock_reclaim.assert_called_once_with(str(tmp_path))


### PR DESCRIPTION
## #11641 — reclaim stale `.claude/scheduled_tasks.lock` before launch

**Durable fix for the #11612 reboot loop** (PM-confirmed via live repro 2026-06-13: clearing the stale lock stopped the loop).

claude-code's scheduler writes `.claude/scheduled_tasks.lock` (JSON, `pid` holder) when a session schedules a task — e.g. an agent running `/loop` in polling mode. If that session dies **uncleanly**, the lock is left behind, and claude-code does **not** reclaim a dead-holder lock — it aborts startup with **exit 1**, before any session transcript. Under the harness auto-reboot loop (#4949) that becomes a crash loop: every respawn hits the same stale lock, and the crashed startup never cleans it. Only the skill clone carried the lock (it alone ran `/loop`), which is why only skill loop-crashed.

### Change
`thin_launcher._reclaim_stale_scheduled_lock(clone_path)`, called in `main()` **before** `Popen` (after the singleton gate). Contract:
- lock exists + holder PID **not alive** → remove + log the reclamation.
- lock exists + holder PID **alive** → leave it (never stomp a live lock).
- no lock → no-op.
- lock present but PID **unreadable** → leave + warn (can't prove it stale; the proven failure mode is a dead-but-parseable PID, so stay conservative).
- unlink race (`FileNotFoundError`) → treat as already-gone.

Reuses the existing `_is_process_alive` helper. Since we can't patch the claude CLI, this is the SquidSquad-side guard; without it the loop recurs after **any** unclean agent death.

### Tests (37 passed in test_thin_launcher.py)
`TestStaleScheduledLockReclaim`: dead-holder reclaim, live-holder preserve, no-lock no-op, unparseable/missing-pid preserve, + a wiring test that `main()` invokes the reclaimer before `Popen`.

### AC coverage
- [x] On spawn, stale lock (dead holder PID) removed before exec'ing claude; reclamation logged
- [x] Live holder PID → lock preserved
- [x] Regression: dead-PID lock → spawn removes it → claude launches; live-PID lock → preserved
- [x] Cross-ref: real cause of the #11612 reboot loop (distinct from event_poll #11601)

### ⚠️ Full-suite gating note (not a defect in this PR)
The repo full suite has **one** pre-existing red — `test_event_poll_exits_cleanly_when_harness_unreachable` (stale pre-#11601 contract) — which is **#11657**, already verified + **pending-ship on PR #11683**, unrelated to this change. This PR's own tests are fully green (37). Transitions to pending-test once #11683 ships to main and main is merged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
