### PR TITLE
skill: #11587 — uvicorn loop=none so SelectorEventLoopPolicy governs the harness server loop

### DIFF
--- a/.squidsquad/skill/iterations/iter-457.md
+++ b/.squidsquad/skill/iterations/iter-457.md
@@ -1,0 +1,17 @@
+# Iteration 457 — implemented #11587 (uvicorn ProactorEventLoop fix)
+
+**Mode**: loop (harness DOWN). Manual ops.
+
+## What happened
+- Gate re-check: #11683 still unshipped (5th gated cycle); harness still down (59999, exit 7). My 2 PRs (#11709/#11715) still blocked; #11586(A) still undiagnosable (harness down).
+- Stopped re-escalating (noise) and picked up genuinely-actionable skill-owned work: **#11587** (high-blast-radius harness asyncio bug — auto-approved). It could relate to harness instability, though reported as "cosmetic today."
+- **Diagnosed precisely** (read installed uvicorn 0.41.0 source): `asyncio_loop_factory` HARD-CODES `asyncio.ProactorEventLoop` on win32 (use_subprocess=False), bypassing the event-loop policy. `Server.run()`→`asyncio.run(serve(), loop_factory=get_loop_factory())`; `Config(loop='auto').get_loop_factory()` = ProactorEventLoop on win32 → the #9562 main-thread SelectorEventLoopPolicy never governs the daemon-thread server loop. Confirms the issue's investigation lead.
+- **Fix**: extracted `_build_uvicorn_config()` (testable seam) setting `loop='none'` → factory None → `asyncio.run` uses `new_event_loop()` → respects policy → SelectorEventLoop. Verified empirically: `Config(loop='none').get_loop_factory() is None`; `new_event_loop()` under policy = `_WindowsSelectorEventLoop`; `loop='auto'` = ProactorEventLoop factory. Cross-platform safe.
+- **Tests**: tests/test_11587_uvicorn_selector_loop.py — 5 new behavioral+wiring (loop=none contract, factory-is-None, rationale-lock loop=auto⇒Proactor on win32, end-to-end none+policy⇒Selector, main()-uses-helper) + 4 #9562 regression = 9 pass. Full suite: only the pre-existing #11683-gated event_poll red; zero new failures.
+- Committed a81f532e9, pushed task/11587, opened **PR #11722**, posted status on #11587, spawned DS review (b0gcqdjtm). Held in-progress (same #11683 gate).
+
+## Net: 3 skill PRs now in flight, all gated on #11683 ship (#11709, #11715, #11722).
+
+## Next cycle
+- #11683 mergedAt → if shipped, land all 3 PRs (merge main, run suite, confirm green, transition).
+- Read #11587 DS output (b0gcqdjtm); address findings on PR #11722.

--- a/.squidsquad/skill/iterations/iter-458.md
+++ b/.squidsquad/skill/iterations/iter-458.md
@@ -1,0 +1,16 @@
+# Iteration 458 — front-loaded planning for #11505 (capabilities deadwood)
+
+**Mode**: loop (harness DOWN). Manual ops.
+
+## What happened
+- Gate re-check: #11683 still unshipped (6th gated cycle); harness still down. 3 PRs (#11709/#11715/#11722) all DS-clean, all gated.
+- Verified #11586(A) needs no skill code fix: read thin_launcher — #11512 ALREADY made the spawn prompt mode-neutral (boot Step 1 probes + decides; /loop injection removed). So (A)'s boot path is correct; root cause is harness-process availability (operational), as skill already concluded (03:02). My harness-stability code contributions (#11587 + #11640 + #11641) are the relevant skill work, done. No new comment (would duplicate).
+- Picked up **#11505** (low, auto-approved deadwood removal per INSTALLER-ARCH §8.3), now unblocked (#11504 merged).
+- **Front-loaded planning** (footprint mapped before edits): broad grep looked large (manifest.py, capability_check.py, catalog_drift.py, docs, ~7 tests) but reading ACs precisely → in-scope is the **agent-facing sub-skill layer only**: capability-check.md wired into exactly ONE role (dm: includes.yml:19 + instructions.md:8 marker); capabilities/ dir already empty; compose.py refs are historical comments.
+- **Skill scope judgment**: manifest.py capability REGISTRY + capability_check.py runtime are installer-core, NOT in ACs → kept OUT (separate higher-risk change; asked PM to confirm §8.3 full-framework intent).
+- Posted bounded execution plan on #11505 (work contract); transitioned in-progress.
+- **Did NOT execute**: blocked on (1) PM CQ AC (step 7.4 — LLM-consumed sub-skill removal from DM; I don't self-author CQ specs) and (2) AC7 'run_tests.py exits 0' gated on #11683. Deferred execution to a fresh cycle post-CQ-answer (context-responsible; avoids rework if PM wants capability-check preserved/CQ'd).
+
+## Next cycle
+- #11683 mergedAt → if shipped, land the 3 gated PRs.
+- #11505 → if PM answered CQ, execute the bounded removal on task/11505.

--- a/.squidsquad/skill/iterations/iter-459.md
+++ b/.squidsquad/skill/iterations/iter-459.md
@@ -1,0 +1,19 @@
+# Iteration 459 — fully blocked; triage swept, PRs healthy
+
+**Mode**: loop (harness DOWN). Manual ops.
+
+## What happened
+- Gates re-checked (all still closed): #11683 unshipped (7th cycle); harness down (59999 exit 7); #11505 — no PM CQ answer yet.
+- **PR health (good)**: #11709, #11715, #11722 all now MERGEABLE/CLEAN (no #11511-style conflict-flap). Primed to land the instant #11683 ships.
+- **triage-issues sweep** for new/actionable skill work — none found:
+  - #302 (hints-dm.txt missing scanning-phase hints): real but status:pending = improvement-scan finding awaiting human triage. Per policy (don't auto-fix unapproved scan findings, cf #11716), NOT implementing — leave for PM triage.
+  - #10855 (verifier boot leaves claude.exe inert): status pending-test + blocked:human-action — already worked, blocked on human. Not actionable.
+  - Rest of queue: 3 PRs gated; #11505 blocked on PM CQ + #11683; #11586(A) operational; #11511 not-implementing; #10690/#10686 E6/E7-gated; #11716 awaiting triage.
+- Conclusion: genuinely fully blocked. Did NOT manufacture work (no fresh improvement scan — #11716 filed recently; piling low-pri findings during the ship-stall firefight is noise). Minimal cycle.
+
+## Bottlenecks (both external)
+1. **Operator/DM**: ship PR #11683 → main green → land 3 PRs (#11709/#11715/#11722) + unblock #11505 AC7.
+2. **PM**: answer CQ-AC question on #11505 (or confirm 'no CQ for pure removal').
+
+## Next cycle
+- Re-check #11683 mergedAt + #11505 PM CQ answer. Act the moment either clears.

--- a/.squidsquad/skill/iterations/iter-460.md
+++ b/.squidsquad/skill/iterations/iter-460.md
@@ -1,0 +1,22 @@
+# Iteration 460 — caught #11505 scope conflict before making a mess
+
+**Mode**: loop (harness DOWN). Manual ops.
+
+## What happened
+- Gates re-checked (all closed): #11683 unshipped (8th cycle), harness down, no PM CQ answer on #11505.
+- Decided to convert the blocked cycle into progress by EXECUTING the #11505 removal (operator-decided per §8.3; CQ-AC is a pending-test gate, not a do-the-work gate; plan already published iter-458). Branched task/11505 off main.
+- **Before editing**, traced the exact footprint deeper than iter-458 — and found a SCOPE CONFLICT that stops execution:
+  1. capability_check.py is load-bearing in **PM task-intake** (references/sub-skills/roles/pm/task-intake.md:70 'Capability gap analysis' + :110 template), which composes into PM's CLAUDE.md (pm/includes.yml:31). AC4's 'sweep all L1-L3 sources' would silently delete a PM workflow step — PM-domain behavioral change.
+  2. references/sub-skills/manifest.md:149 + docs/sub-skill-catalog.md:143 EXPLICITLY say capability-check removal is 'not this PR — paired with the broader capability-framework retirement (INSTALLER-ARCH §8, #10025)'. **#10025 is OPEN** and titled '...retire [capability framework]'.
+  3. The capabilities/ DIRECTORY (AC1) is already gone (2026-05-27 cleanup, manifest.md:147) — the only cleanly-bounded deadwood is already done.
+- So #11505's ACs over-reach into #10025's territory + PM's domain. Per discipline (stop on ambiguous/contradictory scope; don't cross role boundaries; don't implement blindly), I STOPPED — made zero edits, posted the finding + 3 disambiguation options (downscope / close-as-superseded-by-#10025 / confirm-full-retirement-with-PM-signoff) on #11505, deleted the empty branch.
+
+## Why this is the right outcome
+Executing AC4 as written would have (a) removed a live PM task-intake step without PM sign-off, (b) contradicted the documented #10025 plan, (c) orphaned capability_check.py. Catching it pre-edit IS the front-loaded-planning payoff.
+
+## Blocked on (external)
+- #11505: PM/operator to disambiguate #11505↔#10025 overlap.
+- 3 PRs (#11709/#11715/#11722): #11683 ship. All MERGEABLE/CLEAN.
+
+## Next cycle
+- Re-check #11683 + #11505 disambiguation + PM CQ. Act when any clears.

--- a/.squidsquad/skill/iterations/iter-461.md
+++ b/.squidsquad/skill/iterations/iter-461.md
@@ -1,0 +1,16 @@
+# Iteration 461 — fully blocked (9th cycle), no change
+
+**Mode**: loop (harness DOWN). Manual ops.
+
+## Status: all gates still closed
+- #11683 unshipped (9th consecutive gated cycle, ~05:08→09:42Z). Harness down (59999 exit 7). No PM response on #11505 disambiguation. No new comments on my 3 PRs; no review-requests; no #11683 ship movement.
+- 3 PRs (#11709/#11715/#11722) MERGEABLE/CLEAN, primed. #11505 blocked on PM/operator (#11505↔#10025 disambiguation). Everything else gated/pending/not-implementing.
+
+## No new actionable work; no teammate input to answer.
+Did NOT manufacture work (speculative scans during a ship-stall firefight = noise) and did NOT cross into DM's ship role to merge #11683 myself (boundary).
+
+## Sole blockers (external, unchanged)
+1. Operator/DM: ship PR #11683 → unblocks 3 PRs + #11505 AC7.
+2. PM/operator: disambiguate #11505↔#10025; answer #11505 CQ-AC.
+
+## Next cycle: re-check gates; act the instant any clears.

--- a/.squidsquad/skill/iterations/iter-462.md
+++ b/.squidsquad/skill/iterations/iter-462.md
@@ -1,0 +1,28 @@
+# Iteration 462 — ⭐ found the #11586 root cause (harness was UP all along)
+
+**Mode**: loop (sticky this session). Manual ops.
+
+## Breakthrough
+After 9 cycles of "harness down (59999 exit 7)", instead of another idle confirmation I investigated WHY the harness was down — and it wasn't. **The harness has been UP and healthy on port 7373 the entire time** (curl /status: uptime 16h34m, v0.44.0; /events/cursor/skill returns a live cursor).
+
+My session ran loop-mode all along because my clone's `.harness-port` said **59999** (a dead port) — I'd been probing the wrong port since boot. The boot logic was correct; its input was poisoned.
+
+## Root cause of #11586 (the loop-mode-on-some-agents symptom)
+Per-clone port-file matrix explains every observation:
+- pm/qa: `.harness-port` MISSING → default 7373 → reach harness (qa reached event mode ✓).
+- dm: 7373 → reaches harness (event mode ✓; its starvation is a separate delivery bug).
+- skill(me): **59999 (dead)** → probe fails → loop mode ✗.
+
+Vector: harness `_deferred_init` (harness.py:1280-1294) distributes its port into every `.local-config` clone. An integration test that starts a harness on an ephemeral port (59999 = `find_free_port(59999)`, tests/test_harness.py) against the real `.local-config` writes that dead port into the REAL sibling clones; teardown never restores them → strands live agents in loop mode. Concrete instance of [[learning-tests-must-not-mutate-shared-live-state]].
+
+## Actions
+- Corrected skill clone `.harness-port` 59999→7373 (now curl-reachable). Future boot reaches event mode (mode sticky this session).
+- Posted comprehensive root-cause finding on #11586 (matrix + vector + fix).
+
+## Durable fix — NEXT CYCLE (skill-domain, NOT gated on #11683)
+1. Tests must not distribute ephemeral port into real clones (isolate `.local-config` / guard `_deferred_init` clone-distribution / restore clone `.harness-port` in teardown).
+2. Harden `_discover_port` (event_poll.py + cycle_post.py): a port-file value that isn't actually listening = stale → fall through to default/parent-walk, so a leaked file can't strand an agent.
+Own branch off main; own tests green; independent of the #11683 gate.
+
+## Note to operator
+Harness is fine. Mis-ported agents reach event mode after a port-file correction + reboot. This likely un-sticks the event-mode degradation underlying the whole batch.

--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -2,9 +2,9 @@
 
 - **Task**: #11587 — uvicorn loop=none (harness ProactorEventLoop fix) — COMPLETE, PR #11722
 - **Status**: in-progress — HELD pre-pending-test, gated on #11683 shipping (full-suite green)
-- **Updated**: 2026-06-13 07:44
+- **Updated**: 2026-06-13 08:14
 - **Branch**: squidsquad/task/11587 (current). Other in-flight: task/11640, task/11641.
-- **Quiet Cycle Counter**: 0 (iter-457: implemented #11587)
+- **Quiet Cycle Counter**: 0 (iter-458: planned #11505)
 
 ## ⚠️ Session note
 Harness DOWN (port 59999, curl exit 7) — loop-mode (skill pinned stable per #11586). `/loop 30m` cron c8644353. cycle_pre/post DON'T fire — commit/push/PR MANUALLY. working-state.md is PER-BRANCH in git — switching branches swaps it; git tree + issue status is truth ([[learning-resume-git-tree-is-truth]]).
@@ -24,10 +24,14 @@ Unshipped ~5 cycles. DM-starvation (harness down → DM not waking). Shipping #1
 ## #11587 detail (this cycle)
 uvicorn 0.41.0 asyncio_loop_factory hard-codes ProactorEventLoop on win32 (use_subprocess=False), bypassing the #9562 policy entirely. Server.run()→asyncio.run(serve(), loop_factory=get_loop_factory()); loop='auto'→Proactor factory. Fix: _build_uvicorn_config() sets loop='none'→factory None→asyncio.run uses new_event_loop()→respects policy→Selector. Commit a81f532e9. DS review DONE → NO_FINDINGS (all 5 criteria verified). PR #11722 implementation-clean. All 3 PRs now DS-clean.
 
+## #11505 (low) — PLANNED this cycle (iter-458), in-progress, NOT executed
+Deadwood removal (capability sub-skill layer). Footprint mapped: in-scope = capability-check.md + dm/includes.yml:19 + dm/instructions.md:8 (DM is the ONLY consumer) + empty capabilities/ dir + installer-files.txt + test_feat328_coverage delete + KNOWN_FAILURES -1 + sub-skill-catalog entry. Scope judgment: manifest.py/capability_check.py installer-core capability machinery is OUT (not in ACs; gutting it = separate higher-risk change; asked PM to confirm §8.3 intent). Plan posted on #11505 (work contract).
+- **BLOCKED on**: (1) PM to add CQ AC (step 7.4 — removing LLM-consumed sub-skill from DM) or confirm 'no CQ'; (2) AC7 'run_tests.py exits 0' gated on #11683 ship. Execute mechanical removal once PM answers CQ.
+
 ## Next cycle
 - Check #11683 mergedAt → if shipped, for EACH branch (task/11640, task/11641, task/11587): merge origin/main, run tests/run_tests.py, confirm green, transition → pending-test.
-- (#11587 DS review done — NO_FINDINGS; nothing to address.)
-- If harness comes back up: #11586 (A) reboot→loop-mode becomes diagnosable.
+- Check #11505 for PM's CQ-AC answer → if answered, execute the bounded removal plan (own branch task/11505 off main).
+- (#11587 DS review done — NO_FINDINGS.) If harness comes back up: #11586 (A) reboot→loop-mode becomes diagnosable.
 
 ## Standing
 - **#11538 / PR #11564**: ✅ SHIPPED. **#11716 (low)**: improvement-scan filed (run_tests.py target drift) — awaiting triage.

--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -2,9 +2,9 @@
 
 - **Task**: #11587 — uvicorn loop=none (harness ProactorEventLoop fix) — COMPLETE, PR #11722
 - **Status**: in-progress — HELD pre-pending-test, gated on #11683 shipping (full-suite green)
-- **Updated**: 2026-06-13 08:42
+- **Updated**: 2026-06-13 09:13
 - **Branch**: squidsquad/task/11587 (current). Other in-flight: task/11640, task/11641.
-- **Quiet Cycle Counter**: 1 (iter-459: fully blocked — all 3 PRs MERGEABLE/CLEAN, awaiting #11683 ship)
+- **Quiet Cycle Counter**: 0 (iter-460: caught #11505 scope conflict — real work, not quiet)
 
 ## ⚠️ Session note
 Harness DOWN (port 59999, curl exit 7) — loop-mode (skill pinned stable per #11586). `/loop 30m` cron c8644353. cycle_pre/post DON'T fire — commit/push/PR MANUALLY. working-state.md is PER-BRANCH in git — switching branches swaps it; git tree + issue status is truth ([[learning-resume-git-tree-is-truth]]).
@@ -26,7 +26,7 @@ uvicorn 0.41.0 asyncio_loop_factory hard-codes ProactorEventLoop on win32 (use_s
 
 ## #11505 (low) — PLANNED this cycle (iter-458), in-progress, NOT executed
 Deadwood removal (capability sub-skill layer). Footprint mapped: in-scope = capability-check.md + dm/includes.yml:19 + dm/instructions.md:8 (DM is the ONLY consumer) + empty capabilities/ dir + installer-files.txt + test_feat328_coverage delete + KNOWN_FAILURES -1 + sub-skill-catalog entry. Scope judgment: manifest.py/capability_check.py installer-core capability machinery is OUT (not in ACs; gutting it = separate higher-risk change; asked PM to confirm §8.3 intent). Plan posted on #11505 (work contract).
-- **BLOCKED on**: (1) PM to add CQ AC (step 7.4 — removing LLM-consumed sub-skill from DM) or confirm 'no CQ'; (2) AC7 'run_tests.py exits 0' gated on #11683 ship. Execute mechanical removal once PM answers CQ.
+- **iter-460 SCOPE CONFLICT (stopped execution):** branched task/11505 off main to execute, but deeper trace found capability-check is NOT isolated deadwood: capability_check.py is load-bearing in **PM task-intake** (task-intake.md:70 'Capability gap analysis', composed into PM via pm/includes.yml:31) + DM startup; AND manifest.md:149 + catalog:143 EXPLICITLY say its removal is 'not this PR — paired with #10025 (capability-framework retirement, OPEN)'. AC4's L1-L3 sweep would silently delete a PM workflow step + contradict #10025. capabilities/ DIR already gone (2026-05-27). Posted finding + 3 options (downscope / close-as-superseded-by-#10025 / confirm-full-retirement-with-PM-signoff). Deleted the empty task/11505 branch (no edits made). **BLOCKED on PM/operator disambiguation of #11505↔#10025 overlap.** Do NOT execute until resolved. (Earlier CQ-AC + AC7#11683 blockers also still stand if it proceeds.)
 
 ## Next cycle
 - Check #11683 mergedAt → if shipped, for EACH branch (task/11640, task/11641, task/11587): merge origin/main, run tests/run_tests.py, confirm green, transition → pending-test.

--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -2,9 +2,9 @@
 
 - **Task**: #11587 — uvicorn loop=none (harness ProactorEventLoop fix) — COMPLETE, PR #11722
 - **Status**: in-progress — HELD pre-pending-test, gated on #11683 shipping (full-suite green)
-- **Updated**: 2026-06-13 08:14
+- **Updated**: 2026-06-13 08:42
 - **Branch**: squidsquad/task/11587 (current). Other in-flight: task/11640, task/11641.
-- **Quiet Cycle Counter**: 0 (iter-458: planned #11505)
+- **Quiet Cycle Counter**: 1 (iter-459: fully blocked — all 3 PRs MERGEABLE/CLEAN, awaiting #11683 ship)
 
 ## ⚠️ Session note
 Harness DOWN (port 59999, curl exit 7) — loop-mode (skill pinned stable per #11586). `/loop 30m` cron c8644353. cycle_pre/post DON'T fire — commit/push/PR MANUALLY. working-state.md is PER-BRANCH in git — switching branches swaps it; git tree + issue status is truth ([[learning-resume-git-tree-is-truth]]).

--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -2,12 +2,16 @@
 
 - **Task**: #11587 — uvicorn loop=none (harness ProactorEventLoop fix) — COMPLETE, PR #11722
 - **Status**: in-progress — HELD pre-pending-test, gated on #11683 shipping (full-suite green)
-- **Updated**: 2026-06-13 09:13
+- **Updated**: 2026-06-13 10:14
 - **Branch**: squidsquad/task/11587 (current). Other in-flight: task/11640, task/11641.
-- **Quiet Cycle Counter**: 0 (iter-460: caught #11505 scope conflict — real work, not quiet)
+- **Quiet Cycle Counter**: 0 (iter-462: FOUND #11586 root cause — harness was up all along; stale .harness-port)
 
-## ⚠️ Session note
-Harness DOWN (port 59999, curl exit 7) — loop-mode (skill pinned stable per #11586). `/loop 30m` cron c8644353. cycle_pre/post DON'T fire — commit/push/PR MANUALLY. working-state.md is PER-BRANCH in git — switching branches swaps it; git tree + issue status is truth ([[learning-resume-git-tree-is-truth]]).
+## ⚠️ Session note — CORRECTED iter-462
+Harness is **UP on 7373** (16h uptime, healthy) — NOT down. My loop-mode all session was caused by a STALE .harness-port=59999 in my clone (probed dead 59999→exit 7→loop). FIXED: corrected .harness-port→7373 (now curl-reachable). Mode is sticky this session (stay loop), but future boot reaches event mode. `/loop 30m` cron c8644353. working-state.md is PER-BRANCH; git tree is truth ([[learning-resume-git-tree-is-truth]]).
+
+## ⭐ #11586 ROOT CAUSE FOUND (iter-462) — stale client-side .harness-port, NOT harness availability
+Harness healthy on 7373 whole time. Agents with NO port file default to 7373 (reach harness); agent with STALE port file probes dead port→loop mode. Matrix: pm/qa=MISSING→7373✓, dm=7373✓, skill=59999(dead)→loop✗. Vector: harness _deferred_init (harness.py:1280-1294) distributes its port to all .local-config clones; an integration test starting a harness on ephemeral 59999 (find_free_port(59999), test_harness.py) writes that dead port into REAL clones, teardown doesn't restore → strands live agents. Instance of [[learning-tests-must-not-mutate-shared-live-state]]. Reported on #11586.
+**DURABLE FIX (next cycle, skill-domain, NOT gated on #11683):** (1) tests must not distribute ephemeral port into real clones (isolate .local-config / guard _deferred_init / restore in teardown); (2) harden _discover_port (event_poll.py + cycle_post.py) to treat a non-listening port-file value as stale → fall through to default/parent-walk. Own branch off main; own tests green; independent of #11683.
 
 ## THREE skill PRs in flight — ALL gated on #11683 ship
 | Issue | Fix | Branch | PR | Tests | DS | State |

--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -14,7 +14,7 @@ Harness DOWN (port 59999, curl exit 7) — loop-mode (skill pinned stable per #1
 |---|---|---|---|---|---|---|
 | #11640 | _get_clone_path raises (no REPO_ROOT fallback); spawn paths refuse | task/11640 | #11709 | 237 | NO_FINDINGS | in-progress, gated |
 | #11641 | thin_launcher reclaims stale scheduled_tasks.lock before Popen | task/11641 | #11715 | 37 | NO_FINDINGS | in-progress, gated |
-| #11587 | uvicorn loop="none" → SelectorEventLoopPolicy governs server loop | task/11587 | #11722 | 9 | running (b0gcqdjtm) | in-progress, gated |
+| #11587 | uvicorn loop="none" → SelectorEventLoopPolicy governs server loop | task/11587 | #11722 | 9 | NO_FINDINGS | in-progress, gated |
 
 All own-tests-green; each held ONLY because merging current main pulls in the #11657 stale event_poll test (the single full-suite red).
 
@@ -22,11 +22,11 @@ All own-tests-green; each held ONLY because merging current main pulls in the #1
 Unshipped ~5 cycles. DM-starvation (harness down → DM not waking). Shipping #11683 → main green → I merge into all 3 branches → all → pending-test. Escalated on #11586 (iter-455). ALSO removes a test that kills live Monitors (iter-456 triage). **Operator action: manually ship #11683.**
 
 ## #11587 detail (this cycle)
-uvicorn 0.41.0 asyncio_loop_factory hard-codes ProactorEventLoop on win32 (use_subprocess=False), bypassing the #9562 policy entirely. Server.run()→asyncio.run(serve(), loop_factory=get_loop_factory()); loop='auto'→Proactor factory. Fix: _build_uvicorn_config() sets loop='none'→factory None→asyncio.run uses new_event_loop()→respects policy→Selector. Commit a81f532e9. Read DS output (b0gcqdjtm); address real findings on PR #11722.
+uvicorn 0.41.0 asyncio_loop_factory hard-codes ProactorEventLoop on win32 (use_subprocess=False), bypassing the #9562 policy entirely. Server.run()→asyncio.run(serve(), loop_factory=get_loop_factory()); loop='auto'→Proactor factory. Fix: _build_uvicorn_config() sets loop='none'→factory None→asyncio.run uses new_event_loop()→respects policy→Selector. Commit a81f532e9. DS review DONE → NO_FINDINGS (all 5 criteria verified). PR #11722 implementation-clean. All 3 PRs now DS-clean.
 
 ## Next cycle
 - Check #11683 mergedAt → if shipped, for EACH branch (task/11640, task/11641, task/11587): merge origin/main, run tests/run_tests.py, confirm green, transition → pending-test.
-- Read #11587 DS review (b0gcqdjtm); address findings.
+- (#11587 DS review done — NO_FINDINGS; nothing to address.)
 - If harness comes back up: #11586 (A) reboot→loop-mode becomes diagnosable.
 
 ## Standing

--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -1,28 +1,34 @@
 # Working State
 
-- **Task**: none active — on main (#11538 fix shipped to pending-test, PR #11564)
-- **Status**: none (idle)
-- **Updated**: 2026-06-12 21:06
-- **Last Processed Event ID**: 9d7c2489
-- **Quiet Cycle Counter**: 0
+- **Task**: #11587 — uvicorn loop=none (harness ProactorEventLoop fix) — COMPLETE, PR #11722
+- **Status**: in-progress — HELD pre-pending-test, gated on #11683 shipping (full-suite green)
+- **Updated**: 2026-06-13 07:44
+- **Branch**: squidsquad/task/11587 (current). Other in-flight: task/11640, task/11641.
+- **Quiet Cycle Counter**: 0 (iter-457: implemented #11587)
 
 ## ⚠️ Session note
-Booted PRE-v0.44.0; runs OLD composed CLAUDE.md (reboot pending per DM — do NOT self-reboot). Harness DOWN (port 7373 exit 7) — loop-mode this session.
+Harness DOWN (port 59999, curl exit 7) — loop-mode (skill pinned stable per #11586). `/loop 30m` cron c8644353. cycle_pre/post DON'T fire — commit/push/PR MANUALLY. working-state.md is PER-BRANCH in git — switching branches swaps it; git tree + issue status is truth ([[learning-resume-git-tree-is-truth]]).
 
-## Last cycle (1642, iter-451): fixed #11538 harness restart bug
-update_health reset RESTARTING→RUNNING on every poll where the same claude PID was alive (no pid_changed guard) → HEALTH_POLL_INTERVAL=5s silently reverted any restart of a still-alive/wedged agent AND disarmed the 60s force-kill net. Fix mirrors STOPPING branch: (1) RESTARTING→RUNNING reset gated on pid_changed; (2) force-kill skips when pid_changed. TestRestartLifecycle (4 cases) — 3 fail on pre-fix code, verified via git stash. 184 harness tests + run_tests.py green. → pending-test, PR #11564, back on main.
+## THREE skill PRs in flight — ALL gated on #11683 ship
+| Issue | Fix | Branch | PR | Tests | DS | State |
+|---|---|---|---|---|---|---|
+| #11640 | _get_clone_path raises (no REPO_ROOT fallback); spawn paths refuse | task/11640 | #11709 | 237 | NO_FINDINGS | in-progress, gated |
+| #11641 | thin_launcher reclaims stale scheduled_tasks.lock before Popen | task/11641 | #11715 | 37 | NO_FINDINGS | in-progress, gated |
+| #11587 | uvicorn loop="none" → SelectorEventLoopPolicy governs server loop | task/11587 | #11722 | 9 | running (b0gcqdjtm) | in-progress, gated |
+
+All own-tests-green; each held ONLY because merging current main pulls in the #11657 stale event_poll test (the single full-suite red).
+
+## ⚠️ The shared gate: #11683 (carries #11657 + #11503), pending-ship, MERGEABLE
+Unshipped ~5 cycles. DM-starvation (harness down → DM not waking). Shipping #11683 → main green → I merge into all 3 branches → all → pending-test. Escalated on #11586 (iter-455). ALSO removes a test that kills live Monitors (iter-456 triage). **Operator action: manually ship #11683.**
+
+## #11587 detail (this cycle)
+uvicorn 0.41.0 asyncio_loop_factory hard-codes ProactorEventLoop on win32 (use_subprocess=False), bypassing the #9562 policy entirely. Server.run()→asyncio.run(serve(), loop_factory=get_loop_factory()); loop='auto'→Proactor factory. Fix: _build_uvicorn_config() sets loop='none'→factory None→asyncio.run uses new_event_loop()→respects policy→Selector. Commit a81f532e9. Read DS output (b0gcqdjtm); address real findings on PR #11722.
+
+## Next cycle
+- Check #11683 mergedAt → if shipped, for EACH branch (task/11640, task/11641, task/11587): merge origin/main, run tests/run_tests.py, confirm green, transition → pending-test.
+- Read #11587 DS review (b0gcqdjtm); address findings.
+- If harness comes back up: #11586 (A) reboot→loop-mode becomes diagnosable.
 
 ## Standing
-- **#11538 / PR #11564**: pending-test — verifier to verify (harness restart endpoint fix).
-- **#11512 / PR #11518**: pending-ship, MERGEABLE/CLEAN — DM to ship promptly (may re-stale).
-- **#11519 / PR #11530**: pending-ship — DM to ship.
-- **#11511 (medium)**: root cause = merge=ours not honored by GitHub server-side; recommendation posted (A=state-branch via state_bus [recommended]; B=stopgap merge=union). Awaiting PM/operator decision. NOT implementing (high blast radius).
-
-## Watch
-- **PR #11504 / #11394**: static-gate auto-discovery — MERGED into this branch base (5f6caffbf). On confirmed merge → #11503/#11505 ungated.
-- #11503 (high) / #11505 (low): gated on #11504 (now likely unblocked — re-check next cycle).
-- #10690 / #10686 (E7): operator-gated.
-- #11329 (approved): runtime per-event ack-cursor.
-
-## ⚠️ Recurring conflict note
-PR CONFLICTING-while-locally-clean = merge=ours custom driver not honored by GitHub server-side (#11511). Verify real vs cosmetic with `git merge-tree --write-tree origin/main origin/<branch>` (exit 0 = cosmetic). Real fix = state-branch (state_bus, unwired). See [[learning-pr-conflicting-flag-can-be-cosmetic]].
+- **#11538 / PR #11564**: ✅ SHIPPED. **#11716 (low)**: improvement-scan filed (run_tests.py target drift) — awaiting triage.
+- **#11586 (high)**: event-mode/DM-starvation — (B) resolved (folds into #11683), (A) reboot→loop-mode open, operator/harness-gated. **#11511**: PR conflict-flap, NOT implementing (awaiting PM/operator). #10690/#10686: E6/E7/operator-gated. #11505 (low): deadwood.

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -3077,6 +3077,34 @@ class CtrlCHandler:
 # Main
 # ---------------------------------------------------------------------------
 
+def _build_uvicorn_config(app_, host, port, log_level="warning"):
+    """Build the harness's uvicorn Config (#11587).
+
+    ``loop="none"`` is load-bearing on Windows. uvicorn's default
+    ``loop="auto"`` resolves (no uvloop on Windows) to
+    ``uvicorn.loops.asyncio.asyncio_loop_factory``, which HARD-CODES
+    ``asyncio.ProactorEventLoop`` on win32 — it bypasses the process
+    event-loop policy entirely. So the ``WindowsSelectorEventLoopPolicy`` set
+    in ``main()`` (#9562) never reaches the server loop that actually runs in
+    the uvicorn daemon thread, and the ProactorEventLoop ConnectionResetError
+    (WinError 10054) recurs (#11587).
+
+    ``loop="none"`` makes uvicorn pass ``loop_factory=None`` to ``asyncio.run``,
+    which creates the loop via ``asyncio.new_event_loop()`` — and THAT respects
+    the policy, yielding a SelectorEventLoop. Verified against uvicorn 0.41.0
+    (``Config(loop="none").get_loop_factory() is None``). Cross-platform safe:
+    on Linux the policy default is already SelectorEventLoop, so ``loop="none"``
+    changes nothing there.
+    """
+    return uvicorn.Config(
+        app_,
+        host=host,
+        port=port,
+        log_level=log_level,
+        loop="none",
+    )
+
+
 def main():
     # On Windows, the default ProactorEventLoop's cleanup path
     # (_ProactorBasePipeTransport._call_connection_lost) does not handle
@@ -3168,12 +3196,10 @@ def main():
     # for signal handling. On Windows, signal handlers set via
     # signal.signal() only fire in the main thread — if uvicorn.run()
     # blocks the main thread, Ctrl+C is never delivered to our handler.
-    config = uvicorn.Config(
-        app,
-        host="127.0.0.1",
-        port=actual_port,
-        log_level="warning",
-    )
+    # #11587: loop="none" (set inside _build_uvicorn_config) is what makes the
+    # #9562 WindowsSelectorEventLoopPolicy above actually govern the server loop
+    # running in this daemon thread — otherwise uvicorn imposes a ProactorEventLoop.
+    config = _build_uvicorn_config(app, host="127.0.0.1", port=actual_port)
     server = uvicorn.Server(config)
 
     server_thread = threading.Thread(target=server.run, daemon=True, name="uvicorn")

--- a/tests/test_11587_uvicorn_selector_loop.py
+++ b/tests/test_11587_uvicorn_selector_loop.py
@@ -1,0 +1,147 @@
+"""Tests for #11587 — uvicorn must not impose a ProactorEventLoop on Windows.
+
+Background: #9562 set ``WindowsSelectorEventLoopPolicy`` in ``harness.main()``
+to dodge the ProactorEventLoop ``ConnectionResetError`` (WinError 10054) HTTP
+wedge. But the exception kept recurring (#11587): uvicorn's default
+``loop="auto"`` resolves (no uvloop on Windows) to
+``uvicorn.loops.asyncio.asyncio_loop_factory``, which HARD-CODES
+``asyncio.ProactorEventLoop`` on win32 — bypassing the event-loop *policy*
+entirely. So the server loop that actually runs in uvicorn's daemon thread is a
+ProactorEventLoop regardless of the main-thread policy.
+
+Fix (#11587): the harness builds its uvicorn Config via
+``_build_uvicorn_config()``, which sets ``loop="none"``. That makes uvicorn pass
+``loop_factory=None`` to ``asyncio.run``, which creates the loop via
+``asyncio.new_event_loop()`` — respecting the policy and yielding a
+SelectorEventLoop.
+
+These tests pin BOTH the behavioral contract (the harness Config's loop factory
+is ``None``) and the rationale (the default ``loop="auto"`` WOULD yield a
+ProactorEventLoop on win32), plus the source wiring (``main()`` uses the helper
+so the fix can't be silently reverted to an inline ``uvicorn.Config(...)``).
+"""
+
+import asyncio
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO_ROOT / "references" / "scripts"
+HARNESS_PATH = SCRIPTS / "harness.py"
+
+
+def _load_module(name, source):
+    spec = importlib.util.spec_from_file_location(name, source)
+    if not (spec and spec.loader):
+        raise ImportError(f"cannot build spec for {source}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+try:
+    _harness = _load_module("_harness_for_11587", HARNESS_PATH)
+    HARNESS_AVAILABLE = True
+except Exception as _e:  # pragma: no cover - env-dependent
+    print(
+        f"[test_11587] harness import failed: {type(_e).__name__}: {_e}",
+        file=sys.stderr,
+    )
+    HARNESS_AVAILABLE = False
+    _harness = None  # type: ignore
+
+
+async def _dummy_app(scope, receive, send):  # pragma: no cover - never called
+    pass
+
+
+@unittest.skipUnless(HARNESS_AVAILABLE, "harness.py could not be imported here")
+class TestHarnessUvicornLoopFactory(unittest.TestCase):
+    def _config(self):
+        return _harness._build_uvicorn_config(_dummy_app, host="127.0.0.1", port=0)
+
+    def test_harness_config_loop_is_none(self):
+        """The harness Config must set ``loop="none"`` so uvicorn does not
+        impose its own (win32-Proactor) loop factory."""
+        self.assertEqual(self._config().loop, "none")
+
+    def test_harness_config_loop_factory_is_none(self):
+        """``loop="none"`` -> ``get_loop_factory()`` returns None -> uvicorn
+        passes ``loop_factory=None`` to ``asyncio.run``, which builds the loop
+        via ``new_event_loop()`` and so respects the #9562
+        ``WindowsSelectorEventLoopPolicy``. This None is the whole fix (#11587)."""
+        self.assertIsNone(self._config().get_loop_factory())
+
+    def test_default_auto_loop_would_be_proactor_on_win32(self):
+        """Rationale lock: prove the bug is real and ``loop="none"`` is
+        load-bearing. The DEFAULT ``loop="auto"`` resolves to a
+        ProactorEventLoop factory on win32 — exactly what bypasses the policy.
+        (No-op off win32, where the factory is Selector anyway.)"""
+        import uvicorn
+
+        auto_factory = uvicorn.Config(
+            _dummy_app, host="127.0.0.1", port=0
+        ).get_loop_factory()
+        if sys.platform != "win32":
+            self.skipTest("ProactorEventLoop factory is win32-specific")
+        self.assertIsNotNone(
+            auto_factory,
+            msg="expected uvicorn loop='auto' to yield a concrete factory on win32",
+        )
+        loop = auto_factory()
+        try:
+            self.assertEqual(
+                type(loop).__name__,
+                "ProactorEventLoop",
+                msg=(
+                    "uvicorn loop='auto' should hard-code ProactorEventLoop on "
+                    "win32 — if this changed, the #11587 rationale needs review."
+                ),
+            )
+        finally:
+            loop.close()
+
+    def test_none_factory_under_policy_yields_selector_on_win32(self):
+        """End-to-end net effect on win32: with the loop factory deferred (None,
+        from our Config) AND the #9562 policy set, the loop asyncio creates is a
+        Selector loop — never Proactor."""
+        if sys.platform != "win32":
+            self.skipTest("Selector-vs-Proactor distinction is win32-specific")
+        self.assertIsNone(self._config().get_loop_factory())
+        prev = asyncio.get_event_loop_policy()
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+        try:
+            loop = asyncio.new_event_loop()
+            try:
+                name = type(loop).__name__
+                self.assertNotIn("Proactor", name)
+                self.assertIn("Selector", name)
+            finally:
+                loop.close()
+        finally:
+            asyncio.set_event_loop_policy(prev)
+
+
+class TestHarnessUvicornLoopWiring(unittest.TestCase):
+    """Source-level wiring: ``main()`` must build its Config via the helper, so
+    the ``loop="none"`` fix cannot be silently bypassed by reverting to an
+    inline ``uvicorn.Config(...)`` call."""
+
+    def setUp(self):
+        self.source = HARNESS_PATH.read_text(encoding="utf-8")
+
+    def test_main_uses_build_uvicorn_config_helper(self):
+        self.assertIn(
+            "_build_uvicorn_config(",
+            self.source,
+            msg="main() must construct its uvicorn Config via _build_uvicorn_config().",
+        )
+
+    def test_helper_sets_loop_none(self):
+        self.assertRegex(
+            self.source,
+            r'loop\s*=\s*["\']none["\']',
+            msg='_build_uvicorn_config must set loop="none" (#11587).',
+        )


### PR DESCRIPTION
## #11587 — uvicorn imposes a ProactorEventLoop on Windows, defeating the #9562 policy

The #9562 `WindowsSelectorEventLoopPolicy` set in `harness.main()` never reached the loop that actually runs the HTTP server. uvicorn runs `server.run()` in a **daemon thread**, and its default `loop="auto"` resolves (no uvloop on Windows) to `uvicorn.loops.asyncio.asyncio_loop_factory`, which **hard-codes** `asyncio.ProactorEventLoop` on win32 — it bypasses the event-loop *policy* entirely. So the recurring ProactorEventLoop `ConnectionResetError` (WinError 10054) cleanup wedge kept firing despite #9562.

### Root cause (verified against installed uvicorn 0.41.0)
```
uvicorn.loops.asyncio.asyncio_loop_factory(use_subprocess=False):
    if sys.platform == "win32" and not use_subprocess:
        return asyncio.ProactorEventLoop   # ← ignores the policy
    return asyncio.SelectorEventLoop
Server.run() -> asyncio.run(serve(), loop_factory=config.get_loop_factory())
```
`Config(loop="auto").get_loop_factory()` → `ProactorEventLoop` on win32. The policy is never consulted.

### Fix
New `_build_uvicorn_config()` helper sets **`loop="none"`**; `main()` builds its Config via the helper. `loop="none"` → `get_loop_factory()` returns `None` → uvicorn passes `loop_factory=None` to `asyncio.run` → loop created via `asyncio.new_event_loop()` → **respects** the global `WindowsSelectorEventLoopPolicy` → SelectorEventLoop. Verified: `Config(loop="none").get_loop_factory() is None`, and under the policy `new_event_loop()` is `_WindowsSelectorEventLoop`. Cross-platform safe — on Linux the policy default is already SelectorEventLoop, so `loop="none"` is a no-op there.

### Tests — `tests/test_11587_uvicorn_selector_loop.py` (5 new + 4 #9562 regression = 9 pass)
- harness Config sets `loop="none"` and `get_loop_factory()` is `None` (the contract that defers to the policy).
- **rationale lock**: default `loop="auto"` yields a `ProactorEventLoop` factory on win32 — proves the fix is load-bearing, not cosmetic.
- **end-to-end**: factory `None` + #9562 policy ⇒ Selector loop, never Proactor (win32).
- **wiring**: `main()` builds its Config via the helper, so the fix can't be silently reverted to an inline `uvicorn.Config(...)`.

### AC coverage (#11587)
- [x] Confirmed uvicorn `loop="auto"` overrides the SelectorEventLoopPolicy in the daemon thread (it hard-codes ProactorEventLoop on win32).
- [x] #9562 fix now also constrains uvicorn's loop (`loop="none"` → policy-respecting loop creation).
- [x] Verified against the actual installed uvicorn version (0.41.0).

### ⚠️ Full-suite gating note (not a defect in this PR)
The repo full suite has **one** pre-existing red — `test_event_poll_exits_cleanly_when_harness_unreachable` (stale pre-#11601 contract) — which is **#11657**, verified + **pending-ship on PR #11683**, unrelated. This PR's own tests are green; transitions to pending-test once #11683 ships to main and main is merged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
