### PR TITLE
fix(#12799): L1 async-no-pause — agents never block waiting on a human

### DIFF
--- a/references/roles/SOUL.md
+++ b/references/roles/SOUL.md
@@ -36,6 +36,12 @@ This is a behavioral default — check the vault before starting work, not just 
 - Never take shortcuts that compromise quality. Take quality over speed.
 - Be thorough and deliberate in your work. Verify before claiming done.
 
+### Never Block on a Human — Async, No Pausing
+
+Inline mode is the **only** synchronous human channel. In every autonomous mode (loop or event), you must **never pause and wait for a human** — a human answers on human time, and a session blocked on a human stalls its whole queue for minutes to hours of dead clock. "Ask, don't guess" above means *ask asynchronously*, never sit and wait.
+
+When you need a human's attention or decision: assign a tracked ticket to the `human` alias — set `role:<human>` plus the appropriate `pending-human-*` status **via a transition** (never a bare comment; bare comments wake no one and leave no ownership) — then **immediately continue**: pick up your next queue item, or go idle. Do not wait. The human answers asynchronously and the work resumes later via the return path, which is always agent-mediated — **a human never makes the forge transition; you or PM do**: if the human reaches *you* directly (inline), you record their answer into the ticket and re-assign it back to yourself; if they reach PM instead, PM records the answer and re-assigns it to you on their behalf. If a human reaches you about work that was never yours, reply "this isn't my territory — wrong agent" and point them to the right alias or to PM.
+
 ### Shared Discipline
 
 - All timestamps come from `python references/scripts/cycle.py timestamp-short` — never guess or fabricate times.


### PR DESCRIPTION
Closes #12799

### Summary
Operator-flagged: agents (skill especially) were synchronously pausing to wait on a human, stalling the whole queue on human-time. Adds the **async-no-pause** rule to L1 (`references/roles/SOUL.md`, the base-agent soul composed into every role's CLAUDE.md, both event + loop modes) so every agent reads it. Spec is LOCKED in AGENT-RUNTIME §3.1.

**Rule**: in any autonomous mode an agent must never pause/wait for a human. When it needs human attention, it assigns a tracked ticket to the `human` alias (`role:<human>` + `pending-human-*` status, **via a transition** — never a bare comment) and immediately continues (next queue item or idle). The return path is agent-mediated (the originator self-reassigns when answered inline, or PM reassigns on its behalf; a human never makes the forge transition). Inline mode remains the only synchronous human channel.

### Acceptance Criteria
- [x] **AC1 (compose)**: rule present in every composed agent CLAUDE.md (both modes). Verified deterministically — `_assemble_soul` for worker/pm/verifier/dm all contain the section (soul slot is mode-independent → in both event + loop). Live `deploy-all` + reboot is the main-landing step, per the #12585 L1-Soul precedent (source-only PR).
- [ ] **AC2 (comprehension, REQUIRED)**: comprehension AC is in the issue body (PM-authored); verifier derives the CQ spec.
- [x] **AC3 (DS-review)**: high-blast-radius L1 → DeepSeek review done; 1 error finding (return-path attribution — human was wrongly the actor of the re-assignment) FIXED; re-verified compose. Record on main: `.squidsquad/skill/planning/DS-REVIEW-12799.md`.

### Changes
- **Files**: `references/roles/SOUL.md` (source only — +1 section).
- **What**: new "Never Block on a Human — Async, No Pausing" section after Professionalism (bridges its "ask, don't guess" line as *ask asynchronously*).
- **Why**: turns 'waiting on a human' into one tracked, owned, auditable ticket instead of a wedged session that stalls the queue.

### Verifier Status
- [x] Unit tests passing (full static gate green, 4547; compose/references tests green)
- [ ] Smoke tests passing
- [ ] Acceptance criteria met

Note: the l4_file_watcher auto-recomposes `.squidsquad/*/CLAUDE.md` on an L1 source edit; those LLM-polished composed files were reverted from this branch (regenerated at main-landing per precedent) — this PR is source-only.