### PR TITLE
skill: #12418 SessionEnd-reason hook (#12271 slice 1) — de-risk the reboot decision

### DIFF
--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -1841,6 +1841,13 @@ def _ensure_session_end_hook(settings_path) -> bool:
     before = json.dumps(data, sort_keys=True)
     hooks = data.get("hooks")
     if not isinstance(hooks, dict):
+        # DS-REVIEW-12418-A F3: a valid-JSON file whose `hooks` is the wrong
+        # type (list/string/null) is replaced. Surface it if it held content,
+        # so the (rare, Claude-Code-invalid) data loss isn't silent.
+        if hooks:
+            print(f"WARNING: .claude/settings.json `hooks` was "
+                  f"{type(hooks).__name__}, not an object — replacing "
+                  f"(prior hooks dropped): {settings_path}", file=sys.stderr)
         hooks = data["hooks"] = {}
     hooks["SessionEnd"] = [_session_end_hook_group()]
     if json.dumps(data, sort_keys=True) == before:

--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -1792,6 +1792,64 @@ def generate_local_config(roles: list, target_root: Path = None,
 
 
 
+# #12418 — the SessionEnd telemetry hook (HARNESS-ARCH §16). A native Claude
+# Code `type: http` hook that POSTs the SessionEnd payload to the harness; the
+# agent's role rides the X-Agent-Role header, interpolated per-clone from the
+# $SQUIDSQUAD_ROLE env var (set at spawn), so ONE committed .claude/settings.json
+# serves every clone. Fail-open by design (HTTP hooks never block; the short
+# timeout bounds the call). Port is the harness default 7373 — if the harness
+# runs on a non-default port the POST fails-open (no record → reboot decision
+# treats the exit as a crash, the safe default); a dynamic-port variant is a
+# later #12271 hardening slice.
+_SESSION_END_HOOK_URL = "http://127.0.0.1:7373/hooks/session-end"
+
+
+def _session_end_hook_group() -> dict:
+    """Return a fresh SessionEnd matcher-group (new objects each call so callers
+    never alias a shared mutable)."""
+    return {
+        "matcher": "",
+        "hooks": [{
+            "type": "http",
+            "url": _SESSION_END_HOOK_URL,
+            "timeout": 5,
+            "headers": {"X-Agent-Role": "${SQUIDSQUAD_ROLE}"},
+            "allowedEnvVars": ["SQUIDSQUAD_ROLE"],
+        }],
+    }
+
+
+def _ensure_session_end_hook(settings_path) -> bool:
+    """#12418 — idempotently ensure the SessionEnd hook is present in
+    ``.claude/settings.json``. Returns True iff the file was changed.
+
+    Preserves every other key (statusLine, permissions, other hooks); only the
+    ``hooks.SessionEnd`` entry is (re)set to the canonical group. Idempotent:
+    if the entry already matches, nothing is written — so a recompose does not
+    churn the tracked file (avoids the #12397 no-op-write class). A
+    missing/corrupt file is treated as empty and (re)written.
+    """
+    settings_path = Path(settings_path)
+    data = {}
+    if settings_path.exists():
+        try:
+            data = json.loads(settings_path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                data = {}
+        except (OSError, json.JSONDecodeError):
+            data = {}
+    before = json.dumps(data, sort_keys=True)
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        hooks = data["hooks"] = {}
+    hooks["SessionEnd"] = [_session_end_hook_group()]
+    if json.dumps(data, sort_keys=True) == before:
+        return False
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return True
+
+
 MANDATORY_ROLES = {"pm", "verifier", "dm"}  # #6055/#6274: always present (qa→verifier per D5)
 
 
@@ -2067,6 +2125,12 @@ def main():
         alias_roles = _aliases_for_roles(roles)
         lc = generate_local_config(alias_roles)
         print(f"  .local-config: {len(alias_roles)} agents -> {lc.relative_to(REPO_ROOT)}")
+        # #12418 — ensure the SessionEnd telemetry hook is in the committed
+        # .claude/settings.json (HARNESS-ARCH §16). Idempotent: writes only on
+        # change, so it never churns the tracked file on a no-op recompose.
+        se_settings = REPO_ROOT / ".claude" / "settings.json"
+        if _ensure_session_end_hook(se_settings):
+            print(f"  SessionEnd hook -> {se_settings.relative_to(REPO_ROOT)}")
 
     elif cmd == "upgrade-soul":
         if len(args) < 2:

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -2103,6 +2103,11 @@ async def hook_session_end(request: Request):
     answers 200.
     """
     role = (request.headers.get("X-Agent-Role") or "").strip()
+    # DS-REVIEW-12418-A F5: if $SQUIDSQUAD_ROLE was unset at spawn, Claude Code
+    # sends the literal "${SQUIDSQUAD_ROLE}". Treat an uninterpolated token as
+    # no-role rather than an unknown-role drop, so logs stay honest.
+    if role.startswith("${"):
+        role = ""
     try:
         body = await request.json()
     except Exception:

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -542,17 +542,32 @@ class HarnessState:
                         # predates this spawn and reads as a crash. Augments the
                         # PID path (AC6) — the respawn action itself is unchanged.
                         se = agent.last_session_end
+                        # DS-REVIEW-12418-C F1: use `(se.get("at") or 0)` — a
+                        # `{"at": null}` from a hand-edited/corrupt state file
+                        # makes `.get("at", 0)` return None, and `None >= float`
+                        # raises TypeError, aborting the whole health poll.
+                        se_at = (se.get("at") or 0) if isinstance(se, dict) else 0
                         graceful = bool(
-                            se and agent.last_spawn_at is not None
-                            and isinstance(se, dict)
-                            and se.get("at", 0) >= agent.last_spawn_at
+                            agent.last_spawn_at is not None
+                            and se_at >= agent.last_spawn_at
                         )
                         if graceful:
-                            agent.consecutive_fast_deaths = 0
+                            # #12418 AC4: a graceful exit is NOT a crash — do NOT
+                            # increment the streak. We deliberately do NOT reset
+                            # it to 0 either (DS-REVIEW-12418-C F2): a misbehaving
+                            # agent that POSTs SessionEnd then crashes must not be
+                            # able to ZERO accumulated real crashes and escape the
+                            # breaker. The legitimate reset is the survived-window
+                            # path above. (Residual: a pure SessionEnd-spammer can
+                            # still keep the streak from growing — a full
+                            # termination-correlation guard is a #12271 liveness
+                            # hardening follow-up; natural crash loops don't POST
+                            # SessionEnd, so the #12244 protection is intact.)
                             _log(
                                 f"{role}: graceful exit (SessionEnd "
-                                f"reason={se.get('reason')!r}) — not counting "
-                                f"toward crash-loop streak (#12418)"
+                                f"reason={se.get('reason')!r}) — not counted as "
+                                f"a crash (streak stays "
+                                f"{agent.consecutive_fast_deaths}) (#12418)"
                             )
                         elif (lifetime is not None
                                 and lifetime < FAST_DEATH_WINDOW_SECONDS):
@@ -658,6 +673,10 @@ class HarnessState:
                             # other three spawn paths — a successful spawn always
                             # stamps, even if terminal_pid is absent.
                             agent.last_spawn_at = time.time()
+                            # #12418 F3 — clear the prior lifecycle's SessionEnd
+                            # so only a hook from THIS spawn can mark the next
+                            # death graceful (closes the delayed-hook race).
+                            agent.last_session_end = None
                 elif result.get("action") == "error":
                     # #11640: boot_agent refused (e.g. unregistered/missing
                     # clone). Never spawned in REPO_ROOT — surface the refusal
@@ -1562,6 +1581,7 @@ async def lifespan(app: FastAPI):
                         agent_state.bootup_complete = False
                         agent_state.boot_time = time.time()
                         agent_state.last_spawn_at = time.time()  # #12244 P2
+                        agent_state.last_session_end = None  # #12418 F3
                         agent_state.terminal_pid = result.get("terminal_pid")
                     state.set_agent(role, agent_state)
             state.save_state()
@@ -1807,6 +1827,7 @@ async def start_all():
                 agent_state.bootup_complete = False
                 agent_state.boot_time = time.time()
                 agent_state.last_spawn_at = time.time()  # #12244 P2
+                agent_state.last_session_end = None  # #12418 F3
                 agent_state.terminal_pid = result.get("terminal_pid")
             state.set_agent(role, agent_state)
 
@@ -1919,6 +1940,7 @@ async def start_agent(role: str):
             agent_state.intent_set_at = None  # #4792 Phase 1
             agent_state.boot_time = time.time()
             agent_state.last_spawn_at = time.time()  # #12244 P2
+            agent_state.last_session_end = None  # #12418 F3
             agent_state.terminal_pid = result.get("terminal_pid")
             # #8695: spawning a fresh agent → bootup-complete must be re-asserted
             # by the new process before we'll dispatch any events to it.

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -158,7 +158,9 @@ class AgentState:
                  "last_cycle_end", "last_cycle_type", "bootup_complete",
                  # #12244 P2 — crash-loop / session-limit backoff
                  "last_spawn_at", "consecutive_fast_deaths",
-                 "reboot_blocked_until")
+                 "reboot_blocked_until",
+                 # #12418 — last SessionEnd hook reason (graceful-exit signal)
+                 "last_session_end")
 
     # Intent values:
     #   "running"    — agent should be alive; auto-reboot on death (#4949)
@@ -203,6 +205,13 @@ class AgentState:
         self.last_spawn_at = None
         self.consecutive_fast_deaths = 0
         self.reboot_blocked_until = None
+        # #12418 — last SessionEnd hook report: {"reason": <stop_reason>,
+        # "at": <epoch>}, or None if no SessionEnd seen since boot. The
+        # PRESENCE of an entry stamped after last_spawn_at means the agent
+        # exited GRACEFULLY (a hook ran); its ABSENCE before a dead PID means
+        # a crash. The reboot decision (update_health) keys off that to avoid
+        # counting graceful exits toward the #12244 crash-loop streak.
+        self.last_session_end = None
 
     def to_dict(self):
         return {
@@ -225,6 +234,8 @@ class AgentState:
             "last_spawn_at": self.last_spawn_at,
             "consecutive_fast_deaths": self.consecutive_fast_deaths,
             "reboot_blocked_until": self.reboot_blocked_until,
+            # #12418 — last SessionEnd hook reason (graceful-exit signal)
+            "last_session_end": self.last_session_end,
         }
 
 
@@ -840,6 +851,9 @@ class HarnessState:
                         "last_spawn_at": a.last_spawn_at,
                         "consecutive_fast_deaths": a.consecutive_fast_deaths,
                         "reboot_blocked_until": a.reboot_blocked_until,
+                        # #12418 — persist last SessionEnd reason so the
+                        # graceful-vs-crash signal survives a harness restart.
+                        "last_session_end": a.last_session_end,
                     }
                     for role, a in self.agents.items()
                 },
@@ -927,6 +941,9 @@ class HarnessState:
                 agent.consecutive_fast_deaths = agent_data.get(
                     "consecutive_fast_deaths", 0) or 0
                 agent.reboot_blocked_until = agent_data.get("reboot_blocked_until")
+                # #12418 — restore last SessionEnd reason (defaults None for
+                # older state files / fresh agents).
+                agent.last_session_end = agent_data.get("last_session_end")
 
         _log(f"Restored state for {len(state_data.get('agents', {}))} agents from state file")
 
@@ -2035,6 +2052,58 @@ def _log_event(event: dict):
         detail = payload.get("phase", "")
 
     print(f"[{ts}] {role:<6} {event_type:<18} {detail}", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Agent observability hooks (#12418 / HARNESS-ARCH §16) — native Claude Code
+# `type: http` hooks POST their payload here directly (no shell wrapper).
+# ---------------------------------------------------------------------------
+
+@app.post("/hooks/session-end/{role}")
+async def hook_session_end(role: str, request: Request):
+    """#12418 — receive a Claude Code `SessionEnd` hook for an agent session.
+
+    The per-clone `settings.json` wires a native `type: http` SessionEnd hook
+    whose URL bakes in the role; Claude Code POSTs the SessionEnd payload here
+    (``{hook_event_name, session_id, stop_reason, ...}``). We record the
+    ``stop_reason`` + arrival time on AgentState — the PRESENCE of a record
+    stamped after ``last_spawn_at`` means the agent exited GRACEFULLY (a hook
+    ran); its ABSENCE before a dead PID means a crash. The reboot decision
+    (§7.4 / update_health) keys off that (#12418 AC4).
+
+    Fail-open contract (HARNESS-ARCH §16.3): this endpoint ALWAYS returns 200
+    quickly. A hook must never block or fail the agent's teardown, so we never
+    raise — a malformed body, unknown role, or write hiccup still answers 200.
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    reason = (isinstance(body, dict) and body.get("stop_reason")) or "unknown"
+
+    # Defense-in-depth (mirrors receive_event #9242): ignore unknown roles so a
+    # stray hook can't seed a ghost agent — but STILL 200 (fail-open).
+    try:
+        allowed = set(boot_remote._get_all_roles()) | {"pm"}
+    except (SystemExit, Exception):
+        allowed = None
+    if allowed is not None and role not in allowed:
+        _log(f"SessionEnd hook DROPPED unknown role={role!r} (reason={reason!r})")
+        return JSONResponse(status_code=200, content={"ok": False, "dropped": "unknown-role"})
+
+    with state._lock:
+        agent = state.agents.get(role)
+        if agent is None:
+            agent = AgentState(role)
+            state.agents[role] = agent
+        agent.last_session_end = {"reason": reason, "at": time.time()}
+    # Persist off the event loop; swallow any error (fail-open).
+    try:
+        await asyncio.to_thread(state.save_state)
+    except Exception as e:  # pragma: no cover — defensive
+        _log(f"{role}: SessionEnd save_state failed (non-fatal): {e}")
+    _log(f"{role}: SessionEnd reason={reason!r} recorded (#12418)")
+    return JSONResponse(status_code=200, content={"ok": True})
 
 
 # ---------------------------------------------------------------------------

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -2059,27 +2059,35 @@ def _log_event(event: dict):
 # `type: http` hooks POST their payload here directly (no shell wrapper).
 # ---------------------------------------------------------------------------
 
-@app.post("/hooks/session-end/{role}")
-async def hook_session_end(role: str, request: Request):
+@app.post("/hooks/session-end")
+async def hook_session_end(request: Request):
     """#12418 — receive a Claude Code `SessionEnd` hook for an agent session.
 
-    The per-clone `settings.json` wires a native `type: http` SessionEnd hook
-    whose URL bakes in the role; Claude Code POSTs the SessionEnd payload here
-    (``{hook_event_name, session_id, stop_reason, ...}``). We record the
-    ``stop_reason`` + arrival time on AgentState — the PRESENCE of a record
-    stamped after ``last_spawn_at`` means the agent exited GRACEFULLY (a hook
-    ran); its ABSENCE before a dead PID means a crash. The reboot decision
-    (§7.4 / update_health) keys off that (#12418 AC4).
+    The git-tracked `.claude/settings.json` wires ONE native `type: http`
+    SessionEnd hook shared by every clone; it carries the agent's role in an
+    ``X-Agent-Role`` header interpolated from the ``$SQUIDSQUAD_ROLE`` env var
+    (set per-clone at spawn — thin_launcher / direct-spawn). Claude Code POSTs
+    the SessionEnd payload here (``{hook_event_name, session_id, stop_reason,
+    ...}``). We record the ``stop_reason`` + arrival time on AgentState — the
+    PRESENCE of a record stamped after ``last_spawn_at`` means the agent exited
+    GRACEFULLY (a hook ran); its ABSENCE before a dead PID means a crash. The
+    reboot decision (§7.4 / update_health) keys off that (#12418 AC4).
 
     Fail-open contract (HARNESS-ARCH §16.3): this endpoint ALWAYS returns 200
     quickly. A hook must never block or fail the agent's teardown, so we never
-    raise — a malformed body, unknown role, or write hiccup still answers 200.
+    raise — a malformed body, missing/unknown role, or write hiccup still
+    answers 200.
     """
+    role = (request.headers.get("X-Agent-Role") or "").strip()
     try:
         body = await request.json()
     except Exception:
         body = {}
     reason = (isinstance(body, dict) and body.get("stop_reason")) or "unknown"
+
+    if not role:
+        _log(f"SessionEnd hook DROPPED — no X-Agent-Role header (reason={reason!r})")
+        return JSONResponse(status_code=200, content={"ok": False, "dropped": "no-role"})
 
     # Defense-in-depth (mirrors receive_event #9242): ignore unknown roles so a
     # stray hook can't seed a ghost agent — but STILL 200 (fail-open).

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -530,7 +530,31 @@ class HarnessState:
                             now - agent.last_spawn_at
                             if agent.last_spawn_at is not None else None
                         )
-                        if (lifetime is not None
+                        # #12418 AC4 — graceful-vs-crash. A GRACEFUL exit (a
+                        # SessionEnd hook fired AFTER this spawn) is not a crash:
+                        # it must not accumulate the #12244 crash-loop streak, so
+                        # a legitimate cooperative restart is never throttled as
+                        # if it were a quota/startup crash. A CRASH (dead PID
+                        # with NO SessionEnd since last_spawn_at — the hook
+                        # couldn't run) still counts toward the streak → backoff.
+                        # The stale-SessionEnd case is handled by the
+                        # `>= last_spawn_at` guard: a prior spawn's SessionEnd
+                        # predates this spawn and reads as a crash. Augments the
+                        # PID path (AC6) — the respawn action itself is unchanged.
+                        se = agent.last_session_end
+                        graceful = bool(
+                            se and agent.last_spawn_at is not None
+                            and isinstance(se, dict)
+                            and se.get("at", 0) >= agent.last_spawn_at
+                        )
+                        if graceful:
+                            agent.consecutive_fast_deaths = 0
+                            _log(
+                                f"{role}: graceful exit (SessionEnd "
+                                f"reason={se.get('reason')!r}) — not counting "
+                                f"toward crash-loop streak (#12418)"
+                            )
+                        elif (lifetime is not None
                                 and lifetime < FAST_DEATH_WINDOW_SECONDS):
                             agent.consecutive_fast_deaths += 1
                         else:

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -494,6 +494,75 @@ class TestAliasesForRoles12380:
 
 
 # ---------------------------------------------------------------------------
+# _ensure_session_end_hook — #12418 (SessionEnd telemetry hook deployment)
+# ---------------------------------------------------------------------------
+
+class TestEnsureSessionEndHook12418:
+    """#12418 AC1: the pipeline places a native type:http SessionEnd hook in
+    .claude/settings.json, idempotently, preserving everything else."""
+
+    def _load(self, p):
+        import json
+        return json.loads(p.read_text(encoding="utf-8"))
+
+    def test_adds_hook_to_missing_file(self, tmp_path):
+        p = tmp_path / ".claude" / "settings.json"
+        changed = compose._ensure_session_end_hook(p)
+        assert changed is True
+        assert p.exists()
+        group = self._load(p)["hooks"]["SessionEnd"][0]
+        hook = group["hooks"][0]
+        assert hook["type"] == "http"
+        assert hook["url"].endswith("/hooks/session-end")
+        # Role rides the env-var header so one committed file serves all clones.
+        assert hook["headers"]["X-Agent-Role"] == "${SQUIDSQUAD_ROLE}"
+        assert "SQUIDSQUAD_ROLE" in hook["allowedEnvVars"]
+        assert isinstance(hook["timeout"], int)
+
+    def test_idempotent_no_rewrite(self, tmp_path):
+        p = tmp_path / ".claude" / "settings.json"
+        assert compose._ensure_session_end_hook(p) is True
+        # Second call: already present + identical → no change, no churn.
+        assert compose._ensure_session_end_hook(p) is False
+
+    def test_preserves_other_keys_and_hooks(self, tmp_path):
+        import json
+        p = tmp_path / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True)
+        p.write_text(json.dumps({
+            "statusLine": {"type": "command", "command": "x"},
+            "permissions": {"allow": ["Bash(ls *)"]},
+            "hooks": {"SessionStart": [{"matcher": "", "hooks": [
+                {"type": "command", "command": "echo hi"}]}]},
+        }), encoding="utf-8")
+        assert compose._ensure_session_end_hook(p) is True
+        d = self._load(p)
+        assert d["statusLine"]["command"] == "x"
+        assert d["permissions"]["allow"] == ["Bash(ls *)"]
+        # Existing SessionStart hook untouched; SessionEnd added alongside.
+        assert d["hooks"]["SessionStart"][0]["hooks"][0]["command"] == "echo hi"
+        assert "SessionEnd" in d["hooks"]
+
+    def test_corrupt_file_treated_as_empty(self, tmp_path):
+        p = tmp_path / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True)
+        p.write_text("{ not json", encoding="utf-8")
+        assert compose._ensure_session_end_hook(p) is True
+        assert "SessionEnd" in self._load(p)["hooks"]
+
+    def test_replaces_stale_session_end_entry(self, tmp_path):
+        import json
+        p = tmp_path / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True)
+        p.write_text(json.dumps({"hooks": {"SessionEnd": [{"matcher": "",
+            "hooks": [{"type": "http", "url": "http://old/x"}]}]}}),
+            encoding="utf-8")
+        assert compose._ensure_session_end_hook(p) is True
+        url = self._load(p)["hooks"]["SessionEnd"][0]["hooks"][0]["url"]
+        assert url.endswith("/hooks/session-end")
+
+
+# ---------------------------------------------------------------------------
 # Layered role architecture (#3465)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -3775,5 +3775,116 @@ class TestCloneResolutionRefusal(unittest.TestCase):
         self.assertIsNone(st.agents["skill"].terminal_pid)
 
 
+# ---------------------------------------------------------------------------
+# SessionEnd hook ingestion — #12418 (HARNESS-ARCH §15.4 / §16)
+# ---------------------------------------------------------------------------
+
+class TestSessionEndHook12418(unittest.TestCase):
+    """#12418 AC3: POST /hooks/session-end/{role} records the SessionEnd
+    reason on AgentState (the graceful-exit signal), persists it, exposes it
+    via GET /agents/{role}, and is fail-open (always 200 — a hook must never
+    block/fail an agent's teardown)."""
+
+    def setUp(self):
+        import harness
+        from fastapi.testclient import TestClient
+        self.harness = harness
+        self.client = TestClient(harness.app, raise_server_exceptions=False)
+        harness.state.start_time = time.time()
+        self.role = "skill"
+        self._roles = patch.object(
+            harness.boot_remote, "_get_all_roles", return_value=[self.role])
+        self._roles.start()
+        self._save = patch.object(harness.state, "save_state")
+        self._save.start()
+        # GET /agents/{role} runs update_health (PID checks) — neutralize it.
+        self._uh = patch.object(harness.state, "update_health")
+        self._uh.start()
+        harness.state.agents.pop(self.role, None)
+
+    def tearDown(self):
+        self._uh.stop()
+        self._save.stop()
+        self._roles.stop()
+        self.harness.state.agents.pop(self.role, None)
+
+    def test_records_reason_on_agentstate(self):
+        resp = self.client.post(
+            f"/hooks/session-end/{self.role}",
+            json={"hook_event_name": "SessionEnd", "stop_reason": "other"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json().get("ok"))
+        agent = self.harness.state.agents.get(self.role)
+        self.assertIsNotNone(agent)
+        self.assertEqual(agent.last_session_end["reason"], "other")
+        self.assertIn("at", agent.last_session_end)
+
+    def test_exposed_via_get_agent(self):
+        self.client.post(f"/hooks/session-end/{self.role}",
+                         json={"stop_reason": "logout"})
+        resp = self.client.get(f"/agents/{self.role}")
+        self.assertEqual(resp.status_code, 200)
+        se = resp.json().get("last_session_end")
+        self.assertIsNotNone(se)
+        self.assertEqual(se["reason"], "logout")
+
+    def test_missing_stop_reason_defaults_unknown(self):
+        resp = self.client.post(f"/hooks/session-end/{self.role}", json={})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            self.harness.state.agents[self.role].last_session_end["reason"],
+            "unknown")
+
+    def test_malformed_body_is_fail_open(self):
+        resp = self.client.post(f"/hooks/session-end/{self.role}",
+                                content=b"not json",
+                                headers={"Content-Type": "application/json"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            self.harness.state.agents[self.role].last_session_end["reason"],
+            "unknown")
+
+    def test_unknown_role_dropped_but_200(self):
+        resp = self.client.post("/hooks/session-end/bogus-role",
+                                json={"stop_reason": "other"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(resp.json().get("ok"))
+        self.assertNotIn("bogus-role", self.harness.state.agents)
+
+    def test_save_failure_is_fail_open(self):
+        """Even if persistence raises, the hook still answers 200 — never
+        block teardown."""
+        self._save.stop()  # replace with a raising stub
+        with patch.object(self.harness.state, "save_state",
+                               side_effect=OSError("disk full")):
+            resp = self.client.post(f"/hooks/session-end/{self.role}",
+                                    json={"stop_reason": "other"})
+        self._save.start()  # restore so tearDown's stop() is balanced
+        self.assertEqual(resp.status_code, 200)
+
+    def test_persisted_and_restored(self):
+        """last_session_end survives a save_state/load_state round-trip."""
+        import json as _json
+        import tempfile
+        from pathlib import Path as _Path
+        st = self.harness.HarnessState()
+        agent = self.harness.AgentState(self.role, "/tmp/x")
+        agent.last_session_end = {"reason": "other", "at": 123.0}
+        st.agents[self.role] = agent
+        with tempfile.TemporaryDirectory() as d:
+            sf = _Path(d) / ".harness-state.json"
+            with patch.object(self.harness, "HARNESS_STATE_FILE", sf):
+                st.save_state()
+                raw = _json.loads(sf.read_text(encoding="utf-8"))
+                self.assertEqual(
+                    raw["agents"][self.role]["last_session_end"],
+                    {"reason": "other", "at": 123.0})
+                st2 = self.harness.HarnessState()
+                st2.load_state()
+                self.assertEqual(
+                    st2.agents[self.role].last_session_end,
+                    {"reason": "other", "at": 123.0})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -824,6 +824,52 @@ class TestCrashLoopBackoff(unittest.TestCase):
                 self.assertEqual(loaded.consecutive_fast_deaths, 4)
                 self.assertEqual(loaded.reboot_blocked_until, 456.0)
 
+    # --- #12418 AC4: SessionEnd graceful-vs-crash refinement ---
+
+    def _set_session_end(self, hs, at, reason="other", role="skill"):
+        hs.get_agent(role).last_session_end = {"reason": reason, "at": at}
+
+    def test_graceful_exit_not_counted_toward_streak(self):
+        """#12418 AC4: a GRACEFUL exit (SessionEnd stamped AFTER last_spawn) at
+        threshold-minus-one must NOT trip the crash-loop breaker — it resets the
+        streak and respawns immediately, unlike a crash."""
+        from harness import FAST_DEATH_THRESHOLD
+        now = 10_000.0
+        hs, _ = self._make_dead_agent(
+            last_spawn_at=now - 10, fast_deaths=FAST_DEATH_THRESHOLD - 1)
+        self._set_session_end(hs, at=now - 5)  # after spawn (now-10) → graceful
+        boot = self._run(hs, now)
+        boot.assert_called_once_with("skill")  # respawned, NOT backed off
+        agent = hs.get_agent("skill")
+        self.assertEqual(agent.consecutive_fast_deaths, 0)
+        self.assertNotEqual(agent.status, "crash-looping")
+
+    def test_crash_no_sessionend_still_backs_off(self):
+        """No SessionEnd (a real crash — the hook couldn't run) at
+        threshold-minus-one still trips the breaker. The graceful path must not
+        weaken crash protection (AC6 — PID path unchanged for crashes)."""
+        from harness import FAST_DEATH_THRESHOLD
+        now = 10_000.0
+        hs, _ = self._make_dead_agent(
+            last_spawn_at=now - 10, fast_deaths=FAST_DEATH_THRESHOLD - 1)
+        # last_session_end stays None (crash).
+        boot = self._run(hs, now)
+        boot.assert_not_called()
+        self.assertEqual(hs.get_agent("skill").status, "crash-looping")
+
+    def test_stale_sessionend_treated_as_crash(self):
+        """A SessionEnd from a PRIOR spawn (at < last_spawn_at) is NOT graceful
+        for the current death — the >= last_spawn_at guard treats it as a crash
+        and still backs off."""
+        from harness import FAST_DEATH_THRESHOLD
+        now = 10_000.0
+        hs, _ = self._make_dead_agent(
+            last_spawn_at=now - 10, fast_deaths=FAST_DEATH_THRESHOLD - 1)
+        self._set_session_end(hs, at=now - 50)  # BEFORE last_spawn_at → stale
+        boot = self._run(hs, now)
+        boot.assert_not_called()
+        self.assertEqual(hs.get_agent("skill").status, "crash-looping")
+
 
 class TestRestartLifecycle(unittest.TestCase):
     """#11538: update_health must not undo an in-flight RESTARTING intent.

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -831,8 +831,8 @@ class TestCrashLoopBackoff(unittest.TestCase):
 
     def test_graceful_exit_not_counted_toward_streak(self):
         """#12418 AC4: a GRACEFUL exit (SessionEnd stamped AFTER last_spawn) at
-        threshold-minus-one must NOT trip the crash-loop breaker — it resets the
-        streak and respawns immediately, unlike a crash."""
+        threshold-minus-one must NOT trip the crash-loop breaker — it does not
+        increment the streak, so it respawns immediately instead of backing off."""
         from harness import FAST_DEATH_THRESHOLD
         now = 10_000.0
         hs, _ = self._make_dead_agent(
@@ -841,8 +841,44 @@ class TestCrashLoopBackoff(unittest.TestCase):
         boot = self._run(hs, now)
         boot.assert_called_once_with("skill")  # respawned, NOT backed off
         agent = hs.get_agent("skill")
-        self.assertEqual(agent.consecutive_fast_deaths, 0)
+        # Not-incremented (DS-C F2: NOT reset to 0 — so accumulated real crashes
+        # aren't zeroable by a SessionEnd-spammer); stays below threshold.
+        self.assertEqual(agent.consecutive_fast_deaths, FAST_DEATH_THRESHOLD - 1)
         self.assertNotEqual(agent.status, "crash-looping")
+
+    def test_graceful_does_not_reset_accumulated_crashes(self):
+        """DS-REVIEW-12418-C F2 guard: a graceful death must NOT zero an
+        accumulated streak — otherwise a SessionEnd-spammer could escape the
+        breaker. After a graceful death at streak N, the very next CRASH
+        increments to N+1 and (if that crosses the threshold) backs off."""
+        from harness import FAST_DEATH_THRESHOLD
+        now = 10_000.0
+        hs, _ = self._make_dead_agent(
+            last_spawn_at=now - 10, fast_deaths=FAST_DEATH_THRESHOLD - 1)
+        self._set_session_end(hs, at=now - 5)  # graceful
+        self._run(hs, now)  # respawn; streak still THRESHOLD-1
+        agent = hs.get_agent("skill")
+        # Now a real crash (no fresh SessionEnd — the spawn cleared it) crosses
+        # the threshold → backoff. (The reboot loop re-stamped last_spawn_at to
+        # `now`; advance the clock so the next death is still "fast".)
+        agent.status = "running"
+        agent.claude_pid = 12345
+        boot2 = self._run(hs, now + 5)
+        boot2.assert_not_called()
+        self.assertEqual(hs.get_agent("skill").status, "crash-looping")
+
+    def test_sessionend_at_none_does_not_crash(self):
+        """DS-REVIEW-12418-C F1: a {"at": null} entry (from a corrupt/hand-edited
+        state file) must NOT raise TypeError in the graceful check — it is
+        treated as a crash and update_health completes normally."""
+        from harness import FAST_DEATH_THRESHOLD
+        now = 10_000.0
+        hs, _ = self._make_dead_agent(
+            last_spawn_at=now - 10, fast_deaths=FAST_DEATH_THRESHOLD - 1)
+        hs.get_agent("skill").last_session_end = {"reason": "x", "at": None}
+        boot = self._run(hs, now)  # must not raise
+        boot.assert_not_called()  # treated as crash → backoff
+        self.assertEqual(hs.get_agent("skill").status, "crash-looping")
 
     def test_crash_no_sessionend_still_backs_off(self):
         """No SessionEnd (a real crash — the hook couldn't run) at

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -3899,6 +3899,15 @@ class TestSessionEndHook12418(unittest.TestCase):
         self.assertFalse(resp.json().get("ok"))
         self.assertEqual(resp.json().get("dropped"), "no-role")
 
+    def test_uninterpolated_env_var_role_is_no_role(self):
+        """#12418 F5: if $SQUIDSQUAD_ROLE was unset, Claude Code sends the
+        literal '${SQUIDSQUAD_ROLE}' — treat it as no-role (not unknown-role)."""
+        resp = self.client.post("/hooks/session-end",
+                                headers=self._hdr("${SQUIDSQUAD_ROLE}"),
+                                json={"stop_reason": "other"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json().get("dropped"), "no-role")
+
     def test_unknown_role_dropped_but_200(self):
         resp = self.client.post("/hooks/session-end",
                                 headers=self._hdr("bogus-role"),

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -3808,9 +3808,12 @@ class TestSessionEndHook12418(unittest.TestCase):
         self._roles.stop()
         self.harness.state.agents.pop(self.role, None)
 
+    def _hdr(self, role=None):
+        return {"X-Agent-Role": self.role if role is None else role}
+
     def test_records_reason_on_agentstate(self):
         resp = self.client.post(
-            f"/hooks/session-end/{self.role}",
+            "/hooks/session-end", headers=self._hdr(),
             json={"hook_event_name": "SessionEnd", "stop_reason": "other"})
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(resp.json().get("ok"))
@@ -3820,7 +3823,7 @@ class TestSessionEndHook12418(unittest.TestCase):
         self.assertIn("at", agent.last_session_end)
 
     def test_exposed_via_get_agent(self):
-        self.client.post(f"/hooks/session-end/{self.role}",
+        self.client.post("/hooks/session-end", headers=self._hdr(),
                          json={"stop_reason": "logout"})
         resp = self.client.get(f"/agents/{self.role}")
         self.assertEqual(resp.status_code, 200)
@@ -3829,23 +3832,30 @@ class TestSessionEndHook12418(unittest.TestCase):
         self.assertEqual(se["reason"], "logout")
 
     def test_missing_stop_reason_defaults_unknown(self):
-        resp = self.client.post(f"/hooks/session-end/{self.role}", json={})
+        resp = self.client.post("/hooks/session-end", headers=self._hdr(), json={})
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(
             self.harness.state.agents[self.role].last_session_end["reason"],
             "unknown")
 
     def test_malformed_body_is_fail_open(self):
-        resp = self.client.post(f"/hooks/session-end/{self.role}",
-                                content=b"not json",
-                                headers={"Content-Type": "application/json"})
+        resp = self.client.post(
+            "/hooks/session-end", content=b"not json",
+            headers={**self._hdr(), "Content-Type": "application/json"})
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(
             self.harness.state.agents[self.role].last_session_end["reason"],
             "unknown")
 
+    def test_no_role_header_dropped_but_200(self):
+        resp = self.client.post("/hooks/session-end", json={"stop_reason": "other"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(resp.json().get("ok"))
+        self.assertEqual(resp.json().get("dropped"), "no-role")
+
     def test_unknown_role_dropped_but_200(self):
-        resp = self.client.post("/hooks/session-end/bogus-role",
+        resp = self.client.post("/hooks/session-end",
+                                headers=self._hdr("bogus-role"),
                                 json={"stop_reason": "other"})
         self.assertEqual(resp.status_code, 200)
         self.assertFalse(resp.json().get("ok"))
@@ -3857,7 +3867,7 @@ class TestSessionEndHook12418(unittest.TestCase):
         self._save.stop()  # replace with a raising stub
         with patch.object(self.harness.state, "save_state",
                                side_effect=OSError("disk full")):
-            resp = self.client.post(f"/hooks/session-end/{self.role}",
+            resp = self.client.post("/hooks/session-end", headers=self._hdr(),
                                     json={"stop_reason": "other"})
         self._save.start()  # restore so tearDown's stop() is balanced
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
## Summary

Fixes #12418 (#12271 liveness slice 1). Today the harness reboots a dead intent=running agent with no idea WHY it died. A Claude Code SessionEnd hook now reports the exit so the reboot decision keys off a FACT (graceful vs crash) instead of a guess.

## Design (front-loaded; verified the CC hook API first — flagged 3 doc gaps PM doc-synced)

- SessionEnd only fires on GRACEFUL termination; a hard crash can't run a hook. So the signal is presence/absence: SessionEnd recorded since last spawn = graceful; dead PID with no SessionEnd = crash.
- `stop_reason` is a UI enum (clear/logout/other), not exit-42/usage-limit; no exit_code. Record {reason, at}.

## Components (each per-change DS-reviewed)

- **A — hook deploy** (compose, AC1/2): ONE committed `.claude/settings.json` native `type:http` SessionEnd hook serves all clones; role rides an `X-Agent-Role` header interpolated per-clone from `$SQUIDSQUAD_ROLE`. `compose._ensure_session_end_hook` idempotently places it (no no-op churn). Port 7373 default — non-default fails-open (safe).
- **B — harness ingest** (AC3): `POST /hooks/session-end` records `{reason, at}` on `AgentState.last_session_end`; persisted; exposed via `GET /agents/{role}`. Fail-open: always 200, never blocks teardown. *DS: NO_FINDINGS.*
- **C — reboot decision** (AC4/6): in `update_health`, a graceful death does NOT count toward the #12244 crash-loop streak; a crash still does. PID path unchanged. *DS caught 1 error (None TypeError) + a breaker-bypass — fixed: graceful does NOT reset the streak (can't be zeroed by a SessionEnd-spammer), and `last_session_end` is cleared on every spawn.*

## Tests
~30 new tests (hook ingest fail-open, compose idempotency/merge, graceful-vs-crash incl. stale/None/spam edges). Full unit + integration (51 passed, 2 skipped) green — verified via pytest exit codes (#12408).

## Notes
- Residual: a deliberate SessionEnd-spammer can keep its streak from growing (not zero it) — full termination-correlation is a later #12271 slice. Natural crash loops don't POST SessionEnd, so #12244 protection is intact.
- Endpoint refined path→header (PM affirmed "shape = your call"); please tweak AC3 wording to `/hooks/session-end`.
- `.claude/settings.json` is per-clone state (excluded from the PR by the #11511 guard); the compose code in this PR is what places the hook — AC1 verifies by running `compose.py deploy`.