### PR TITLE
#12906 (Phase 1 of #12895): harness recompose ensure-main + pull-first

### DIFF
--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -5,6 +5,7 @@ Single source of truth for git operations used by agents.
 
 Usage:
     python scripts/git_ops.py pull                      # git pull (merge)
+    python scripts/git_ops.py ensure-main-and-pull [role]  # on-main + pull before a recompose (#12906)
     python scripts/git_ops.py add-all                   # git add -A
     python scripts/git_ops.py commit <role> <message>    # git commit with role prefix
     python scripts/git_ops.py push                      # git push
@@ -234,6 +235,48 @@ def pull(role=None):
         print("Pulled (stashed and popped)")
         _emit("git-pull", {"result": "stash"}, role=role)
     return True
+
+
+def ensure_main_and_pull(role=None):
+    """Put the clone on ``main`` and pull origin before a recompose/deploy.
+
+    #12906 (Phase 1 of #12895): every harness-side recompose path
+    (`compose.py deploy*` driven by the L4 file-watcher and the
+    post-merge deploy-all) MUST run against *current* source. A clone
+    that is on a feature branch or behind origin would otherwise
+    regenerate composed ``CLAUDE.md`` from stale source and push that
+    revert fleet-wide. This guard closes the root condition: ensure
+    main, then merge-pull origin.
+
+    Returns ``(ok: bool, detail: str)``. Never raises — the contract is
+    enforced here (a blanket ``try/except``) so every caller, including
+    the harness merge path that calls this directly, can trust ``ok`` and
+    abort the recompose on ``ok=False`` rather than wrap defensively. On
+    ``ok=False`` the agents keep their last-known-good composed output
+    until a later recompose succeeds.
+    """
+    try:
+        result = _run("git branch --show-current", check=False)
+        branch = result.stdout.strip() if result.returncode == 0 else ""
+        if branch != "main":
+            sw = _run_list(["git", "checkout", "main"], check=False)
+            if sw.returncode != 0:
+                detail = (sw.stderr or sw.stdout or "").strip()[:200]
+                print(
+                    f"WARNING: ensure_main_and_pull could not switch to main "
+                    f"from {branch!r}: {detail}",
+                    file=sys.stderr,
+                )
+                return False, f"checkout-main-failed (on {branch!r})"
+        if not pull(role=role):
+            return False, "pull-failed"
+        return True, "on-main-synced"
+    except Exception as exc:  # noqa: BLE001 — "Never raises" is the contract
+        print(
+            f"WARNING: ensure_main_and_pull raised unexpectedly: {exc!r}",
+            file=sys.stderr,
+        )
+        return False, f"unexpected: {exc!r}"
 
 
 def add_all():
@@ -1259,6 +1302,10 @@ def main():
 
     if cmd == "pull":
         pull(role=rest[0] if rest else None)
+    elif cmd == "ensure-main-and-pull":
+        ok, detail = ensure_main_and_pull(role=rest[0] if rest else None)
+        print(detail)
+        sys.exit(0 if ok else 1)
     elif cmd == "add-all":
         add_all()
     elif cmd == "commit":

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -3748,6 +3748,24 @@ async def merge_pr(request: Request):
 
             if refs_changed:
                 _log(f"PR #{pr_number} touched references/ — running compose...")
+                # #12906 (Phase 1 of #12895): the PR was merged on the
+                # remote — the local clone must be put on main + pulled
+                # BEFORE deploy-all, or compose regenerates every
+                # CLAUDE.md from pre-merge (stale) source and pushes that
+                # revert fleet-wide. If the clone can't be freshened,
+                # abort the recompose so agents keep last-known-good
+                # composed output until a later recompose succeeds.
+                fresh_ok, fresh_detail = git_ops.ensure_main_and_pull("harness")
+                if not fresh_ok:
+                    _log(f"WARNING: aborting compose after PR #{pr_number} — "
+                         f"could not freshen source ({fresh_detail}). Agents "
+                         f"keep current CLAUDE.md until next recompose.")
+                    _emit_event("compose-completed", "harness", payload={
+                        "success": False,
+                        "error": f"freshen-source-failed: {fresh_detail}",
+                        "trigger_pr": str(pr_number),
+                    })
+                    return
                 compose_result = subprocess.run(
                     [sys.executable, str(SCRIPT_DIR / "compose.py"), "deploy-all"],
                     capture_output=True, text=True, encoding="utf-8", errors="replace",

--- a/references/scripts/l4_file_watcher.py
+++ b/references/scripts/l4_file_watcher.py
@@ -192,6 +192,80 @@ def emit_results(results, *, emit_event):
         )
 
 
+def _default_ensure_fresh_source(*, repo_root):
+    """Put the harness clone on ``main`` + pull origin before a recompose.
+
+    #12906 (Phase 1 of #12895): a behind-origin (or on-a-feature-branch)
+    clone recomposes every affected alias's ``CLAUDE.md`` from STALE L4
+    source; the post-cycle auto-commit then pushes that revert
+    fleet-wide. The guard freshens the clone first, and if it can't be
+    made fresh the caller ABORTS the batch so agents keep their
+    last-known-good composed output. Delegates to the canonical
+    ``git_ops.ensure_main_and_pull`` so this and the post-merge
+    deploy-all path share one implementation.
+
+    Lives behind ``ensure_fresh_source=`` injection (same pattern as
+    ``run_compose=``) so unit tests never shell out to git. Returns
+    ``(ok, detail)``.
+    """
+    try:
+        import git_ops
+    except Exception as exc:  # noqa: BLE001 — import failure must not crash watch
+        return False, f"git_ops import failed: {exc!r}"
+    try:
+        return git_ops.ensure_main_and_pull(role="harness")
+    except Exception as exc:  # noqa: BLE001 — guard must never crash the watch
+        return False, f"ensure_main_and_pull raised: {exc!r}"
+
+
+def _freshen_or_abort(ensure_fresh_source, *, repo_root, what, emit_event=None):
+    """Resolve the (possibly-injected) freshness guard, run it, and return
+    ``True`` to proceed / ``False`` to abort the recompose.
+
+    Runs ONCE per role-class recompose (one ``_on_change`` /
+    ``recompose_path`` call). A burst that touches multiple role-class
+    files fires one guard per role-class — the later pulls are fast
+    already-up-to-date no-ops, so this is harmless re-checking, not a
+    per-file storm.
+
+    On abort it logs a WARNING **and**, when ``emit_event`` is supplied,
+    surfaces the failure on the event bus as a ``compose-failed`` event
+    targeted at PM — mirroring the registry-unreadable path so a
+    stale-source abort is observable to operators, not just a console
+    line (DS-12906 F1). ``what`` labels the trigger (a path or
+    role-class) for both the log line and the event reason.
+    """
+    if ensure_fresh_source is None:
+        def ensure_fresh_source():
+            return _default_ensure_fresh_source(repo_root=repo_root)
+    try:
+        ok, detail = ensure_fresh_source()
+    except Exception as exc:  # noqa: BLE001 — guard must never crash the watch
+        ok, detail = False, f"freshness guard raised: {exc!r}"
+    if not ok:
+        print(
+            f"WARNING: l4_file_watcher aborting recompose for {what!r} — "
+            f"could not freshen source ({detail}). Agents keep their "
+            f"current CLAUDE.md until the next successful recompose "
+            f"(#12906 / #12895 stale-source guard).",
+            file=sys.stderr,
+        )
+        if emit_event is not None:
+            emit_event(
+                "assigned-to",
+                "harness",
+                payload={
+                    "target_alias": "pm",
+                    "event_context": "compose-failed",
+                    "reason": "freshen-source-failed",
+                    "stderr": f"recompose for {what!r} aborted: {detail}"[
+                        :_COMPOSE_FAILED_STDERR_MAX
+                    ],
+                },
+            )
+    return ok
+
+
 def _default_run_compose(alias, *, repo_root):
     """Shell out to ``compose.py deploy <alias>`` and return (ok, stdout, stderr).
 
@@ -220,6 +294,7 @@ def recompose_path(
     registry,
     emit_event,
     run_compose=None,
+    ensure_fresh_source=None,
 ):
     """Handle a single L4 file change end-to-end.
 
@@ -229,10 +304,18 @@ def recompose_path(
 
     Returns ``[]`` when ``path`` is not a watched role-class file —
     the watcher uses this as the "ignore unrelated change" signal
-    that drives the AC6 test about temp files.
+    that drives the AC6 test about temp files. Also returns ``[]`` when
+    the #12906 freshness guard aborts the batch (clone could not be put
+    on main + synced) — no recompose runs against stale source.
     """
     role_class = role_class_from_path(path, repo_root=repo_root)
     if role_class is None:
+        return []
+    # #12906 (Phase 1 of #12895): freshen source ONCE before composing.
+    if not _freshen_or_abort(
+        ensure_fresh_source, repo_root=repo_root, what=str(path),
+        emit_event=emit_event,
+    ):
         return []
     if run_compose is None:
         def run_compose(alias):
@@ -326,6 +409,7 @@ def make_change_callback(
     registry_provider,
     emit_event,
     run_compose=None,
+    ensure_fresh_source=None,
 ):
     """Build the callback the watcher/debouncer hands a role-class to.
 
@@ -340,6 +424,14 @@ def make_change_callback(
     collapses to one recompose.
     """
     def _on_change(role_class):
+        # #12906: freshen source ONCE per batch BEFORE reading the
+        # registry — a pull can update config.md's ## Aliases, so the
+        # registry must be read against post-pull source.
+        if not _freshen_or_abort(
+            ensure_fresh_source, repo_root=repo_root, what=role_class,
+            emit_event=emit_event,
+        ):
+            return
         try:
             registry = registry_provider()
         except Exception as exc:  # noqa: BLE001 — registry parse failure
@@ -376,6 +468,7 @@ def start_watcher(
     registry_provider,
     emit_event,
     run_compose=None,
+    ensure_fresh_source=None,
     debounce_seconds=DEFAULT_DEBOUNCE_SECONDS,
 ):
     """Start a ``watchdog.Observer`` watching ``.squidsquad/project/``.
@@ -407,6 +500,7 @@ def start_watcher(
         registry_provider=registry_provider,
         emit_event=emit_event,
         run_compose=run_compose,
+        ensure_fresh_source=ensure_fresh_source,
     )
     debouncer = _Debouncer(debounce_seconds, on_change)
 

--- a/tests/test_l4_file_watcher_e3.py
+++ b/tests/test_l4_file_watcher_e3.py
@@ -44,6 +44,17 @@ def _ok_compose(alias):
     return True, f"deployed {alias}\n", ""
 
 
+def _fresh_ok():
+    """No-op #12906 freshness guard for tests — never shells out to git.
+
+    Injected (same pattern as ``run_compose``) wherever a test drives a
+    batch-entry point (``recompose_path`` / ``make_change_callback``) so
+    the default guard's real ``git checkout main`` + ``git pull`` never
+    fire against the live repo during the unit suite.
+    """
+    return True, "test-stub"
+
+
 def _fail_compose(alias):
     return False, "", f"compose failed for {alias}: missing manifest"
 
@@ -234,6 +245,7 @@ class TestRecomposePath:
             registry=_REGISTRY,
             emit_event=sink,
             run_compose=_ok_compose,
+            ensure_fresh_source=_fresh_ok,
         )
         assert [r.alias for r in results] == ["pm", "pm-mobile"]
         assert {e["payload"]["target_alias"] for e in sink.events} == {
@@ -266,6 +278,7 @@ class TestRecomposePath:
             registry=_REGISTRY,
             emit_event=sink,
             run_compose=tracking,
+            ensure_fresh_source=_fresh_ok,
         )
         assert results == []
         assert calls == []
@@ -381,6 +394,7 @@ class TestChangeCallback:
             registry_provider=provider,
             emit_event=sink,
             run_compose=_ok_compose,
+            ensure_fresh_source=_fresh_ok,
         )
         cb("pm")  # registries[0]: 1 pm alias -> 1 event
         cb("pm")  # registries[1]: 2 pm aliases -> 2 events
@@ -408,6 +422,7 @@ class TestChangeCallback:
             registry_provider=boom,
             emit_event=sink,
             run_compose=_ok_compose,
+            ensure_fresh_source=_fresh_ok,
         )
         cb("pm")
         assert len(sink.events) == 1
@@ -554,6 +569,257 @@ class TestHarnessSupervisor:
         observers[0][0]._alive = False
         state._supervise_l4_once(starter)
         assert stale_debouncer.flush_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# #12906 (Phase 1 of #12895) — freshness guard: every recompose batch
+# does ensure-main + pull BEFORE composing, and aborts if it can't.
+# ---------------------------------------------------------------------------
+
+
+class TestFreshnessGuard12906:
+    """AC1 — the recompose path freshens source before any compose, fires
+    the guard exactly once per batch, and aborts (no compose, no events)
+    when the clone can't be made fresh — so a behind-origin clone never
+    recomposes CLAUDE.md from stale source."""
+
+    def test_recompose_path_freshens_before_compose(self, tmp_path):
+        order = []
+
+        def guard():
+            order.append("fresh")
+            return True, "stub"
+
+        def compose(alias):
+            order.append(f"compose:{alias}")
+            return True, "", ""
+
+        target = tmp_path / ".squidsquad" / "project" / "pm.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("# pm\n")
+        results = lfw.recompose_path(
+            target, repo_root=tmp_path, registry=_REGISTRY,
+            emit_event=_EventSink(), run_compose=compose,
+            ensure_fresh_source=guard,
+        )
+        assert len(results) == 2
+        # Guard fires exactly ONCE per batch, and strictly before any
+        # compose — the "pull first" ordering AC1 demands.
+        assert order.count("fresh") == 1
+        assert order[0] == "fresh"
+        assert order[1:] == ["compose:pm", "compose:pm-mobile"]
+
+    def test_recompose_path_abort_skips_compose_and_events(self, tmp_path):
+        sink = _EventSink()
+        composed = []
+
+        def guard():
+            return False, "pull-failed"
+
+        def compose(alias):
+            composed.append(alias)
+            return True, "", ""
+
+        target = tmp_path / ".squidsquad" / "project" / "pm.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("# pm\n")
+        results = lfw.recompose_path(
+            target, repo_root=tmp_path, registry=_REGISTRY,
+            emit_event=sink, run_compose=compose,
+            ensure_fresh_source=guard,
+        )
+        assert results == []      # batch aborted
+        assert composed == []     # no compose against stale source
+        # No restart-required, but the abort surfaces one compose-failed
+        # to PM so the stale-source halt is observable (DS-12906 F1).
+        assert len(sink.events) == 1
+        e = sink.events[0]
+        assert e["payload"]["target_alias"] == "pm"
+        assert e["payload"]["event_context"] == "compose-failed"
+        assert e["payload"]["reason"] == "freshen-source-failed"
+        assert "pull-failed" in e["payload"]["stderr"]
+
+    def test_recompose_path_guard_raise_aborts(self, tmp_path):
+        sink = _EventSink()
+        composed = []
+
+        def guard():
+            raise RuntimeError("git exploded")
+
+        def compose(alias):
+            composed.append(alias)
+            return True, "", ""
+
+        target = tmp_path / ".squidsquad" / "project" / "pm.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("# pm\n")
+        results = lfw.recompose_path(
+            target, repo_root=tmp_path, registry=_REGISTRY,
+            emit_event=sink, run_compose=compose,
+            ensure_fresh_source=guard,
+        )
+        # A guard that raises is treated as a failed freshen → abort,
+        # and the abort still surfaces a compose-failed to PM.
+        assert results == []
+        assert composed == []
+        assert len(sink.events) == 1
+        assert sink.events[0]["payload"]["event_context"] == "compose-failed"
+        assert "git exploded" in sink.events[0]["payload"]["stderr"]
+
+    def test_on_change_freshens_before_registry_read(self, tmp_path):
+        # The production watch path reads the registry AFTER the pull, so
+        # a config.md ## Aliases change pulled in is reflected.
+        order = []
+
+        def guard():
+            order.append("fresh")
+            return True, "stub"
+
+        def provider():
+            order.append("registry")
+            return _REGISTRY
+
+        def compose(alias):
+            order.append(f"compose:{alias}")
+            return True, "", ""
+
+        cb = lfw.make_change_callback(
+            repo_root=tmp_path, registry_provider=provider,
+            emit_event=_EventSink(), run_compose=compose,
+            ensure_fresh_source=guard,
+        )
+        cb("dm")  # dm role-class -> one alias
+        assert order == ["fresh", "registry", "compose:dm-skill"]
+
+    def test_on_change_abort_skips_registry_and_compose(self, tmp_path):
+        sink = _EventSink()
+        reads = []
+
+        def guard():
+            return False, "checkout-main-failed"
+
+        def provider():
+            reads.append("registry")
+            return _REGISTRY
+
+        cb = lfw.make_change_callback(
+            repo_root=tmp_path, registry_provider=provider,
+            emit_event=sink, run_compose=_ok_compose,
+            ensure_fresh_source=guard,
+        )
+        cb("pm")
+        assert reads == []  # registry never read on abort
+        # The abort surfaces a single compose-failed to PM (not silence).
+        assert len(sink.events) == 1
+        e = sink.events[0]
+        assert e["payload"]["target_alias"] == "pm"
+        assert e["payload"]["event_context"] == "compose-failed"
+        assert e["payload"]["reason"] == "freshen-source-failed"
+
+    def test_default_guard_aborts_when_git_ops_unavailable(
+        self, tmp_path, monkeypatch
+    ):
+        # If git_ops can't be imported, the default guard must abort the
+        # batch (return ok=False) rather than crash the watch thread.
+        monkeypatch.setitem(sys.modules, "git_ops", None)
+        ok, detail = lfw._default_ensure_fresh_source(repo_root=tmp_path)
+        assert ok is False
+        assert "git_ops" in detail
+
+
+class TestEnsureMainAndPull12906:
+    """AC1 — the canonical git_ops guard: a behind / feature-branch clone
+    is put on main and pulled BEFORE the caller composes. Drives git_ops
+    with stubbed git so the live repo is never touched."""
+
+    class _R:
+        def __init__(self, rc, out="", err=""):
+            self.returncode = rc
+            self.stdout = out
+            self.stderr = err
+
+    def _patch(self, monkeypatch, *, branch, checkout_rc=0, pull_ok=True):
+        import git_ops
+        order = []
+        R = self._R
+
+        def fake_run(cmd, check=True):
+            if "branch --show-current" in cmd:
+                return R(0, branch + "\n")
+            return R(0)
+
+        def fake_run_list(cmd, check=True):
+            if cmd[:2] == ["git", "checkout"]:
+                order.append(f"checkout:{cmd[2]}")
+                return R(checkout_rc, err="cannot checkout: dirty tree")
+            return R(0)
+
+        def fake_pull(role=None):
+            order.append(f"pull:{role}")
+            return pull_ok
+
+        monkeypatch.setattr(git_ops, "_run", fake_run)
+        monkeypatch.setattr(git_ops, "_run_list", fake_run_list)
+        monkeypatch.setattr(git_ops, "pull", fake_pull)
+        return git_ops, order
+
+    def test_behind_feature_branch_switches_then_pulls(self, monkeypatch):
+        git_ops, order = self._patch(
+            monkeypatch, branch="squidsquad/task/12906")
+        ok, _detail = git_ops.ensure_main_and_pull("harness")
+        assert ok is True
+        # checkout main BEFORE pull — the AC1 "behind clone pulls first".
+        assert order == ["checkout:main", "pull:harness"]
+
+    def test_on_main_skips_checkout_still_pulls(self, monkeypatch):
+        git_ops, order = self._patch(monkeypatch, branch="main")
+        ok, _detail = git_ops.ensure_main_and_pull("harness")
+        assert ok is True
+        assert order == ["pull:harness"]  # no checkout when already on main
+
+    def test_pull_failure_returns_false(self, monkeypatch):
+        git_ops, _order = self._patch(
+            monkeypatch, branch="main", pull_ok=False)
+        ok, detail = git_ops.ensure_main_and_pull("harness")
+        assert ok is False
+        assert detail == "pull-failed"
+
+    def test_checkout_failure_aborts_before_pull(self, monkeypatch):
+        git_ops, order = self._patch(
+            monkeypatch, branch="feature", checkout_rc=1)
+        ok, detail = git_ops.ensure_main_and_pull("harness")
+        assert ok is False
+        assert "checkout-main-failed" in detail
+        assert "pull:harness" not in order  # never pulled on a failed switch
+
+    def test_never_raises_contract_on_unexpected_exception(self, monkeypatch):
+        # DS-12906 F3: the harness merge path calls this directly and
+        # trusts the "Never raises" contract. An OSError from _run (e.g.
+        # git binary deleted) must return (False, ...), not propagate.
+        import git_ops
+
+        def boom(*_a, **_k):
+            raise OSError("git binary missing")
+
+        monkeypatch.setattr(git_ops, "_run", boom)
+        ok, detail = git_ops.ensure_main_and_pull("harness")
+        assert ok is False
+        assert "unexpected" in detail
+
+
+class TestPostMergeDeployFreshness12906:
+    """AC1 — the OTHER harness-side recompose path (post-merge
+    deploy-all) must also ensure-main + pull before composing. Static
+    grep so the guard can't be silently dropped in a refactor."""
+
+    def test_deploy_all_preceded_by_ensure_main_and_pull(self):
+        src = (SCRIPTS / "harness.py").read_text(encoding="utf-8")
+        idx = src.index('"deploy-all"')
+        guard = src.rfind("ensure_main_and_pull", 0, idx)
+        assert guard != -1, (
+            "post-merge deploy-all must be preceded by "
+            "git_ops.ensure_main_and_pull (#12906 stale-source guard)"
+        )
 
 
 class TestHarnessLifespanWiring:


### PR DESCRIPTION
## #12906 — Phase 1 of #12895: harness recompose ensure-main + pull-first

Closes #12906.

### What
Every harness-side recompose/deploy path now ensures the clone is on `main` and pulls origin (merge, never rebase) **before** running `compose.py deploy*`. A behind-origin or feature-branch clone can no longer regenerate composed `CLAUDE.md`/`CLAUDE.linked.md` from stale source and push that revert fleet-wide (the #12895 root condition; observed 3× on 2026-06-19).

### How
- **`git_ops.ensure_main_and_pull(role)`** — new canonical guard. Ensures `main`, then merge-pulls. Returns `(ok, detail)`, never raises (blanket guard so the direct harness caller can trust `ok`).
- **`l4_file_watcher.py`** — both recompose batch entries (`_on_change` for the file-watch, `recompose_path` for the post-commit hook) freshen source **once** before composing, via an injectable `ensure_fresh_source=` (same pattern as `run_compose=`). In the watch path the guard runs **before** `registry_provider()` so a pulled-in `config.md ## Aliases` change is reflected. On failure the batch **aborts** (no compose against stale source) and surfaces a `compose-failed`-to-PM event so the halt is observable; agents keep last-known-good composed output.
- **`harness.py`** — the post-merge `compose.py deploy-all` path (the one that reverted during #12800's ship) now calls `ensure_main_and_pull("harness")` first; on failure it skips deploy-all and emits `compose-completed success:False` rather than composing from pre-merge source.

### Scope boundary
Phase 1 = pull-first guard only. The Phase 2 non-interruption layer (deploy-signal at the ack-cursor boundary → agent halts → harness deploy/restart) stays on #12895, pending PM's doc-first arch spec. Not built here.

### Tests
- AC1: guard runs before compose, exactly once per batch, and aborts (no compose, no events except the PM `compose-failed`) when the clone can't be freshened; behind/feature-branch clone switches to main then pulls; on-main skips checkout; pull-fail / checkout-fail / unexpected-exception all return `(False, …)`. Static-grep gate locks the post-merge deploy-all guard.
- AC2: `compose.py deploy-all` from current source produces zero composed drift (verified); existing l4/harness/git_ops suites green.
- AC3: no files added/removed under `references/` → `installer-files.txt` unchanged. (Filed #12907 separately for the pre-existing gap: all 9 `l4_*.py` scripts are absent from the manifest.)

DS review: 4 warnings, all resolved (`.squidsquad/skill/planning/DS-REVIEW-12906.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
