### PR TITLE
fix(#12903): run_tests.py integration_only guard drift (real_agent_subprocess + gh_shim_tracker)

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -236,47 +236,42 @@ def run_static_tests():
             junit_path.unlink()
 
 
+# #12903: single source of truth for integration target names + their
+# modules. Both run_integration_tests() (dispatch) AND main()'s
+# `integration_only` guard derive from this tuple, so the two can never
+# drift again. (The bug: #9398 added the last two targets to the dispatch
+# but not to the guard, so `run_tests.py real_agent_subprocess` fell through
+# to run the full static gate first.)
+_INTEGRATION_MODULES = (
+    ("harness", "test_harness"),
+    ("status_flow", "test_status_flow"),
+    ("event_mode_e2e", "test_event_mode_e2e"),
+    ("agent_subprocess", "test_event_mode_agent_subprocess"),
+    # #9398 Phase A real-subprocess scenarios — heavy (spawns real harness +
+    # agent subprocesses; ~10-15s per test on Windows).
+    ("real_agent_subprocess", "test_9398_real_agent_subprocess"),
+    # #9398 Phase A — gh PATH-shim <-> tracker.py handshake (subprocess-spawns
+    # tracker.py with the shim on PATH; fast).
+    ("gh_shim_tracker", "test_9398_gh_shim_tracker_integration"),
+)
+# Canonical integration target names — the only names both the guard and the
+# dispatch recognize.
+INTEGRATION_TARGET_NAMES = tuple(name for name, _ in _INTEGRATION_MODULES)
+
+
 def run_integration_tests(targets):
     """Run integration tests via unittest."""
     print("\n=== Integration Tests (unittest) ===\n")
+    import importlib
     loader = unittest.TestLoader()
     suite = unittest.TestSuite()
 
-    if not targets or "harness" in targets:
-        from integration import test_harness
-        suite.addTests(loader.loadTestsFromModule(test_harness))
-
-    if not targets or "status_flow" in targets:
-        from integration import test_status_flow
-        suite.addTests(loader.loadTestsFromModule(test_status_flow))
-
-    if not targets or "event_mode_e2e" in targets:
-        from integration import test_event_mode_e2e
-        suite.addTests(loader.loadTestsFromModule(test_event_mode_e2e))
-
-    if not targets or "agent_subprocess" in targets:
-        from integration import test_event_mode_agent_subprocess
-        suite.addTests(
-            loader.loadTestsFromModule(test_event_mode_agent_subprocess)
-        )
-
-    if not targets or "real_agent_subprocess" in targets:
-        # #9398 Phase A real-subprocess scenarios. Heavy — spawns real
-        # harness + agent subprocesses; ~10-15s per test on Windows.
-        from integration import test_9398_real_agent_subprocess
-        suite.addTests(
-            loader.loadTestsFromModule(test_9398_real_agent_subprocess)
-        )
-
-    if not targets or "gh_shim_tracker" in targets:
-        # #9398 Phase A — gh PATH-shim ↔ tracker.py handshake.
-        # Subprocess-spawns tracker.py with shim on PATH; fast.
-        from integration import test_9398_gh_shim_tracker_integration
-        suite.addTests(
-            loader.loadTestsFromModule(
-                test_9398_gh_shim_tracker_integration
-            )
-        )
+    # Lazy per-target import preserved (modules import only when their target
+    # runs) — now driven by the shared _INTEGRATION_MODULES registry.
+    for name, module_name in _INTEGRATION_MODULES:
+        if not targets or name in targets:
+            module = importlib.import_module(f"integration.{module_name}")
+            suite.addTests(loader.loadTestsFromModule(module))
 
     runner = unittest.TextTestRunner(verbosity=2)
     try:
@@ -301,9 +296,9 @@ def main():
 
     targets = [a for a in sys.argv[1:] if not a.startswith("-")]
     static_only = targets == ["static"]
-    integration_only = any(
-        t in targets for t in ("harness", "status_flow", "event_mode_e2e", "agent_subprocess")
-    )
+    # #12903: derive from the shared registry so the guard always matches the
+    # set of targets run_integration_tests() actually dispatches.
+    integration_only = any(t in targets for t in INTEGRATION_TARGET_NAMES)
 
     all_passed = True
 

--- a/tests/test_run_tests_integration_guard_12903.py
+++ b/tests/test_run_tests_integration_guard_12903.py
@@ -1,0 +1,61 @@
+"""Regression test for #12903 — run_tests.py integration target guard.
+
+main()'s `integration_only` guard must recognize EVERY integration target
+that run_integration_tests() dispatches. The two lists drifted when #9398
+added `real_agent_subprocess` + `gh_shim_tracker` to the dispatch but not to
+the guard, so `run_tests.py real_agent_subprocess` fell through to run the
+full static gate first. Both now derive from the shared
+`_INTEGRATION_MODULES` registry — these tests lock that invariant.
+"""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "tests"))
+
+import run_tests  # noqa: E402
+
+
+EXPECTED_TARGETS = {
+    "harness", "status_flow", "event_mode_e2e", "agent_subprocess",
+    "real_agent_subprocess", "gh_shim_tracker",
+}
+
+
+def _is_integration_only(targets):
+    """Mirror of main()'s guard expression, for isolated testing."""
+    return any(t in targets for t in run_tests.INTEGRATION_TARGET_NAMES)
+
+
+class TestIntegrationTargetGuard12903:
+    def test_guard_recognizes_all_six_targets(self):
+        assert set(run_tests.INTEGRATION_TARGET_NAMES) == EXPECTED_TARGETS
+
+    def test_previously_omitted_targets_present(self):
+        """The exact bug: these two were dispatched but not in the guard."""
+        assert "real_agent_subprocess" in run_tests.INTEGRATION_TARGET_NAMES
+        assert "gh_shim_tracker" in run_tests.INTEGRATION_TARGET_NAMES
+
+    def test_each_target_alone_is_integration_only(self):
+        """Invoking any single integration target must skip the static gate."""
+        for name in run_tests.INTEGRATION_TARGET_NAMES:
+            assert _is_integration_only([name]), name
+
+    def test_static_and_empty_are_not_integration_only(self):
+        assert not _is_integration_only(["static"])
+        assert not _is_integration_only([])
+
+    def test_guard_and_dispatch_share_one_source(self):
+        """Drift-proofing: the guard names ARE the registry names — no second
+        hand-maintained list that can fall out of sync again."""
+        assert run_tests.INTEGRATION_TARGET_NAMES == tuple(
+            name for name, _ in run_tests._INTEGRATION_MODULES
+        )
+
+    def test_registry_modules_exist_on_disk(self):
+        """Catch a typo'd module name in the registry without importing the
+        (heavy) integration modules."""
+        integ = REPO_ROOT / "tests" / "integration"
+        for name, module_name in run_tests._INTEGRATION_MODULES:
+            assert (integ / f"{module_name}.py").exists(), (name, module_name)


### PR DESCRIPTION
Fixes #12903 (LOW). `main()`'s `integration_only` guard listed only 4 integration target names while `run_integration_tests()` dispatched 6 — the two drifted when #9398 added `real_agent_subprocess` + `gh_shim_tracker`. So `run_tests.py real_agent_subprocess` (or `gh_shim_tracker`) alone fell through to run the full static gate first (wasted runtime + conflated exit code).

## Fix (root, drift-proof)
- Introduced a single `_INTEGRATION_MODULES` registry (name → module) in `tests/run_tests.py`. **Both** the dispatch loop in `run_integration_tests()` AND the `integration_only` guard in `main()` now derive from it, so they can never drift again.
- `run_integration_tests()` dispatch refactored from 6 hand-written `if` blocks to a data-driven `importlib` loop over the registry (lazy per-target import preserved).
- `INTEGRATION_TARGET_NAMES = tuple(name for name, _ in _INTEGRATION_MODULES)` drives the guard.

## Tests
- `tests/test_run_tests_integration_guard_12903.py` (6 tests): guard recognizes all 6 targets; the two previously-omitted present; each target alone is integration-only; `static`/empty are not; guard==registry (one source); registry module files exist on disk.
- Verified end-to-end: `run_tests.py gh_shim_tracker` now runs integration-only (no static gate first).
- Full static gate: 4635 passed, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)