### PR TITLE
fix(#12511): block unit-test egress to the live harness event bus

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,6 +134,62 @@ def pytest_runtest_teardown(item, nextitem):
     return res
 
 
+# ---------------------------------------------------------------------------
+# #12511: live-harness egress guard — unit tests must NOT POST to the live bus.
+#
+# Root cause of #12511: tests that call `tracker.transition(...)` /
+# `tracker.add_comment(...)` in-process trigger `event_bus.emit(...)`, which
+# discovers the running dev harness's `.harness-port` (default 7373) and fires a
+# real `POST /events`. On a self-hosting box (a live harness running) this leaks
+# illegal `status-transition` events for fixture issues (#999 etc.) onto the
+# PRODUCTION bus, spuriously waking every event-mode agent (wasted wake/token
+# cost + noise that obscures real events). Same family as #12282 (cycle_post
+# /restart leak) and #12342.
+#
+# This autouse guard intercepts `urllib.request.urlopen` for every pytest unit
+# test and suppresses any request targeting the LIVE harness port — turning the
+# leak into a no-op so the production bus stays clean, regardless of which test
+# emits. It is scoped to the live port only, so tests that mock urlopen or run
+# an isolated harness on another port (and event_bus's own tests) are unaffected.
+# Integration tests run under unittest via run_tests.py (not pytest), so this
+# pytest fixture does not touch their intentional real-harness emits.
+# ---------------------------------------------------------------------------
+def _live_harness_port():
+    """The port of the dev box's running harness (the one a leak would hit)."""
+    pf = SQUIDSQUAD_DIR / ".harness-port"
+    if pf.exists():
+        try:
+            return int(pf.read_text(encoding="utf-8").strip())
+        except (ValueError, OSError):
+            pass
+    return 7373  # harness default (#12282: the 7373 fallback IS the live-egress trap)
+
+
+# nodeid -> list of suppressed URLs. Exposed for the #12511 regression test and
+# for debugging which test attempted a live POST.
+_SUPPRESSED_LIVE_EGRESS = {}
+
+
+@pytest.fixture(autouse=True)
+def _block_live_harness_egress(request):
+    import urllib.request as _ur
+    import unittest.mock as _m
+    needle = f"127.0.0.1:{_live_harness_port()}"
+    real_urlopen = _ur.urlopen
+
+    def guarded_urlopen(req, *a, **k):
+        url = req.full_url if hasattr(req, "full_url") else str(req)
+        if needle in url:
+            # Suppress the live POST. event_bus.emit is fire-and-forget and
+            # ignores the return value, so a no-op is invisible to callers.
+            _SUPPRESSED_LIVE_EGRESS.setdefault(request.node.nodeid, []).append(url)
+            return None
+        return real_urlopen(req, *a, **k)
+
+    with _m.patch.object(_ur, "urlopen", guarded_urlopen):
+        yield
+
+
 @pytest.fixture
 def repo_root():
     return REPO_ROOT

--- a/tests/test_12511_live_harness_egress_guard.py
+++ b/tests/test_12511_live_harness_egress_guard.py
@@ -1,0 +1,72 @@
+"""#12511 — unit tests must not POST to the LIVE harness event bus.
+
+Root cause: `tracker.transition(...)` / `tracker.add_comment(...)` call
+`event_bus.emit(...)`, which discovers the dev box's running harness port
+(`.harness-port`, default 7373) and fires a real `POST /events`. On a
+self-hosting box this leaked illegal `status-transition` events for fixture
+issues (#999) onto the production bus, spuriously waking every agent.
+
+The fix is the autouse `_block_live_harness_egress` guard in tests/conftest.py.
+These tests assert the guard's contract: live-harness egress is suppressed,
+other egress passes through, and a forced in-process transition (the #12511
+repro) does not reach the live bus.
+"""
+
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+import conftest  # the guard + its record live here
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "references" / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _live_url(path="/events"):
+    return f"http://127.0.0.1:{conftest._live_harness_port()}{path}"
+
+
+class TestEgressGuard:
+    def test_post_to_live_harness_is_suppressed_and_recorded(self, request):
+        req = urllib.request.Request(
+            _live_url(), data=b"{}",
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        # The autouse guard intercepts this — no real connection, returns None.
+        result = urllib.request.urlopen(req, timeout=2)
+        assert result is None, "guard must suppress (no live POST escapes)"
+        assert request.node.nodeid in conftest._SUPPRESSED_LIVE_EGRESS
+        assert any("/events" in u for u in conftest._SUPPRESSED_LIVE_EGRESS[request.node.nodeid])
+
+    def test_guard_does_not_overblock_other_ports(self):
+        # A different port is NOT the live harness — the guard must delegate to
+        # the real urlopen, which (nothing listening) raises a URLError. The
+        # point is it is NOT silently suppressed (would return None instead).
+        other = "http://127.0.0.1:7999/events"
+        with pytest.raises(urllib.error.URLError):
+            urllib.request.urlopen(other, timeout=2)
+
+
+class TestForcedTransitionDoesNotLeak:
+    """The #12511 repro: a forced transition emits a status-transition event;
+    under the guard it must not reach the live bus."""
+
+    def test_emit_status_transition_is_suppressed(self, request):
+        import event_bus
+        # event_bus.emit only POSTs if it discovers a .harness-port. Point its
+        # discovery at the live .squidsquad so it resolves the live port, then
+        # assert the guard suppressed the resulting POST rather than letting it
+        # hit the production bus.
+        live_port_file = REPO_ROOT / ".squidsquad" / ".harness-port"
+        if not live_port_file.exists():
+            pytest.skip("no live .harness-port on this box — emit no-ops before the wire")
+        before = len(conftest._SUPPRESSED_LIVE_EGRESS.get(request.node.nodeid, []))
+        event_bus.emit("status-transition", "skill",
+                       payload={"issue_number": "999", "from": "shipped", "to": "in-progress"})
+        after = len(conftest._SUPPRESSED_LIVE_EGRESS.get(request.node.nodeid, []))
+        assert after == before + 1, "emit's live POST must be intercepted by the guard"


### PR DESCRIPTION
Closes #12511 (test-isolation leak: force-transition tests emit real status-transition events to the LIVE event bus — the recurring #999 flurry).

## Root cause
Tests that call `tracker.transition(...)` / `add_comment(...)` in-process trigger `event_bus.emit(...)`, which discovers the running dev harness's `.harness-port` (default 7373) and fires a real `POST /events`. On a self-hosting box this leaks illegal `status-transition` events for fixture issues (#999) onto the **production bus**, spuriously waking every event-mode agent. Forge state is never affected — the defect is bus pollution + wasted wakes. Same family as #12282 / #12342.

## Blast radius (measured)
24 unit tests across `test_12475_force_bypasses_legality`, `test_tracker`, `test_tracker_authority` — each a single incidental POST none of them assert.

## Fix (test isolation — no production change, matches #12282)
Autouse guard `_block_live_harness_egress` in `tests/conftest.py` intercepts `urllib.request.urlopen` for every pytest unit test and **suppresses any request to the live harness port**, turning the leak into a no-op regardless of which test emits. Scoped to the live port, so tests that mock urlopen / run an isolated harness on another port (and event_bus's own tests) are unaffected. Integration tests run under unittest via `run_tests.py` (not pytest), so their intentional real-harness emits are untouched. **Recurrence-proof** — any future transition test is covered automatically.

## Tests
`test_12511_live_harness_egress_guard.py`: guard suppresses a live-port POST, does NOT overblock other ports, and intercepts a real `event_bus.emit` status-transition (the #999 repro). Full suite green: **static 4562 + integration 53, 0 failures**.

## Deferred (optional, flagged to PM)
The issue also floats harness-side defense-in-depth (reject events for nonexistent issue numbers). Left out — removing the source (test leak) already eliminates the #999 events; harness-side validation is a separate hardening with its own risk surface, not bundled here.