### PR TITLE
fix(#12475): --force is a full legality override for tracker.py transitions

### DIFF
--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -362,6 +362,32 @@ def _get_issue_role_labels(number):
     return roles
 
 
+def _get_issue_status_labels(number):
+    """Return the set of `status:*` labels currently on an issue.
+
+    e.g. labels `status:approved`, `role:skill` -> {"status:approved"}. Returns
+    an empty set on API failure (caller decides how to treat missing data).
+    Used by the forced-transition path (#12475) to remove whatever status label
+    is ACTUALLY present rather than trusting the caller-supplied from-status —
+    a wrong from-status would otherwise leave the issue with two status labels.
+    """
+    result = _run_list(
+        ["gh", "issue", "view", str(number), "--json", "labels"],
+        check=False,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return set()
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return set()
+    return {
+        lbl.get("name", "")
+        for lbl in data.get("labels", [])
+        if lbl.get("name", "").startswith("status:")
+    }
+
+
 def _check_authority(number, from_label, to_label, caller_role):
     """Decide whether `caller_role` may perform (from_label -> to_label) on #number.
 
@@ -1122,6 +1148,8 @@ def transition(number, from_status, to_status, role=None, force=False):
                 f"Forced illegal transition {from_label} -> {to_label} on "
                 f"#{number} (--force human override)",
             )
+            # fall through — force allows the illegal edge; the authority and
+            # ship-integrity gates below still run (steps 4/5 are never bypassed).
         else:
             _log_diagnostic("error", f"Illegal transition {from_label} -> {to_label} on #{number}")
             print(
@@ -1149,6 +1177,14 @@ def transition(number, from_status, to_status, role=None, force=False):
             sys.exit(1)
 
     # 3. Guard: block guarded transitions if unread feedback exists
+    if force and (from_label, to_label) in _GUARDED_TRANSITIONS:
+        # Force skips the unread-feedback block — surface that it was skipped so
+        # a human override past genuinely-unread QA feedback is auditable (#12475).
+        _log_diagnostic(
+            "warning",
+            f"Forced transition {from_label} -> {to_label} on #{number} "
+            f"bypassed the unread-feedback guard (--force)",
+        )
     if (from_label, to_label) in _GUARDED_TRANSITIONS and not force:
         # Match the caller's actual comment format (role is non-None here
         # because authority check required it; fall back to skill-lead
@@ -1255,11 +1291,29 @@ def transition(number, from_status, to_status, role=None, force=False):
                 )
                 sys.exit(1)
 
+    # Determine which status label(s) to remove. On the normal (non-forced)
+    # path the legality matrix guarantees `from_label` is the actual current
+    # status, so remove exactly that (no extra gh round-trip on the hot path).
+    # On the forced path (#12475) the caller-supplied `from_status` is NOT
+    # trusted: a wrong value would no-op the remove and leave the issue with
+    # two status:* labels. So query the live status labels and strip ALL of
+    # them (except the target) — a forced status change always lands exactly
+    # one status label. Falls back to `from_label` if the query fails.
+    remove_labels = [from_label]
+    if force:
+        live_status = _get_issue_status_labels(number)
+        stale = sorted(live_status - {to_label})
+        if stale:
+            remove_labels = stale
+
     adapter = _get_forge_adapter()
     if adapter:
-        adapter.edit_labels(number, add=[to_label], remove=[from_label])
+        adapter.edit_labels(number, add=[to_label], remove=remove_labels)
     else:
-        _run_list(["gh", "issue", "edit", str(number), "--remove-label", from_label, "--add-label", to_label])
+        cmd = ["gh", "issue", "edit", str(number), "--add-label", to_label]
+        for lbl in remove_labels:
+            cmd += ["--remove-label", lbl]
+        _run_list(cmd)
 
     # Auto-convert draft PR to ready on pending-test or pending-ship
     if to_label in ("status:pending-test", "status:pending-ship"):

--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -27,7 +27,8 @@ Role authority (who may call `transition`):
                                      in-progress -> approved (must match issue's `role:*` label)
   - DM  (--role dm  or dm-lead)    : in-progress -> pending-ship, pending-ship -> shipped,
                                      pending-ship -> in-progress (merge conflict rollback)
-  - Human override                 : --force bypasses authority + unread-feedback guards
+  - Human override                 : --force bypasses legality + authority + unread-feedback
+                                     guards (any status change); ship-integrity gates still apply
 """
 
 import json
@@ -163,8 +164,11 @@ LEGAL_TRANSITIONS = {
 # this table will be rejected with "no authority mapping" unless --force is
 # passed. This fails closed by design.
 #
-# Bypass: --force overrides authority (and the unread-feedback guard) but
-# NOT legality. Humans use --force when intervening manually.
+# Bypass: --force overrides the legality matrix, authority, AND the unread-
+# feedback guard (#12475) — the full human override for setting any status.
+# The ship-integrity gates (TC-coverage; unmerged-PR/branch on ->shipped) are
+# the only checks --force does NOT bypass. Humans use --force when intervening
+# manually (e.g. correcting a mis-transition).
 
 ROLE_AUTHORITY = {
     # PM owns the intake lifecycle
@@ -1092,22 +1096,41 @@ def transition(number, from_status, to_status, role=None, force=False):
         to_status: target status (short or full label)
         role: caller's role (e.g. "skill-lead", "pm", "verifier-lead"). Required
               unless `force` is set. Checked against ROLE_AUTHORITY.
-        force: human override — bypasses role authority AND the unread-feedback
-              guard. Does NOT bypass legality.
+        force: human override — bypasses the legality matrix, role authority,
+              AND the unread-feedback guard, permitting any from->to status
+              change (#12475). Does NOT bypass the ship-integrity gates
+              (TC-coverage on pending-test->pending-ship; unmerged PR/branch on
+              ->shipped) — those remain hard invariants even under --force.
     """
     from_label = _resolve_status(from_status)
     to_label = _resolve_status(to_status)
 
-    # 1. Enforce legal transitions (never bypassed)
+    # 1. Enforce legal transitions (bypassable with --force — #12475)
+    #    --force is the human override: it permits setting status to ANY value,
+    #    bypassing the legality matrix in addition to the authority + unread-
+    #    feedback guards. This is the path a human (or PM on a human directive)
+    #    uses to correct a mis-transition (e.g. walk a task over-approved in an
+    #    'approve all' batch back from approved -> planning). The ship-INTEGRITY
+    #    gates below (step 4 TC-coverage, step 5 unmerged-PR/branch) remain hard
+    #    invariants even under --force — they protect `shipped` integrity and
+    #    are out of scope for this override.
     legal = LEGAL_TRANSITIONS.get(from_label, set())
     if to_label not in legal:
-        _log_diagnostic("error", f"Illegal transition {from_label} -> {to_label} on #{number}")
-        print(
-            f"ERROR: Illegal transition {from_label} -> {to_label}. "
-            f"Legal from {from_label}: {sorted(legal)}",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+        if force:
+            _log_diagnostic(
+                "warning",
+                f"Forced illegal transition {from_label} -> {to_label} on "
+                f"#{number} (--force human override)",
+            )
+        else:
+            _log_diagnostic("error", f"Illegal transition {from_label} -> {to_label} on #{number}")
+            print(
+                f"ERROR: Illegal transition {from_label} -> {to_label}. "
+                f"Legal from {from_label}: {sorted(legal)}. "
+                f"Use --force to override (humans only).",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     # 2. Enforce role authority (bypassable with --force)
     if not force:

--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -363,13 +363,16 @@ def _get_issue_role_labels(number):
 
 
 def _get_issue_status_labels(number):
-    """Return the set of `status:*` labels currently on an issue.
+    """Return the set of FULL `status:*` labels currently on an issue.
 
-    e.g. labels `status:approved`, `role:skill` -> {"status:approved"}. Returns
-    an empty set on API failure (caller decides how to treat missing data).
-    Used by the forced-transition path (#12475) to remove whatever status label
-    is ACTUALLY present rather than trusting the caller-supplied from-status —
-    a wrong from-status would otherwise leave the issue with two status labels.
+    e.g. labels `status:approved`, `role:skill` -> {"status:approved"}. Note the
+    return shape differs from `_get_issue_role_labels`, which strips its prefix
+    ("skill"); this returns the full label string ("status:approved") because the
+    swap site removes full label names. Returns an empty set on API failure
+    (caller decides how to treat missing data). Used by the forced-transition
+    path (#12475) to remove whatever status label is ACTUALLY present rather than
+    trusting the caller-supplied from-status — a wrong from-status would
+    otherwise leave the issue with two status labels.
     """
     result = _run_list(
         ["gh", "issue", "view", str(number), "--json", "labels"],

--- a/tests/test_12475_force_bypasses_legality.py
+++ b/tests/test_12475_force_bypasses_legality.py
@@ -1,0 +1,146 @@
+"""Regression tests for #12475 — `tracker.py transition --force` must bypass
+the legal-transition matrix (the human override that lets a human/PM correct a
+mis-transition), while STILL enforcing the two ship-integrity gates.
+
+Before #12475, `--force` only bypassed the authority + unread-feedback guards;
+the legality matrix (step 1 of `transition()`) was unconditional, so a task
+over-approved in an 'approve all' batch could not be walked back
+`approved -> planning` — the reproducer below.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "references" / "scripts"))
+
+import tracker  # noqa: E402
+
+
+@pytest.fixture
+def stub_forge(monkeypatch):
+    """Stub the forge so transition() side-effects (label swap, close, event)
+    don't touch gh / the network. Returns the MagicMock adapter for asserts."""
+    adapter = MagicMock()
+    monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: adapter)
+    # Default ship-integrity probes to "clean" so they don't block unless a
+    # test overrides them; harmless for non-shipped targets (never called).
+    monkeypatch.setattr(tracker, "_check_unmerged_pr", lambda _n: None)
+    monkeypatch.setattr(tracker, "_check_unmerged_branch", lambda _n: None)
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# The reproducer: approved -> planning is illegal, but --force must allow it.
+# ---------------------------------------------------------------------------
+
+
+class TestForceBypassesLegality:
+    def test_repro_approved_to_planning_forced_succeeds(self, stub_forge):
+        """#12475 exact repro: walk an over-approved task back to planning."""
+        result = tracker.transition(
+            12451, "approved", "planning", role="pm-lead", force=True
+        )
+        assert result is True
+        stub_forge.edit_labels.assert_called_once_with(
+            12451, add=["status:planning"], remove=["status:approved"]
+        )
+
+    def test_same_transition_without_force_is_rejected(self, stub_forge):
+        """Regression guard: the legality matrix still blocks when NOT forced.
+
+        approved's only legal target is in-progress; planning must be rejected.
+        """
+        with pytest.raises(SystemExit) as exc:
+            tracker.transition(12451, "approved", "planning", role="pm-lead", force=False)
+        assert exc.value.code == 1
+        stub_forge.edit_labels.assert_not_called()
+
+    @pytest.mark.parametrize("frm,to", [
+        ("approved", "pending"),
+        ("in-progress", "approved"),   # legal, sanity (force is a no-op on legal)
+        ("pending-test", "planning"),
+        ("shipped", "in-progress"),    # out of a terminal state
+    ])
+    def test_force_permits_arbitrary_status_change(self, stub_forge, frm, to):
+        """--force permits ANY from->to (none of these touch a ship gate)."""
+        result = tracker.transition(999, frm, to, role="pm-lead", force=True)
+        assert result is True
+        stub_forge.edit_labels.assert_called_once_with(
+            999, add=[f"status:{to}"], remove=[f"status:{frm}"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Ship-integrity gates remain hard invariants EVEN under --force.
+# ---------------------------------------------------------------------------
+
+
+class TestForceDoesNotBypassShipIntegrity:
+    def test_force_to_shipped_still_blocked_by_unmerged_pr(self, monkeypatch, stub_forge):
+        """Forcing ->shipped with an open PR must still block (step 5)."""
+        monkeypatch.setattr(tracker, "_check_unmerged_pr", lambda _n: (777, "http://pr/777"))
+        # approved -> shipped is illegal; --force bypasses legality and reaches
+        # the unmerged-PR gate, which must still fire.
+        with pytest.raises(SystemExit) as exc:
+            tracker.transition(999, "approved", "shipped", role="pm-lead", force=True)
+        assert exc.value.code == 1
+        stub_forge.edit_labels.assert_not_called()
+
+    def test_force_to_shipped_still_blocked_by_unmerged_branch(self, monkeypatch, stub_forge):
+        """Forcing ->shipped with an unmerged branch (and no merged PR) blocks."""
+        monkeypatch.setattr(tracker, "_check_unmerged_branch", lambda _n: ("squidsquad/task/999", 3))
+        monkeypatch.setattr(tracker, "_check_merged_pr", lambda _n: None)
+        with pytest.raises(SystemExit) as exc:
+            tracker.transition(999, "approved", "shipped", role="pm-lead", force=True)
+        assert exc.value.code == 1
+        stub_forge.edit_labels.assert_not_called()
+
+    def test_force_pending_test_to_pending_ship_still_hits_tc_gate(self, monkeypatch, stub_forge):
+        """Forcing pending-test->pending-ship still enforces TC coverage (step 4)."""
+        fake_tc = MagicMock()
+        fake_tc._discover_files.return_value = (Path("TEST-PLAN-999.md"), None)  # plan, no QA-RESULTS
+        monkeypatch.setitem(sys.modules, "tc_coverage", fake_tc)
+        # pending-test -> pending-ship IS legal, but force or not the TC gate
+        # must block when a test plan exists with no QA-RESULTS.
+        with pytest.raises(SystemExit) as exc:
+            tracker.transition(999, "pending-test", "pending-ship", role="pm-lead", force=True)
+        assert exc.value.code == 1
+        stub_forge.edit_labels.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Side-effects of a forced arbitrary transition run coherently (no stranding).
+# ---------------------------------------------------------------------------
+
+
+class TestForcedTransitionSideEffects:
+    def test_forced_to_shipped_auto_closes_when_clean(self, stub_forge):
+        """A forced ->shipped with clean ship gates still auto-closes the issue."""
+        # stub_forge defaults _check_unmerged_pr/_branch to None (clean).
+        result = tracker.transition(999, "approved", "shipped", role="pm-lead", force=True)
+        assert result is True
+        stub_forge.edit_labels.assert_called_once_with(
+            999, add=["status:shipped"], remove=["status:approved"]
+        )
+        stub_forge.close_issue.assert_called_once_with(999)
+
+    def test_forced_transition_emits_status_event(self, monkeypatch, stub_forge):
+        """The status-transition event still emits for a forced illegal edge."""
+        emitted = {}
+
+        def _fake_emit(event_type, role, payload=None):
+            emitted["type"] = event_type
+            emitted["role"] = role
+            emitted["payload"] = payload
+
+        fake_bus = MagicMock()
+        fake_bus.emit = _fake_emit
+        monkeypatch.setitem(sys.modules, "event_bus", fake_bus)
+        tracker.transition(999, "approved", "planning", role="pm-lead", force=True)
+        assert emitted["type"] == "status-transition"
+        assert emitted["payload"]["from"] == "approved"
+        assert emitted["payload"]["to"] == "planning"

--- a/tests/test_12475_force_bypasses_legality.py
+++ b/tests/test_12475_force_bypasses_legality.py
@@ -68,12 +68,29 @@ class TestForceBypassesLegality:
         ("pending-test", "planning"),
         ("shipped", "in-progress"),    # out of a terminal state
     ])
-    def test_force_permits_arbitrary_status_change(self, stub_forge, frm, to):
-        """--force permits ANY from->to (none of these touch a ship gate)."""
+    def test_force_permits_arbitrary_status_change(self, monkeypatch, stub_forge, frm, to):
+        """--force permits ANY from->to (none of these touch a ship gate).
+
+        Exercises the REAL forced path: the live status label equals `frm`, so
+        the forced swap removes the live label (== from) and adds `to`. (Not the
+        empty-live-set fallback — that is covered separately.)"""
+        monkeypatch.setattr(
+            tracker, "_get_issue_status_labels", lambda _n: {f"status:{frm}"}
+        )
         result = tracker.transition(999, frm, to, role="pm-lead", force=True)
         assert result is True
         stub_forge.edit_labels.assert_called_once_with(
             999, add=[f"status:{to}"], remove=[f"status:{frm}"]
+        )
+
+    def test_force_arbitrary_change_falls_back_to_from_on_api_failure(self, stub_forge):
+        """When the live-label query fails (empty set), the forced swap falls
+        back to removing the caller-supplied from_label (best effort)."""
+        # stub_forge defaults _get_issue_status_labels to empty (API-failure sim).
+        result = tracker.transition(999, "approved", "pending", role="pm-lead", force=True)
+        assert result is True
+        stub_forge.edit_labels.assert_called_once_with(
+            999, add=["status:pending"], remove=["status:approved"]
         )
 
 

--- a/tests/test_12475_force_bypasses_legality.py
+++ b/tests/test_12475_force_bypasses_legality.py
@@ -30,6 +30,9 @@ def stub_forge(monkeypatch):
     # test overrides them; harmless for non-shipped targets (never called).
     monkeypatch.setattr(tracker, "_check_unmerged_pr", lambda _n: None)
     monkeypatch.setattr(tracker, "_check_unmerged_branch", lambda _n: None)
+    # Default live status labels to empty so the forced-swap helper falls back
+    # to from_label unless a test injects a specific live state.
+    monkeypatch.setattr(tracker, "_get_issue_status_labels", lambda _n: set())
     return adapter
 
 
@@ -90,6 +93,16 @@ class TestForceDoesNotBypassShipIntegrity:
         assert exc.value.code == 1
         stub_forge.edit_labels.assert_not_called()
 
+    def test_force_on_LEGAL_ship_still_blocked_by_unmerged_pr(self, monkeypatch, stub_forge):
+        """Regression guard (DS-12475 F12): the ship gate keys on to_label, so
+        even a LEGAL forced pending-ship -> shipped must block on an open PR —
+        catches a future `if not force` accidentally added to step 5."""
+        monkeypatch.setattr(tracker, "_check_unmerged_pr", lambda _n: (778, "http://pr/778"))
+        with pytest.raises(SystemExit) as exc:
+            tracker.transition(999, "pending-ship", "shipped", role="dm-lead", force=True)
+        assert exc.value.code == 1
+        stub_forge.edit_labels.assert_not_called()
+
     def test_force_to_shipped_still_blocked_by_unmerged_branch(self, monkeypatch, stub_forge):
         """Forcing ->shipped with an unmerged branch (and no merged PR) blocks."""
         monkeypatch.setattr(tracker, "_check_unmerged_branch", lambda _n: ("squidsquad/task/999", 3))
@@ -106,6 +119,18 @@ class TestForceDoesNotBypassShipIntegrity:
         monkeypatch.setitem(sys.modules, "tc_coverage", fake_tc)
         # pending-test -> pending-ship IS legal, but force or not the TC gate
         # must block when a test plan exists with no QA-RESULTS.
+        with pytest.raises(SystemExit) as exc:
+            tracker.transition(999, "pending-test", "pending-ship", role="pm-lead", force=True)
+        assert exc.value.code == 1
+        stub_forge.edit_labels.assert_not_called()
+
+    def test_force_tc_gate_blocks_on_failing_coverage(self, monkeypatch, stub_forge):
+        """Step 4 also blocks (under force) when QA-RESULTS exists but coverage
+        fails — the check_coverage != 0 branch (DS-12475 F15)."""
+        fake_tc = MagicMock()
+        fake_tc._discover_files.return_value = (Path("TEST-PLAN-999.md"), Path("QA-RESULTS-999.md"))
+        fake_tc.check_coverage.return_value = 1  # coverage fails
+        monkeypatch.setitem(sys.modules, "tc_coverage", fake_tc)
         with pytest.raises(SystemExit) as exc:
             tracker.transition(999, "pending-test", "pending-ship", role="pm-lead", force=True)
         assert exc.value.code == 1
@@ -128,6 +153,52 @@ class TestForcedTransitionSideEffects:
         )
         stub_forge.close_issue.assert_called_once_with(999)
 
+    def test_forced_swap_strips_live_status_label_not_claimed_from(self, monkeypatch, stub_forge):
+        """DS-12475 F2/F14: a wrong from_status under force must NOT leave two
+        status labels. The swap removes the ACTUAL live status label(s), not the
+        caller's claimed from. Here the issue is really in-progress but the
+        caller wrongly passes from=approved; the remove must target the live
+        label so the issue ends with exactly status:planning."""
+        monkeypatch.setattr(
+            tracker, "_get_issue_status_labels", lambda _n: {"status:in-progress"}
+        )
+        result = tracker.transition(999, "approved", "planning", role="pm-lead", force=True)
+        assert result is True
+        stub_forge.edit_labels.assert_called_once_with(
+            999, add=["status:planning"], remove=["status:in-progress"]
+        )
+
+    def test_forced_swap_strips_multiple_stale_status_labels(self, monkeypatch, stub_forge):
+        """If the issue is already corrupted with two status labels, a forced
+        transition cleans BOTH and lands exactly the target."""
+        monkeypatch.setattr(
+            tracker, "_get_issue_status_labels",
+            lambda _n: {"status:approved", "status:in-progress"},
+        )
+        result = tracker.transition(999, "approved", "planning", role="pm-lead", force=True)
+        assert result is True
+        args, kwargs = stub_forge.edit_labels.call_args
+        assert kwargs["add"] == ["status:planning"]
+        assert sorted(kwargs["remove"]) == ["status:approved", "status:in-progress"]
+
+    def test_nonforced_swap_does_not_query_live_labels(self, monkeypatch, stub_forge):
+        """The hot non-forced path must NOT add a gh round-trip — it trusts
+        from_label (legality guarantees it is the real predecessor)."""
+        called = {"n": 0}
+
+        def _spy(_n):
+            called["n"] += 1
+            return {"status:in-progress"}
+
+        monkeypatch.setattr(tracker, "_get_issue_status_labels", _spy)
+        # in-progress -> approved is a legal edge for the assigned worker.
+        monkeypatch.setattr(tracker, "_get_issue_role_labels", lambda _n: {"skill"})
+        tracker.transition(999, "in-progress", "approved", role="skill-lead", force=False)
+        assert called["n"] == 0
+        stub_forge.edit_labels.assert_called_once_with(
+            999, add=["status:approved"], remove=["status:in-progress"]
+        )
+
     def test_forced_transition_emits_status_event(self, monkeypatch, stub_forge):
         """The status-transition event still emits for a forced illegal edge."""
         emitted = {}
@@ -144,3 +215,5 @@ class TestForcedTransitionSideEffects:
         assert emitted["type"] == "status-transition"
         assert emitted["payload"]["from"] == "approved"
         assert emitted["payload"]["to"] == "planning"
+        assert emitted["payload"]["issue_number"] == "999"
+        assert emitted["role"] == "pm"  # "pm-lead" -> bare alias

--- a/tests/test_tracker_authority.py
+++ b/tests/test_tracker_authority.py
@@ -499,18 +499,38 @@ class TestTransitionEnforcement:
         # gh was actually called
         assert any("edit" in c for c in gh_calls)
 
-    def test_illegal_transition_rejected_even_with_force(self, monkeypatch, capsys):
-        """--force does NOT bypass legality (can't jump pending -> shipped)."""
+    def test_illegal_transition_rejected_without_force(self, monkeypatch, capsys):
+        """Without --force the legality matrix still blocks illegal edges."""
         def _fail(*a, **kw):
             raise AssertionError("gh should not be called on illegal transition")
 
         monkeypatch.setattr(tracker, "_run_list", _fail)
         with pytest.raises(SystemExit) as excinfo:
-            tracker.transition(1, "pending", "shipped",
-                               role="pm-lead", force=True)
+            tracker.transition(1, "approved", "planning",
+                               role="pm-lead", force=False)
         assert excinfo.value.code == 1
         err = capsys.readouterr().err
         assert "Illegal transition" in err
+
+    def test_force_bypasses_legality(self, monkeypatch):
+        """#12475: --force IS a full legality override — approved -> planning
+        (illegal in the forward matrix) succeeds, letting a human walk back a
+        mis-transition. Ship-integrity gates are covered in
+        test_12475_force_bypasses_legality.py."""
+        gh_calls = []
+
+        class FakeResult:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        def _fake_run_list(cmd, **kw):
+            gh_calls.append(cmd)
+            return FakeResult()
+
+        monkeypatch.setattr(tracker, "_run_list", _fake_run_list)
+        tracker.transition(1, "approved", "planning", role="pm-lead", force=True)
+        assert any("edit" in c for c in gh_calls)
 
     def test_missing_role_rejected(self, monkeypatch, capsys):
         def _fail(*a, **kw):


### PR DESCRIPTION
## Summary
`tracker.py transition ... --force` now bypasses the **legal-transition matrix** in addition to the authority + unread-feedback guards it already bypassed — the full human override. Resolves #12475 (operator directive 2026-06-16): a human/PM can correct a mis-transition (e.g. walk a task over-approved in an 'approve all' batch back from `approved → planning`), which the forward-only matrix previously forbade.

## What changed
- **Legality bypass (step 1)** is skipped under `--force` (logs an audit warning instead of exiting).
- **Ship-integrity gates stay hard invariants** even under `--force`: step 4 TC-coverage (`pending-test → pending-ship`) and step 5 unmerged-PR/branch (`→ shipped`). The directive scoped the override to legality + authority + unread-feedback; those two gates protect `shipped` integrity (#9999 / TC-coverage).
- **Force-robust label swap:** the forced path queries the issue's **live** `status:*` labels and removes all of them (except the target), so a wrong caller-supplied `from_status` can't leave the issue with two status labels — and a pre-corrupted double-label issue gets cleaned. The non-forced hot path is unchanged (no extra `gh` round-trip).
- Audit warning emitted when `--force` skips the unread-feedback guard.
- Docstring / `--help` / comments updated to the new contract.

## Review
Two adversarial DS-style reviews. Round 1 (BLOCK) caught the `from_label`-trust double-label corruption path + test gaps → fixed (live-label strip + tests). Round 2 (SHIP) caught one test-clarity nit → fixed.

## Tests
`tests/test_12475_force_bypasses_legality.py` (17): repro, arbitrary forced edges (real live-label swap + API-failure fallback), all three ship-gate preservations (incl. a LEGAL forced `pending-ship → shipped` still blocked by an open PR), failing-coverage gate, live-label-strip + multi-stale-label cleanup, non-forced-path no-query, side-effect coherence (auto-close, event payload). Updated `test_tracker_authority.py` to the new contract. Full unit suite green.

## Upgrade / migration
Pure behavioral widening of an existing flag; no config/schema change. Existing installs pick it up on next pull (it's a script). No CQ spec — deterministic script behavior, no composed agent-instruction change (flagged for verifier confirmation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)