### PR TITLE
fix(#12824): harness 500 traceback capture + fail-soft emission path

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -2055,6 +2055,13 @@ app = FastAPI(
 # ---------------------------------------------------------------------------
 
 
+# Bound the error log so a recurring fault can't fill the disk (#12824
+# DS-review F3): .squidsquad/ lives inside the repo checkout, so exhaustion
+# would break ALL harness persistence (state saves, event persistence, port
+# file). Single-file rotation caps total at ~2× this threshold.
+_HARNESS_ERROR_LOG_MAX_BYTES = 1_000_000
+
+
 def _harness_error_log_path() -> Path:
     """Path to the persisted harness error log. Resolved per-call so test
     isolation (SQUIDSQUAD_DIR override) is honored and the helper is patchable."""
@@ -2075,6 +2082,14 @@ def _persist_harness_error(context: str) -> None:
     try:
         log_path = _harness_error_log_path()
         log_path.parent.mkdir(parents=True, exist_ok=True)
+        # Rotate before append if the log has grown past the cap (DS-review F3).
+        try:
+            if (log_path.exists()
+                    and log_path.stat().st_size > _HARNESS_ERROR_LOG_MAX_BYTES):
+                log_path.replace(log_path.with_name(log_path.name + ".1"))
+        except OSError:
+            # Rotation is best-effort — fall through to the append regardless.
+            pass
         with open(log_path, "a", encoding="utf-8") as fh:
             fh.write(entry)
     except Exception:
@@ -2087,12 +2102,19 @@ async def _capture_unhandled_exception(request: Request, exc: Exception):
     """Global 500 handler (#12824): persist the traceback, then return the
     standard 500 contract.
 
-    Starlette routes ``HTTPException`` (the intentional 400/404 raises) through
-    its own handler, so this only fires on genuinely-unhandled exceptions — the
-    500s we want diagnosable. The response body matches Starlette's default
-    ``ServerErrorMiddleware`` 500 so no caller contract changes; the only added
-    behavior is the on-disk traceback.
+    Starlette routes ``HTTPException`` (the intentional 400/404/503 raises)
+    through ``ServerErrorMiddleware``'s sibling ``ExceptionMiddleware``, so this
+    handler only fires on genuinely-unhandled exceptions — the 500s we want
+    diagnosable. The ``isinstance`` re-raise below is defensive belt-and-braces
+    (DS-review F1): it makes the "4xx are unaffected" invariant explicit and
+    robust even if that middleware split ever changes. The response body matches
+    Starlette's default ``ServerErrorMiddleware`` 500 so no caller contract
+    changes; the only added behavior is the on-disk traceback.
     """
+    if isinstance(exc, HTTPException):
+        # Intentional 4xx/503 — let Starlette render the real status. (Currently
+        # unreachable here; see docstring.)
+        raise exc
     _persist_harness_error(
         f"{request.method} {request.url.path} :: "
         f"{type(exc).__name__}: {exc}"

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -30,6 +30,7 @@ import subprocess
 import sys
 import threading
 import time
+import traceback
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -2044,6 +2045,65 @@ app = FastAPI(
 )
 
 
+# ---------------------------------------------------------------------------
+# Error capture (#12824) — persist unhandled-exception tracebacks to disk.
+#
+# The #12824 assigned-to 500 transient could not be root-caused: the traceback
+# went only to the harness terminal stdout, which was lost by the time the bug
+# was investigated. These helpers write method+path+traceback to a persisted
+# log so the NEXT 500 (or any swallowed internal hiccup) is diagnosable.
+# ---------------------------------------------------------------------------
+
+
+def _harness_error_log_path() -> Path:
+    """Path to the persisted harness error log. Resolved per-call so test
+    isolation (SQUIDSQUAD_DIR override) is honored and the helper is patchable."""
+    return SQUIDSQUAD_DIR / "harness-errors.log"
+
+
+def _persist_harness_error(context: str) -> None:
+    """Append the *current* exception's traceback to the harness error log.
+
+    Call from inside an ``except`` block — ``traceback.format_exc()`` captures
+    the active exception. ``context`` describes where it fired (method+path, or
+    the swallowed-work site). Best-effort: any failure writing the log is
+    itself swallowed so the error-logger can never mask the original fault.
+    """
+    tb = traceback.format_exc()
+    ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    entry = f"\n===== {ts} {context} =====\n{tb}\n"
+    try:
+        log_path = _harness_error_log_path()
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(log_path, "a", encoding="utf-8") as fh:
+            fh.write(entry)
+    except Exception:
+        # Never let the error-logger itself raise — it runs on the failure path.
+        pass
+
+
+@app.exception_handler(Exception)
+async def _capture_unhandled_exception(request: Request, exc: Exception):
+    """Global 500 handler (#12824): persist the traceback, then return the
+    standard 500 contract.
+
+    Starlette routes ``HTTPException`` (the intentional 400/404 raises) through
+    its own handler, so this only fires on genuinely-unhandled exceptions — the
+    500s we want diagnosable. The response body matches Starlette's default
+    ``ServerErrorMiddleware`` 500 so no caller contract changes; the only added
+    behavior is the on-disk traceback.
+    """
+    _persist_harness_error(
+        f"{request.method} {request.url.path} :: "
+        f"{type(exc).__name__}: {exc}"
+    )
+    _log(
+        f"500 on {request.method} {request.url.path}: "
+        f"{type(exc).__name__}: {exc} (traceback → harness-errors.log)"
+    )
+    return JSONResponse(status_code=500, content={"detail": "Internal Server Error"})
+
+
 def _validate_role(role: str) -> str:
     """Validate that a role is configured. Returns the role name or raises 404."""
     configured = boot_remote._get_all_roles()
@@ -2839,11 +2899,38 @@ async def receive_event(request: Request):
                 # #9242: disk write off the asyncio event loop.
                 await asyncio.to_thread(state.save_state)
 
-    # Update AgentState from event
-    _update_agent_from_event(body)
+    # Update AgentState from event.
+    # #12824: fail-soft. The event_lifecycle.append above is the
+    # routing-critical work (it is what wakes event-mode agents); this
+    # post-append bookkeeping is non-critical. A throw here must NOT 500 the
+    # emission path — assigned-to nudges and EAD handoff routing ride this same
+    # path, and a 500 on it silently breaks waking dormant agents (#12824).
+    # Swallow + persist the traceback (so the next occurrence is diagnosable)
+    # rather than failing the request.
+    try:
+        _update_agent_from_event(body)
+    except Exception:
+        _persist_harness_error(
+            f"POST /events post-append _update_agent_from_event "
+            f"(type={event_type!r}, role={role!r})"
+        )
+        _log(
+            f"post-append _update_agent_from_event failed for "
+            f"type={event_type!r} role={role!r} — swallowed (see harness-errors.log)"
+        )
 
     # Log to console
-    _log_event(body)
+    try:
+        _log_event(body)
+    except Exception:
+        _persist_harness_error(
+            f"POST /events post-append _log_event "
+            f"(type={event_type!r}, role={role!r})"
+        )
+        _log(
+            f"post-append _log_event failed for type={event_type!r} "
+            f"role={role!r} — swallowed (see harness-errors.log)"
+        )
 
     return {"status": "ok"}
 

--- a/tests/test_12824_harness_error_capture.py
+++ b/tests/test_12824_harness_error_capture.py
@@ -1,0 +1,155 @@
+"""Regression for #12824 — harness `POST /events` 500 (assigned-to) could not be
+root-caused because the traceback went only to terminal stdout and was lost.
+
+Two additive behaviors land here:
+
+1. **Global exception handler** — any unhandled exception on a harness route is
+   persisted (method+path+traceback) to ``.squidsquad/harness-errors.log`` before
+   the standard 500 is returned, so the NEXT 500 is diagnosable.
+2. **Fail-soft post-append work** in ``receive_event`` — the routing-critical
+   ``event_lifecycle.append`` is what wakes event-mode agents; the non-critical
+   post-append bookkeeping (``_update_agent_from_event`` / ``_log_event``) is now
+   wrapped so a throw there is swallowed (and its traceback persisted) rather than
+   500-ing the emission path that carries assigned-to nudges + handoff routing.
+
+Both protect the wake/handoff path #12824 reported as broken.
+"""
+
+import sys
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "references" / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+try:
+    from fastapi.testclient import TestClient
+    import harness
+    from harness import app, state, event_lifecycle
+    _HTTP_OK = True
+except Exception:  # pragma: no cover - import guard
+    _HTTP_OK = False
+
+
+@unittest.skipUnless(_HTTP_OK, "fastapi / harness not importable")
+class TestGlobalExceptionHandler(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        state.start_time = time.time()
+        state.port = 7373
+        cls.client = TestClient(app, raise_server_exceptions=False)
+
+    def test_handler_is_registered(self):
+        """Additive: a handler for the base ``Exception`` is registered so all
+        unhandled exceptions route through traceback-capture (not just terminal
+        stdout)."""
+        self.assertIn(Exception, app.exception_handlers)
+
+    def test_unhandled_exception_returns_500_and_persists_traceback(self):
+        """An unhandled throw on the route → standard 500 body + the capture
+        helper invoked with a context naming the method, path, and exception."""
+        with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+             patch.object(event_lifecycle, "append",
+                          side_effect=RuntimeError("boom-12824")), \
+             patch("harness._persist_harness_error") as mock_persist:
+            resp = self.client.post(
+                "/events",
+                json={"event_type": "status-transition", "role": "skill"},
+            )
+        self.assertEqual(resp.status_code, 500)
+        self.assertEqual(resp.json(), {"detail": "Internal Server Error"})
+        mock_persist.assert_called_once()
+        ctx = mock_persist.call_args.args[0]
+        self.assertIn("POST", ctx)
+        self.assertIn("/events", ctx)
+        self.assertIn("RuntimeError", ctx)
+        self.assertIn("boom-12824", ctx)
+
+    def test_intentional_httpexception_is_not_captured(self):
+        """The 400 (missing fields) is an intentional ``HTTPException`` — Starlette
+        routes it through its own handler, so it must NOT hit the 500 capture."""
+        with patch("harness._persist_harness_error") as mock_persist:
+            resp = self.client.post("/events", json={"role": "skill"})  # no event_type
+        self.assertEqual(resp.status_code, 400)
+        mock_persist.assert_not_called()
+
+
+@unittest.skipUnless(_HTTP_OK, "fastapi / harness not importable")
+class TestReceiveEventFailSoft(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        state.start_time = time.time()
+        state.port = 7373
+        cls.client = TestClient(app, raise_server_exceptions=False)
+
+    def test_update_agent_throw_is_swallowed_emission_still_200(self):
+        """A throw in the non-critical ``_update_agent_from_event`` must NOT 500
+        the routing-critical emission — append still ran, response is 200, and
+        the traceback is persisted."""
+        with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+             patch.object(event_lifecycle, "append") as mock_append, \
+             patch("harness._update_agent_from_event",
+                   side_effect=RuntimeError("update-boom")), \
+             patch("harness._persist_harness_error") as mock_persist:
+            resp = self.client.post(
+                "/events",
+                json={"event_type": "assigned-to", "role": "skill",
+                      "payload": {"target_alias": "skill"}},
+            )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"status": "ok"})
+        mock_append.assert_called_once()  # routing-critical work still happened
+        mock_persist.assert_called_once()  # traceback captured
+
+    def test_log_event_throw_is_swallowed_emission_still_200(self):
+        """A throw in the non-critical ``_log_event`` is likewise swallowed."""
+        with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+             patch.object(event_lifecycle, "append") as mock_append, \
+             patch("harness._log_event",
+                   side_effect=RuntimeError("log-boom")), \
+             patch("harness._persist_harness_error") as mock_persist:
+            resp = self.client.post(
+                "/events",
+                json={"event_type": "assigned-to", "role": "skill",
+                      "payload": {"target_alias": "skill"}},
+            )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"status": "ok"})
+        mock_append.assert_called_once()
+        mock_persist.assert_called_once()
+
+
+@unittest.skipUnless(_HTTP_OK, "fastapi / harness not importable")
+class TestPersistHarnessError(unittest.TestCase):
+    def test_writes_traceback_to_log_path(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            log_path = Path(td) / "sub" / "harness-errors.log"
+            with patch("harness._harness_error_log_path", return_value=log_path):
+                try:
+                    raise ValueError("trace-me-12824")
+                except ValueError:
+                    harness._persist_harness_error("UNIT /test ctx")
+            text = log_path.read_text(encoding="utf-8")
+            self.assertIn("UNIT /test ctx", text)
+            self.assertIn("ValueError", text)
+            self.assertIn("trace-me-12824", text)
+
+    def test_logger_failure_is_swallowed(self):
+        """The error-logger runs on the failure path — it must never itself raise
+        (else it masks the original fault)."""
+        with patch("harness._harness_error_log_path",
+                   side_effect=OSError("cannot resolve path")):
+            try:
+                raise ValueError("x")
+            except ValueError:
+                # Must not propagate.
+                harness._persist_harness_error("ctx")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_12824_harness_error_capture.py
+++ b/tests/test_12824_harness_error_capture.py
@@ -69,12 +69,22 @@ class TestGlobalExceptionHandler(unittest.TestCase):
         self.assertIn("RuntimeError", ctx)
         self.assertIn("boom-12824", ctx)
 
-    def test_intentional_httpexception_is_not_captured(self):
+    def test_intentional_400_httpexception_is_not_captured(self):
         """The 400 (missing fields) is an intentional ``HTTPException`` — Starlette
         routes it through its own handler, so it must NOT hit the 500 capture."""
         with patch("harness._persist_harness_error") as mock_persist:
             resp = self.client.post("/events", json={"role": "skill"})  # no event_type
         self.assertEqual(resp.status_code, 400)
+        mock_persist.assert_not_called()
+
+    def test_intentional_404_httpexception_is_not_captured(self):
+        """The 404 (unknown role via _validate_role) must also stay 404, not be
+        converted to 500 by the global handler (DS-review F1 — the invariant the
+        handler's isinstance re-raise guards)."""
+        with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+             patch("harness._persist_harness_error") as mock_persist:
+            resp = self.client.get("/events/cursor/bogus-role-xyz")
+        self.assertEqual(resp.status_code, 404)
         mock_persist.assert_not_called()
 
 
@@ -149,6 +159,27 @@ class TestPersistHarnessError(unittest.TestCase):
             except ValueError:
                 # Must not propagate.
                 harness._persist_harness_error("ctx")
+
+    def test_log_rotates_past_size_cap(self):
+        """DS-review F3: an oversized log rotates to ``.1`` so a recurring fault
+        cannot grow it unbounded and exhaust the disk."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            log_path = Path(td) / "harness-errors.log"
+            rotated = Path(td) / "harness-errors.log.1"
+            # Seed an oversized current log.
+            log_path.write_text("X" * (harness._HARNESS_ERROR_LOG_MAX_BYTES + 10),
+                                encoding="utf-8")
+            with patch("harness._harness_error_log_path", return_value=log_path):
+                try:
+                    raise ValueError("post-rotation-entry")
+                except ValueError:
+                    harness._persist_harness_error("ROT /test")
+            # Old bulk moved aside; fresh log holds only the new entry.
+            self.assertTrue(rotated.exists(), "oversized log should rotate to .1")
+            fresh = log_path.read_text(encoding="utf-8")
+            self.assertIn("post-rotation-entry", fresh)
+            self.assertNotIn("XXXX", fresh)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #12824 — harness `POST /events` `assigned-to` returned 500 transiently, breaking PM nudge + EAD handoff routing (waking dormant event-mode agents). The 500 could not be root-caused because the traceback went only to terminal stdout and was lost.

## Changes (`references/scripts/harness.py`)

1. **Global exception handler** (`@app.exception_handler(Exception)`) — persists `method + path + traceback` to `.squidsquad/harness-errors.log`, then returns the standard 500 body. Makes the *next* unhandled 500 diagnosable instead of lost. Intentional `HTTPException`s (4xx/503) are unaffected — Starlette routes them through `ExceptionMiddleware`, separate from the `Exception`/500 handler in `ServerErrorMiddleware`; a defensive `isinstance` re-raise makes that invariant explicit.
2. **Fail-soft post-append bookkeeping** in `receive_event` — the routing-critical `event_lifecycle.append` is what wakes event-mode agents; a throw in the non-critical `_update_agent_from_event` / `_log_event` is now swallowed (traceback persisted) rather than 500-ing the emission path that carries `assigned-to` nudges + handoffs.
3. **Bounded error log** — single-file rotation at 1 MB so a recurring fault can't fill the disk (`.squidsquad/` is inside the repo checkout).

## DeepSeek review

Reviewed per logical change. F1 (handler swallows 4xx) was a **false positive** — proven by `test_intentional_404_httpexception_is_not_captured`; added the defensive guard anyway. F3 (unbounded log) **valid** → rotation. F2 (expand fail-soft to ack-cursor) **declined**: per `cursor-management` a non-200 ack IS the agent's retry signal, so swallowing it to 200 would wedge the cursor; `assigned-to` never enters that branch and the global handler already makes those 500s diagnosable.

## Tests — `tests/test_12824_harness_error_capture.py` (9, all green)

Handler registered; unhandled→500+capture; 400 & 404 stay intentional (not captured); both fail-soft paths stay 200 with append still run; helper writes traceback; helper swallows its own failure; oversized log rotates.

Full suite: **4559 passed / 15 skipped**, +53 integration ok.