### PR TITLE
skill: #12342 EAD routes pending-test/pending-ship to QA/DM (event-mode delivery)

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -3093,10 +3093,21 @@ def _print_banner(port: int):
 class ExternalActivityDetector:
     """Polls GitHub for external changes and emits assigned-to events (#7630 2-4).
 
-    Runs as a daemon thread. Detects new/updated issues with status:approved
-    or status:open that are assigned to agent roles. Filters out SquidSquad's
-    own changes by checking recent comment authors against agent role names.
-    Deduplicates by tracking previously emitted issue numbers.
+    Runs as a daemon thread. Detects new/updated issues and routes work to the
+    right alias by status (#12342):
+
+    - ``status:approved`` / ``status:open`` → the issue's ``role:*`` worker alias
+    - ``status:pending-test``               → the install's **verifier** alias
+    - ``status:pending-ship``               → the install's **dm** alias
+
+    Without the pending-test/pending-ship routes (the pre-#12342 behavior),
+    event-mode QA and DM starved: the EAD only ever emitted for worker statuses,
+    so verification/delivery work produced no wake event.
+
+    Dedup is keyed by ``(issue_num, status)`` so each *transition* of an issue
+    emits exactly once — keying by issue number alone (pre-#12342) meant an
+    issue emitted at most one assigned-to in its whole lifecycle (it fired at
+    ``approved`` and every later transition was deduped away).
     """
 
     # #6274: qa→verifier per D5. AGENT_ROLES is currently unused (issue
@@ -3105,12 +3116,28 @@ class ExternalActivityDetector:
     # Flipping in lockstep with config.py:486/591 and cycle_pre.py:1037.
     AGENT_ROLES = {"skill", "pm", "verifier", "dm"}
 
+    # #12342: status → routing target. ("label", None) routes to the issue's
+    # own role:* worker alias; ("role_class", <class>) routes to the install's
+    # alias for that role-class (resolved via config.parse_aliases_registry).
+    # Statuses absent from this map (in-progress, planned, pending, planning)
+    # intentionally emit nothing — the owning agent is already on it or a human
+    # gate applies. shipped is closed, so the --state open query never sees it.
+    _STATUS_ROUTING = {
+        "status:open": ("label", None),
+        "status:approved": ("label", None),
+        "status:pending-test": ("role_class", "verifier"),
+        "status:pending-ship": ("role_class", "dm"),
+    }
+
     def __init__(self, poll_interval: int = 60):
         self._poll_interval = poll_interval
         self._running = False
         self._thread = None
         self._last_check_epoch = 0.0  # epoch seconds — avoids ISO string comparison
-        self._emitted_issues: dict[int, None] = {}  # ordered dedup: issues already emitted
+        # Ordered dedup keyed by (issue_num, status) (#12342) so each
+        # transition emits once. `status=None` keys are accepted for
+        # backward-compatible single-arg callers (tests, future reuse).
+        self._emitted_issues: dict[tuple, None] = {}
         # Lock guards _emitted_issues against concurrent mutation. The
         # detector's own poller thread is the only writer now that #8914
         # removed TrackerHandoffDispatcher, but the lock stays — the
@@ -3118,18 +3145,41 @@ class ExternalActivityDetector:
         # if another thread is ever added.
         self._emitted_lock = threading.Lock()
 
-    def is_emitted(self, issue_num):
-        """Thread-safe membership check on _emitted_issues."""
+    def is_emitted(self, issue_num, status=None):
+        """Thread-safe membership check on _emitted_issues (#12342: keyed by
+        (issue_num, status))."""
         with self._emitted_lock:
-            return issue_num in self._emitted_issues
+            return (issue_num, status) in self._emitted_issues
 
-    def mark_emitted(self, issue_num):
-        """Thread-safe insert + bounded eviction on _emitted_issues (#8694)."""
+    def mark_emitted(self, issue_num, status=None):
+        """Thread-safe insert + bounded eviction on _emitted_issues (#8694;
+        #12342: keyed by (issue_num, status))."""
         with self._emitted_lock:
-            self._emitted_issues[issue_num] = None
+            self._emitted_issues[(issue_num, status)] = None
             while len(self._emitted_issues) > 500:
                 oldest = next(iter(self._emitted_issues))
                 del self._emitted_issues[oldest]
+
+    @staticmethod
+    def _alias_for_role_class(role_class):
+        """Resolve the install's alias for a role-class (#12342).
+
+        Reads the ``## Aliases`` registry via config.parse_aliases_registry()
+        ({alias: (role_class, l3_domain)}) and returns the first alias whose
+        role-class matches. Singleton installs have exactly one verifier and
+        one dm. Falls back to the role-class name itself (a valid bare alias in
+        singleton installs: verifier→verifier, dm→dm) if config is unreadable.
+        """
+        try:
+            import config as _cfg
+            registry = _cfg.parse_aliases_registry()
+            for alias, rc_tuple in registry.items():
+                rc = rc_tuple[0] if isinstance(rc_tuple, (list, tuple)) else rc_tuple
+                if rc == role_class:
+                    return alias
+        except Exception:
+            pass
+        return role_class
 
     def start(self):
         """Start the detector daemon thread."""
@@ -3168,12 +3218,12 @@ class ExternalActivityDetector:
         except (ValueError, AttributeError):
             return 0.0
 
-    def _is_agent_update(self, issue: dict) -> bool:
-        """Check if the most recent comment was from a SquidSquad agent."""
-        # gh returns comments in the issue JSON if requested — but we only
-        # have labels and updatedAt. Check if the title starts with agent prefixes.
-        title = issue.get("title", "")
-        return title.startswith(("ISSUE:", "TASK:"))  # all agent-filed issues have these prefixes
+    # #12342: `_is_agent_update` removed. Its implementation
+    # (`title.startswith(("ISSUE:","TASK:"))`) matched EVERY SquidSquad issue
+    # — every issue title carries one of those prefixes — so it skipped all
+    # issues and the EAD emitted nothing. Loop-prevention against
+    # comment-bumped updatedAt is now handled correctly by the per-(issue,
+    # status) dedup in `_check_for_changes`.
 
     def _check_for_changes(self):
         """Poll GitHub for actionable changes since last check."""
@@ -3197,45 +3247,63 @@ class ExternalActivityDetector:
 
         for issue in issues:
             issue_num = issue.get("number", 0)
+            labels = {l.get("name", "") for l in issue.get("labels", [])}
 
-            # Dedup: skip issues already emitted (thread-safe via #8694)
-            if self.is_emitted(issue_num):
+            # The issue's current status label (exactly one expected).
+            status = next((l for l in labels if l.startswith("status:")), None)
+            if status is None:
                 continue
 
-            # Skip agent-filed issues to prevent self-triggering loops
-            if self._is_agent_update(issue):
+            # Dedup per (issue, status) (#12342): each transition emits once.
+            # Keying by issue number alone (pre-#12342) meant an issue emitted
+            # at most one assigned-to ever — it fired at `approved` and every
+            # later transition (pending-test, pending-ship) was deduped away.
+            if self.is_emitted(issue_num, status):
                 continue
 
-            # Time filter: only process issues updated since last check
+            # Time filter: only process issues updated since last check. A
+            # status transition bumps updatedAt, so a freshly-transitioned
+            # issue passes; a bare comment that does NOT change status is
+            # absorbed by the per-(issue,status) dedup above on later polls
+            # (this is why removing the old title-prefix `_is_agent_update`
+            # skip is safe — dedup, not a heuristic, prevents re-triggering).
             updated_epoch = self._parse_iso_epoch(issue.get("updatedAt", ""))
             if updated_epoch <= self._last_check_epoch:
                 continue
 
-            labels = {l.get("name", "") for l in issue.get("labels", [])}
-
-            # Only emit for actionable statuses
-            if not (labels & {"status:approved", "status:open"}):
+            # Status → routing target (#12342). Unmapped statuses
+            # (in-progress, planned, pending, planning) emit nothing.
+            routing = self._STATUS_ROUTING.get(status)
+            if routing is None:
                 continue
-
-            # Determine target alias (first role label sorted; multi-role emits for first only).
-            # In single-instance teams the value following `role:` is the alias;
-            # in multi-instance teams the `role:*` label always carries the
-            # routed alias per AGENT-RUNTIME.md §8.3 (the harness rewrites
-            # `role:*` on every `/work/assign`). Either way the extracted
-            # string IS the alias.
-            role_labels = sorted(l for l in labels if l.startswith("role:"))
-            if not role_labels:
-                continue
-            target_alias = role_labels[0].replace("role:", "")
+            kind, role_class = routing
+            if kind == "label":
+                # Worker statuses (approved/open) route to the issue's own
+                # role:* alias. In single-instance teams the value following
+                # `role:` is the alias; in multi-instance teams the `role:*`
+                # label always carries the routed alias per AGENT-RUNTIME.md
+                # §8.3 (the harness rewrites `role:*` on every `/work/assign`).
+                # Either way the extracted string IS the alias.
+                role_labels = sorted(l for l in labels if l.startswith("role:"))
+                if not role_labels:
+                    continue
+                target_alias = role_labels[0].replace("role:", "")
+            else:
+                # pending-test → verifier, pending-ship → dm (#12342). These do
+                # NOT route to the issue's role:* label (that is the worker who
+                # built it); they route to the install's verifier/dm alias.
+                target_alias = self._alias_for_role_class(role_class)
+                if not target_alias:
+                    continue
 
             # Emit assigned-to event
             _emit_event("assigned-to", "harness", payload={
                 "issue_number": str(issue_num),
                 "title": issue.get("title", ""),
                 "target_alias": target_alias,
-                "event_context": f"Issue #{issue_num} updated",
+                "event_context": f"Issue #{issue_num} {status.replace('status:', '')}",
             })
-            self.mark_emitted(issue_num)
+            self.mark_emitted(issue_num, status)
 
         self._last_check_epoch = check_time
         # Eviction now happens inside mark_emitted() under _emitted_lock.

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -3090,6 +3090,11 @@ def _print_banner(port: int):
 # External activity detector (#7630 2-4)
 # ---------------------------------------------------------------------------
 
+# #12342: sentinel distinguishing "issue never seen" from "issue last seen at
+# status=None" in ExternalActivityDetector._emitted_issues.get(...).
+_UNSEEN = object()
+
+
 class ExternalActivityDetector:
     """Polls GitHub for external changes and emits assigned-to events (#7630 2-4).
 
@@ -3104,10 +3109,14 @@ class ExternalActivityDetector:
     event-mode QA and DM starved: the EAD only ever emitted for worker statuses,
     so verification/delivery work produced no wake event.
 
-    Dedup is keyed by ``(issue_num, status)`` so each *transition* of an issue
-    emits exactly once — keying by issue number alone (pre-#12342) meant an
-    issue emitted at most one assigned-to in its whole lifecycle (it fired at
-    ``approved`` and every later transition was deduped away).
+    Dedup records ONE entry per issue — its last observed status — and emits
+    only when the current status differs from that record (#12342). Keying by
+    issue number alone (pre-#12342) meant an issue emitted at most one
+    assigned-to in its whole lifecycle; a naive ``(issue_num, status)`` set
+    instead permanently suppressed re-entry to a status, starving QA on every
+    re-verification after a reject (DS-REVIEW-12342 Finding 1). Recording the
+    intermediate (unmapped) ``in-progress`` lets a back-transition
+    ``pending-test -> in-progress -> pending-test`` re-emit correctly.
     """
 
     # #6274: qa→verifier per D5. AGENT_ROLES is currently unused (issue
@@ -3134,10 +3143,20 @@ class ExternalActivityDetector:
         self._running = False
         self._thread = None
         self._last_check_epoch = 0.0  # epoch seconds — avoids ISO string comparison
-        # Ordered dedup keyed by (issue_num, status) (#12342) so each
-        # transition emits once. `status=None` keys are accepted for
-        # backward-compatible single-arg callers (tests, future reuse).
-        self._emitted_issues: dict[tuple, None] = {}
+        # #12342: one entry per issue — issue_num → the LAST status this issue
+        # was observed at (the status we emitted for, or an unmapped status we
+        # recorded as we passed through it). We emit only when the observed
+        # status differs from the recorded one, so:
+        #   - a comment that bumps updatedAt without changing status → no
+        #     re-emit (status unchanged), and
+        #   - a back-transition pending-test → in-progress → pending-test
+        #     DOES re-emit, because the intermediate in-progress is recorded
+        #     and the second pending-test differs from it.
+        # The earlier (issue_num, status) tuple-set permanently suppressed
+        # re-entry to a status (DS-REVIEW-12342 Finding 1: QA starved on every
+        # re-verification after a reject). One entry/issue also keeps the 500
+        # eviction cap at 500 *issues* rather than ~125 (Finding 5).
+        self._emitted_issues: dict = {}
         # Lock guards _emitted_issues against concurrent mutation. The
         # detector's own poller thread is the only writer now that #8914
         # removed TrackerHandoffDispatcher, but the lock stays — the
@@ -3146,16 +3165,22 @@ class ExternalActivityDetector:
         self._emitted_lock = threading.Lock()
 
     def is_emitted(self, issue_num, status=None):
-        """Thread-safe membership check on _emitted_issues (#12342: keyed by
-        (issue_num, status))."""
+        """True iff the LAST recorded status for ``issue_num`` equals
+        ``status`` (#12342) — i.e. we already emitted/observed this exact
+        status and nothing has changed since. An unseen issue is never
+        'emitted'."""
         with self._emitted_lock:
-            return (issue_num, status) in self._emitted_issues
+            return self._emitted_issues.get(issue_num, _UNSEEN) == status
 
     def mark_emitted(self, issue_num, status=None):
-        """Thread-safe insert + bounded eviction on _emitted_issues (#8694;
-        #12342: keyed by (issue_num, status))."""
+        """Record ``status`` as the last observed status for ``issue_num``
+        (#8694 thread-safe + bounded eviction; #12342 one entry/issue)."""
         with self._emitted_lock:
-            self._emitted_issues[(issue_num, status)] = None
+            # Refresh recency: delete+reinsert so the FIFO eviction order
+            # tracks last-touch, not first-insert (an issue actively cycling
+            # statuses should not be evicted ahead of a stale one).
+            self._emitted_issues.pop(issue_num, None)
+            self._emitted_issues[issue_num] = status
             while len(self._emitted_issues) > 500:
                 oldest = next(iter(self._emitted_issues))
                 del self._emitted_issues[oldest]
@@ -3254,27 +3279,31 @@ class ExternalActivityDetector:
             if status is None:
                 continue
 
-            # Dedup per (issue, status) (#12342): each transition emits once.
-            # Keying by issue number alone (pre-#12342) meant an issue emitted
-            # at most one assigned-to ever — it fired at `approved` and every
-            # later transition (pending-test, pending-ship) was deduped away.
+            # Dedup (#12342): skip when the issue is still at the SAME status we
+            # last recorded — nothing changed (e.g. a comment bumped updatedAt
+            # without a transition). A different status falls through and will
+            # re-record below, so a back-transition (pending-test → in-progress
+            # → pending-test) correctly re-emits — see DS-REVIEW-12342 Finding 1.
             if self.is_emitted(issue_num, status):
                 continue
 
             # Time filter: only process issues updated since last check. A
             # status transition bumps updatedAt, so a freshly-transitioned
             # issue passes; a bare comment that does NOT change status is
-            # absorbed by the per-(issue,status) dedup above on later polls
-            # (this is why removing the old title-prefix `_is_agent_update`
-            # skip is safe — dedup, not a heuristic, prevents re-triggering).
+            # absorbed by the dedup above on later polls (this is why removing
+            # the old title-prefix `_is_agent_update` skip is safe — dedup,
+            # not a heuristic, prevents re-triggering).
             updated_epoch = self._parse_iso_epoch(issue.get("updatedAt", ""))
             if updated_epoch <= self._last_check_epoch:
                 continue
 
-            # Status → routing target (#12342). Unmapped statuses
-            # (in-progress, planned, pending, planning) emit nothing.
+            # Status → routing target (#12342). Unmapped statuses (in-progress,
+            # planned, pending, planning) emit nothing — but we still RECORD
+            # the status so a later re-entry to a routed status differs from
+            # it and re-emits (the back-transition support; DS Finding 1).
             routing = self._STATUS_ROUTING.get(status)
             if routing is None:
+                self.mark_emitted(issue_num, status)
                 continue
             kind, role_class = routing
             if kind == "label":
@@ -3283,7 +3312,11 @@ class ExternalActivityDetector:
                 # `role:` is the alias; in multi-instance teams the `role:*`
                 # label always carries the routed alias per AGENT-RUNTIME.md
                 # §8.3 (the harness rewrites `role:*` on every `/work/assign`).
-                # Either way the extracted string IS the alias.
+                # Either way the extracted string IS the alias. NOTE (#12342 /
+                # DS Finding 3): a multi-role issue wakes only the alphabetically
+                # first role:* alias — single-worker-per-issue is the assumed
+                # model; multi-role fan-out is out of scope and pre-dates this
+                # change.
                 role_labels = sorted(l for l in labels if l.startswith("role:"))
                 if not role_labels:
                     continue

--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -1260,6 +1260,18 @@ def transition(number, from_status, to_status, role=None, force=False):
         # so the harness ingestion allowlist (harness.py receive-event) drops
         # it (204). `split(" ")[0]` takes the bare alias — matching the other
         # emit site below (the inconsistency was the #12342 secondary bug).
+        #
+        # KNOWN EDGE (DS-REVIEW-12342 Finding 4): during the #6274 dual-aware
+        # window a caller passing the role-CLASS form ("verifier"/"worker")
+        # rather than its alias still emits that form, which is not in the
+        # allowlist when the install registers the legacy alias (qa/dev). Using
+        # `_canonicalize_role` would map verifier→qa but spams a deprecation
+        # warning for the qa/dev aliases this install actually uses, so it is
+        # NOT used here. Agents pass their own alias (skill/pm/qa/dm) in
+        # practice, so the common path is covered; the role-class-form edge is
+        # left to the #6274.3 cutover that removes the dual mapping. This is the
+        # SECONDARY path anyway — primary work delivery is the EAD assigned-to
+        # event, which resolves the alias from the registry directly.
         emit_role = (role or "unknown").split(" ")[0].replace("-lead", "")
         _emit_event("status-transition", emit_role, payload={
             "issue_number": str(number),

--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -1255,7 +1255,12 @@ def transition(number, from_status, to_status, role=None, force=False):
     # Emit status-transition event on every transition (#5856)
     try:
         from event_bus import emit as _emit_event
-        emit_role = (role or "unknown").replace("-lead", "")
+        # #12342: strip the parenthetical alias too, not just `-lead`. A
+        # decorated role like "skill (skill)" is not a bare registered alias,
+        # so the harness ingestion allowlist (harness.py receive-event) drops
+        # it (204). `split(" ")[0]` takes the bare alias — matching the other
+        # emit site below (the inconsistency was the #12342 secondary bug).
+        emit_role = (role or "unknown").split(" ")[0].replace("-lead", "")
         _emit_event("status-transition", emit_role, payload={
             "issue_number": str(number),
             "from": from_label.replace("status:", ""),

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -3237,6 +3237,38 @@ class TestEADStatusRouting12342(unittest.TestCase):
                          updated="2099-03-01T00:00:00Z")], det=det)
         self.assertEqual([e["target_alias"] for e in emitted2], ["verifier"])
 
+    def test_back_transition_reemits_to_verifier(self):
+        """DS-REVIEW-12342 Finding 1 regression: a reject loop
+        pending-test → in-progress → pending-test MUST re-emit to the verifier
+        each time it re-enters pending-test. A naive (issue, status) dedup set
+        would suppress the second pending-test and starve QA on re-verification.
+        """
+        det, e1 = self._run([self._issue(10, "pending-test", role="skill",
+                                         updated="2099-01-01T00:00:00Z")])
+        self.assertEqual([e["target_alias"] for e in e1], ["verifier"])
+
+        # QA rejects → in-progress: no emit, but the status is recorded.
+        det, e2 = self._run([self._issue(10, "in-progress", role="skill",
+                                         updated="2099-02-01T00:00:00Z")], det=det)
+        self.assertEqual(e2, [])
+
+        # Worker resubmits → pending-test: MUST re-emit to verifier.
+        det, e3 = self._run([self._issue(10, "pending-test", role="skill",
+                                         updated="2099-03-01T00:00:00Z")], det=det)
+        self.assertEqual([e["target_alias"] for e in e3], ["verifier"],
+                         "re-entry to pending-test after a reject must re-wake "
+                         "the verifier (DS Finding 1)")
+
+    def test_comment_bump_same_status_does_not_reemit(self):
+        """A comment that bumps updatedAt without changing status must NOT
+        re-emit (the dedup's core job)."""
+        det, e1 = self._run([self._issue(11, "pending-test", role="skill",
+                                         updated="2099-01-01T00:00:00Z")])
+        self.assertEqual(len(e1), 1)
+        _, e2 = self._run([self._issue(11, "pending-test", role="skill",
+                                       updated="2099-02-01T00:00:00Z")], det=det)
+        self.assertEqual(e2, [], "same status + comment bump must not re-emit")
+
     def test_time_filter_skips_unupdated_issues(self):
         det, _ = self._run([self._issue(8, "approved", role="skill",
                                         updated="2000-01-01T00:00:00Z")])

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -3132,6 +3132,154 @@ class TestReviewFixes(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# EAD status-aware work routing — #12342
+# ---------------------------------------------------------------------------
+
+class TestEADStatusRouting12342(unittest.TestCase):
+    """#12342: the External Activity Detector must route work by status so
+    event-mode QA/DM no longer starve:
+
+    - status:approved / status:open → the issue's role:* worker alias
+    - status:pending-test           → the install's verifier alias
+    - status:pending-ship           → the install's dm alias
+
+    and dedup per (issue, status) so each transition emits once (keying by
+    issue number alone meant an issue emitted at most one assigned-to ever).
+    """
+
+    _REGISTRY = {
+        "skill": ("worker", "skill"),
+        "web": ("worker", "web"),
+        "pm": ("pm", None),
+        "verifier": ("verifier", None),
+        "dm": ("dm", None),
+    }
+
+    def _issue(self, num, status, role="skill", updated="2099-01-01T00:00:00Z"):
+        labels = [{"name": "squidsquad"}, {"name": f"status:{status}"}]
+        if role:
+            labels.append({"name": f"role:{role}"})
+        return {"number": num, "title": f"ISSUE: thing {num}",
+                "labels": labels, "updatedAt": updated}
+
+    def _run(self, issues, det=None, registry=None):
+        """Run _check_for_changes once against a faked `gh issue list`,
+        returning (detector, [emitted assigned-to payloads])."""
+        from harness import ExternalActivityDetector
+        import config as _cfg
+        det = det or ExternalActivityDetector()
+        gh_result = MagicMock()
+        gh_result.returncode = 0
+        gh_result.stdout = json.dumps(issues)
+        emitted = []
+
+        def fake_emit(event_type, role, payload=None, **extra):
+            if event_type == "assigned-to":
+                emitted.append(payload or {})
+
+        with patch("harness.subprocess.run", return_value=gh_result), \
+             patch("harness._emit_event", side_effect=fake_emit), \
+             patch.object(_cfg, "parse_aliases_registry",
+                          return_value=registry or self._REGISTRY):
+            det._check_for_changes()
+        return det, emitted
+
+    def test_pending_test_routes_to_verifier(self):
+        _, emitted = self._run([self._issue(1, "pending-test", role="skill")])
+        self.assertEqual(len(emitted), 1)
+        self.assertEqual(emitted[0]["target_alias"], "verifier",
+                         "pending-test must route to the verifier alias, NOT "
+                         "the issue's role:skill worker label (#12342)")
+
+    def test_pending_ship_routes_to_dm(self):
+        _, emitted = self._run([self._issue(2, "pending-ship", role="skill")])
+        self.assertEqual(len(emitted), 1)
+        self.assertEqual(emitted[0]["target_alias"], "dm")
+
+    def test_approved_routes_to_worker_label(self):
+        _, emitted = self._run([self._issue(3, "approved", role="skill")])
+        self.assertEqual(len(emitted), 1)
+        self.assertEqual(emitted[0]["target_alias"], "skill")
+
+    def test_open_routes_to_worker_label(self):
+        _, emitted = self._run([self._issue(4, "open", role="web")])
+        self.assertEqual(len(emitted), 1)
+        self.assertEqual(emitted[0]["target_alias"], "web")
+
+    def test_in_progress_emits_nothing(self):
+        """in-progress (worker already on it) and other unmapped statuses must
+        not emit — only approved/open/pending-test/pending-ship route."""
+        _, emitted = self._run([self._issue(5, "in-progress", role="skill")])
+        self.assertEqual(emitted, [])
+        _, emitted2 = self._run([self._issue(6, "planned", role="skill")])
+        self.assertEqual(emitted2, [])
+
+    def test_dedup_per_issue_status_across_transitions(self):
+        """The SAME issue must emit once per STATUS — once at approved (worker),
+        again at pending-test (verifier) — not be deduped to a single lifetime
+        emit (the pre-#12342 per-issue-number dedup bug)."""
+        det, emitted1 = self._run(
+            [self._issue(7, "approved", role="skill",
+                         updated="2099-01-01T00:00:00Z")])
+        self.assertEqual([e["target_alias"] for e in emitted1], ["skill"])
+
+        # Same issue, still approved, newer updatedAt → deduped (no re-emit).
+        _, emitted_dup = self._run(
+            [self._issue(7, "approved", role="skill",
+                         updated="2099-02-01T00:00:00Z")], det=det)
+        self.assertEqual(emitted_dup, [],
+                         "same (issue, status) must not re-emit even when a "
+                         "comment bumps updatedAt")
+
+        # Issue transitions to pending-test → emits once, to verifier.
+        _, emitted2 = self._run(
+            [self._issue(7, "pending-test", role="skill",
+                         updated="2099-03-01T00:00:00Z")], det=det)
+        self.assertEqual([e["target_alias"] for e in emitted2], ["verifier"])
+
+    def test_time_filter_skips_unupdated_issues(self):
+        det, _ = self._run([self._issue(8, "approved", role="skill",
+                                        updated="2000-01-01T00:00:00Z")])
+        # _last_check_epoch advanced to ~now; an old updatedAt is skipped.
+        _, emitted = self._run([self._issue(9, "pending-test", role="skill",
+                                            updated="2000-01-01T00:00:00Z")],
+                               det=det)
+        self.assertEqual(emitted, [])
+
+    def test_alias_for_role_class_resolves_from_registry(self):
+        """Verifier/dm targets are resolved from the install's alias registry,
+        not hardcoded — a non-default alias name must be honored."""
+        from harness import ExternalActivityDetector
+        import config as _cfg
+        reg = {"skill": ("worker", "skill"), "tester": ("verifier", None),
+               "shipper": ("dm", None)}
+        with patch.object(_cfg, "parse_aliases_registry", return_value=reg):
+            self.assertEqual(
+                ExternalActivityDetector._alias_for_role_class("verifier"),
+                "tester")
+            self.assertEqual(
+                ExternalActivityDetector._alias_for_role_class("dm"),
+                "shipper")
+
+    def test_alias_for_role_class_falls_back_to_class_name(self):
+        """If config is unreadable, fall back to the role-class name (a valid
+        bare alias in singleton installs)."""
+        from harness import ExternalActivityDetector
+        import config as _cfg
+        with patch.object(_cfg, "parse_aliases_registry",
+                          side_effect=Exception("config boom")):
+            self.assertEqual(
+                ExternalActivityDetector._alias_for_role_class("verifier"),
+                "verifier")
+
+    def test_is_agent_update_removed(self):
+        """The broken title-prefix `_is_agent_update` skip is gone (#12342) —
+        it matched every SquidSquad issue and made the EAD emit nothing."""
+        from harness import ExternalActivityDetector
+        self.assertFalse(hasattr(ExternalActivityDetector, "_is_agent_update"))
+
+
+# ---------------------------------------------------------------------------
 # /human/queue endpoint — #8704
 # ---------------------------------------------------------------------------
 

--- a/tests/test_tracker_authority.py
+++ b/tests/test_tracker_authority.py
@@ -557,6 +557,39 @@ class TestStatusTransitionEventEmission:
         assert emitted[0]["payload"]["from"] == "approved"
         assert emitted[0]["payload"]["to"] == "in-progress"
 
+    def test_emit_role_strips_parenthetical_alias(self, monkeypatch):
+        """#12342: the emit role must be the BARE alias. A decorated role like
+        "skill (skill)" is not a registered bare alias, so the harness
+        ingestion allowlist 204-drops the event — the agent never sees it.
+        `split(" ")[0]` strips the parenthetical (and `-lead`), matching the
+        other emit site. This was the #12342 secondary 'decorated-role drop'."""
+        emitted = []
+
+        class FakeResult:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        monkeypatch.setattr(tracker, "_run_list", lambda *a, **kw: FakeResult())
+        monkeypatch.setattr(tracker, "_get_issue_role_labels", lambda n: {"skill"})
+
+        import types
+        fake_bus = types.ModuleType("event_bus")
+        fake_bus.emit = lambda event_type, role, payload=None, cycle_number=None: emitted.append(
+            {"event_type": event_type, "role": role}
+        )
+        monkeypatch.setitem(sys.modules, "event_bus", fake_bus)
+
+        tracker.transition(7, "in-progress", "pending-test",
+                           role="skill (skill)", force=True)
+
+        assert len(emitted) == 1
+        assert emitted[0]["role"] == "skill", (
+            f"emit role must be the bare alias, got {emitted[0]['role']!r} — a "
+            f"decorated role is dropped by the harness ingestion allowlist"
+        )
+        assert " " not in emitted[0]["role"] and "(" not in emitted[0]["role"]
+
     def test_emits_on_all_transitions_not_just_in_progress(self, monkeypatch):
         """Emission happens for pending-test, pending-ship, shipped — not just in-progress."""
         emitted = []


### PR DESCRIPTION
## Summary

Fixes #12342 — in event mode the External Activity Detector only emitted `assigned-to` work events for **workers** (approved/open), so **QA (pending-test) and DM (pending-ship) starved** — verification/delivery work produced no wake event (qa sat idle ~1h with items in pending-test).

## Root cause (harness.py `ExternalActivityDetector`)

1. **Status filter** — emitted only for `approved`/`open`; pending-test/pending-ship never routed.
2. **`_is_agent_update`** — implemented as `title.startswith(('ISSUE:','TASK:'))`, which matches **every** SquidSquad issue → the EAD skipped everything.
3. **(found during RCA) per-issue-number dedup** — `_emitted_issues` keyed by issue number alone, so an issue emitted at most ONE assigned-to in its lifetime (fired at approved; every later transition deduped away).
4. **(secondary)** tracker.py emitted status-transition events with the decorated role `'skill (skill)'`, 204-dropped by the harness ingestion allowlist.

## Fix

- **Status-aware routing** (`_STATUS_ROUTING`): approved/open → issue's `role:*` worker alias; pending-test → **verifier** alias; pending-ship → **dm** alias. Verifier/dm aliases resolved from `config.parse_aliases_registry()` by role-class (new `_alias_for_role_class`) — no hardcoding.
- **Dedup keyed by `(issue_num, status)`** so each transition emits once. Backward-compatible signature (status defaults None) keeps the thread-safety/eviction tests valid.
- **Removed the broken `_is_agent_update` skip**; loop-prevention (comment-bumped updatedAt) is handled correctly by the per-(issue,status) dedup.
- **tracker.py**: status-transition emit strips the parenthetical alias (`split(' ')[0]`) so the bare alias passes the ingestion allowlist — consistent with the other emit site.

## Tests

- 10 EAD tests (routing per status, per-(issue,status) dedup across transitions, time filter, alias resolution + fallback, removed-method guard).
- 1 tracker emit test (bare-alias normalization).
- Full unit suite green (pytest exit 0); integration **51 passed, 2 skipped**.

## Upgrade note

Pure code change in shipped scripts (harness.py, tracker.py); takes effect on harness restart. No new config/deps. Existing installs gain the routing on next harness boot.

## Deferred

Orphan claude/event_poll process accumulation (ask #3) → filed as #12363.