### PR TITLE
#11511: advisory mergeability + pre-commit state guard (Parts 1+2)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -32,3 +32,9 @@
 # merge=union would produce duplicate field lines (invalid config).
 # Version regressions caught by _validate_config_version().
 .squidsquad/config.md merge=ours
+
+# Git hooks are POSIX /bin/sh scripts — force LF so the shebang never breaks on
+# a CRLF checkout. core.autocrlf=true on Windows would otherwise risk a CRLF
+# blob, which yields `/bin/sh^M: bad interpreter` and a silently dead state
+# guard on POSIX clones (#11511 Part 2).
+references/git-hooks/* text eol=lf

--- a/.squidsquad/config.md
+++ b/.squidsquad/config.md
@@ -113,7 +113,7 @@
 ## Auto Versioning
 
 - **Ship Threshold**: 10
-- **Shipped Since Last Bump**: 13
+- **Shipped Since Last Bump**: 12
 
 ## Agent Effort
 

--- a/references/git-hooks/pre-commit
+++ b/references/git-hooks/pre-commit
@@ -1,0 +1,19 @@
+#!/bin/sh
+# SquidSquad pre-commit guard (#11511) — keep transient state off feature branches.
+#
+# When a commit lands on a non-working (feature) branch, any staged
+# .squidsquad/ or .claude/ state/ephemeral file is UNSTAGED before the commit
+# is created. This backstops the raw-git path (POLLING mode / branch races)
+# that bypasses git_ops' already-safe commit-code / commit-state routing, which
+# is what flaps PR mergeability to CONFLICTING (transient state on main + the
+# feature branch -> GitHub sees an overlapping-line conflict).
+#
+# FAIL-OPEN by design: the guard never blocks a commit (a blocking hook could
+# wedge every agent's cycle). All logic lives in the tested git_ops subcommand;
+# this shim only invokes it and always exits 0.
+# No 2>&1: the guard prints its unstaged-file notice to stderr on purpose, and
+# merging it into stdout would hide it (git only reliably surfaces hook stderr).
+python references/scripts/git_ops.py guard-staged-state \
+  || python3 references/scripts/git_ops.py guard-staged-state \
+  || true
+exit 0

--- a/references/installer-files.txt
+++ b/references/installer-files.txt
@@ -1,7 +1,7 @@
 # SquidSquad installer file manifest
 # Every file the wizard needs, fetched by npx squidsquad before
 # launching Claude. One path per line, relative to repo root.
-# Total: 196 files
+# Total: 197 files
 #
 # Maintained alongside the wizard - when you add a new role,
 # capability, preset, or sub-skill, add its files here too.
@@ -50,6 +50,7 @@ references/scripts/vault_entity.py
 references/scripts/vault_optimize.py
 references/scripts/vault_remember.py
 references/scripts/wizard.py
+references/git-hooks/pre-commit
 references/roles/worker/android/includes.yml
 references/roles/worker/android/instructions.md
 references/roles/worker/android/SOUL.md

--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -22,6 +22,7 @@ Usage:
     python scripts/git_ops.py task-end <role> <number>    # return to working branch
     python scripts/git_ops.py has-changes               # check if working tree dirty
     python scripts/git_ops.py last-hash                 # print last commit hash (short)
+    python scripts/git_ops.py check-real-conflict <base> <head>  # real conflict? exit 0=clean/1=conflict/2=err
     python scripts/git_ops.py --help
 """
 
@@ -985,6 +986,52 @@ def last_hash():
     return h
 
 
+def check_real_conflict(base, head):
+    """Report whether merging <head> into <base> has a REAL content conflict.
+
+    GitHub flags a PR ``CONFLICTING`` whenever transient files (e.g.
+    ``working-state.md``) differ across branch and base — even when there is no
+    real conflict — because GitHub honors NO user ``.gitattributes`` merge
+    driver server-side (community discussion #9288; see
+    [[learning-pr-conflicting-flag-can-be-cosmetic]]). This helper is the
+    deterministic ground truth so agents/DM treat GitHub's flag as ADVISORY and
+    stop burning cycles hand-nudging cosmetic flaps (#11511).
+
+    Runs ``git merge-tree --write-tree`` (a non-destructive, in-memory three-way
+    merge) in BOTH directions; a real conflict in either is a real conflict.
+    Refs should be ``origin/*`` so the comparison matches what GitHub evaluates
+    — callers should ``git fetch`` first.
+
+    Returns True (clean), False (real conflict), or None (a ref won't resolve).
+    main() maps these to exit 0 / 1 / 2.
+    """
+    for ref in (base, head):
+        rc = _run_list(["git", "rev-parse", "--verify", "--quiet", ref], check=False)
+        if rc.returncode != 0:
+            print(f"ERROR: cannot resolve ref '{ref}' -- fetch first "
+                  f"(e.g. `git fetch origin`)?", file=sys.stderr)
+            return None
+
+    conflict_lines = []
+    real_conflict = False
+    for a, b in ((base, head), (head, base)):
+        result = _run_list(["git", "merge-tree", "--write-tree", a, b], check=False)
+        if result.returncode != 0:
+            real_conflict = True
+            conflict_lines += [l for l in result.stdout.splitlines()
+                               if "CONFLICT" in l or l.startswith("Conflict")]
+
+    if not real_conflict:
+        print(f"CLEAN: no real conflict merging {head} into {base} "
+              f"(any GitHub CONFLICTING flag is cosmetic -- merge on content)")
+        return True
+
+    print(f"CONFLICT: real merge conflict merging {head} into {base}")
+    for l in dict.fromkeys(conflict_lines):  # de-dup, preserve order
+        print(f"  {l}")
+    return False
+
+
 def _parse_args():
     args = sys.argv[1:]
     if not args or args[0] == "--help":
@@ -1085,6 +1132,15 @@ def main():
         has_changes()
     elif cmd == "last-hash":
         last_hash()
+    elif cmd == "check-real-conflict":
+        if len(rest) < 2:
+            print("Usage: git_ops.py check-real-conflict <base-ref> <head-ref>",
+                  file=sys.stderr)
+            sys.exit(2)
+        verdict = check_real_conflict(rest[0], rest[1])
+        if verdict is None:
+            sys.exit(2)        # could not resolve a ref
+        sys.exit(0 if verdict else 1)   # 0 = clean, 1 = real conflict
     else:
         print(f"Unknown command: {cmd}", file=sys.stderr)
         sys.exit(1)

--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -23,6 +23,8 @@ Usage:
     python scripts/git_ops.py has-changes               # check if working tree dirty
     python scripts/git_ops.py last-hash                 # print last commit hash (short)
     python scripts/git_ops.py check-real-conflict <base> <head>  # real conflict? exit 0=clean/1=conflict/2=err
+    python scripts/git_ops.py guard-staged-state         # pre-commit hook: unstage state files on a feature branch (fail-open)
+    python scripts/git_ops.py install-hooks              # activate the pre-commit state guard (core.hooksPath)
     python scripts/git_ops.py --help
 """
 
@@ -1032,6 +1034,170 @@ def check_real_conflict(base, head):
     return False
 
 
+# Path to the tracked git-hooks directory, repo-relative (the value we set
+# core.hooksPath to). Tracked in-repo so the hook is version-controlled and
+# ships via installer-files.txt — no copy-into-.git/hooks step needed.
+_HOOKS_DIR_REL = "references/git-hooks"
+
+
+def guard_staged_state():
+    """Unstage transient state/ephemeral files when committing to a feature branch (#11511).
+
+    git_ops' own commit paths already route state correctly: ``commit_code``
+    stages code only, ``commit_role_scoped`` refuses off the working branch
+    (#11083), ``commit_state`` errors off it. The remaining leak is a RAW
+    ``git add -A && git commit`` (POLLING mode / branch races) that bypasses
+    git_ops and sweeps ``.squidsquad/<role>/working-state.md`` (and siblings)
+    onto a feature branch. That is what flaps PR mergeability to CONFLICTING
+    (the file differs across the branch and main on overlapping lines, and
+    GitHub honors no user .gitattributes merge driver server-side — see
+    [[learning-pr-conflicting-flag-can-be-cosmetic]]).
+
+    Installed as a ``pre-commit`` hook, this guard fires on every commit:
+
+    - On the configured working branch (or a detached/unknown HEAD): no-op.
+    - On any other (feature) branch: unstage every staged file classified as
+      state/ephemeral by ``_is_state_file`` (the SAME classifier ``commit_code``
+      uses, so routing stays single-source). The files stay in the working
+      tree for the next working-branch cycle to commit: ``.squidsquad/`` files
+      via ``commit_state``; ``.claude/`` files via the working branch's normal
+      state-commit path (``commit_state`` stages only ``.squidsquad/``).
+
+    FAIL-OPEN: always returns normally (exit 0 at the call site). A pre-commit
+    hook that aborts could wedge every agent's cycle, so this guard only ever
+    *narrows* a commit, never blocks one.
+
+    Returns the list of paths it unstaged (empty when it was a no-op).
+    """
+    working = _get_working_branch()
+    # check=False: a failing `git branch --show-current` (corrupt HEAD, perms)
+    # must not raise mid-commit -- empty `current` falls through to fail-open.
+    current = _run("git branch --show-current", check=False).stdout.strip()
+    # Empty current = detached HEAD or no branch -> can't classify; stay out of
+    # the way (fail-open). On the working branch, state belongs here -> no-op.
+    if not current or current == working:
+        return []
+
+    staged = _run_list(["git", "diff", "--cached", "--name-only"], check=False)
+    if staged.returncode != 0:
+        return []
+    state_staged = [p.strip().strip('"') for p in staged.stdout.splitlines()
+                    if p.strip() and _is_state_file(p.strip().strip('"'))]
+    if not state_staged:
+        return []
+
+    # Unstage (reset, not restore --staged: works on older git and leaves the
+    # working-tree copy untouched). Per-path so one bad path can't drop the lot.
+    for p in state_staged:
+        _run_list(["git", "reset", "-q", "HEAD", "--", p], check=False)
+
+    print(
+        f"WARNING: pre-commit guard unstaged {len(state_staged)} transient "
+        f"state file(s) from feature branch '{current}' (state belongs on "
+        f"'{working}', not in a PR -- #11511):",
+        file=sys.stderr,
+    )
+    for p in state_staged[:20]:
+        print(f"  {p}", file=sys.stderr)
+    if len(state_staged) > 20:
+        print(f"  ... and {len(state_staged) - 20} more", file=sys.stderr)
+    return state_staged
+
+
+def install_hooks():
+    """Activate the tracked pre-commit guard by pointing core.hooksPath at it (#11511).
+
+    Idempotent. Sets ``core.hooksPath`` to the in-repo ``references/git-hooks``
+    directory (tracked, version-controlled) and makes the ``pre-commit`` shim
+    executable. Because the hooks live in-repo, there is nothing to copy into
+    ``.git/hooks`` and the activation survives a fresh clone the moment this
+    runs.
+
+    Safety: if ``core.hooksPath`` is already set to a DIFFERENT (foreign,
+    non-SquidSquad) value, leave it alone and warn — we never clobber a user's
+    own hooks configuration.
+
+    Returns True if the guard is active after the call, False on a skip/error.
+    """
+    hook = REPO_ROOT / _HOOKS_DIR_REL / "pre-commit"
+    if not hook.exists():
+        print(f"WARNING: hook not found at {hook}; skipping install-hooks",
+              file=sys.stderr)
+        return False
+
+    current = _run("git config --get core.hooksPath", check=False).stdout.strip()
+    if current and current != _HOOKS_DIR_REL:
+        print(
+            f"WARNING: core.hooksPath already set to '{current}' (not "
+            f"'{_HOOKS_DIR_REL}') -- leaving it; SquidSquad state guard not "
+            f"activated. Set it manually if intended.",
+            file=sys.stderr,
+        )
+        return False
+
+    if current != _HOOKS_DIR_REL:
+        rc = _run_list(["git", "config", "core.hooksPath", _HOOKS_DIR_REL], check=False)
+        # A failed write (read-only .git/config, perms) leaves the guard
+        # inactive -- honor the docstring contract and report False, don't
+        # claim the guard is live when core.hooksPath never took.
+        if rc.returncode != 0:
+            print(
+                f"WARNING: failed to set core.hooksPath to '{_HOOKS_DIR_REL}' "
+                f"(git config exited {rc.returncode}); state guard not activated.",
+                file=sys.stderr,
+            )
+            return False
+
+    # Executable bit. On POSIX git only fires a hook whose exec bit is set, so a
+    # chmod failure means the guard is installed but won't run -- report False
+    # and warn. On Windows git ignores the exec bit (the shim runs via sh), so a
+    # chmod failure there is benign and the guard is still active.
+    try:
+        import os
+        import stat
+        os.chmod(hook, os.stat(hook).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    except OSError as e:
+        if os.name == "posix":
+            print(
+                f"WARNING: core.hooksPath set but could not make {hook} "
+                f"executable ({e}); pre-commit state guard may not fire.",
+                file=sys.stderr,
+            )
+            return False
+    return True
+
+
+def _ensure_hooks_installed():
+    """Self-heal hook activation on every git_ops invocation (#11511).
+
+    git_ops is the deterministic git entry point every agent uses each cycle in
+    BOTH wake modes, so calling this once per invocation guarantees the
+    pre-commit guard is active in every clone — covering already-provisioned
+    installs with zero installer/wizard/upgrade surgery. Fully wrapped: a hook
+    that won't install must never break a git operation.
+    """
+    try:
+        current = _run("git config --get core.hooksPath", check=False).stdout.strip()
+        if not current:
+            # Unset -> activate our guard (covers fresh / already-provisioned
+            # clones with zero installer surgery).
+            install_hooks()
+        # When core.hooksPath is already ours we noop here: the hook is tracked
+        # with mode 100755, so git restores its exec bit on every checkout/pull
+        # -- no per-invocation chmod is needed and re-running install_hooks()
+        # would add a pointless os.chmod to every git_ops call (#11511 DS
+        # re-review2). The shipped-executable invariant is locked by
+        # TestHookShippedExecutable11511.
+        # A foreign (non-empty, non-ours) hooksPath is the operator's own
+        # config: respect it SILENTLY on the self-heal path. install_hooks()
+        # would re-emit its foreign-hooksPath WARNING on every git_ops
+        # invocation (each call is a fresh process, so a warn-once flag can't
+        # help). The explicit `install-hooks` command still surfaces that
+        # warning when the operator asks for it directly.
+    except Exception:
+        pass
+
+
 def _parse_args():
     args = sys.argv[1:]
     if not args or args[0] == "--help":
@@ -1042,6 +1208,14 @@ def _parse_args():
 
 def main():
     cmd, rest = _parse_args()
+
+    # Self-heal the pre-commit state guard on every invocation except the guard
+    # itself (which the hook calls mid-commit) and `install-hooks` (which calls
+    # install_hooks() explicitly in dispatch -- self-healing first would emit a
+    # duplicate foreign-hooksPath WARNING). Keeps the commit path lean and
+    # avoids re-checking what's already active (#11511).
+    if cmd not in ("guard-staged-state", "install-hooks"):
+        _ensure_hooks_installed()
 
     if cmd == "pull":
         pull(role=rest[0] if rest else None)
@@ -1141,6 +1315,12 @@ def main():
         if verdict is None:
             sys.exit(2)        # could not resolve a ref
         sys.exit(0 if verdict else 1)   # 0 = clean, 1 = real conflict
+    elif cmd == "guard-staged-state":
+        guard_staged_state()
+        sys.exit(0)            # FAIL-OPEN: the guard never blocks a commit
+    elif cmd == "install-hooks":
+        ok = install_hooks()
+        sys.exit(0 if ok else 1)
     else:
         print(f"Unknown command: {cmd}", file=sys.stderr)
         sys.exit(1)

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1727,3 +1727,273 @@ class TestCheckRealConflict11511:
         mock_run.side_effect = [_mock_result(returncode=128)]  # rev-parse base fails
         assert git_ops.check_real_conflict("origin/nope", "origin/feat") is None
         assert mock_run.call_count == 1   # short-circuited before head/merge-tree
+
+
+class TestGuardStagedState11511:
+    """#11511 Part 2: the pre-commit guard that keeps transient state off
+    feature branches even on the raw-git path (POLLING mode / branch races).
+    FAIL-OPEN — it only ever unstages state files, never blocks a commit.
+    """
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    @patch("git_ops._get_working_branch", return_value="main")
+    def test_on_working_branch_is_noop(self, _wb, mock_run, mock_run_list):
+        mock_run.return_value = _mock_result(stdout="main\n")  # current branch
+        assert git_ops.guard_staged_state() == []
+        # No diff/reset attempted when already on the working branch.
+        mock_run_list.assert_not_called()
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    @patch("git_ops._get_working_branch", return_value="main")
+    def test_detached_head_is_noop(self, _wb, mock_run, mock_run_list):
+        mock_run.return_value = _mock_result(stdout="\n")  # empty = detached/unknown
+        assert git_ops.guard_staged_state() == []
+        mock_run_list.assert_not_called()
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    @patch("git_ops._get_working_branch", return_value="main")
+    def test_branch_lookup_is_fail_open(self, _wb, mock_run, mock_run_list):
+        # The branch-current probe must run with check=False so a failing git
+        # (corrupt HEAD, perms) can't raise mid-commit and break fail-open.
+        mock_run.return_value = _mock_result(stdout="\n")
+        git_ops.guard_staged_state()
+        assert mock_run.call_count == 1
+        assert mock_run.call_args.kwargs.get("check") is False
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    @patch("git_ops._get_working_branch", return_value="main")
+    def test_branch_lookup_failure_is_fail_open(self, _wb, mock_run, mock_run_list):
+        # Behavioral fail-open: a *failing* `git branch --show-current` (corrupt
+        # HEAD -> returncode 128, empty stdout) must return [] without raising
+        # and without attempting any diff/reset -- not just pass check=False.
+        mock_run.return_value = _mock_result(returncode=128, stdout="")
+        assert git_ops.guard_staged_state() == []
+        mock_run_list.assert_not_called()
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    @patch("git_ops._get_working_branch", return_value="main")
+    def test_feature_branch_unstages_state_files(self, _wb, mock_run, mock_run_list):
+        mock_run.return_value = _mock_result(stdout="squidsquad/task/11511\n")
+        # diff --cached lists both code and state; only state should be unstaged.
+        mock_run_list.side_effect = [
+            _mock_result(stdout="references/scripts/git_ops.py\n"
+                                ".squidsquad/skill/working-state.md\n"
+                                ".claude/scheduled_tasks.json\n"),  # diff --cached
+            _mock_result(returncode=0),  # reset working-state.md
+            _mock_result(returncode=0),  # reset scheduled_tasks.json
+        ]
+        unstaged = git_ops.guard_staged_state()
+        assert unstaged == [".squidsquad/skill/working-state.md",
+                            ".claude/scheduled_tasks.json"]
+        # One diff call + one reset per state file; code file left staged.
+        reset_calls = [c for c in mock_run_list.call_args_list
+                       if c.args[0][:2] == ["git", "reset"]]
+        assert len(reset_calls) == 2
+        reset_paths = [c.args[0][-1] for c in reset_calls]
+        assert "references/scripts/git_ops.py" not in reset_paths
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    @patch("git_ops._get_working_branch", return_value="main")
+    def test_feature_branch_code_only_is_noop(self, _wb, mock_run, mock_run_list):
+        mock_run.return_value = _mock_result(stdout="squidsquad/task/11511\n")
+        mock_run_list.return_value = _mock_result(
+            stdout="references/scripts/git_ops.py\ntests/test_git_ops.py\n")
+        assert git_ops.guard_staged_state() == []
+        # Only the diff ran; nothing to reset.
+        assert mock_run_list.call_count == 1
+
+
+class TestInstallHooks11511:
+    """#11511 Part 2: activation of the pre-commit guard via core.hooksPath.
+    Idempotent; never clobbers a foreign hooksPath value.
+    """
+
+    def _make_hook(self, tmp_path):
+        hook_dir = tmp_path / git_ops._HOOKS_DIR_REL
+        hook_dir.mkdir(parents=True)
+        (hook_dir / "pre-commit").write_text("#!/bin/sh\nexit 0\n")
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_missing_hook_returns_false(self, mock_run, mock_run_list, tmp_path, monkeypatch):
+        monkeypatch.setattr(git_ops, "REPO_ROOT", tmp_path)  # no hook created
+        assert git_ops.install_hooks() is False
+        mock_run_list.assert_not_called()
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_sets_hookspath_when_unset(self, mock_run, mock_run_list, tmp_path, monkeypatch):
+        monkeypatch.setattr(git_ops, "REPO_ROOT", tmp_path)
+        self._make_hook(tmp_path)
+        mock_run.return_value = _mock_result(stdout="\n")  # core.hooksPath unset
+        mock_run_list.return_value = _mock_result(returncode=0)  # config write OK
+        assert git_ops.install_hooks() is True
+        set_calls = [c for c in mock_run_list.call_args_list
+                     if c.args[0][:3] == ["git", "config", "core.hooksPath"]]
+        assert len(set_calls) == 1
+        assert set_calls[0].args[0][-1] == git_ops._HOOKS_DIR_REL
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_idempotent_when_already_ours(self, mock_run, mock_run_list, tmp_path, monkeypatch):
+        monkeypatch.setattr(git_ops, "REPO_ROOT", tmp_path)
+        self._make_hook(tmp_path)
+        mock_run.return_value = _mock_result(stdout=git_ops._HOOKS_DIR_REL + "\n")
+        assert git_ops.install_hooks() is True
+        # Already ours -> no re-set of core.hooksPath.
+        set_calls = [c for c in mock_run_list.call_args_list
+                     if c.args[0][:3] == ["git", "config", "core.hooksPath"]]
+        assert not set_calls
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_foreign_hookspath_not_clobbered(self, mock_run, mock_run_list, tmp_path, monkeypatch):
+        monkeypatch.setattr(git_ops, "REPO_ROOT", tmp_path)
+        self._make_hook(tmp_path)
+        mock_run.return_value = _mock_result(stdout=".husky\n")  # user's own hooks
+        assert git_ops.install_hooks() is False
+        set_calls = [c for c in mock_run_list.call_args_list
+                     if c.args[0][:3] == ["git", "config", "core.hooksPath"]]
+        assert not set_calls  # left the foreign value alone
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_returns_false_when_config_write_fails(self, mock_run, mock_run_list, tmp_path, monkeypatch):
+        # Contract: "Returns True if the guard is active after the call." A
+        # failed `git config core.hooksPath` write (read-only .git/config) must
+        # report False, not claim activation that never took.
+        monkeypatch.setattr(git_ops, "REPO_ROOT", tmp_path)
+        self._make_hook(tmp_path)
+        mock_run.return_value = _mock_result(stdout="\n")  # core.hooksPath unset
+        mock_run_list.return_value = _mock_result(returncode=1)  # write fails
+        assert git_ops.install_hooks() is False
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_chmod_failure_returns_false_on_posix(
+        self, mock_run, mock_run_list, tmp_path, monkeypatch
+    ):
+        # On POSIX git only fires a hook with the exec bit set. If chmod fails
+        # the guard is installed but won't run -> report False, not a false
+        # "active" (#11511 DS re-review Finding 1).
+        import os
+        monkeypatch.setattr(git_ops, "REPO_ROOT", tmp_path)
+        self._make_hook(tmp_path)
+        mock_run.return_value = _mock_result(stdout="\n")  # core.hooksPath unset
+        mock_run_list.return_value = _mock_result(returncode=0)  # config write OK
+        monkeypatch.setattr(os, "name", "posix")
+        monkeypatch.setattr(os, "chmod", lambda *a, **k: (_ for _ in ()).throw(OSError("noexec")))
+        assert git_ops.install_hooks() is False
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_chmod_failure_benign_on_windows(
+        self, mock_run, mock_run_list, tmp_path, monkeypatch
+    ):
+        # On Windows git ignores the exec bit (the shim runs via sh), so a chmod
+        # failure is benign and the guard is still active -> True.
+        import os
+        monkeypatch.setattr(git_ops, "REPO_ROOT", tmp_path)
+        self._make_hook(tmp_path)
+        mock_run.return_value = _mock_result(stdout="\n")
+        mock_run_list.return_value = _mock_result(returncode=0)
+        monkeypatch.setattr(os, "name", "nt")
+        monkeypatch.setattr(os, "chmod", lambda *a, **k: (_ for _ in ()).throw(OSError("denied")))
+        assert git_ops.install_hooks() is True
+
+
+class TestHookShippedExecutable11511:
+    """#11511 DS re-review2: the pre-commit hook must be tracked with the
+    executable mode (100755). On POSIX git only fires a hook whose exec bit is
+    set, and `git checkout`/`pull` restore a tracked file to its RECORDED mode.
+    If the hook were tracked 100644, a later checkout would silently drop the
+    exec bit and the guard would stop firing -- the self-heal noops when
+    core.hooksPath is already ours, so nothing would restore it. Tracking the
+    hook 100755 fixes the exec bit at the source so it survives every checkout.
+    This is a repo invariant, so it reads the real git index (not a mock).
+    """
+
+    def test_hook_tracked_executable(self):
+        import subprocess
+        out = subprocess.run(
+            ["git", "ls-files", "-s", "--", "references/git-hooks/pre-commit"],
+            cwd=str(git_ops.REPO_ROOT),
+            capture_output=True,
+            text=True,
+        )
+        assert out.returncode == 0, out.stderr
+        line = out.stdout.strip()
+        assert line, "pre-commit hook is not tracked in git"
+        mode = line.split()[0]
+        assert mode == "100755", (
+            f"pre-commit hook tracked as mode {mode}, expected 100755 "
+            f"(POSIX needs the exec bit or git silently skips the guard)"
+        )
+
+
+class TestEnsureHooksInstalled11511:
+    """#11511 DS re-review Finding 4: the self-heal path installs our guard when
+    core.hooksPath is unset, but respects a foreign value SILENTLY (no per-
+    invocation WARNING -- each git_ops call is a fresh process, so a warn-once
+    flag can't help). The explicit `install-hooks` command still warns.
+    """
+
+    @patch("git_ops.install_hooks")
+    @patch("git_ops._run")
+    def test_installs_when_unset(self, mock_run, mock_install):
+        mock_run.return_value = _mock_result(stdout="\n")  # hooksPath unset
+        git_ops._ensure_hooks_installed()
+        mock_install.assert_called_once()
+
+    @patch("git_ops.install_hooks")
+    @patch("git_ops._run")
+    def test_noop_when_already_ours(self, mock_run, mock_install):
+        mock_run.return_value = _mock_result(stdout=git_ops._HOOKS_DIR_REL + "\n")
+        git_ops._ensure_hooks_installed()
+        mock_install.assert_not_called()
+
+    @patch("git_ops.install_hooks")
+    @patch("git_ops._run")
+    def test_silent_skip_on_foreign(self, mock_run, mock_install):
+        # Foreign hooksPath -> do NOT call install_hooks (which would warn every
+        # invocation). Respect the operator's config silently.
+        mock_run.return_value = _mock_result(stdout=".husky\n")
+        git_ops._ensure_hooks_installed()
+        mock_install.assert_not_called()
+
+
+class TestEnsureHooksDispatch11511:
+    """#11511 Part 2: main() self-heals hooks on every invocation EXCEPT the
+    guard (called mid-commit) and install-hooks (which installs explicitly --
+    self-healing first would double the foreign-hooksPath WARNING).
+    """
+
+    @patch("git_ops.install_hooks", return_value=True)
+    @patch("git_ops._ensure_hooks_installed")
+    def test_install_hooks_cmd_skips_self_heal(self, mock_ensure, mock_install, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["git_ops.py", "install-hooks"])
+        with pytest.raises(SystemExit):
+            git_ops.main()
+        mock_ensure.assert_not_called()   # no duplicate self-heal pass
+        mock_install.assert_called_once()  # explicit dispatch still installs
+
+    @patch("git_ops.guard_staged_state")
+    @patch("git_ops._ensure_hooks_installed")
+    def test_guard_cmd_skips_self_heal(self, mock_ensure, _mock_guard, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["git_ops.py", "guard-staged-state"])
+        with pytest.raises(SystemExit):
+            git_ops.main()
+        mock_ensure.assert_not_called()
+
+    @patch("git_ops.has_changes")
+    @patch("git_ops._ensure_hooks_installed")
+    def test_other_cmd_self_heals(self, mock_ensure, _mock_has, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["git_ops.py", "has-changes"])
+        git_ops.main()
+        mock_ensure.assert_called_once()

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1678,3 +1678,52 @@ class TestGitPush:
         git_ops._git_push([])
         cmd = mock_run.call_args[0][0]
         assert cmd == ["git", "push"]
+
+
+class TestCheckRealConflict11511:
+    """#11511: deterministic ground truth for whether a PR's CONFLICTING flag
+    is a REAL conflict or a cosmetic flap (GitHub honors no user .gitattributes
+    merge driver server-side). Runs `git merge-tree --write-tree` both ways;
+    a real conflict in either direction is a real conflict.
+    """
+
+    @patch("git_ops._run_list")
+    def test_clean_returns_true(self, mock_run):
+        # rev-parse base, rev-parse head, merge-tree both ways — all clean
+        mock_run.side_effect = [
+            _mock_result(returncode=0),   # rev-parse base
+            _mock_result(returncode=0),   # rev-parse head
+            _mock_result(returncode=0),   # merge-tree base head
+            _mock_result(returncode=0),   # merge-tree head base
+        ]
+        assert git_ops.check_real_conflict("origin/main", "origin/feat") is True
+
+    @patch("git_ops._run_list")
+    def test_real_conflict_returns_false(self, mock_run):
+        mock_run.side_effect = [
+            _mock_result(returncode=0),   # rev-parse base
+            _mock_result(returncode=0),   # rev-parse head
+            _mock_result(stdout="CONFLICT (content): Merge conflict in foo.py",
+                         returncode=1),   # merge-tree base head
+            _mock_result(returncode=0),   # merge-tree head base
+        ]
+        assert git_ops.check_real_conflict("origin/main", "origin/feat") is False
+
+    @patch("git_ops._run_list")
+    def test_conflict_in_either_direction_is_conflict(self, mock_run):
+        # First direction clean, reverse direction conflicts — still a conflict.
+        mock_run.side_effect = [
+            _mock_result(returncode=0),   # rev-parse base
+            _mock_result(returncode=0),   # rev-parse head
+            _mock_result(returncode=0),   # merge-tree base head (clean)
+            _mock_result(stdout="CONFLICT (content): Merge conflict in bar.py",
+                         returncode=1),   # merge-tree head base
+        ]
+        assert git_ops.check_real_conflict("origin/main", "origin/feat") is False
+
+    @patch("git_ops._run_list")
+    def test_unresolvable_ref_returns_none(self, mock_run):
+        # rev-parse of the base ref fails -> short-circuit, no merge-tree runs.
+        mock_run.side_effect = [_mock_result(returncode=128)]  # rev-parse base fails
+        assert git_ops.check_real_conflict("origin/nope", "origin/feat") is None
+        assert mock_run.call_count == 1   # short-circuited before head/merge-tree


### PR DESCRIPTION
Closes #11511.

**Part 1** (82e8d4ba6): git_ops `check-real-conflict` merge-tree helper — deterministic ground truth so GitHub CONFLICTING is treated as advisory (DS NO_FINDINGS).
**Part 2** (b2a8b1ba6): pre-commit state guard — `guard_staged_state` + `install_hooks` + fail-open pre-commit shim + `.gitattributes` eol=lf for the POSIX hook. Auto-unstages transient state files (config.md, working-state, etc.) from feature-branch commits so per-agent state never lands in PRs.

**Verification**: git_ops targeted tests 146 pass; full `run_tests.py` EXIT:0 (static green + integration 53 OK); DS re-review2 NO_FINDINGS. The new pre-commit guard self-validated on this very commit (it unstaged config.md).

**Note**: Part 2 committed by PM as an operator-delegated unstick — skill was deadlocked re-running its full-suite gate as a background job that its own context-pressure reboots kept killing (false SUITE_EXIT:1; see #12142). QA owns authoritative verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)