### PR TITLE
feat(#12458): pause-aware liveness guard (#12271 slice c)

### DIFF
--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -1895,11 +1895,54 @@ def _ensure_session_end_hook(settings_path) -> bool:
 
 
 def _ensure_activity_hooks(settings_path) -> bool:
-    """#12443 — ensure the PostToolUse + PostToolUseFailure activity-heartbeat
-    hooks are present in ``.claude/settings.json`` (see ``_ensure_hook_entries``)."""
+    """#12443/#12458 — ensure the per-tool-call hooks are present in
+    ``.claude/settings.json`` (see ``_ensure_hook_entries``). All three are
+    async command hooks (NEVER block the tool call): PostToolUse/
+    PostToolUseFailure are the #12443 activity heartbeat; PreToolUse (#12458)
+    additionally opens the in-flight window so a long tool call isn't mistaken
+    for a wedge (the harness sets in_flight_until on the PreToolUse event)."""
     return _ensure_hook_entries(settings_path, {
+        "PreToolUse": _activity_hook_group(),
         "PostToolUse": _activity_hook_group(),
         "PostToolUseFailure": _activity_hook_group(),
+    })
+
+
+# #12458 (#12271 slice c) — pause-aware lifecycle hooks. Unlike the per-tool-
+# call hooks, these fire at LOW frequency (waiting on a prompt, compacting, an
+# API failure), so a native type:http hook (a brief synchronous block is
+# acceptable) is fine — no async command wrapper needed. Role rides the
+# X-Agent-Role header (the slice-a pattern); the harness /hooks/pause endpoint
+# dispatches on the hook event name.
+_PAUSE_HOOK_URL = "http://127.0.0.1:7373/hooks/pause"
+
+
+def _pause_hook_group() -> dict:
+    """Return a fresh pause-hook matcher-group (native http, new objects each
+    call)."""
+    return {
+        "matcher": "",
+        "hooks": [{
+            "type": "http",
+            "url": _PAUSE_HOOK_URL,
+            "timeout": 5,
+            "headers": {"X-Agent-Role": "${SQUIDSQUAD_ROLE}"},
+            "allowedEnvVars": ["SQUIDSQUAD_ROLE"],
+        }],
+    }
+
+
+def _ensure_pause_hooks(settings_path) -> bool:
+    """#12458 — ensure the pause-explaining lifecycle hooks (Notification,
+    PreCompact, PostCompact, StopFailure) are present in
+    ``.claude/settings.json`` (see ``_ensure_hook_entries``). StopFailure uses a
+    catch-all matcher; the harness extracts the cause best-effort and falls back
+    to the normal reboot path on an unrecognised cause (safe default)."""
+    return _ensure_hook_entries(settings_path, {
+        "Notification": _pause_hook_group(),
+        "PreCompact": _pause_hook_group(),
+        "PostCompact": _pause_hook_group(),
+        "StopFailure": _pause_hook_group(),
     })
 
 
@@ -2184,10 +2227,15 @@ def main():
         se_settings = REPO_ROOT / ".claude" / "settings.json"
         if _ensure_session_end_hook(se_settings):
             print(f"  SessionEnd hook -> {se_settings.relative_to(REPO_ROOT)}")
-        # #12443 — ensure the PostToolUse + PostToolUseFailure activity-heartbeat
-        # hooks are present too (same idempotent settings.json integration).
+        # #12443/#12458 — ensure the per-tool-call hooks (PreToolUse +
+        # PostToolUse + PostToolUseFailure) are present too (same idempotent
+        # settings.json integration).
         if _ensure_activity_hooks(se_settings):
             print(f"  Activity hooks -> {se_settings.relative_to(REPO_ROOT)}")
+        # #12458 — ensure the pause-aware lifecycle hooks (Notification /
+        # PreCompact / PostCompact / StopFailure) are present.
+        if _ensure_pause_hooks(se_settings):
+            print(f"  Pause hooks -> {se_settings.relative_to(REPO_ROOT)}")
 
     elif cmd == "upgrade-soul":
         if len(args) < 2:

--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -1914,6 +1914,18 @@ def _ensure_activity_hooks(settings_path) -> bool:
 # acceptable) is fine — no async command wrapper needed. Role rides the
 # X-Agent-Role header (the slice-a pattern); the harness /hooks/pause endpoint
 # dispatches on the hook event name.
+#
+# Two documented tradeoffs (DS-REVIEW-12458-plumbing F3/F4):
+#  - Port is the harness default 7373. If the harness runs on a non-default
+#    port the POST fails-open (no record → the reboot decision treats the
+#    silence as UNEXPLAINED, the safe-conservative default — same as the
+#    SessionEnd hook).
+#  - `Notification` is the one event here that fires BEFORE the agent is
+#    paused (it announces a pending permission/idle prompt). As a synchronous
+#    http hook it can delay the prompt's display by up to `timeout` seconds if
+#    the harness is unreachable. Acceptable for an unattended autonomous agent
+#    (prompts are rare and the timeout is short); flagged so a future
+#    interactive context can revisit (→ async command if it matters).
 _PAUSE_HOOK_URL = "http://127.0.0.1:7373/hooks/pause"
 
 

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -96,6 +96,33 @@ FAST_DEATH_THRESHOLD = 3
 CRASH_BACKOFF_BASE_SECONDS = 30
 CRASH_BACKOFF_CAP_SECONDS = 1800  # 30m — a sane ceiling, not infinite
 
+# #12458 (#12271 slice c) — pause-aware liveness guard. Agent silence / a dead
+# PID is treated as death ONLY when no hook explains it. Each "explained pause"
+# carries a STALENESS CEILING so a stuck/never-cleared flag can never mask a
+# genuine death forever (the AC4 contract: past the ceiling, the agent is
+# wedged and the normal death path resumes). The ceilings are generous —
+# set above the longest LEGITIMATE duration of each state.
+#   tool_call_max — longest legit single tool call (full test suite, slow
+#     build, long subagent). PreToolUse sets an in-flight deadline; PostToolUse
+#     clears it. Within the deadline a silent/dead agent is "running a tool",
+#     past it (still no PostToolUse) it is wedged.
+TOOL_CALL_MAX_SECONDS = 900          # 15m hard ceiling for one tool call
+#   compacting — Claude Code summarising context in place (PreCompact, cleared
+#     by PostCompact). Bounded so a crash mid-compaction still reboots.
+COMPACTING_MAX_SECONDS = 300         # 5m
+#   waiting — blocked on a human/permission/idle prompt (Notification). Cleared
+#     by the next activity heartbeat. Bounded generously: a truly-waiting agent
+#     stays alive (it still heartbeats nothing, but it is not dead); a crashed
+#     agent whose stale "waiting" flag was never cleared falls through after
+#     the ceiling so the normal death path can reboot it.
+WAITING_MAX_SECONDS = 1800           # 30m
+#   StopFailure causes that mean "throttled, not faulty" → back off rather than
+#     immediately respawn (a tight respawn would re-hit the same limit). Folds
+#     into the #12244 backoff. Other causes (auth/billing) are surfaced but do
+#     NOT auto-backoff (they need operator action, not a wait).
+STOP_FAILURE_BACKOFF_CAUSES = frozenset({"rate_limit", "overloaded"})
+STOP_FAILURE_RECENT_SECONDS = 180    # a StopFailure older than this is stale
+
 # #9242: Diagnostic escape hatch. When True (set by `main()` from
 # `--no-auto-start` or `SQUIDSQUAD_HARNESS_NO_AUTO_START=1`), the
 # deferred-init thread skips the auto-spawn-all-agents block. Lets
@@ -162,7 +189,10 @@ class AgentState:
                  # #12418 — last SessionEnd hook reason (graceful-exit signal)
                  "last_session_end",
                  # #12443 — activity heartbeat (progress-based liveness)
-                 "last_activity_at", "last_activity")
+                 "last_activity_at", "last_activity",
+                 # #12458 — pause-aware liveness guard (explained-silence state)
+                 "in_flight_until", "waiting_since", "compacting_since",
+                 "last_stop_failure")
 
     # Intent values:
     #   "running"    — agent should be alive; auto-reboot on death (#4949)
@@ -224,6 +254,56 @@ class AgentState:
         # yet drive the reboot decision (that is #12271 slice d).
         self.last_activity_at = None
         self.last_activity = None
+        # #12458 — pause-aware liveness guard (HARNESS-ARCH §15.1). Each field
+        # is an "explained silence" set by a hook and consumed by the reboot
+        # decision via active_pause(); each has a staleness ceiling so a never-
+        # cleared flag cannot mask a genuine death forever (AC4/AC5).
+        #   in_flight_until — epoch deadline (PreToolUse set: now+tool_call_max;
+        #     PostToolUse/PostToolUseFailure clear). now < deadline → mid-call.
+        #   waiting_since — epoch a Notification (permission/idle prompt) fired;
+        #     cleared by the next activity heartbeat. Agent blocked on input.
+        #   compacting_since — epoch PreCompact fired (PostCompact clears).
+        #   last_stop_failure — {"cause": <str>, "at": <epoch>}; a recent
+        #     rate_limit/overloaded means "throttled" → back off, not respawn.
+        self.in_flight_until = None
+        self.waiting_since = None
+        self.compacting_since = None
+        self.last_stop_failure = None
+
+    def active_pause(self, now):
+        """#12458 — return a short reason string if a hook currently explains
+        this agent's silence/death (so the reboot decision should HOLD OFF), or
+        None if nothing explains it (→ treat as a candidate death).
+
+        Each branch is bounded by its staleness ceiling: an explained pause only
+        suppresses reboot for as long as that state could LEGITIMATELY last —
+        past the ceiling the flag is treated as stale and ignored, so a crash
+        that left a flag set still reboots once the ceiling elapses (AC4/AC5).
+        Order is by confidence: an in-flight tool call is the strongest signal.
+        """
+        if self.in_flight_until is not None and now < self.in_flight_until:
+            return "in-flight"
+        if (self.compacting_since is not None
+                and 0 <= now - self.compacting_since < COMPACTING_MAX_SECONDS):
+            return "compacting"
+        if (self.waiting_since is not None
+                and 0 <= now - self.waiting_since < WAITING_MAX_SECONDS):
+            return "waiting"
+        return None
+
+    def stopfailure_backoff_due(self, now):
+        """#12458 (AC3d) — True if the most recent StopFailure is a recent
+        throttle (rate_limit/overloaded), meaning a dead agent should BACK OFF
+        rather than respawn immediately (an immediate respawn would re-hit the
+        same limit). Stale or non-throttle causes (auth/billing) return False —
+        those need operator action, surfaced elsewhere, not an auto-wait."""
+        sf = self.last_stop_failure
+        if not isinstance(sf, dict):
+            return False
+        cause = sf.get("cause")
+        at = sf.get("at") or 0
+        return (cause in STOP_FAILURE_BACKOFF_CAUSES
+                and 0 <= now - at < STOP_FAILURE_RECENT_SECONDS)
 
     def to_dict(self):
         return {
@@ -251,6 +331,11 @@ class AgentState:
             # #12443 — activity heartbeat (progress-based liveness)
             "last_activity_at": self.last_activity_at,
             "last_activity": self.last_activity,
+            # #12458 — pause-aware liveness guard state
+            "in_flight_until": self.in_flight_until,
+            "waiting_since": self.waiting_since,
+            "compacting_since": self.compacting_since,
+            "last_stop_failure": self.last_stop_failure,
         }
 
 
@@ -917,6 +1002,13 @@ class HarnessState:
                         # last-known activity isn't lost on recovery.
                         "last_activity_at": a.last_activity_at,
                         "last_activity": a.last_activity,
+                        # #12458 — persist pause state so a harness restart
+                        # mid-pause doesn't immediately false-reboot a paused
+                        # agent (the ceilings still bound any stale flag).
+                        "in_flight_until": a.in_flight_until,
+                        "waiting_since": a.waiting_since,
+                        "compacting_since": a.compacting_since,
+                        "last_stop_failure": a.last_stop_failure,
                     }
                     for role, a in self.agents.items()
                 },
@@ -1011,6 +1103,12 @@ class HarnessState:
                 # state files / fresh agents).
                 agent.last_activity_at = agent_data.get("last_activity_at")
                 agent.last_activity = agent_data.get("last_activity")
+                # #12458 — restore pause state (defaults None for older state
+                # files / fresh agents).
+                agent.in_flight_until = agent_data.get("in_flight_until")
+                agent.waiting_since = agent_data.get("waiting_since")
+                agent.compacting_since = agent_data.get("compacting_since")
+                agent.last_stop_failure = agent_data.get("last_stop_failure")
 
         _log(f"Restored state for {len(state_data.get('agents', {}))} agents from state file")
 

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -569,17 +569,19 @@ class HarnessState:
                         agent.intent_set_at = None  # #4792 Phase 1
                         state_changed = True
                         _log(f"{role}: alive with new PID (stale intent={old_intent}), reset to running (#7637)")
-                elif agent.status == "crash-looping":
+                elif agent.status in ("crash-looping", "paused"):
                     # #12244 P2: a dead agent waiting out its backoff normally
                     # KEEPS the "crash-looping" status (preserved like
                     # "starting") so the resume branch below recognises it and
                     # operators see the real reason — instead of being
-                    # relabelled "unknown" on the next poll. BUT an operator
-                    # stop wins over a backoff: when intent is STOPPING/STOPPED,
-                    # abandon the wait and settle to "stopped" so the STOPPING
-                    # fulfillment below can finish it (otherwise a crash-looping
-                    # agent + /stop would wedge forever — neither is_dead nor
-                    # the resume branch fire for STOPPING intent).
+                    # relabelled "unknown" on the next poll. #12458: "paused"
+                    # (an explained-silence HOLD) is preserved the same way and
+                    # has its own resume branch below. BUT an operator stop wins
+                    # over either hold: when intent is STOPPING/STOPPED, abandon
+                    # the wait and settle to "stopped" so the STOPPING
+                    # fulfillment below can finish it (otherwise a held agent +
+                    # /stop would wedge forever — neither is_dead nor the resume
+                    # branch fire for STOPPING intent).
                     if agent.intent in (
                         AgentState.INTENT_STOPPING, AgentState.INTENT_STOPPED
                     ):
@@ -605,108 +607,163 @@ class HarnessState:
                     AgentState.INTENT_RUNNING,
                     AgentState.INTENT_RESTARTING,
                 )
-                if is_dead and was_alive and should_reboot:
-                    if _NO_AUTO_REBOOT:
-                        # #10538: observe-but-don't-respawn. State stays
-                        # honest (PID cleared, bootup gate reset) so the
-                        # next operator-driven `POST /agents/{role}/start`
-                        # behaves the same as a normal fresh spawn.
+                now = time.time()
+
+                # #12458 (#12271 slice c) — pause-aware guard. A death candidate
+                # is a FRESH death (PID died this poll) OR a previously-HELD
+                # "paused" agent still not alive. If a hook explains the silence
+                # (active_pause: mid-tool-call / compacting / waiting, each
+                # bounded by its staleness ceiling), HOLD instead of rebooting —
+                # re-evaluated every poll, released the moment the ceiling
+                # elapses (active_pause → None), after which the unexplained
+                # silence runs the normal death/backoff path. AC5: a genuine
+                # death with NO pause signal is unaffected (active_pause returns
+                # None immediately, so death_candidate falls straight through to
+                # the confirmed-death branch exactly as before #12458).
+                fresh_death = is_dead and was_alive
+                held = agent.status == "paused" and not alive
+                death_candidate = (fresh_death or held) and should_reboot
+                pause_reason = agent.active_pause(now) if death_candidate else None
+
+                if death_candidate and pause_reason is not None:
+                    # Explained silence → HOLD reboot (mirrors the crash-looping
+                    # hold: "paused" is preserved across polls by the status
+                    # block above and re-evaluated here each poll).
+                    if agent.status != "paused":
                         _log(
-                            f"[no-auto-reboot] {role} died; "
-                            f"intent={agent.intent}; not respawning per "
-                            f"SQUIDSQUAD_HARNESS_NO_AUTO_REBOOT"
+                            f"{role}: dead/silent PID but '{pause_reason}' hook "
+                            f"active — holding off reboot (explained pause, "
+                            f"#12458)"
                         )
+                    agent.status = "paused"
+                    agent.claude_pid = None
+                    agent.bootup_complete = False
+                    state_changed = True
+                elif death_candidate and _NO_AUTO_REBOOT:
+                    # #10538: observe-but-don't-respawn. State stays
+                    # honest (PID cleared, bootup gate reset) so the
+                    # next operator-driven `POST /agents/{role}/start`
+                    # behaves the same as a normal fresh spawn.
+                    _log(
+                        f"[no-auto-reboot] {role} died; "
+                        f"intent={agent.intent}; not respawning per "
+                        f"SQUIDSQUAD_HARNESS_NO_AUTO_REBOOT"
+                    )
+                    agent.claude_pid = None
+                    agent.bootup_complete = False
+                    state_changed = True
+                elif death_candidate and agent.stopfailure_backoff_due(now):
+                    # #12458 AC3d — the death coincides with a recent throttle
+                    # (rate_limit / overloaded). Respawning immediately would
+                    # re-hit the same limit, so back off via the crash-loop
+                    # timer (count it as a fast death so repeated throttles
+                    # escalate the wait) — NOT a tight respawn. Reuses the
+                    # crash-looping resume path below.
+                    agent.consecutive_fast_deaths += 1
+                    over = max(0, agent.consecutive_fast_deaths
+                               - FAST_DEATH_THRESHOLD)
+                    backoff = min(
+                        CRASH_BACKOFF_BASE_SECONDS * (2 ** over),
+                        CRASH_BACKOFF_CAP_SECONDS,
+                    )
+                    agent.reboot_blocked_until = now + backoff
+                    agent.status = "crash-looping"
+                    agent.claude_pid = None
+                    agent.bootup_complete = False
+                    state_changed = True
+                    sf = agent.last_stop_failure or {}
+                    _log(
+                        f"{role}: StopFailure cause={sf.get('cause')!r} "
+                        f"(throttle) — backing off {backoff:.0f}s before respawn "
+                        f"rather than re-hitting the limit (#12458)."
+                    )
+                elif death_candidate:
+                    # #12244 P2 — crash-loop / session-limit backoff. Count
+                    # back-to-back fast deaths; once they cross the
+                    # threshold, hold off the respawn (exponential, capped)
+                    # and surface a paused status instead of tight-looping
+                    # and burning quota.
+                    lifetime = (
+                        now - agent.last_spawn_at
+                        if agent.last_spawn_at is not None else None
+                    )
+                    # #12418 AC4 — graceful-vs-crash. A GRACEFUL exit (a
+                    # SessionEnd hook fired AFTER this spawn) is not a crash:
+                    # it must not accumulate the #12244 crash-loop streak, so
+                    # a legitimate cooperative restart is never throttled as
+                    # if it were a quota/startup crash. A CRASH (dead PID
+                    # with NO SessionEnd since last_spawn_at — the hook
+                    # couldn't run) still counts toward the streak → backoff.
+                    # The stale-SessionEnd case is handled by the
+                    # `>= last_spawn_at` guard: a prior spawn's SessionEnd
+                    # predates this spawn and reads as a crash. Augments the
+                    # PID path (AC6) — the respawn action itself is unchanged.
+                    se = agent.last_session_end
+                    # DS-REVIEW-12418-C F1: use `(se.get("at") or 0)` — a
+                    # `{"at": null}` from a hand-edited/corrupt state file
+                    # makes `.get("at", 0)` return None, and `None >= float`
+                    # raises TypeError, aborting the whole health poll.
+                    se_at = (se.get("at") or 0) if isinstance(se, dict) else 0
+                    graceful = bool(
+                        agent.last_spawn_at is not None
+                        and se_at >= agent.last_spawn_at
+                    )
+                    if graceful:
+                        # #12418 AC4: a graceful exit is NOT a crash — do NOT
+                        # increment the streak. We deliberately do NOT reset
+                        # it to 0 either (DS-REVIEW-12418-C F2): a misbehaving
+                        # agent that POSTs SessionEnd then crashes must not be
+                        # able to ZERO accumulated real crashes and escape the
+                        # breaker. The legitimate reset is the survived-window
+                        # path above. (Residual: a pure SessionEnd-spammer can
+                        # still keep the streak from growing — a full
+                        # termination-correlation guard is a #12271 liveness
+                        # hardening follow-up; natural crash loops don't POST
+                        # SessionEnd, so the #12244 protection is intact.)
+                        _log(
+                            f"{role}: graceful exit (SessionEnd "
+                            f"reason={se.get('reason')!r}) — not counted as "
+                            f"a crash (streak stays "
+                            f"{agent.consecutive_fast_deaths}) (#12418)"
+                        )
+                    elif (lifetime is not None
+                            and lifetime < FAST_DEATH_WINDOW_SECONDS):
+                        agent.consecutive_fast_deaths += 1
+                    else:
+                        # Lived long enough (or no spawn record) — not a
+                        # crash loop; a one-off death reboots immediately.
+                        agent.consecutive_fast_deaths = 0
+
+                    if (agent.consecutive_fast_deaths
+                            >= FAST_DEATH_THRESHOLD):
+                        over = (agent.consecutive_fast_deaths
+                                - FAST_DEATH_THRESHOLD)
+                        backoff = min(
+                            CRASH_BACKOFF_BASE_SECONDS * (2 ** over),
+                            CRASH_BACKOFF_CAP_SECONDS,
+                        )
+                        agent.reboot_blocked_until = now + backoff
+                        agent.status = "crash-looping"
                         agent.claude_pid = None
                         agent.bootup_complete = False
                         state_changed = True
+                        _log(
+                            f"{role}: {agent.consecutive_fast_deaths} "
+                            f"consecutive fast deaths "
+                            f"(<{FAST_DEATH_WINDOW_SECONDS}s each) — "
+                            f"backing off {backoff:.0f}s before respawn "
+                            f"(status=crash-looping). Likely a Claude "
+                            f"session/usage limit or a startup crash; not "
+                            f"hammering the respawn."
+                        )
                     else:
-                        # #12244 P2 — crash-loop / session-limit backoff. Count
-                        # back-to-back fast deaths; once they cross the
-                        # threshold, hold off the respawn (exponential, capped)
-                        # and surface a paused status instead of tight-looping
-                        # and burning quota.
-                        now = time.time()
-                        lifetime = (
-                            now - agent.last_spawn_at
-                            if agent.last_spawn_at is not None else None
-                        )
-                        # #12418 AC4 — graceful-vs-crash. A GRACEFUL exit (a
-                        # SessionEnd hook fired AFTER this spawn) is not a crash:
-                        # it must not accumulate the #12244 crash-loop streak, so
-                        # a legitimate cooperative restart is never throttled as
-                        # if it were a quota/startup crash. A CRASH (dead PID
-                        # with NO SessionEnd since last_spawn_at — the hook
-                        # couldn't run) still counts toward the streak → backoff.
-                        # The stale-SessionEnd case is handled by the
-                        # `>= last_spawn_at` guard: a prior spawn's SessionEnd
-                        # predates this spawn and reads as a crash. Augments the
-                        # PID path (AC6) — the respawn action itself is unchanged.
-                        se = agent.last_session_end
-                        # DS-REVIEW-12418-C F1: use `(se.get("at") or 0)` — a
-                        # `{"at": null}` from a hand-edited/corrupt state file
-                        # makes `.get("at", 0)` return None, and `None >= float`
-                        # raises TypeError, aborting the whole health poll.
-                        se_at = (se.get("at") or 0) if isinstance(se, dict) else 0
-                        graceful = bool(
-                            agent.last_spawn_at is not None
-                            and se_at >= agent.last_spawn_at
-                        )
-                        if graceful:
-                            # #12418 AC4: a graceful exit is NOT a crash — do NOT
-                            # increment the streak. We deliberately do NOT reset
-                            # it to 0 either (DS-REVIEW-12418-C F2): a misbehaving
-                            # agent that POSTs SessionEnd then crashes must not be
-                            # able to ZERO accumulated real crashes and escape the
-                            # breaker. The legitimate reset is the survived-window
-                            # path above. (Residual: a pure SessionEnd-spammer can
-                            # still keep the streak from growing — a full
-                            # termination-correlation guard is a #12271 liveness
-                            # hardening follow-up; natural crash loops don't POST
-                            # SessionEnd, so the #12244 protection is intact.)
-                            _log(
-                                f"{role}: graceful exit (SessionEnd "
-                                f"reason={se.get('reason')!r}) — not counted as "
-                                f"a crash (streak stays "
-                                f"{agent.consecutive_fast_deaths}) (#12418)"
-                            )
-                        elif (lifetime is not None
-                                and lifetime < FAST_DEATH_WINDOW_SECONDS):
-                            agent.consecutive_fast_deaths += 1
-                        else:
-                            # Lived long enough (or no spawn record) — not a
-                            # crash loop; a one-off death reboots immediately.
-                            agent.consecutive_fast_deaths = 0
-
-                        if (agent.consecutive_fast_deaths
-                                >= FAST_DEATH_THRESHOLD):
-                            over = (agent.consecutive_fast_deaths
-                                    - FAST_DEATH_THRESHOLD)
-                            backoff = min(
-                                CRASH_BACKOFF_BASE_SECONDS * (2 ** over),
-                                CRASH_BACKOFF_CAP_SECONDS,
-                            )
-                            agent.reboot_blocked_until = now + backoff
-                            agent.status = "crash-looping"
-                            agent.claude_pid = None
-                            agent.bootup_complete = False
-                            state_changed = True
-                            _log(
-                                f"{role}: {agent.consecutive_fast_deaths} "
-                                f"consecutive fast deaths "
-                                f"(<{FAST_DEATH_WINDOW_SECONDS}s each) — "
-                                f"backing off {backoff:.0f}s before respawn "
-                                f"(status=crash-looping). Likely a Claude "
-                                f"session/usage limit or a startup crash; not "
-                                f"hammering the respawn."
-                            )
-                        else:
-                            reboot_roles.append(role)
-                            agent.status = "starting"
-                            agent.claude_pid = None  # Clear stale PID
-                            # #8695: the replacement process needs to re-emit
-                            # bootup-complete before we'll dispatch events to it.
-                            agent.bootup_complete = False
-                            state_changed = True
+                        reboot_roles.append(role)
+                        agent.status = "starting"
+                        agent.claude_pid = None  # Clear stale PID
+                        # #8695: the replacement process needs to re-emit
+                        # bootup-complete before we'll dispatch events to it.
+                        agent.bootup_complete = False
+                        state_changed = True
 
                 # #12244 P2 — resume from crash-loop backoff once the window
                 # elapses. A paused ("crash-looping") agent is not is_dead and

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -2419,6 +2419,17 @@ async def hook_activity(request: Request):
             state.agents[role] = agent
         agent.last_activity_at = now
         agent.last_activity = activity
+        # #12458 — manage the in-flight tool-call window (pause guard). A
+        # PreToolUse opens it (deadline now + tool_call_max so a long tool call
+        # isn't mistaken for a wedge); a Post* closes it. Any activity also
+        # clears a stale 'waiting' — the agent is doing things again, so it is
+        # no longer blocked on a prompt.
+        ev = activity["event"]
+        if ev == "PreToolUse":
+            agent.in_flight_until = now + TOOL_CALL_MAX_SECONDS
+        elif ev in ("PostToolUse", "PostToolUseFailure"):
+            agent.in_flight_until = None
+        agent.waiting_since = None
         if now - _last_activity_save_at >= _ACTIVITY_SAVE_THROTTLE_SECONDS:
             _last_activity_save_at = now
             should_save = True
@@ -2432,6 +2443,81 @@ async def hook_activity(request: Request):
             await asyncio.to_thread(state.save_state)
         except Exception as e:  # pragma: no cover — defensive
             _log(f"{role}: activity save_state failed (non-fatal): {e}")
+    return JSONResponse(status_code=200, content={"ok": True})
+
+
+@app.post("/hooks/pause")
+async def hook_pause(request: Request):
+    """#12458 (#12271 slice c) — receive a pause-explaining lifecycle hook so
+    the reboot decision (update_health) holds off while the silence is
+    explained (HARNESS-ARCH §15.1). Low-frequency relative to /hooks/activity,
+    so these are native http hooks (a brief block is acceptable) and the write
+    is NOT throttled.
+
+    Dispatches on the hook event:
+      - Notification   → waiting_since = now   (blocked on a prompt/idle/input)
+      - PreCompact     → compacting_since = now (summarising context in place)
+      - PostCompact    → compacting_since = None (compaction done)
+      - StopFailure    → last_stop_failure = {cause, at}; a recent
+        rate_limit/overloaded makes a subsequent death back off (AC3d). The
+        cause is read best-effort from several candidate fields; an
+        unrecognised cause records 'unknown', which does NOT trigger backoff
+        (safe default: the normal reboot path runs, today's behavior).
+
+    Role rides the X-Agent-Role header (same contract as /hooks/session-end).
+    Fail-open: ALWAYS 200, never blocks or raises.
+    """
+    role = (request.headers.get("X-Agent-Role") or "").strip()
+    if role.startswith("${"):
+        role = ""
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    if not isinstance(body, dict):
+        body = {}
+
+    if not role:
+        _log("Pause hook DROPPED — no X-Agent-Role header")
+        return JSONResponse(status_code=200, content={"ok": False, "dropped": "no-role"})
+    try:
+        allowed = set(boot_remote._get_all_roles()) | {"pm"}
+    except (SystemExit, Exception):
+        allowed = None
+    if allowed is not None and role not in allowed:
+        _log(f"Pause hook DROPPED unknown role={role!r}")
+        return JSONResponse(status_code=200, content={"ok": False, "dropped": "unknown-role"})
+
+    event = body.get("event") or body.get("hook_event_name") or ""
+    now = time.time()
+    with state._lock:
+        agent = state.agents.get(role)
+        if agent is None:
+            agent = AgentState(role)
+            state.agents[role] = agent
+        if event == "Notification":
+            agent.waiting_since = now
+        elif event == "PreCompact":
+            agent.compacting_since = now
+        elif event == "PostCompact":
+            agent.compacting_since = None
+        elif event == "StopFailure":
+            # Best-effort cause extraction — the exact StopFailure payload field
+            # is config/version dependent; an unknown cause is the safe default
+            # (no backoff → normal reboot path, unchanged behavior).
+            cause = (body.get("cause") or body.get("reason")
+                     or body.get("matcher") or body.get("stop_reason")
+                     or "unknown")
+            agent.last_stop_failure = {"cause": cause, "at": now}
+        else:
+            _log(f"{role}: pause hook unrecognised event={event!r} — ignored")
+            return JSONResponse(status_code=200,
+                                content={"ok": False, "dropped": "unknown-event"})
+    _log(f"{role}: pause hook {event} recorded (#12458)")
+    try:
+        await asyncio.to_thread(state.save_state)
+    except Exception as e:  # pragma: no cover — defensive
+        _log(f"{role}: pause save_state failed (non-fatal): {e}")
     return JSONResponse(status_code=200, content={"ok": True})
 
 

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -281,7 +281,14 @@ class AgentState:
         that left a flag set still reboots once the ceiling elapses (AC4/AC5).
         Order is by confidence: an in-flight tool call is the strongest signal.
         """
-        if self.in_flight_until is not None and now < self.in_flight_until:
+        # DS-REVIEW-12458-guard F2: bound the in-flight hold by the SAME ceiling
+        # the deadline was set with, so a stale/never-cleared deadline or a
+        # backward clock step (NTP) can't hold the reboot longer than one
+        # legitimate tool call. The deadline must be in the future (diff > 0) but
+        # not by more than tool_call_max — the clock-skew guard the other
+        # branches get via `0 <= age < MAX`, expressed here on the deadline.
+        if (self.in_flight_until is not None
+                and 0 < self.in_flight_until - now <= TOOL_CALL_MAX_SECONDS):
             return "in-flight"
         if (self.compacting_since is not None
                 and 0 <= now - self.compacting_since < COMPACTING_MAX_SECONDS):
@@ -628,17 +635,22 @@ class HarnessState:
                 if death_candidate and pause_reason is not None:
                     # Explained silence → HOLD reboot (mirrors the crash-looping
                     # hold: "paused" is preserved across polls by the status
-                    # block above and re-evaluated here each poll).
+                    # block above and re-evaluated here each poll). DS-REVIEW-
+                    # 12458-guard F1: signal a change ONLY on the initial
+                    # transition into "paused" — the status block preserves the
+                    # hold silently thereafter, so re-asserting the same values
+                    # every 5s poll would churn save_state for no change (the
+                    # crash-looping hold doesn't either).
                     if agent.status != "paused":
                         _log(
                             f"{role}: dead/silent PID but '{pause_reason}' hook "
                             f"active — holding off reboot (explained pause, "
                             f"#12458)"
                         )
-                    agent.status = "paused"
-                    agent.claude_pid = None
-                    agent.bootup_complete = False
-                    state_changed = True
+                        agent.status = "paused"
+                        agent.claude_pid = None
+                        agent.bootup_complete = False
+                        state_changed = True
                 elif death_candidate and _NO_AUTO_REBOOT:
                     # #10538: observe-but-don't-respawn. State stays
                     # honest (PID cleared, bootup gate reset) so the
@@ -656,10 +668,24 @@ class HarnessState:
                     # #12458 AC3d — the death coincides with a recent throttle
                     # (rate_limit / overloaded). Respawning immediately would
                     # re-hit the same limit, so back off via the crash-loop
-                    # timer (count it as a fast death so repeated throttles
-                    # escalate the wait) — NOT a tight respawn. Reuses the
-                    # crash-looping resume path below.
-                    agent.consecutive_fast_deaths += 1
+                    # timer — NOT a tight respawn. Reuses the crash-looping
+                    # resume path below.
+                    #
+                    # DS-REVIEW-12458-guard F3: only COUNT it toward the crash
+                    # streak when the exit was NOT graceful — a cooperative exit
+                    # (SessionEnd after this spawn) that merely coincides with a
+                    # stale throttle must not accumulate the #12244 streak (the
+                    # #12418 AC4 contract). We still apply the backoff either way
+                    # (don't re-hit the limit), but a graceful exit doesn't
+                    # escalate the streak.
+                    se = agent.last_session_end
+                    se_at = (se.get("at") or 0) if isinstance(se, dict) else 0
+                    graceful = bool(
+                        agent.last_spawn_at is not None
+                        and se_at >= agent.last_spawn_at
+                    )
+                    if not graceful:
+                        agent.consecutive_fast_deaths += 1
                     over = max(0, agent.consecutive_fast_deaths
                                - FAST_DEATH_THRESHOLD)
                     backoff = min(
@@ -2421,15 +2447,20 @@ async def hook_activity(request: Request):
         agent.last_activity = activity
         # #12458 — manage the in-flight tool-call window (pause guard). A
         # PreToolUse opens it (deadline now + tool_call_max so a long tool call
-        # isn't mistaken for a wedge); a Post* closes it. Any activity also
-        # clears a stale 'waiting' — the agent is doing things again, so it is
-        # no longer blocked on a prompt.
+        # isn't mistaken for a wedge); a Post* closes it. A real TOOL-CALL event
+        # also clears a stale 'waiting' — the agent is demonstrably executing,
+        # so it is no longer blocked on a prompt. DS-REVIEW-12458-plumbing F2:
+        # scope the waiting-clear to the three tool-use events, NOT every
+        # activity — a cycle_post heartbeat (or any non-tool event) is a weaker
+        # signal and a late one from a prior cycle could otherwise race a fresh
+        # Notification and prematurely clear a legitimate wait.
         ev = activity["event"]
         if ev == "PreToolUse":
             agent.in_flight_until = now + TOOL_CALL_MAX_SECONDS
+            agent.waiting_since = None
         elif ev in ("PostToolUse", "PostToolUseFailure"):
             agent.in_flight_until = None
-        agent.waiting_since = None
+            agent.waiting_since = None
         if now - _last_activity_save_at >= _ACTIVITY_SAVE_THROTTLE_SECONDS:
             _last_activity_save_at = now
             should_save = True
@@ -2504,10 +2535,12 @@ async def hook_pause(request: Request):
         elif event == "StopFailure":
             # Best-effort cause extraction — the exact StopFailure payload field
             # is config/version dependent; an unknown cause is the safe default
-            # (no backoff → normal reboot path, unchanged behavior).
+            # (no backoff → normal reboot path, unchanged behavior). DS-REVIEW-
+            # 12458-plumbing F5: `matcher` is the hook TRIGGER pattern, not the
+            # stop reason — excluded so a future named matcher can't be
+            # mistaken for the cause.
             cause = (body.get("cause") or body.get("reason")
-                     or body.get("matcher") or body.get("stop_reason")
-                     or "unknown")
+                     or body.get("stop_reason") or "unknown")
             agent.last_stop_failure = {"cause": cause, "at": now}
         else:
             _log(f"{role}: pause hook unrecognised event={event!r} — ignored")

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -577,7 +577,8 @@ class TestEnsureActivityHooks12443:
         changed = compose._ensure_activity_hooks(p)
         assert changed is True
         hooks = self._load(p)["hooks"]
-        for name in ("PostToolUse", "PostToolUseFailure"):
+        # #12458: PreToolUse joins the per-tool-call async command hooks.
+        for name in ("PreToolUse", "PostToolUse", "PostToolUseFailure"):
             assert name in hooks, f"{name} hook missing"
             hook = hooks[name][0]["hooks"][0]
             # AC2: must be a non-blocking async COMMAND hook, not a blocking
@@ -621,6 +622,47 @@ class TestEnsureActivityHooks12443:
         p.write_text("{ not json", encoding="utf-8")
         assert compose._ensure_activity_hooks(p) is True
         assert "PostToolUse" in self._load(p)["hooks"]
+
+
+class TestEnsurePauseHooks12458:
+    """#12458 AC1: the pipeline places the pause-aware lifecycle hooks
+    (Notification / PreCompact / PostCompact / StopFailure) in settings.json as
+    native http hooks (low-frequency, block-OK), idempotently, coexisting with
+    the per-tool-call activity hooks + SessionEnd."""
+
+    def _load(self, p):
+        import json
+        return json.loads(p.read_text(encoding="utf-8"))
+
+    def test_adds_all_pause_hooks(self, tmp_path):
+        p = tmp_path / ".claude" / "settings.json"
+        assert compose._ensure_pause_hooks(p) is True
+        hooks = self._load(p)["hooks"]
+        for name in ("Notification", "PreCompact", "PostCompact", "StopFailure"):
+            assert name in hooks, f"{name} hook missing"
+            hook = hooks[name][0]["hooks"][0]
+            # Low-freq → native http (a brief block is fine), role via header.
+            assert hook["type"] == "http"
+            assert hook["url"].endswith("/hooks/pause")
+            assert hook["headers"]["X-Agent-Role"] == "${SQUIDSQUAD_ROLE}"
+
+    def test_idempotent_no_rewrite(self, tmp_path):
+        p = tmp_path / ".claude" / "settings.json"
+        assert compose._ensure_pause_hooks(p) is True
+        assert compose._ensure_pause_hooks(p) is False
+
+    def test_coexists_with_activity_and_session_end(self, tmp_path):
+        """All three hook families (session-end, activity, pause) coexist after
+        the deploy-order ensures run, none clobbering the others."""
+        p = tmp_path / ".claude" / "settings.json"
+        assert compose._ensure_session_end_hook(p) is True
+        assert compose._ensure_activity_hooks(p) is True
+        assert compose._ensure_pause_hooks(p) is True
+        hooks = self._load(p)["hooks"]
+        for name in ("SessionEnd", "PreToolUse", "PostToolUse",
+                     "PostToolUseFailure", "Notification", "PreCompact",
+                     "PostCompact", "StopFailure"):
+            assert name in hooks, f"{name} missing"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -4136,6 +4136,118 @@ class TestSessionEndHook12418(unittest.TestCase):
                     {"reason": "other", "at": 123.0})
 
 
+class TestPauseStateHelpers12458(unittest.TestCase):
+    """#12458 (#12271 slice c): AgentState.active_pause() returns the reason a
+    hook explains the agent's silence (so reboot should hold off), each bounded
+    by a staleness ceiling; stopfailure_backoff_due() flags a recent throttle."""
+
+    def setUp(self):
+        import harness
+        self.h = harness
+        self.a = harness.AgentState("skill", "/tmp/x")
+
+    def test_in_flight_within_deadline_is_paused(self):
+        now = 1000.0
+        self.a.in_flight_until = now + 100  # deadline in the future
+        self.assertEqual(self.a.active_pause(now), "in-flight")
+
+    def test_in_flight_past_deadline_not_paused(self):
+        now = 1000.0
+        self.a.in_flight_until = now - 1  # deadline elapsed (tool_call_max hit)
+        self.assertIsNone(self.a.active_pause(now))
+
+    def test_compacting_within_ceiling_is_paused(self):
+        now = 1000.0
+        self.a.compacting_since = now - 10
+        self.assertEqual(self.a.active_pause(now), "compacting")
+
+    def test_compacting_past_ceiling_not_paused(self):
+        now = 1000.0
+        self.a.compacting_since = now - (self.h.COMPACTING_MAX_SECONDS + 1)
+        self.assertIsNone(self.a.active_pause(now))
+
+    def test_waiting_within_ceiling_is_paused(self):
+        now = 1000.0
+        self.a.waiting_since = now - 10
+        self.assertEqual(self.a.active_pause(now), "waiting")
+
+    def test_waiting_past_ceiling_not_paused(self):
+        now = 1000.0
+        self.a.waiting_since = now - (self.h.WAITING_MAX_SECONDS + 1)
+        self.assertIsNone(self.a.active_pause(now))
+
+    def test_no_signals_not_paused(self):
+        self.assertIsNone(self.a.active_pause(1000.0))
+
+    def test_in_flight_takes_priority_over_waiting(self):
+        now = 1000.0
+        self.a.in_flight_until = now + 100
+        self.a.waiting_since = now - 10
+        self.assertEqual(self.a.active_pause(now), "in-flight")
+
+    def test_clock_skew_negative_age_not_paused(self):
+        """A flag stamped in the FUTURE (clock skew / corrupt state) must not
+        read as an indefinite pause — the `0 <= age` guard rejects it."""
+        now = 1000.0
+        self.a.compacting_since = now + 500
+        self.assertIsNone(self.a.active_pause(now))
+
+    def test_recent_rate_limit_backoff_due(self):
+        now = 1000.0
+        self.a.last_stop_failure = {"cause": "rate_limit", "at": now - 5}
+        self.assertTrue(self.a.stopfailure_backoff_due(now))
+
+    def test_recent_overloaded_backoff_due(self):
+        now = 1000.0
+        self.a.last_stop_failure = {"cause": "overloaded", "at": now - 5}
+        self.assertTrue(self.a.stopfailure_backoff_due(now))
+
+    def test_stale_rate_limit_not_due(self):
+        now = 1000.0
+        self.a.last_stop_failure = {"cause": "rate_limit",
+                                    "at": now - (self.h.STOP_FAILURE_RECENT_SECONDS + 1)}
+        self.assertFalse(self.a.stopfailure_backoff_due(now))
+
+    def test_non_throttle_cause_not_due(self):
+        """auth/billing failures need operator action, not an auto-backoff."""
+        now = 1000.0
+        self.a.last_stop_failure = {"cause": "authentication_failed", "at": now - 5}
+        self.assertFalse(self.a.stopfailure_backoff_due(now))
+
+    def test_missing_stop_failure_not_due(self):
+        self.assertFalse(self.a.stopfailure_backoff_due(1000.0))
+        self.a.last_stop_failure = "not-a-dict"
+        self.assertFalse(self.a.stopfailure_backoff_due(1000.0))
+
+    def test_null_at_does_not_crash(self):
+        """A {'at': null} from a hand-edited state file must not TypeError."""
+        now = 1000.0
+        self.a.last_stop_failure = {"cause": "rate_limit", "at": None}
+        self.assertFalse(self.a.stopfailure_backoff_due(now))
+
+    def test_pause_state_persisted_and_restored(self):
+        import json as _json, tempfile
+        from pathlib import Path as _Path
+        st = self.h.HarnessState()
+        a = self.h.AgentState("skill", "/tmp/x")
+        a.in_flight_until = 111.0
+        a.waiting_since = 222.0
+        a.compacting_since = 333.0
+        a.last_stop_failure = {"cause": "rate_limit", "at": 444.0}
+        st.agents["skill"] = a
+        with tempfile.TemporaryDirectory() as d:
+            sf = _Path(d) / ".harness-state.json"
+            with patch.object(self.h, "HARNESS_STATE_FILE", sf):
+                st.save_state()
+                st2 = self.h.HarnessState()
+                st2.load_state()
+        r = st2.agents["skill"]
+        self.assertEqual(r.in_flight_until, 111.0)
+        self.assertEqual(r.waiting_since, 222.0)
+        self.assertEqual(r.compacting_since, 333.0)
+        self.assertEqual(r.last_stop_failure, {"cause": "rate_limit", "at": 444.0})
+
+
 class TestActivityHook12443(unittest.TestCase):
     """#12443: POST /hooks/activity records the activity heartbeat
     (last_activity_at + enriched {event, tool, phase}) on AgentState, exposes it

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -4248,6 +4248,141 @@ class TestPauseStateHelpers12458(unittest.TestCase):
         self.assertEqual(r.last_stop_failure, {"cause": "rate_limit", "at": 444.0})
 
 
+class TestPauseGuard12458(unittest.TestCase):
+    """#12458 (#12271 slice c): update_health's reboot decision is GUARDED — a
+    dead-PID agent is NOT rebooted while a hook explains the silence (in-flight /
+    waiting / compacting), and a recent throttle (StopFailure) backs off instead
+    of immediate respawn. AC5: a genuine death with NO pause signal still reboots
+    exactly as before."""
+
+    def _make_agent(self, status="running", **pause):
+        from harness import HarnessState, AgentState
+        hs = HarnessState()
+        agent = AgentState("skill", "/clone")
+        agent.status = status
+        agent.intent = AgentState.INTENT_RUNNING
+        agent.claude_pid = 12345
+        agent.last_spawn_at = None  # avoid fast-death-window effects unless set
+        for k, v in pause.items():
+            setattr(agent, k, v)
+        hs.set_agent("skill", agent)
+        return hs, agent
+
+    def _run(self, hs, now):
+        """One update_health poll, claude PID dead. Returns the boot_agent mock."""
+        boot = patch("harness.boot_remote.boot_agent",
+                     return_value={"success": True, "terminal_pid": 999})
+        patches = [
+            patch("harness.boot_remote._get_all_roles", return_value=["skill"]),
+            patch("harness.boot_remote._get_clone_path", return_value="/clone"),
+            patch("harness.boot_remote._is_process_alive", return_value=False),
+            patch("harness.reboot_agent._read_claude_pid", return_value=(None, False)),
+            patch("harness.time.time", return_value=now),
+            patch("harness._log"),
+            patch.object(hs, "save_state"),
+        ]
+        boot_mock = boot.start()
+        for p in patches:
+            p.start()
+        try:
+            hs.update_health()
+        finally:
+            for p in patches:
+                p.stop()
+            boot.stop()
+        return boot_mock
+
+    # --- AC5: genuine death (no pause) still reboots ---
+    def test_genuine_death_no_pause_reboots(self):
+        now = 10_000.0
+        hs, _ = self._make_agent()
+        boot = self._run(hs, now)
+        boot.assert_called_once_with("skill")
+        self.assertEqual(hs.get_agent("skill").status, "starting")
+
+    # --- AC3a: in-flight within tool_call_max → HOLD ---
+    def test_in_flight_within_deadline_holds_reboot(self):
+        now = 10_000.0
+        hs, _ = self._make_agent(in_flight_until=now + 100)
+        boot = self._run(hs, now)
+        boot.assert_not_called()
+        self.assertEqual(hs.get_agent("skill").status, "paused")
+
+    def test_in_flight_past_deadline_reboots(self):
+        """AC4: past tool_call_max (deadline elapsed) the agent IS wedged."""
+        now = 10_000.0
+        hs, _ = self._make_agent(in_flight_until=now - 1)
+        boot = self._run(hs, now)
+        boot.assert_called_once_with("skill")
+
+    # --- AC3b: waiting → HOLD ---
+    def test_waiting_holds_reboot(self):
+        now = 10_000.0
+        hs, _ = self._make_agent(waiting_since=now - 10)
+        boot = self._run(hs, now)
+        boot.assert_not_called()
+        self.assertEqual(hs.get_agent("skill").status, "paused")
+
+    # --- AC3c: compacting → HOLD ---
+    def test_compacting_holds_reboot(self):
+        now = 10_000.0
+        hs, _ = self._make_agent(compacting_since=now - 10)
+        boot = self._run(hs, now)
+        boot.assert_not_called()
+        self.assertEqual(hs.get_agent("skill").status, "paused")
+
+    # --- AC3d: StopFailure throttle → backoff, not immediate respawn ---
+    def test_stopfailure_rate_limit_backs_off(self):
+        from harness import CRASH_BACKOFF_BASE_SECONDS
+        now = 10_000.0
+        hs, _ = self._make_agent(
+            last_stop_failure={"cause": "rate_limit", "at": now - 5})
+        boot = self._run(hs, now)
+        boot.assert_not_called()
+        agent = hs.get_agent("skill")
+        self.assertEqual(agent.status, "crash-looping")
+        self.assertIsNotNone(agent.reboot_blocked_until)
+        self.assertGreater(agent.reboot_blocked_until, now)
+
+    def test_stale_stopfailure_does_not_backoff(self):
+        """An OLD StopFailure is not a current throttle → normal death path."""
+        from harness import STOP_FAILURE_RECENT_SECONDS
+        now = 10_000.0
+        hs, _ = self._make_agent(
+            last_stop_failure={"cause": "rate_limit",
+                               "at": now - (STOP_FAILURE_RECENT_SECONDS + 10)})
+        boot = self._run(hs, now)
+        boot.assert_called_once_with("skill")  # reboots as a normal death
+
+    # --- resume: a held agent whose ceiling has elapsed reboots ---
+    def test_held_agent_reboots_once_pause_clears(self):
+        now = 10_000.0
+        # already "paused", and its in-flight deadline is now in the past
+        hs, _ = self._make_agent(status="paused", in_flight_until=now - 1)
+        boot = self._run(hs, now)
+        boot.assert_called_once_with("skill")
+        self.assertEqual(hs.get_agent("skill").status, "starting")
+
+    def test_held_agent_stays_paused_while_pause_active(self):
+        now = 10_000.0
+        hs, _ = self._make_agent(status="paused", compacting_since=now - 10)
+        boot = self._run(hs, now)
+        boot.assert_not_called()
+        self.assertEqual(hs.get_agent("skill").status, "paused")
+
+    # --- operator stop wins over a pause hold ---
+    def test_operator_stop_wins_over_pause(self):
+        from harness import AgentState
+        now = 10_000.0
+        hs, agent = self._make_agent(status="paused", in_flight_until=now + 100)
+        agent.intent = AgentState.INTENT_STOPPING
+        boot = self._run(hs, now)
+        boot.assert_not_called()
+        a = hs.get_agent("skill")
+        # settles to stopped (intent fulfilled), NOT held forever
+        self.assertEqual(a.intent, AgentState.INTENT_STOPPED)
+
+
 class TestActivityHook12443(unittest.TestCase):
     """#12443: POST /hooks/activity records the activity heartbeat
     (last_activity_at + enriched {event, tool, phase}) on AgentState, exposes it

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -4530,5 +4530,121 @@ class TestActivityHook12443(unittest.TestCase):
                     st2.agents[self.role].last_activity["tool"], "Bash")
 
 
+class TestPauseHook12458(unittest.TestCase):
+    """#12458: POST /hooks/pause records pause-explaining lifecycle signals
+    (Notification→waiting, PreCompact→compacting, PostCompact→clear,
+    StopFailure→cause) and is fail-open; and /hooks/activity manages the
+    in-flight tool-call window (PreToolUse opens, Post* closes) + clears
+    waiting."""
+
+    def setUp(self):
+        import harness
+        from fastapi.testclient import TestClient
+        self.h = harness
+        self.client = TestClient(harness.app, raise_server_exceptions=False)
+        harness.state.start_time = time.time()
+        self.role = "skill"
+        self._roles = patch.object(
+            harness.boot_remote, "_get_all_roles", return_value=[self.role])
+        self._roles.start()
+        self._save = patch.object(harness.state, "save_state")
+        self._save.start()
+        self._uh = patch.object(harness.state, "update_health")
+        self._uh.start()
+        harness.state.agents.pop(self.role, None)
+        harness._last_activity_save_at = 0.0
+
+    def tearDown(self):
+        self._uh.stop()
+        self._save.stop()
+        self._roles.stop()
+        self.h.state.agents.pop(self.role, None)
+
+    def _hdr(self, role=None):
+        return {"X-Agent-Role": self.role if role is None else role}
+
+    def _agent(self):
+        return self.h.state.agents.get(self.role)
+
+    # --- /hooks/pause dispatch ---
+    def test_notification_sets_waiting(self):
+        r = self.client.post("/hooks/pause", headers=self._hdr(),
+                             json={"event": "Notification"})
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue(r.json().get("ok"))
+        self.assertIsInstance(self._agent().waiting_since, float)
+
+    def test_precompact_sets_compacting_postcompact_clears(self):
+        self.client.post("/hooks/pause", headers=self._hdr(),
+                         json={"event": "PreCompact"})
+        self.assertIsInstance(self._agent().compacting_since, float)
+        self.client.post("/hooks/pause", headers=self._hdr(),
+                         json={"event": "PostCompact"})
+        self.assertIsNone(self._agent().compacting_since)
+
+    def test_stopfailure_records_cause(self):
+        r = self.client.post("/hooks/pause", headers=self._hdr(),
+                             json={"hook_event_name": "StopFailure",
+                                   "matcher": "rate_limit"})
+        self.assertEqual(r.status_code, 200)
+        sf = self._agent().last_stop_failure
+        self.assertEqual(sf["cause"], "rate_limit")
+        self.assertIn("at", sf)
+
+    def test_stopfailure_unknown_cause_defaults(self):
+        self.client.post("/hooks/pause", headers=self._hdr(),
+                         json={"event": "StopFailure"})
+        self.assertEqual(self._agent().last_stop_failure["cause"], "unknown")
+
+    def test_unknown_event_dropped_but_200(self):
+        r = self.client.post("/hooks/pause", headers=self._hdr(),
+                             json={"event": "Bogus"})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json().get("dropped"), "unknown-event")
+
+    def test_no_role_dropped_but_200(self):
+        r = self.client.post("/hooks/pause", json={"event": "Notification"})
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json().get("dropped"), "no-role")
+
+    def test_unknown_role_dropped_but_200(self):
+        r = self.client.post("/hooks/pause", headers=self._hdr("bogus"),
+                             json={"event": "Notification"})
+        self.assertEqual(r.status_code, 200)
+        self.assertNotIn("bogus", self.h.state.agents)
+
+    def test_malformed_body_fail_open(self):
+        r = self.client.post("/hooks/pause", content=b"not json",
+                             headers={**self._hdr(), "Content-Type": "application/json"})
+        self.assertEqual(r.status_code, 200)  # empty body → unknown-event, still 200
+
+    # --- /hooks/activity in-flight management ---
+    def test_pretooluse_opens_in_flight_window(self):
+        r = self.client.post("/hooks/activity", headers=self._hdr(),
+                             json={"event": "PreToolUse", "tool": "Bash"})
+        self.assertEqual(r.status_code, 200)
+        agent = self._agent()
+        self.assertIsInstance(agent.in_flight_until, float)
+        # deadline is ~now + tool_call_max
+        self.assertGreater(agent.in_flight_until, time.time() + 1)
+
+    def test_posttooluse_closes_in_flight_window(self):
+        self.client.post("/hooks/activity", headers=self._hdr(),
+                         json={"event": "PreToolUse"})
+        self.assertIsNotNone(self._agent().in_flight_until)
+        self.client.post("/hooks/activity", headers=self._hdr(),
+                         json={"event": "PostToolUse"})
+        self.assertIsNone(self._agent().in_flight_until)
+
+    def test_activity_clears_waiting(self):
+        # set waiting via a Notification, then any activity clears it
+        self.client.post("/hooks/pause", headers=self._hdr(),
+                         json={"event": "Notification"})
+        self.assertIsNotNone(self._agent().waiting_since)
+        self.client.post("/hooks/activity", headers=self._hdr(),
+                         json={"event": "PostToolUse"})
+        self.assertIsNone(self._agent().waiting_since)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -4156,6 +4156,14 @@ class TestPauseStateHelpers12458(unittest.TestCase):
         self.a.in_flight_until = now - 1  # deadline elapsed (tool_call_max hit)
         self.assertIsNone(self.a.active_pause(now))
 
+    def test_in_flight_deadline_too_far_future_not_paused(self):
+        """DS-REVIEW-12458-guard F2: a deadline further out than tool_call_max
+        (stale flag / backward clock step) must NOT hold indefinitely — the
+        ceiling caps the hold at one legitimate tool call."""
+        now = 1000.0
+        self.a.in_flight_until = now + self.h.TOOL_CALL_MAX_SECONDS + 100
+        self.assertIsNone(self.a.active_pause(now))
+
     def test_compacting_within_ceiling_is_paused(self):
         now = 1000.0
         self.a.compacting_since = now - 10
@@ -4343,6 +4351,25 @@ class TestPauseGuard12458(unittest.TestCase):
         self.assertEqual(agent.status, "crash-looping")
         self.assertIsNotNone(agent.reboot_blocked_until)
         self.assertGreater(agent.reboot_blocked_until, now)
+
+    def test_graceful_exit_with_throttle_backs_off_without_streak(self):
+        """DS-REVIEW-12458-guard F3: a GRACEFUL exit (SessionEnd after spawn)
+        that coincides with a recent throttle still BACKS OFF (don't re-hit the
+        limit) but must NOT accumulate the #12244 crash streak (the #12418 AC4
+        contract — a cooperative exit is not a crash)."""
+        now = 10_000.0
+        hs, agent = self._make_agent(
+            last_spawn_at=now - 10,
+            last_session_end={"reason": "other", "at": now - 5},  # after spawn
+            last_stop_failure={"cause": "rate_limit", "at": now - 3},
+        )
+        boot = self._run(hs, now)
+        boot.assert_not_called()  # backed off, not respawned
+        a = hs.get_agent("skill")
+        self.assertEqual(a.status, "crash-looping")
+        self.assertIsNotNone(a.reboot_blocked_until)
+        # graceful → streak NOT incremented
+        self.assertEqual(a.consecutive_fast_deaths, 0)
 
     def test_stale_stopfailure_does_not_backoff(self):
         """An OLD StopFailure is not a current throttle → normal death path."""
@@ -4585,15 +4612,17 @@ class TestPauseHook12458(unittest.TestCase):
     def test_stopfailure_records_cause(self):
         r = self.client.post("/hooks/pause", headers=self._hdr(),
                              json={"hook_event_name": "StopFailure",
-                                   "matcher": "rate_limit"})
+                                   "reason": "rate_limit"})
         self.assertEqual(r.status_code, 200)
         sf = self._agent().last_stop_failure
         self.assertEqual(sf["cause"], "rate_limit")
         self.assertIn("at", sf)
 
     def test_stopfailure_unknown_cause_defaults(self):
+        """F5: matcher is NOT a cause source — a payload with only a matcher
+        records 'unknown' (→ safe default, no backoff)."""
         self.client.post("/hooks/pause", headers=self._hdr(),
-                         json={"event": "StopFailure"})
+                         json={"event": "StopFailure", "matcher": "rate_limit"})
         self.assertEqual(self._agent().last_stop_failure["cause"], "unknown")
 
     def test_unknown_event_dropped_but_200(self):

--- a/tests/test_harness_route_contract.py
+++ b/tests/test_harness_route_contract.py
@@ -73,6 +73,10 @@ EXPECTED_CALLERS = {
     # that cycle_post imports). activity_hook is the module that literally holds
     # the route path; cycle_post reaches it via post_activity(), not a literal.
     ("POST", "/hooks/activity"):                ["activity_hook"],
+    # #12458 — pause-aware liveness hooks (Notification / PreCompact /
+    # PostCompact / StopFailure): POSTed only by Claude Code's native type:http
+    # hooks in settings.json (no in-repo Python caller).
+    ("POST", "/hooks/pause"):                   _EXTERNAL,
 }
 
 


### PR DESCRIPTION
## Summary
Implements #12458 — slice (c) of #12271 (progress-based liveness). Adds the **pause-aware guard**: agent silence / a dead PID is treated as death ONLY when no hook explains it. A legitimately-paused agent (mid-long-tool-call, waiting on a prompt, compacting, or rate-limited) is no longer false-rebooted. **Guards** the existing reboot decision; does NOT yet retire PID-poll (that's slice d).

## Mechanism
- **Record** (new hooks, deployed per-clone via the slice-a/b settings.json integration):
  - `PreToolUse` (async command) opens an in-flight window (`in_flight_until = now + tool_call_max`); `PostToolUse`/`PostToolUseFailure` close it.
  - `Notification` / `PreCompact` / `PostCompact` / `StopFailure` (native http → new `/hooks/pause`) record waiting / compacting / last-throttle.
- **Guard** (`update_health`): a dead-PID agent is HELD (status `paused`) while `active_pause()` is set — each pause bounded by a staleness ceiling (`TOOL_CALL_MAX` 900s / `COMPACTING_MAX` 300s / `WAITING_MAX` 1800s) with a clock-skew guard, so a stale flag can never mask a genuine death. Released the moment the ceiling elapses → normal death path. A recent `rate_limit`/`overloaded` StopFailure backs off (don't re-hit the limit) instead of an immediate respawn.

## Safety (the load-bearing invariants)
- **AC5**: a genuine death with NO pause signal reboots **exactly as before** (`active_pause`→None immediately). The full #12244 crash-loop suite stays green.
- The guard mirrors the proven crash-looping hold/resume pattern (a `paused` status preserved across polls + re-evaluated), so the status-machine's one-shot `was_alive` is handled correctly.
- Operator stop still wins over a hold; graceful exits don't accumulate the crash streak even under a throttle (#12418 contract preserved).

## Changes
- `harness.py`: 4 AgentState pause fields + `active_pause()`/`stopfailure_backoff_due()` (persisted); the guard in `update_health`; `/hooks/pause` endpoint + in-flight management on `/hooks/activity`.
- `compose.py`: deploys PreToolUse (async command) + the 4 pause hooks (http); route-contract manifest += `/hooks/pause`.

## Verification
- Full curated static gate green (pytest exit 0, confirmed twice). New tests: `TestPauseStateHelpers12458` (17), `TestPauseGuard12458` (11, incl. AC5 + all guard branches + resume + operator-stop), `TestPauseHook12458` (11), `TestEnsurePauseHooks12458`.
- **DS-review-per-change** at both boundaries: guard (DeepSeek — 2 errors caught: in-flight clock-skew ceiling + graceful-throttle streak; fixed) and plumbing (Sonnet fallback after model_router exit 2 — waiting-clear scoping + nits; fixed).

Notes: StopFailure cause extraction is best-effort (unknown → safe-default normal reboot); §16 doc-sync for PM (PreToolUse async-command, pause hooks http). Next: slice (d) retire PID-poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)