### PR TITLE
feat(#12443): activity-heartbeat hooks (#12271 liveness slice b)

### DIFF
--- a/references/installer-files.txt
+++ b/references/installer-files.txt
@@ -12,6 +12,7 @@ start.ps1
 references/commands/squidsquad-compose.md
 references/commands/squidsquad-upgrade.md
 references/wizard/WIZARD.md
+references/scripts/activity_hook.py
 references/scripts/add_role.py
 references/scripts/boot_remote.py
 references/scripts/capability_check.py

--- a/references/scripts/activity_hook.py
+++ b/references/scripts/activity_hook.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+"""#12443 — activity-heartbeat poster (HARNESS-ARCH §15.1, #12271 slice b).
+
+Two roles:
+
+1. **Claude Code command hook** — wired per-clone (by compose) as the
+   ``PostToolUse`` / ``PostToolUseFailure`` hook with ``async: true``, so Claude
+   Code backgrounds it and IGNORES its exit code/output: it can never block,
+   delay, or fail the agent's tool call (AC2). Run that way it reads the agent
+   role from the inherited ``$SQUIDSQUAD_ROLE`` env var and the hook payload
+   (``tool_name`` / ``hook_event_name``) from stdin, then POSTs a lightweight
+   heartbeat to the harness ``POST /hooks/activity``.
+
+2. **Importable poster** — ``cycle_post`` imports ``post_activity()`` to emit a
+   heartbeat at cycle end (AC3), passing its own liveness-aware harness port.
+
+Why a command hook and not a native ``type: http`` hook: native http hooks are
+SYNCHRONOUS (they block the tool call; their default timeout is 600s) and only
+``type: command`` hooks support ``async``/fire-and-forget — verified against the
+Claude Code hook API (#12443). These fire on EVERY tool call, so they MUST be
+async command hooks. (SessionEnd, slice a, is once-per-session, so it stays a
+native http hook.)
+
+Fail-open contract (HARNESS-ARCH §15.5 / §16.3): NOTHING here raises and the
+process ALWAYS exits 0 — a telemetry hook must never stall, fail, or error the
+agent's work.
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+_DEFAULT_PORT = 7373
+# Bound the POST. ``async: true`` already keeps the hook off the agent's
+# critical path, so this only caps how long this background process lingers.
+_HEARTBEAT_TIMEOUT = 2
+
+
+def _repo_root() -> Path:
+    # references/scripts/activity_hook.py → repo root is three parents up.
+    return Path(__file__).resolve().parent.parent.parent
+
+
+def _discover_port() -> int:
+    """Best-effort harness port: this clone's ``.squidsquad/.harness-port``,
+    else the default 7373. No liveness probe — fail-open means a wrong/dead
+    port just yields a swallowed connection error and a no-op heartbeat."""
+    try:
+        txt = (_repo_root() / ".squidsquad" / ".harness-port").read_text(
+            encoding="utf-8").strip()
+        return int(txt)
+    except (OSError, ValueError):
+        return _DEFAULT_PORT
+
+
+def post_activity(role, event, tool=None, phase=None, port=None,
+                  timeout=_HEARTBEAT_TIMEOUT) -> bool:
+    """POST an activity heartbeat to the harness. Returns True on a 2xx
+    response, False otherwise. NEVER raises — every error (no role, unreachable
+    harness, timeout, bad response) is swallowed (fail-open telemetry)."""
+    if not role:
+        return False
+    if port is None:
+        port = _discover_port()
+    url = f"http://127.0.0.1:{port}/hooks/activity"
+    body = {"event": event}
+    if tool:
+        body["tool"] = tool
+    if phase:
+        body["phase"] = phase
+    try:
+        req = urllib.request.Request(
+            url, data=json.dumps(body).encode("utf-8"), method="POST",
+            headers={"Content-Type": "application/json", "X-Agent-Role": role},
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return 200 <= resp.status < 300
+    except Exception:
+        return False
+
+
+def main() -> int:
+    """Command-hook entrypoint: role from env, payload from stdin → heartbeat."""
+    role = (os.environ.get("SQUIDSQUAD_ROLE") or "").strip()
+    payload = {}
+    try:
+        raw = sys.stdin.read()
+        if raw:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                payload = parsed
+    except Exception:
+        payload = {}
+    event = payload.get("hook_event_name") or "PostToolUse"
+    tool = payload.get("tool_name")
+    post_activity(role, event, tool=tool)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        # Absolute fail-open: a telemetry hook must never surface a non-zero
+        # exit to Claude Code, even on an unforeseen error.
+        sys.exit(0)

--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -1819,15 +1819,47 @@ def _session_end_hook_group() -> dict:
     }
 
 
-def _ensure_session_end_hook(settings_path) -> bool:
-    """#12418 — idempotently ensure the SessionEnd hook is present in
+# #12443 — activity-heartbeat hooks (HARNESS-ARCH §15.1). PostToolUse /
+# PostToolUseFailure fire on EVERY tool call, so they MUST NOT block or delay
+# the agent (AC2). Native `type: http` hooks are SYNCHRONOUS (they block the
+# tool call; default timeout 600s) and only `type: command` hooks support
+# `async` — verified against the Claude Code hook API (#12443) — so these are
+# async command hooks: Claude Code backgrounds them and ignores exit/output,
+# giving true zero-latency fire-and-forget. (SessionEnd, slice a, stays http: a
+# brief block once-per-session at teardown is fine.) They invoke the tiny
+# cross-platform poster via the EXEC form (command + args) so the
+# `${CLAUDE_PROJECT_DIR}` token — substituted by Claude Code itself, not the
+# shell, so it works on Windows and POSIX — resolves the script path without
+# any shell-quoting hazard. The agent role is read by the script from the
+# inherited `$SQUIDSQUAD_ROLE` env var (command-hook subprocesses inherit the
+# agent's environment).
+_ACTIVITY_HOOK_REL = "references/scripts/activity_hook.py"
+
+
+def _activity_hook_group() -> dict:
+    """Return a fresh activity-hook matcher-group (new objects each call)."""
+    return {
+        "matcher": "",
+        "hooks": [{
+            "type": "command",
+            "command": "python",
+            "args": ["${CLAUDE_PROJECT_DIR}/" + _ACTIVITY_HOOK_REL],
+            "async": True,
+            "timeout": 30,
+        }],
+    }
+
+
+def _ensure_hook_entries(settings_path, entries: dict) -> bool:
+    """#12418/#12443 — idempotently set each ``hooks.<name> = [group]`` in
     ``.claude/settings.json``. Returns True iff the file was changed.
 
-    Preserves every other key (statusLine, permissions, other hooks); only the
-    ``hooks.SessionEnd`` entry is (re)set to the canonical group. Idempotent:
-    if the entry already matches, nothing is written — so a recompose does not
+    Preserves every other key (statusLine, permissions, hooks not in
+    ``entries``); only the named ``hooks.<name>`` entries are (re)set. Idempotent:
+    if the result already matches, nothing is written — so a recompose does not
     churn the tracked file (avoids the #12397 no-op-write class). A
-    missing/corrupt file is treated as empty and (re)written.
+    missing/corrupt file is treated as empty and (re)written; a non-dict
+    ``hooks`` is replaced (warning if it held content — DS-REVIEW-12418-A F3).
     """
     settings_path = Path(settings_path)
     data = {}
@@ -1841,20 +1873,34 @@ def _ensure_session_end_hook(settings_path) -> bool:
     before = json.dumps(data, sort_keys=True)
     hooks = data.get("hooks")
     if not isinstance(hooks, dict):
-        # DS-REVIEW-12418-A F3: a valid-JSON file whose `hooks` is the wrong
-        # type (list/string/null) is replaced. Surface it if it held content,
-        # so the (rare, Claude-Code-invalid) data loss isn't silent.
         if hooks:
             print(f"WARNING: .claude/settings.json `hooks` was "
                   f"{type(hooks).__name__}, not an object — replacing "
                   f"(prior hooks dropped): {settings_path}", file=sys.stderr)
         hooks = data["hooks"] = {}
-    hooks["SessionEnd"] = [_session_end_hook_group()]
+    for name, group in entries.items():
+        hooks[name] = [group]
     if json.dumps(data, sort_keys=True) == before:
         return False
     settings_path.parent.mkdir(parents=True, exist_ok=True)
     settings_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     return True
+
+
+def _ensure_session_end_hook(settings_path) -> bool:
+    """#12418 — ensure the SessionEnd telemetry hook is present in
+    ``.claude/settings.json`` (see ``_ensure_hook_entries``)."""
+    return _ensure_hook_entries(
+        settings_path, {"SessionEnd": _session_end_hook_group()})
+
+
+def _ensure_activity_hooks(settings_path) -> bool:
+    """#12443 — ensure the PostToolUse + PostToolUseFailure activity-heartbeat
+    hooks are present in ``.claude/settings.json`` (see ``_ensure_hook_entries``)."""
+    return _ensure_hook_entries(settings_path, {
+        "PostToolUse": _activity_hook_group(),
+        "PostToolUseFailure": _activity_hook_group(),
+    })
 
 
 MANDATORY_ROLES = {"pm", "verifier", "dm"}  # #6055/#6274: always present (qa→verifier per D5)
@@ -2138,6 +2184,10 @@ def main():
         se_settings = REPO_ROOT / ".claude" / "settings.json"
         if _ensure_session_end_hook(se_settings):
             print(f"  SessionEnd hook -> {se_settings.relative_to(REPO_ROOT)}")
+        # #12443 — ensure the PostToolUse + PostToolUseFailure activity-heartbeat
+        # hooks are present too (same idempotent settings.json integration).
+        if _ensure_activity_hooks(se_settings):
+            print(f"  Activity hooks -> {se_settings.relative_to(REPO_ROOT)}")
 
     elif cmd == "upgrade-soul":
         if len(args) < 2:

--- a/references/scripts/cycle_post.py
+++ b/references/scripts/cycle_post.py
@@ -923,6 +923,22 @@ def _do_stop_after_cycle_check(data, role):
     return False
 
 
+def _do_activity_heartbeat(role):
+    """#12443 — emit an activity heartbeat at cycle end (HARNESS-ARCH §15.1).
+
+    A completed cycle is a liveness signal that covers quiet stretches with no
+    tool calls in the wrapper window (the PostToolUse hooks cover the rest).
+    Reuses the liveness-aware harness-port discovery. Fail-open: a telemetry
+    failure (harness down, import error, anything) must NEVER break the cycle.
+    """
+    try:
+        import activity_hook
+        activity_hook.post_activity(
+            role, "cycle_post", phase="cleanup", port=_discover_harness_port())
+    except Exception:
+        pass
+
+
 def _do_working_state_update(data, role):
     """Update working state file if agent provided update content."""
     update = data.get("working_state_update")
@@ -1026,6 +1042,9 @@ def main():
         }, cycle_number=data.get("cycle_number"))
     except (ImportError, Exception):
         pass
+
+    # 8b. Activity heartbeat (#12443) — a completed cycle is a liveness signal.
+    _do_activity_heartbeat(role)
 
     # 9. Intent + context pressure check (MUST be last — after commit, after log)
     # Queries harness API for intent, checks context pressure. Exit 42 = harness respawns.

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -2230,6 +2230,13 @@ async def hook_activity(request: Request):
         body = {}
 
     if not role:
+        # Log the DROP paths (DS-REVIEW-12443-harness F1): these fire only on a
+        # MISCONFIGURED header, so a healthy agent never logs here — a steady
+        # stream is the diagnostic signal that the X-Agent-Role wiring is wrong
+        # (distinguishes "no heartbeats" from "heartbeats silently dropped").
+        # The SUCCESS path is logged only at the throttle cadence below (it
+        # fires per tool call — logging each would be spam).
+        _log("Activity hook DROPPED — no X-Agent-Role header")
         return JSONResponse(status_code=200, content={"ok": False, "dropped": "no-role"})
 
     # Defense-in-depth (mirrors /hooks/session-end + receive_event #9242): drop
@@ -2239,6 +2246,7 @@ async def hook_activity(request: Request):
     except (SystemExit, Exception):
         allowed = None
     if allowed is not None and role not in allowed:
+        _log(f"Activity hook DROPPED unknown role={role!r}")
         return JSONResponse(status_code=200, content={"ok": False, "dropped": "unknown-role"})
 
     now = time.time()
@@ -2260,6 +2268,11 @@ async def hook_activity(request: Request):
             _last_activity_save_at = now
             should_save = True
     if should_save:
+        # Throttled success log (DS-REVIEW-12443-harness F1): a low-noise
+        # "still alive" breadcrumb at the persistence cadence (~once/30s per
+        # agent), NOT per tool call. Confirms heartbeats are arriving + being
+        # recorded without flooding the log.
+        _log(f"{role}: activity recorded ({activity.get('event')}, #12443)")
         try:
             await asyncio.to_thread(state.save_state)
         except Exception as e:  # pragma: no cover — defensive

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -160,7 +160,9 @@ class AgentState:
                  "last_spawn_at", "consecutive_fast_deaths",
                  "reboot_blocked_until",
                  # #12418 — last SessionEnd hook reason (graceful-exit signal)
-                 "last_session_end")
+                 "last_session_end",
+                 # #12443 — activity heartbeat (progress-based liveness)
+                 "last_activity_at", "last_activity")
 
     # Intent values:
     #   "running"    — agent should be alive; auto-reboot on death (#4949)
@@ -212,6 +214,16 @@ class AgentState:
         # a crash. The reboot decision (update_health) keys off that to avoid
         # counting graceful exits toward the #12244 crash-loop streak.
         self.last_session_end = None
+        # #12443 — activity heartbeat (HARNESS-ARCH §15.1). last_activity_at is
+        # the epoch of the most recent heartbeat (a PostToolUse / PostToolUse-
+        # Failure command hook, or a cycle_post emit); last_activity carries the
+        # enriched context ({at, event, tool, phase}, §15.2) for display. A
+        # working loop emits these continuously; a wedged loop stops, so silence
+        # — evaluated relative to dispatched work — is the death signal.
+        # OBSERVATIONAL ONLY this slice (#12443): recorded + exposed, does NOT
+        # yet drive the reboot decision (that is #12271 slice d).
+        self.last_activity_at = None
+        self.last_activity = None
 
     def to_dict(self):
         return {
@@ -236,6 +248,9 @@ class AgentState:
             "reboot_blocked_until": self.reboot_blocked_until,
             # #12418 — last SessionEnd hook reason (graceful-exit signal)
             "last_session_end": self.last_session_end,
+            # #12443 — activity heartbeat (progress-based liveness)
+            "last_activity_at": self.last_activity_at,
+            "last_activity": self.last_activity,
         }
 
 
@@ -897,6 +912,11 @@ class HarnessState:
                         # #12418 — persist last SessionEnd reason so the
                         # graceful-vs-crash signal survives a harness restart.
                         "last_session_end": a.last_session_end,
+                        # #12443 — persist activity heartbeat (throttled writer;
+                        # see /hooks/activity). Survives a harness restart so the
+                        # last-known activity isn't lost on recovery.
+                        "last_activity_at": a.last_activity_at,
+                        "last_activity": a.last_activity,
                     }
                     for role, a in self.agents.items()
                 },
@@ -987,6 +1007,10 @@ class HarnessState:
                 # #12418 — restore last SessionEnd reason (defaults None for
                 # older state files / fresh agents).
                 agent.last_session_end = agent_data.get("last_session_end")
+                # #12443 — restore activity heartbeat (defaults None for older
+                # state files / fresh agents).
+                agent.last_activity_at = agent_data.get("last_activity_at")
+                agent.last_activity = agent_data.get("last_activity")
 
         _log(f"Restored state for {len(state_data.get('agents', {}))} agents from state file")
 
@@ -2162,6 +2186,84 @@ async def hook_session_end(request: Request):
     except Exception as e:  # pragma: no cover — defensive
         _log(f"{role}: SessionEnd save_state failed (non-fatal): {e}")
     _log(f"{role}: SessionEnd reason={reason!r} recorded (#12418)")
+    return JSONResponse(status_code=200, content={"ok": True})
+
+
+# #12443 — activity-heartbeat persistence throttle. These hooks fire on EVERY
+# tool call, so we update the in-memory AgentState immediately (that is what
+# GET /agents/{role} reads) but rate-limit the state-FILE write: a heartbeat
+# only persists to disk if the last persist was at least this many seconds ago.
+# Disk staleness up to this window is harmless — last_activity_at matters for
+# live liveness (in-memory), and persistence only backstops a harness restart.
+_ACTIVITY_SAVE_THROTTLE_SECONDS = 30
+_last_activity_save_at = 0.0
+
+
+@app.post("/hooks/activity")
+async def hook_activity(request: Request):
+    """#12443 — receive an agent activity heartbeat (HARNESS-ARCH §15.1).
+
+    Emitted by the per-clone `PostToolUse` / `PostToolUseFailure` async command
+    hooks (every tool call) and by `cycle_post` (every completed cycle). The
+    heartbeat proves the agent's real loop is PROGRESSING — a wedged loop stops
+    making tool calls and completing cycles, so the heartbeat stops. We record
+    `last_activity_at` (+ enriched {event, tool, phase}) per agent; the reboot
+    decision does NOT yet consume it (observational this slice — #12271 d).
+
+    Role rides the `X-Agent-Role` header (same contract as /hooks/session-end).
+
+    Fail-open contract (§16.3): ALWAYS 200, never blocks or raises. Disk
+    persistence is throttled (`_ACTIVITY_SAVE_THROTTLE_SECONDS`) since these
+    fire per tool call — the in-memory value that GET /agents/{role} reads is
+    always current; only the state-file write is rate-limited.
+    """
+    global _last_activity_save_at
+    role = (request.headers.get("X-Agent-Role") or "").strip()
+    # Mirror /hooks/session-end F5: an uninterpolated token = no-role.
+    if role.startswith("${"):
+        role = ""
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    if not isinstance(body, dict):
+        body = {}
+
+    if not role:
+        return JSONResponse(status_code=200, content={"ok": False, "dropped": "no-role"})
+
+    # Defense-in-depth (mirrors /hooks/session-end + receive_event #9242): drop
+    # unknown roles so a stray hook can't seed a ghost agent — but STILL 200.
+    try:
+        allowed = set(boot_remote._get_all_roles()) | {"pm"}
+    except (SystemExit, Exception):
+        allowed = None
+    if allowed is not None and role not in allowed:
+        return JSONResponse(status_code=200, content={"ok": False, "dropped": "unknown-role"})
+
+    now = time.time()
+    activity = {
+        "at": now,
+        "event": body.get("event") or body.get("hook_event_name"),
+        "tool": body.get("tool") or body.get("tool_name"),
+        "phase": body.get("phase"),
+    }
+    should_save = False
+    with state._lock:
+        agent = state.agents.get(role)
+        if agent is None:
+            agent = AgentState(role)
+            state.agents[role] = agent
+        agent.last_activity_at = now
+        agent.last_activity = activity
+        if now - _last_activity_save_at >= _ACTIVITY_SAVE_THROTTLE_SECONDS:
+            _last_activity_save_at = now
+            should_save = True
+    if should_save:
+        try:
+            await asyncio.to_thread(state.save_state)
+        except Exception as e:  # pragma: no cover — defensive
+            _log(f"{role}: activity save_state failed (non-fatal): {e}")
     return JSONResponse(status_code=200, content={"ok": True})
 
 

--- a/tests/test_activity_hook.py
+++ b/tests/test_activity_hook.py
@@ -1,0 +1,111 @@
+"""#12443 — tests for activity_hook.py, the activity-heartbeat poster.
+
+Covers AC2/AC6 fail-open behavior: harness unreachable → no raise, returns
+False, exit 0; and the happy path POSTs the heartbeat with the role header.
+"""
+import io
+import json
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "references", "scripts"))
+
+import activity_hook  # noqa: E402
+
+
+class TestPostActivity(unittest.TestCase):
+    def test_no_role_returns_false_no_post(self):
+        """No role → no-op, never reaches the network."""
+        with patch("activity_hook.urllib.request.urlopen") as m:
+            self.assertFalse(activity_hook.post_activity("", "PostToolUse"))
+            m.assert_not_called()
+
+    def test_unreachable_harness_is_fail_open(self):
+        """Connection error → swallowed, returns False, NEVER raises."""
+        import urllib.error
+        with patch("activity_hook.urllib.request.urlopen",
+                   side_effect=urllib.error.URLError("refused")):
+            # Must not raise.
+            self.assertFalse(
+                activity_hook.post_activity("skill", "PostToolUse", port=7373))
+
+    def test_any_exception_is_swallowed(self):
+        with patch("activity_hook.urllib.request.urlopen",
+                   side_effect=RuntimeError("boom")):
+            self.assertFalse(
+                activity_hook.post_activity("skill", "PostToolUse", port=7373))
+
+    def test_happy_path_posts_with_role_header(self):
+        captured = {}
+
+        class _Resp:
+            status = 200
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+
+        def _fake_urlopen(req, timeout=None):
+            captured["url"] = req.full_url
+            captured["role"] = req.headers.get("X-agent-role")  # urllib title-cases
+            captured["body"] = json.loads(req.data.decode("utf-8"))
+            return _Resp()
+
+        with patch("activity_hook.urllib.request.urlopen", side_effect=_fake_urlopen):
+            ok = activity_hook.post_activity(
+                "skill", "PostToolUse", tool="Bash", phase="implement", port=7373)
+        self.assertTrue(ok)
+        self.assertTrue(captured["url"].endswith("/hooks/activity"))
+        self.assertEqual(captured["role"], "skill")
+        self.assertEqual(captured["body"]["event"], "PostToolUse")
+        self.assertEqual(captured["body"]["tool"], "Bash")
+        self.assertEqual(captured["body"]["phase"], "implement")
+
+    def test_non_2xx_returns_false(self):
+        class _Resp:
+            status = 500
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+        with patch("activity_hook.urllib.request.urlopen", return_value=_Resp()):
+            self.assertFalse(
+                activity_hook.post_activity("skill", "PostToolUse", port=7373))
+
+
+class TestMainEntrypoint(unittest.TestCase):
+    def test_main_reads_env_role_and_stdin_payload(self):
+        payload = {"hook_event_name": "PostToolUseFailure", "tool_name": "Edit"}
+        calls = {}
+
+        def _fake_post(role, event, tool=None, **kw):
+            calls.update(role=role, event=event, tool=tool)
+            return True
+
+        with patch.dict(os.environ, {"SQUIDSQUAD_ROLE": "skill"}), \
+             patch("activity_hook.post_activity", side_effect=_fake_post), \
+             patch("sys.stdin", io.StringIO(json.dumps(payload))):
+            rc = activity_hook.main()
+        self.assertEqual(rc, 0)
+        self.assertEqual(calls["role"], "skill")
+        self.assertEqual(calls["event"], "PostToolUseFailure")
+        self.assertEqual(calls["tool"], "Edit")
+
+    def test_main_empty_stdin_still_heartbeats(self):
+        """No payload (empty stdin) → still emits a heartbeat (the activity
+        FACT is the signal); event defaults, never raises."""
+        calls = {}
+        with patch.dict(os.environ, {"SQUIDSQUAD_ROLE": "skill"}), \
+             patch("activity_hook.post_activity",
+                   side_effect=lambda *a, **k: calls.update(a=a) or True), \
+             patch("sys.stdin", io.StringIO("")):
+            self.assertEqual(activity_hook.main(), 0)
+        self.assertEqual(calls["a"][0], "skill")
+
+    def test_main_malformed_stdin_is_fail_open(self):
+        with patch.dict(os.environ, {"SQUIDSQUAD_ROLE": "skill"}), \
+             patch("activity_hook.post_activity", return_value=True), \
+             patch("sys.stdin", io.StringIO("{ not json")):
+            self.assertEqual(activity_hook.main(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -562,6 +562,67 @@ class TestEnsureSessionEndHook12418:
         assert url.endswith("/hooks/session-end")
 
 
+class TestEnsureActivityHooks12443:
+    """#12443 AC1: the pipeline places PostToolUse + PostToolUseFailure
+    activity-heartbeat hooks in .claude/settings.json — async command hooks (NOT
+    blocking http), idempotently, preserving everything else (incl. slice-a's
+    SessionEnd hook)."""
+
+    def _load(self, p):
+        import json
+        return json.loads(p.read_text(encoding="utf-8"))
+
+    def test_adds_both_hooks_to_missing_file(self, tmp_path):
+        p = tmp_path / ".claude" / "settings.json"
+        changed = compose._ensure_activity_hooks(p)
+        assert changed is True
+        hooks = self._load(p)["hooks"]
+        for name in ("PostToolUse", "PostToolUseFailure"):
+            assert name in hooks, f"{name} hook missing"
+            hook = hooks[name][0]["hooks"][0]
+            # AC2: must be a non-blocking async COMMAND hook, not a blocking
+            # native http hook.
+            assert hook["type"] == "command"
+            assert hook["async"] is True
+            assert hook["command"] == "python"
+            # Exec form + CC-substituted project-dir token = cross-platform path.
+            assert hook["args"] == [
+                "${CLAUDE_PROJECT_DIR}/references/scripts/activity_hook.py"]
+            assert isinstance(hook["timeout"], int)
+
+    def test_idempotent_no_rewrite(self, tmp_path):
+        p = tmp_path / ".claude" / "settings.json"
+        assert compose._ensure_activity_hooks(p) is True
+        assert compose._ensure_activity_hooks(p) is False
+
+    def test_coexists_with_session_end_hook(self, tmp_path):
+        """Slice-a's SessionEnd hook and slice-b's activity hooks are both
+        present after the two idempotent ensures run in sequence (the deploy
+        order), and neither clobbers the other or other keys."""
+        import json
+        p = tmp_path / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True)
+        p.write_text(json.dumps({
+            "statusLine": {"type": "command", "command": "x"},
+        }), encoding="utf-8")
+        assert compose._ensure_session_end_hook(p) is True
+        assert compose._ensure_activity_hooks(p) is True
+        d = self._load(p)
+        assert d["statusLine"]["command"] == "x"
+        assert "SessionEnd" in d["hooks"]
+        assert "PostToolUse" in d["hooks"]
+        assert "PostToolUseFailure" in d["hooks"]
+        # SessionEnd stays a native http hook (once-per-session, block-OK).
+        assert d["hooks"]["SessionEnd"][0]["hooks"][0]["type"] == "http"
+
+    def test_corrupt_file_treated_as_empty(self, tmp_path):
+        p = tmp_path / ".claude" / "settings.json"
+        p.parent.mkdir(parents=True)
+        p.write_text("{ not json", encoding="utf-8")
+        assert compose._ensure_activity_hooks(p) is True
+        assert "PostToolUse" in self._load(p)["hooks"]
+
+
 # ---------------------------------------------------------------------------
 # Layered role architecture (#3465)
 # ---------------------------------------------------------------------------

--- a/tests/test_cycle_post.py
+++ b/tests/test_cycle_post.py
@@ -94,6 +94,19 @@ def _block_live_harness_egress(monkeypatch):
 
     monkeypatch.setattr(cycle_post.urllib.request, "urlopen", _guard)
 
+    # #12443: the step-8b cycle_post heartbeat calls activity_hook.post_activity,
+    # which has its OWN urllib (not cycle_post's) and would otherwise leak to the
+    # live harness on 7373 from any full-main() test (e.g.
+    # test_exits_on_context_pressure) — the same #12282 class. Neutralize the
+    # poster to a no-op by default; a test that wants to assert the heartbeat
+    # re-patches it inside its own body (overriding this).
+    try:
+        import activity_hook
+        monkeypatch.setattr(activity_hook, "post_activity",
+                            lambda *a, **k: False)
+    except ImportError:
+        pass
+
 
 # ---------------------------------------------------------------------------
 # Validation
@@ -519,6 +532,36 @@ class TestStopAfterCycleCheck:
     # test_legacy_restart_sentinel_still_works removed in #8918 — the
     # underlying function _do_restart_sentinel was deleted. Harness intent
     # API (#4966) is the sole restart authority.
+
+
+class TestActivityHeartbeat12443:
+    """#12443 AC3: cycle_post emits an activity heartbeat at cycle end (a
+    completed cycle is a liveness signal), reusing the liveness-aware port
+    discovery, and fail-open (telemetry must never break the cycle)."""
+
+    def test_emits_heartbeat_at_cycle_end(self, patch_dirs, squid_dir):
+        import activity_hook
+        # Re-patch over the autouse no-op to assert the call shape.
+        with patch.object(activity_hook, "post_activity") as m, \
+             patch.object(cycle_post, "_discover_harness_port", return_value=9999):
+            cycle_post._do_activity_heartbeat("skill")
+        m.assert_called_once()
+        args, kwargs = m.call_args
+        assert args[0] == "skill"
+        assert args[1] == "cycle_post"
+        assert kwargs.get("port") == 9999
+
+    def test_heartbeat_is_fail_open(self, patch_dirs, squid_dir):
+        """A telemetry failure (poster raises) must NOT propagate."""
+        import activity_hook
+        with patch.object(activity_hook, "post_activity",
+                          side_effect=RuntimeError("boom")):
+            cycle_post._do_activity_heartbeat("skill")  # must not raise
+
+    def test_heartbeat_import_error_is_fail_open(self, patch_dirs, squid_dir):
+        """Even if activity_hook can't be imported, the cycle continues."""
+        with patch.dict("sys.modules", {"activity_hook": None}):
+            cycle_post._do_activity_heartbeat("skill")  # must not raise
 
 
 class TestContextPressureRestartRouting:

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -3987,5 +3987,152 @@ class TestSessionEndHook12418(unittest.TestCase):
                     {"reason": "other", "at": 123.0})
 
 
+class TestActivityHook12443(unittest.TestCase):
+    """#12443: POST /hooks/activity records the activity heartbeat
+    (last_activity_at + enriched {event, tool, phase}) on AgentState, exposes it
+    via GET /agents/{role}, throttles the state-FILE write (fires per tool
+    call), and is fail-open (always 200 — a telemetry hook must never block or
+    fail the agent)."""
+
+    def setUp(self):
+        import harness
+        from fastapi.testclient import TestClient
+        self.harness = harness
+        self.client = TestClient(harness.app, raise_server_exceptions=False)
+        harness.state.start_time = time.time()
+        self.role = "skill"
+        self._roles = patch.object(
+            harness.boot_remote, "_get_all_roles", return_value=[self.role])
+        self._roles.start()
+        self._save = patch.object(harness.state, "save_state")
+        self._save_mock = self._save.start()
+        self._uh = patch.object(harness.state, "update_health")
+        self._uh.start()
+        harness.state.agents.pop(self.role, None)
+        # Reset the persistence throttle so the first POST in each test persists.
+        harness._last_activity_save_at = 0.0
+
+    def tearDown(self):
+        self._uh.stop()
+        self._save.stop()
+        self._roles.stop()
+        self.harness.state.agents.pop(self.role, None)
+
+    def _hdr(self, role=None):
+        return {"X-Agent-Role": self.role if role is None else role}
+
+    def test_records_activity_on_agentstate(self):
+        resp = self.client.post(
+            "/hooks/activity", headers=self._hdr(),
+            json={"event": "PostToolUse", "tool": "Bash", "phase": "implement"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json().get("ok"))
+        agent = self.harness.state.agents.get(self.role)
+        self.assertIsNotNone(agent)
+        self.assertIsInstance(agent.last_activity_at, float)
+        self.assertEqual(agent.last_activity["event"], "PostToolUse")
+        self.assertEqual(agent.last_activity["tool"], "Bash")
+        self.assertEqual(agent.last_activity["phase"], "implement")
+
+    def test_accepts_raw_hook_payload_fields(self):
+        """A raw Claude Code hook payload uses hook_event_name / tool_name —
+        the endpoint falls back to those when event/tool aren't set."""
+        resp = self.client.post(
+            "/hooks/activity", headers=self._hdr(),
+            json={"hook_event_name": "PostToolUseFailure", "tool_name": "Edit"})
+        self.assertEqual(resp.status_code, 200)
+        act = self.harness.state.agents[self.role].last_activity
+        self.assertEqual(act["event"], "PostToolUseFailure")
+        self.assertEqual(act["tool"], "Edit")
+
+    def test_exposed_via_get_agent(self):
+        self.client.post("/hooks/activity", headers=self._hdr(),
+                         json={"event": "cycle_post"})
+        resp = self.client.get(f"/agents/{self.role}")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIsInstance(data.get("last_activity_at"), float)
+        self.assertEqual(data["last_activity"]["event"], "cycle_post")
+
+    def test_no_role_header_dropped_but_200(self):
+        resp = self.client.post("/hooks/activity", json={"event": "PostToolUse"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(resp.json().get("ok"))
+        self.assertEqual(resp.json().get("dropped"), "no-role")
+
+    def test_uninterpolated_env_var_role_is_no_role(self):
+        resp = self.client.post("/hooks/activity",
+                                headers=self._hdr("${SQUIDSQUAD_ROLE}"),
+                                json={"event": "PostToolUse"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json().get("dropped"), "no-role")
+
+    def test_unknown_role_dropped_but_200(self):
+        resp = self.client.post("/hooks/activity",
+                                headers=self._hdr("bogus-role"),
+                                json={"event": "PostToolUse"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(resp.json().get("ok"))
+        self.assertNotIn("bogus-role", self.harness.state.agents)
+
+    def test_malformed_body_is_fail_open(self):
+        resp = self.client.post(
+            "/hooks/activity", content=b"not json",
+            headers={**self._hdr(), "Content-Type": "application/json"})
+        self.assertEqual(resp.status_code, 200)
+        # Still records the heartbeat (the activity FACT is the signal, not the
+        # body) — event is just None when the payload is unreadable.
+        self.assertIsInstance(
+            self.harness.state.agents[self.role].last_activity_at, float)
+
+    def test_save_failure_is_fail_open(self):
+        """Even if persistence raises, the hook still answers 200."""
+        self._save.stop()
+        with patch.object(self.harness.state, "save_state",
+                          side_effect=OSError("disk full")):
+            resp = self.client.post("/hooks/activity", headers=self._hdr(),
+                                    json={"event": "PostToolUse"})
+        self._save_mock = self._save.start()  # restore for tearDown balance
+        self.assertEqual(resp.status_code, 200)
+
+    def test_disk_write_is_throttled(self):
+        """Heartbeats fire per tool call — the in-memory value updates every
+        time, but the state-FILE write is rate-limited. Two rapid POSTs persist
+        at most once."""
+        self.client.post("/hooks/activity", headers=self._hdr(),
+                         json={"event": "PostToolUse"})
+        first_at = self.harness.state.agents[self.role].last_activity_at
+        self.client.post("/hooks/activity", headers=self._hdr(),
+                         json={"event": "PostToolUse"})
+        second_at = self.harness.state.agents[self.role].last_activity_at
+        # In-memory advanced on BOTH calls...
+        self.assertGreaterEqual(second_at, first_at)
+        # ...but save_state was called at most once (throttled).
+        self.assertLessEqual(self._save_mock.call_count, 1)
+
+    def test_persisted_and_restored(self):
+        """last_activity_at + last_activity survive a save/load round-trip."""
+        import json as _json
+        import tempfile
+        from pathlib import Path as _Path
+        st = self.harness.HarnessState()
+        agent = self.harness.AgentState(self.role, "/tmp/x")
+        agent.last_activity_at = 456.0
+        agent.last_activity = {"at": 456.0, "event": "PostToolUse", "tool": "Bash"}
+        st.agents[self.role] = agent
+        with tempfile.TemporaryDirectory() as d:
+            sf = _Path(d) / ".harness-state.json"
+            with patch.object(self.harness, "HARNESS_STATE_FILE", sf):
+                st.save_state()
+                raw = _json.loads(sf.read_text(encoding="utf-8"))
+                self.assertEqual(
+                    raw["agents"][self.role]["last_activity_at"], 456.0)
+                st2 = self.harness.HarnessState()
+                st2.load_state()
+                self.assertEqual(st2.agents[self.role].last_activity_at, 456.0)
+                self.assertEqual(
+                    st2.agents[self.role].last_activity["tool"], "Bash")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_harness_route_contract.py
+++ b/tests/test_harness_route_contract.py
@@ -65,6 +65,14 @@ EXPECTED_CALLERS = {
     ("GET",  "/human/queue"):                   _EXTERNAL,
     ("POST", "/shutdown"):                      ["squidsquad_cli"],
     ("POST", "/merge"):                         _EXTERNAL,
+    # #12418 — SessionEnd telemetry hook: POSTed only by Claude Code's native
+    # type:http hook wired in .claude/settings.json (no in-repo Python caller).
+    ("POST", "/hooks/session-end"):             _EXTERNAL,
+    # #12443 — activity heartbeat: POSTed by activity_hook.py (the PostToolUse/
+    # PostToolUseFailure command-hook entrypoint AND the post_activity() poster
+    # that cycle_post imports). activity_hook is the module that literally holds
+    # the route path; cycle_post reaches it via post_activity(), not a literal.
+    ("POST", "/hooks/activity"):                ["activity_hook"],
 }
 
 


### PR DESCRIPTION
## Summary
Implements #12443 — slice (b) of #12271 (progress-based agent liveness). Adds the **activity heartbeat**: the signal that proves an agent's real loop is *progressing* (not just that the PID exists), covering the window `event_poll`/PID-poll cannot see. Observational only this slice (AC5) — it does NOT yet drive the reboot decision (slice d).

## Mechanism
- **Emit (every tool call):** per-clone `PostToolUse` + `PostToolUseFailure` hooks POST a lightweight heartbeat to the harness.
- **Emit (every cycle):** `cycle_post` emits one at cycle end (covers quiet stretches with no tool calls).
- **Record:** harness `POST /hooks/activity` records `last_activity_at` (+ `{event, tool, phase}`) per agent on `AgentState`, exposed via `GET /agents/{role}`.

## Key design call (verified against the Claude Code hook API; flagged to PM for §16 doc-sync)
The activity hooks are **`type:command` + `async:true`**, NOT native `type:http`. Native http hooks are **synchronous** (they block the tool call; default timeout 600s) and only command hooks support `async`/fire-and-forget. Since these fire on *every* tool call, AC2 ("backgrounded, NEVER blocks or delays the tool call") forces async command hooks. SessionEnd (slice a, once-per-session) stays http. AC1 grants "endpoint shape is skill's call." The poster is a tiny cross-platform `activity_hook.py` invoked via the exec form (`python` + `args:["${CLAUDE_PROJECT_DIR}/references/scripts/activity_hook.py"]`; `${CLAUDE_PROJECT_DIR}` is Claude-Code-substituted, cross-platform); role read from the inherited `$SQUIDSQUAD_ROLE`.

## Changes
- `activity_hook.py` (new): cross-platform heartbeat poster; fail-open, always exit 0.
- `harness.py`: `AgentState.last_activity_at`/`last_activity` (persisted), `POST /hooks/activity` (mirrors `/hooks/session-end`; **throttled** state-file write — in-memory always fresh, disk write rate-limited since per-tool-call; logs drop paths + throttled success).
- `compose.py`: deploys both hooks; refactored slice-a's `_ensure_session_end_hook` into a shared idempotent `_ensure_hook_entries` + added `_ensure_activity_hooks`.
- `cycle_post.py`: `_do_activity_heartbeat` at cycle end (fail-open).
- `installer-files.txt` += `activity_hook.py`; route-contract manifest += both `/hooks/*` routes (also closed slice-1's latent `/hooks/session-end` gap that #12408's masking gate hid).

## Verification
- Full curated static gate green (pytest exit 0; ~2236 passed).
- New tests: `TestActivityHook12443` (harness, 10), `test_activity_hook.py` (poster fail-open + happy path, 8), `TestEnsureActivityHooks12443` (compose), `TestActivityHeartbeat12443` (cycle_post). Hardened the #12282 egress guard for `activity_hook`'s own urllib.
- **DS-review-per-change** at both logical boundaries: harness (1 warning — silent drop paths — fixed), emitters (NO_FINDINGS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)