### PR TITLE
fix(#12820): production harness refuses 2nd instance instead of poisoning clone .harness-port files

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -31,6 +31,8 @@ import sys
 import threading
 import time
 import traceback
+import urllib.error
+import urllib.request
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -3851,12 +3853,19 @@ def _reboot_affected_agents(pr_number, files_changed):
 # ---------------------------------------------------------------------------
 
 def find_free_port(default: int = DEFAULT_PORT) -> int:
-    """Find an available port, preferring the default."""
+    """Find an available port, preferring the default.
+
+    When ``default`` is 0 the OS assigns an ephemeral port; this returns the
+    actually-bound port number (not 0) so a caller that opts into ephemeral
+    binding via ``--port 0`` (the integration test harness) gets the real
+    number to advertise in its ``.harness-port`` file (#12820).
+    """
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
         s.bind(("127.0.0.1", default))
+        actual = s.getsockname()[1]
         s.close()
-        return default
+        return actual
     except OSError:
         s.close()
         # Find any free port
@@ -3887,6 +3896,77 @@ def _read_config_port() -> int:
         pass
 
     return DEFAULT_PORT
+
+
+def _probe_harness_status(port: int, timeout: float = 2.0) -> bool:
+    """Return True iff a live SquidSquad harness answers ``GET /status`` on ``port``.
+
+    The production singleton path (#12820) uses this to tell apart:
+    - a LIVE harness already holding the canonical port → refuse to start, so
+      a second harness can never bind an ephemeral port and poison every
+      clone's ``.harness-port`` file (the root cause of #12820); and
+    - a stale socket / TIME_WAIT slot left by a just-exited harness mid-restart
+      → safe to reclaim the canonical port (uvicorn's ``SO_REUSEADDR`` bind
+      rebinds a TIME_WAIT slot cleanly).
+
+    A ``200`` from some unrelated server that lacks the harness-shaped
+    ``harness`` key reads as "not a harness" (False) — better to try to claim
+    our reserved port than refuse to boot for an unrelated squatter.
+    """
+    try:
+        with urllib.request.urlopen(
+            f"http://127.0.0.1:{port}/status", timeout=timeout
+        ) as resp:
+            if resp.status != 200:
+                return False
+            body = json.loads(resp.read().decode("utf-8"))
+            return isinstance(body, dict) and "harness" in body
+    except (urllib.error.URLError, OSError, ValueError):
+        return False
+
+
+def _resolve_listen_port(explicit_port) -> int:
+    """Resolve the port the harness listens on, or refuse to start (#12820).
+
+    ``explicit_port`` is ``args.port`` — ``None`` when no ``--port`` was passed.
+
+    - **Explicit** (including ``--port 0``): legacy ``find_free_port`` behavior,
+      ephemeral fallback allowed. This is the integration test harness path
+      (``real_harness`` passes ``--port 0``); it self-writes its port into an
+      isolated tmp ``.harness-port`` and never touches real clones.
+    - **None** (production singleton): probe the canonical port. A live harness
+      there → ``SystemExit(1)`` (refuse — never bind an ephemeral port and
+      poison clone ``.harness-port`` files). Otherwise claim the canonical port;
+      uvicorn's ``SO_REUSEADDR`` bind reclaims a TIME_WAIT slot left by a
+      just-exited harness during a supervised restart.
+
+    Returns the resolved port. Raises ``SystemExit(1)`` on refuse-to-start.
+    """
+    if explicit_port is not None:
+        actual = find_free_port(explicit_port)
+        if actual != explicit_port and explicit_port != 0:
+            print(f"Port {explicit_port} in use — using {actual}")
+        return actual
+
+    desired = _read_config_port()
+    if _probe_harness_status(desired):
+        print(
+            f"A SquidSquad harness is already running and responding on "
+            f"127.0.0.1:{desired}. Refusing to start a second instance — a "
+            f"second harness would bind an ephemeral port and poison every "
+            f"clone's .harness-port file, forcing the team into polling "
+            f"fallback (#12820). Use the running harness, or stop it first."
+        )
+        sys.exit(1)
+    # Free, or a stale/TIME_WAIT slot from a just-exited harness (restart):
+    # claim the canonical port. uvicorn's bind sets SO_REUSEADDR so a
+    # TIME_WAIT slot rebinds cleanly. A genuinely live *non-harness* squatter
+    # on the reserved canonical port is an operator configuration error: on
+    # Unix uvicorn's bind then fails loudly (EADDRINUSE — SO_REUSEADDR only
+    # bypasses TIME_WAIT, not a live listener); on Windows SO_REUSEADDR may
+    # permit a duplicate bind, but the /status probe above already rules out a
+    # live *harness* peer, which is the case that actually matters for #12820.
+    return desired
 
 
 # ---------------------------------------------------------------------------
@@ -4443,12 +4523,12 @@ def main():
         or env_freshness.lower() in ("1", "true", "yes")
     )
 
-    # Determine port
-    desired_port = args.port or _read_config_port()
-    actual_port = find_free_port(desired_port)
-
-    if actual_port != desired_port:
-        print(f"Port {desired_port} in use — using {actual_port}")
+    # Determine port (#12820 — see _resolve_listen_port). The production
+    # singleton path (no --port) acquires the canonical port or refuses; it
+    # never binds an ephemeral port, so it cannot poison clone .harness-port
+    # files. An explicit --port (incl. --port 0) keeps the legacy
+    # ephemeral-fallback behavior the integration test harness relies on.
+    actual_port = _resolve_listen_port(args.port)
 
     state.port = actual_port
     _print_banner(actual_port)

--- a/tests/integration/fixtures/event_mode_subprocess.py
+++ b/tests/integration/fixtures/event_mode_subprocess.py
@@ -189,9 +189,14 @@ def real_harness(
         env["SQUIDSQUAD_DIR"] = str(squid_dir)
         env["SQUIDSQUAD_HARNESS_NO_AUTO_START"] = "1"
 
+        # Always pass an explicit --port so the test harness takes the
+        # explicit-port branch (ephemeral when 0) and NEVER the production
+        # singleton path, which refuses to start when the live harness on a
+        # dev box already holds the canonical port (#12820). port_hint=None
+        # → --port 0 (OS-assigned ephemeral); the real port is read back from
+        # the isolated .harness-port file by _wait_for_port_file().
         cmd = [sys.executable, str(HARNESS_PATH)]
-        if port_hint is not None:
-            cmd.extend(["--port", str(port_hint)])
+        cmd.extend(["--port", str(port_hint if port_hint is not None else 0)])
 
         # Pipe stdout/stderr to files in the tmpdir, NOT to PIPE
         # handles. The harness chats heavily on stdout (lifespan,

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1222,6 +1222,97 @@ class TestPortManagement(unittest.TestCase):
         finally:
             s.close()
 
+    def test_find_free_port_zero_returns_real_port(self):
+        """#12820: find_free_port(0) returns the OS-assigned ephemeral port,
+        not the literal 0 — so a --port 0 caller can advertise the real port."""
+        from harness import find_free_port
+        port = find_free_port(0)
+        self.assertNotEqual(port, 0)
+        self.assertGreater(port, 0)
+
+
+class TestSingletonPortGuard(unittest.TestCase):
+    """#12820: production harness must acquire the canonical port or refuse —
+    never bind an ephemeral port (which would poison clone .harness-port files).
+    """
+
+    def _serve(self, body: bytes):
+        """Spin a throwaway HTTP server returning ``body`` for GET /status.
+        Returns (port, shutdown_callable). Lets HTTPServer bind an OS-assigned
+        ephemeral port itself (no probe-then-rebind gap) and reads the actual
+        port back from server_address — avoids a TOCTOU race on the port."""
+        import http.server
+        import threading
+
+        class _Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):  # noqa: N802
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *a):  # silence test noise
+                pass
+
+        httpd = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+        port = httpd.server_address[1]
+        t = threading.Thread(target=httpd.serve_forever, daemon=True)
+        t.start()
+        return port, httpd.shutdown
+
+    def test_probe_no_server(self):
+        """No listener on the port → not a live harness."""
+        from harness import _probe_harness_status, find_free_port
+        dead_port = find_free_port(0)  # found free, nothing bound to it now
+        self.assertFalse(_probe_harness_status(dead_port, timeout=1.0))
+
+    def test_probe_live_harness(self):
+        """A server returning harness-shaped /status JSON → live harness."""
+        from harness import _probe_harness_status
+        port, shutdown = self._serve(b'{"harness": {"status": "running"}, "agents": []}')
+        try:
+            self.assertTrue(_probe_harness_status(port, timeout=2.0))
+        finally:
+            shutdown()
+
+    def test_probe_non_harness_200(self):
+        """A 200 from an unrelated server lacking the 'harness' key → not ours."""
+        from harness import _probe_harness_status
+        port, shutdown = self._serve(b'{"hello": "world"}')
+        try:
+            self.assertFalse(_probe_harness_status(port, timeout=2.0))
+        finally:
+            shutdown()
+
+    def test_resolve_explicit_port_zero_is_ephemeral(self):
+        """--port 0 takes the explicit path and yields a real ephemeral port."""
+        from harness import _resolve_listen_port
+        port = _resolve_listen_port(0)
+        self.assertGreater(port, 0)
+
+    def test_resolve_explicit_specific_free_port(self):
+        """An explicit free --port is returned unchanged (no probe, no refuse)."""
+        from harness import _resolve_listen_port, find_free_port
+        free = find_free_port(0)
+        self.assertEqual(_resolve_listen_port(free), free)
+
+    def test_resolve_production_free_claims_canonical(self):
+        """Production path (no --port): canonical port free → claim it."""
+        import harness
+        with patch.object(harness, "_read_config_port", return_value=59321), \
+             patch.object(harness, "_probe_harness_status", return_value=False):
+            self.assertEqual(harness._resolve_listen_port(None), 59321)
+
+    def test_resolve_production_live_harness_refuses(self):
+        """Production path: a live harness on the canonical port → refuse (exit 1),
+        never falls back to an ephemeral port that would poison clones."""
+        import harness
+        with patch.object(harness, "_read_config_port", return_value=59322), \
+             patch.object(harness, "_probe_harness_status", return_value=True):
+            with self.assertRaises(SystemExit) as ctx:
+                harness._resolve_listen_port(None)
+            self.assertEqual(ctx.exception.code, 1)
+
 
 class TestCLIPortDiscovery(unittest.TestCase):
     """Test CLI port discovery from .harness-port file."""


### PR DESCRIPTION
## What changed

The production harness (started with no `--port`) now **acquires the canonical port or refuses to start** — it never silently binds an ephemeral port.

- `find_free_port` returns the real bound port via `getsockname` (fixes `--port 0` returning literal `0`).
- New `_probe_harness_status(port)` — `GET /status`, true iff harness-shaped JSON.
- New `_resolve_listen_port(explicit)` — production path probes the canonical port: a **live harness ⇒ refuse + `exit(1)`** (never bind ephemeral ⇒ never poison clones); otherwise claim the canonical port. Explicit `--port` (incl. `--port 0`) keeps the legacy ephemeral fallback the integration test harness relies on.
- `real_harness` fixture now passes `--port 0` (explicit ephemeral opt-in) so the test harness never hits the production refuse path.

## Why

RCA (#12820): when the canonical port (7373) is held by the live singleton, `find_free_port` silently fell back to an ephemeral port. A second harness then self-wrote that dead ephemeral port to its clone `.harness-port` **and distributed it to every clone**, forcing the whole team into permanent polling fallback (qa unreachable in event mode). This also explains the #10855/#12409 'inert/zombie' framing — a polling agent doesn't heartbeat the event bus.

## Key decisions

- **`/status` probe is the discriminator** between a live singleton (refuse) and a stale/TIME_WAIT slot from a just-exited harness during supervised restart (reclaim). uvicorn 0.41 `bind_socket` always sets `SO_REUSEADDR`, so the restart-over-TIME_WAIT reclaim is handled by uvicorn's own bind — no manual REUSE needed.
- **Never bind ephemeral on the production path** ⇒ clone-file poisoning is structurally impossible (the port write is gated behind a successful serve on the canonical port).
- Secondary RCA (what process starts a 2nd harness against qa's real clone) remains untraced, but the hardening makes the trigger harmless regardless.

## Files touched

- `references/scripts/harness.py` — port acquisition (find_free_port, _probe_harness_status, _resolve_listen_port, main()).
- `tests/integration/fixtures/event_mode_subprocess.py` — real_harness passes `--port 0`.
- `tests/test_harness.py` — TestSingletonPortGuard (7 tests) + find_free_port(0) test.

## Testing

Full suite green on the submitted code: static **4567 passed / 15 skipped** (gate PASS), integration **53 OK**. DeepSeek review: 3 warning-severity findings, all applied (Windows SO_REUSEADDR comment accuracy, test TOCTOU, import hygiene).