### PR TITLE
feat(installer): #12525 minimal bare-harness launchers (start-harness.sh/.bat)

### DIFF
--- a/references/installer-files.txt
+++ b/references/installer-files.txt
@@ -1,7 +1,7 @@
 # SquidSquad installer file manifest
 # Every file the wizard needs, fetched by npx squidsquad before
 # launching Claude. One path per line, relative to repo root.
-# Total: 197 files
+# Total: 202 files
 #
 # Maintained alongside the wizard - when you add a new role,
 # capability, preset, or sub-skill, add its files here too.
@@ -9,6 +9,8 @@
 SKILL.md
 start.sh
 start.ps1
+start-harness.sh
+start-harness.bat
 references/commands/squidsquad-compose.md
 references/commands/squidsquad-upgrade.md
 references/wizard/WIZARD.md

--- a/start-harness.bat
+++ b/start-harness.bat
@@ -1,0 +1,15 @@
+@echo off
+REM SquidSquad — BARE harness launcher (#12525).
+REM
+REM Brings up ONLY the harness in a visible, persistent window. Unlike
+REM start.bat / start.ps1 (the FULL setup launchers), this does NOT sync clones
+REM and does NOT install dependencies — it assumes the environment is already
+REM set up. Run start.ps1 once for that; use this for the greenfield install
+REM smoke test and for debugging a harness you want to watch.
+REM
+REM Double-click it, or run from a terminal: start-harness.bat [harness args...]
+REM The window stays open (pause) so harness output and any startup error remain
+REM visible after it exits.
+cd /d "%~dp0"
+python references\scripts\harness.py %*
+pause

--- a/start-harness.sh
+++ b/start-harness.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# SquidSquad — BARE harness launcher (#12525).
+#
+# Brings up ONLY the harness, in the foreground. Unlike start.sh / start.ps1
+# (the FULL setup launchers), this does NOT sync clones and does NOT install
+# dependencies — it assumes the environment is already set up. Run start.sh
+# once for that; use this for the greenfield install smoke test and for
+# debugging a harness you want to watch.
+#
+# Usage: ./start-harness.sh [harness args...]
+cd "$(dirname "$0")"
+exec python3 references/scripts/harness.py "$@"

--- a/tests/test_12525_bare_harness_launcher.py
+++ b/tests/test_12525_bare_harness_launcher.py
@@ -1,0 +1,131 @@
+"""Contract tests for the bare-harness launchers (#12525).
+
+`start-harness.sh` / `start-harness.bat` bring up ONLY the harness, with no
+clone-sync and no dep-install (unlike the full start.sh / start.ps1). The
+visible-window / double-click behaviour (AC1/AC2) is OS-level and not
+unit-testable; these tests pin the deterministic contract: the right harness
+invocation, the absence of any git/pip step (AC3), manifest membership (AC4),
+and that the existing full launchers are untouched (AC5).
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SH = REPO_ROOT / "start-harness.sh"
+BAT = REPO_ROOT / "start-harness.bat"
+MANIFEST = REPO_ROOT / "references" / "installer-files.txt"
+
+# Any git/pip/clone-sync footprint that would betray the "bare" contract.
+_HEAVYWEIGHT = re.compile(
+    r"\bgit\b|\bpip\b|pip3|--rebase|requirements\.txt|ensurepip|apt\b|brew\b|"
+    r"\.local-config|Sync",
+    re.IGNORECASE,
+)
+
+
+def _exec_lines(text, comment_prefix):
+    """Executable (non-comment, non-blank) lines only. The header prose
+    legitimately names git/pip/start.ps1 to explain what the bare launcher
+    avoids — the contract checks must look at the COMMANDS, not the comments."""
+    out = []
+    for ln in text.splitlines():
+        s = ln.strip()
+        if not s or s.upper().startswith(comment_prefix.upper()):
+            continue
+        out.append(ln)
+    return "\n".join(out)
+
+
+class TestFilesExist:
+    def test_sh_present(self):
+        assert SH.is_file(), "start-harness.sh must exist at repo root"
+
+    def test_bat_present(self):
+        assert BAT.is_file(), "start-harness.bat must exist at repo root"
+
+
+class TestShContract:
+    def text(self):
+        return SH.read_text(encoding="utf-8")
+
+    def test_runs_harness_in_foreground(self):
+        # exec → foreground (AC2); targets references/scripts/harness.py.
+        assert "references/scripts/harness.py" in self.text()
+        assert "exec python3" in self.text()
+
+    def test_cds_to_script_dir(self):
+        assert 'cd "$(dirname "$0")"' in self.text()
+
+    def test_no_git_or_pip(self):
+        # AC3 — no clone-sync, no dep-install (scan commands, not the header).
+        hits = _HEAVYWEIGHT.findall(_exec_lines(self.text(), "#"))
+        assert not hits, f"start-harness.sh must not git/pip/sync; found {hits}"
+
+    def test_documents_distinction(self):
+        # AC4 — header explains bare vs full launcher.
+        assert "BARE" in self.text() and "start.sh" in self.text()
+
+
+class TestBatContract:
+    def text(self):
+        return BAT.read_text(encoding="utf-8")
+
+    def test_runs_harness(self):
+        assert r"references\scripts\harness.py" in self.text()
+
+    def test_window_stays_open(self):
+        # AC1 — persistent visible window.
+        assert "pause" in self.text()
+
+    def test_cds_to_script_dir(self):
+        assert "cd /d \"%~dp0\"" in self.text()
+
+    def test_no_git_or_pip(self):
+        # AC3 — scan commands, not the REM header (which names what it avoids).
+        hits = _HEAVYWEIGHT.findall(_exec_lines(self.text(), "REM"))
+        assert not hits, f"start-harness.bat must not git/pip/sync; found {hits}"
+
+    def test_does_not_delegate_to_ps1(self):
+        # The bare launcher runs python directly, not via start.ps1 (the header
+        # may MENTION start.ps1 to explain the distinction — check commands only).
+        assert "start.ps1" not in _exec_lines(self.text(), "REM")
+
+    def test_documents_distinction(self):
+        assert "BARE" in self.text() and "start.ps1" in self.text()
+
+
+class TestManifest:
+    def text(self):
+        return MANIFEST.read_text(encoding="utf-8")
+
+    def test_both_listed(self):
+        # AC4 — ship with installs. One path per line.
+        lines = {ln.strip() for ln in self.text().splitlines()}
+        assert "start-harness.sh" in lines
+        assert "start-harness.bat" in lines
+
+    def test_count_header_matches_payload(self):
+        text = self.text()
+        m = re.search(r"# Total:\s*(\d+)\s*files", text)
+        assert m, "manifest must carry a `# Total: N files` header"
+        declared = int(m.group(1))
+        payload = [
+            ln.strip() for ln in text.splitlines()
+            if ln.strip() and not ln.lstrip().startswith("#")
+        ]
+        assert declared == len(payload), (
+            f"header says {declared} files but manifest lists {len(payload)}"
+        )
+
+
+class TestFullLaunchersUntouched:
+    """AC5 — the existing full-setup launchers keep their sync + dep logic."""
+
+    def test_start_sh_still_full(self):
+        text = (REPO_ROOT / "start.sh").read_text(encoding="utf-8")
+        assert "requirements.txt" in text  # still installs deps
+        assert "git pull --rebase" in text  # still syncs clones
+
+    def test_start_ps1_present(self):
+        assert (REPO_ROOT / "start.ps1").is_file()

--- a/tests/test_12525_bare_harness_launcher.py
+++ b/tests/test_12525_bare_harness_launcher.py
@@ -127,5 +127,11 @@ class TestFullLaunchersUntouched:
         assert "requirements.txt" in text  # still installs deps
         assert "git pull --rebase" in text  # still syncs clones
 
-    def test_start_ps1_present(self):
-        assert (REPO_ROOT / "start.ps1").is_file()
+    def test_start_ps1_still_full(self):
+        # start.bat delegates to start.ps1, so a stripped start.ps1 would regress
+        # the full-setup path undetected — assert its sync+dep logic survives too.
+        ps1 = REPO_ROOT / "start.ps1"
+        assert ps1.is_file()
+        text = ps1.read_text(encoding="utf-8")
+        assert "requirements.txt" in text  # still installs deps
+        assert "git pull --rebase" in text  # still syncs clones


### PR DESCRIPTION
## #12525 — Minimal bare-harness launchers

Two launchers that bring up ONLY the harness — **no clone-sync, no dep-install** (unlike `start.sh`/`start.ps1`, the full-setup launchers). For the greenfield install smoke test and for debugging a harness you can actually see.

### What changed
- **`start-harness.sh`**: `exec python3 references/scripts/harness.py "$@"` (foreground).
- **`start-harness.bat`**: `python references\scripts\harness.py %*` + `pause` (visible, persistent, double-clickable window). Runs python directly — does NOT delegate to start.ps1.
- Both carry a header documenting the bare-vs-full distinction (AC4 doc part).
- **`installer-files.txt`**: both added so they ship with installs. Count corrected 197→202 (the header was already stale — 197 declared vs 200 actual — corrected to the true 202; a count-consistency regression test now guards it).
- No change to existing `start.*` (AC5).

### Tests (16)
Harness invocation, the no-git/no-pip command contract (scanning executable lines, not the header prose), `.bat` window-persistence + non-delegation, manifest membership + count consistency, and that `start.sh`/`start.ps1` both retain their sync+dep logic (AC5; the `start.ps1` assertion was added per DS review since `start.bat` delegates to it).

### Verification
- 16 tests pass; `run_tests.py` green; DeepSeek review (12525-c1): one warning (start.ps1 AC5 gap) — **fixed**, re-reviewed clean.

### Note for PM (non-blocking)
The issue Scope mentions "+ a one-liner in INSTALLER-ARCH / README" — those are PM's doc surface. The bare-vs-full distinction is documented in each script header (satisfies AC4's "documented as the bare launcher vs start.*"); the INSTALLER-ARCH/README mention is left for PM.

Resolves #12525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)