### PR TITLE
skill: #11745 — self-closing Windows agent terminals (no orphan tabs)

### DIFF
--- a/references/scripts/boot_remote.py
+++ b/references/scripts/boot_remote.py
@@ -380,52 +380,65 @@ def _spawn_terminal(clone_root, role, boot_script, script_type):
 
 
 def _spawn_windows(clone_root, role, script_path, script_type):
-    """Spawn on Windows using wt.exe or fallback. Returns (success, message, terminal_pid)."""
-    wt = shutil.which("wt")
-    if wt:
-        try:
-            if script_type == "thin":
-                cmd = [wt, "new-tab", "--title", f"squidsquad-{role}",
-                       "-d", str(clone_root),
-                       "python", script_path, role]
-            elif script_type == "ps1":
-                cmd = [wt, "new-tab", "--title", f"squidsquad-{role}",
-                       "-d", str(clone_root),
-                       "pwsh", "-NoExit", "-File", script_path]
-            else:
-                cmd = [wt, "new-tab", "--title", f"squidsquad-{role}",
-                       "-d", str(clone_root),
-                       "bash", script_path]
-            proc = subprocess.Popen(
-                cmd,
-                creationflags=subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP,
-                cwd=str(clone_root),
-            )
-            launcher = "thin launcher" if script_type == "thin" else "wt.exe"
-            # wt.exe exits after creating the tab — proc.pid is short-lived (#7630 P-5)
-            return True, f"spawned via {launcher} (Windows Terminal)", proc.pid
-        except Exception as e:
-            return False, f"wt.exe spawn failed: {e}", None
+    """Spawn on Windows in a self-closing console window. Returns (success, message, terminal_pid).
 
-    # Fallback: cmd /c start
+    #11745 (operator-ratified Option A, 2026-06-13): spawn via ``cmd /c start``
+    rather than ``wt new-tab``. A Windows Terminal tab's close behavior is
+    governed solely by the profile's ``closeOnExit`` (default ``automatic``,
+    which for a directly-launched command behaves as ``graceful`` → the tab
+    stays open on a non-zero/killed exit), and there is NO wt CLI flag to
+    override it (microsoft/terminal#15747). So a killed agent orphaned its tab,
+    and orphans piled up across reboots. ``start`` instead opens a standalone
+    console window whose lifetime IS the spawned process's: the OS closes the
+    window when the process exits with ANY code — no orphan accumulation. The
+    trade-off (separate windows instead of unified wt tabs) was accepted by the
+    operator. ``/D`` sets the window's working directory (replaces wt's ``-d``).
+    """
+    title = f"squidsquad-{role}"
+    if script_type == "thin":
+        inner = ["python", script_path, role]
+    elif script_type == "ps1":
+        # Drop -NoExit (#11745): it pinned pwsh open forever after the boot
+        # script returned, which is itself a guaranteed-orphan source.
+        inner = ["pwsh", "-File", script_path]
+    else:
+        inner = ["bash", script_path]
+
+    def _q(value):
+        """Quote a token for the cmd.exe command line if it has spaces/is empty."""
+        text = str(value)
+        return '"' + text + '"' if (" " in text or not text) else text
+
     try:
-        if script_type == "thin":
-            cmd = ["cmd", "/c", "start", f"squidsquad-{role}",
-                   "python", script_path, role]
-        elif script_type == "ps1":
-            cmd = ["cmd", "/c", "start", f"squidsquad-{role}",
-                   "pwsh", "-NoExit", "-File", script_path]
-        else:
-            cmd = ["cmd", "/c", "start", f"squidsquad-{role}",
-                   "bash", script_path]
+        # Build the command line BY HAND and pass it to Popen as a string so
+        # Windows uses it verbatim. A list would route through list2cmdline,
+        # which does NOT quote a no-space token — and `START`'s syntax is
+        # `start ["title"] [/D dir] command`: an UNquoted first token is taken
+        # as the *program to run*, not the window title. So `start squidsquad-skill
+        # python ...` would try to exec `squidsquad-skill` and the agent would
+        # never launch. The title MUST be quoted (#11745 DS Finding 1).
+        #
+        # Known limitation (#11745 DS Finding 2): because this routes through
+        # `cmd /c`, cmd.exe interprets metacharacters (& | < > ^ %) in the
+        # path/args. Clone roots and script paths come from the controlled
+        # project filesystem and role names are [\w-]+, so such characters do
+        # not occur in practice — this is a documented unsupported input class,
+        # not a silent break.
+        start_cmd = " ".join(
+            ["cmd", "/c", "start", '"' + title + '"', "/D", _q(clone_root)]
+            + [_q(arg) for arg in inner]
+        )
         proc = subprocess.Popen(
-            cmd,
+            start_cmd,
             creationflags=subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP,
             cwd=str(clone_root),
         )
-        return True, "spawned via cmd /c start (fallback)", proc.pid
+        # cmd.exe exits after issuing `start` — proc.pid is short-lived, as the
+        # prior wt path also noted (#7630 P-5). The self-closing console it
+        # spawned owns the agent process.
+        return True, "spawned via cmd /c start (self-closing window, #11745)", proc.pid
     except Exception as e:
-        return False, f"Windows fallback spawn failed: {e}", None
+        return False, f"Windows spawn failed: {e}", None
 
 
 def _spawn_macos(clone_root, role, script_path, script_type):

--- a/tests/test_boot_remote.py
+++ b/tests/test_boot_remote.py
@@ -569,6 +569,104 @@ class TestSpawnMacosTempFile:
 
 
 # ---------------------------------------------------------------------------
+# #11745 — _spawn_windows uses a self-closing console window, not a wt tab
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform != "win32",
+                    reason="_spawn_windows evaluates Windows-only subprocess "
+                           "creation flags (DETACHED_PROCESS); Windows-only path")
+class TestSpawnWindows11745:
+    """#11745: a killed agent must not leave an orphan terminal. The Windows
+    spawn was switched from ``wt new-tab`` (whose tab close is governed by the
+    profile's closeOnExit and stays open on a non-zero/killed exit, with no CLI
+    override — microsoft/terminal#15747) to ``cmd /c start``, which opens a
+    standalone console the OS closes on ANY exit code. These tests lock the
+    spawn-command construction; the live spawn→kill→window-gone cycle is
+    verifier/operator manual verification (per the issue AC).
+    """
+
+    @patch("boot_remote.subprocess.Popen")
+    def test_thin_spawns_self_closing_cmd_start(self, mock_popen, tmp_path):
+        """thin launcher → `cmd /c start "title" /D <dir> python <script> <role>`.
+
+        Popen receives a STRING (not a list) so Windows uses it verbatim — and
+        the title MUST be quoted (DS Finding 1: an unquoted no-space first token
+        is taken by START as the program to run, not the window title).
+        """
+        mock_popen.return_value.pid = 4321
+        script = str(tmp_path / "thin_launcher.py")
+        ok, msg, pid = boot_remote._spawn_windows(tmp_path, "skill", script, "thin")
+
+        assert ok is True
+        assert pid == 4321
+        cmd = mock_popen.call_args[0][0]
+        assert isinstance(cmd, str)
+        # Title MUST be quoted, else START misreads it as the program (Finding 1)
+        assert 'cmd /c start "squidsquad-skill"' in cmd
+        assert "/D" in cmd                          # working directory flag
+        assert "python" in cmd
+        assert script in cmd
+        assert cmd.rstrip().endswith("skill")       # the role arg
+
+    @patch("boot_remote.subprocess.Popen")
+    def test_does_not_use_wt_new_tab(self, mock_popen, tmp_path):
+        """The orphaning wt-tab path must be gone — no `wt new-tab` invocation."""
+        mock_popen.return_value.pid = 1
+        script = str(tmp_path / "thin_launcher.py")
+        boot_remote._spawn_windows(tmp_path, "skill", script, "thin")
+
+        cmd = mock_popen.call_args[0][0]
+        assert "new-tab" not in cmd
+        assert "wt " not in cmd and "wt.exe" not in cmd
+
+    @patch("boot_remote.subprocess.Popen")
+    def test_ps1_path_drops_noexit(self, mock_popen, tmp_path):
+        """Legacy ps1 path must NOT carry -NoExit (a guaranteed-orphan source)."""
+        mock_popen.return_value.pid = 2
+        script = str(tmp_path / "start-skill.ps1")
+        ok, _msg, _pid = boot_remote._spawn_windows(tmp_path, "skill", script, "ps1")
+
+        assert ok is True
+        cmd = mock_popen.call_args[0][0]
+        assert "-NoExit" not in cmd
+        assert "pwsh" in cmd and "-File" in cmd
+        assert 'start "squidsquad-skill"' in cmd     # title still quoted
+
+    @patch("boot_remote.subprocess.Popen")
+    def test_detached_creation_flags_preserved(self, mock_popen, tmp_path):
+        """Spawn stays detached so the parent harness isn't bound to the window."""
+        mock_popen.return_value.pid = 3
+        script = str(tmp_path / "thin_launcher.py")
+        boot_remote._spawn_windows(tmp_path, "skill", script, "thin")
+
+        flags = mock_popen.call_args[1]["creationflags"]
+        assert flags & boot_remote.subprocess.DETACHED_PROCESS
+        assert flags & boot_remote.subprocess.CREATE_NEW_PROCESS_GROUP
+
+    @patch("boot_remote.subprocess.Popen")
+    def test_clone_root_with_spaces_is_quoted(self, mock_popen, tmp_path):
+        """A clone path containing spaces must be quoted after /D (Finding 1 sibling)."""
+        mock_popen.return_value.pid = 9
+        spaced = tmp_path / "clone with space"
+        spaced.mkdir()
+        script = str(spaced / "thin_launcher.py")
+        boot_remote._spawn_windows(spaced, "skill", script, "thin")
+
+        cmd = mock_popen.call_args[0][0]
+        assert f'/D "{spaced}"' in cmd
+
+    def test_spawn_failure_returns_false(self, tmp_path):
+        """When subprocess.Popen raises, _spawn_windows returns (False, error, None)."""
+        script = str(tmp_path / "thin_launcher.py")
+        with patch("boot_remote.subprocess.Popen", side_effect=OSError("boom")):
+            ok, msg, pid = boot_remote._spawn_windows(tmp_path, "skill", script, "thin")
+        assert ok is False
+        assert "Windows spawn failed" in msg
+        assert pid is None
+
+
+# ---------------------------------------------------------------------------
 # #9941 — _write_booting_sentinel atomic create-or-fail
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #11745 (operator-ratified Option A, 2026-06-13).

## Problem
Killing an agent left its Windows Terminal tab open; orphans piled up across reboots/restarts. A wt tab's close is governed solely by the profile's `closeOnExit` (default `automatic`→`graceful` keeps the tab open on a non-zero/killed exit) and there is **no wt CLI flag** to override it ([microsoft/terminal#15747](https://github.com/microsoft/terminal/issues/15747)).

## Fix
`_spawn_windows` now spawns via `cmd /c start` — a standalone console window the OS closes when the process exits with **any** exit code, so orphans never accumulate. Also drops the legacy ps1 path's `pwsh -NoExit` (a guaranteed-orphan source).

The command is built as a quoted **string** passed to `Popen` verbatim: `START` requires the title double-quoted, otherwise an unquoted no-space token is taken as the *program to run* — **this would have broken every Windows spawn** and was caught by the DS review (Finding 1). Spaced paths are quoted via a `_q` helper.

## Trade-off / scope
- Separate windows instead of unified wt tabs (operator-accepted).
- cmd metacharacters (`& | < > ^ %`) in clone/script paths are a documented unsupported-input class (controlled filesystem, `[\w-]` role names).
- macOS/Linux orphan handling is **follow-up** — Option A's mechanism is Windows-specific; Windows is the immediate pain.

## Tests / review
- `TestSpawnWindows11745` (win32-guarded) locks the spawn-command construction incl. title-quoting and spaced-path cases.
- Full suite green (run_tests.py exit 0).
- DeepSeek review: initial pass caught the title-quoting bug; re-review after fix = **NO_FINDINGS**.
- Live spawn→kill→window-gone cycle = verifier/operator manual verification (per the issue AC).

## Upgrade awareness
`boot_remote.py` ships to all installs; existing installs get the fix on `/squidsquad-upgrade` + agent reboot. Behavior change (tabs→separate windows) is visible post-reboot. No config/migration needed.