### PR TITLE
#12907: add 9 l4_*.py to installer-files.txt (L4 subsystem was unshipped)

### DIFF
--- a/references/installer-files.txt
+++ b/references/installer-files.txt
@@ -1,7 +1,7 @@
 # SquidSquad installer file manifest
 # Every file the wizard needs, fetched by npx squidsquad before
 # launching Claude. One path per line, relative to repo root.
-# Total: 206 files
+# Total: 215 files
 #
 # Maintained alongside the wizard - when you add a new role,
 # capability, preset, or sub-skill, add its files here too.
@@ -36,6 +36,15 @@ references/scripts/forgejo_setup.py
 references/scripts/git_ops.py
 references/scripts/harness.py
 references/scripts/health_check.py
+references/scripts/l4_audit_gate.py
+references/scripts/l4_compose_dryrun.py
+references/scripts/l4_conflict_preempt.py
+references/scripts/l4_file_watcher.py
+references/scripts/l4_mini_cq.py
+references/scripts/l4_op_processor.py
+references/scripts/l4_parser.py
+references/scripts/l4_removal.py
+references/scripts/l4_write_commit.py
 references/scripts/manifest.py
 references/scripts/migrate_state_branch.py
 references/scripts/model_router.py

--- a/tests/test_installer_wiring.py
+++ b/tests/test_installer_wiring.py
@@ -266,6 +266,44 @@ class TestInstallerFileManifest:
         dupes = [f for f in manifest_entries if manifest_entries.count(f) > 1]
         assert not dupes, f"Duplicate entries in installer-files.txt: {set(dupes)}"
 
+    def test_l4_subsystem_scripts_listed(self, manifest_entries):
+        """#12907: the L4 customization + file-watch subsystem must ship.
+
+        harness.py imports l4_file_watcher (start_l4_watcher) and the L4
+        customization pipeline (parser/op-processor/audit-gate/…) is
+        driven at runtime — none of these were in the manifest, so fresh
+        installs received no L4 subsystem. Lock the whole family so the
+        omission can't silently recur.
+        """
+        l4_scripts = sorted(
+            f"references/scripts/{p.name}"
+            for p in (REPO_ROOT / "references" / "scripts").glob("l4_*.py")
+        )
+        assert l4_scripts, "no l4_*.py scripts found on disk — test stale"
+        missing = [s for s in l4_scripts if s not in manifest_entries]
+        assert not missing, (
+            f"installer-files.txt missing L4 subsystem scripts: {missing}"
+        )
+
+    def test_header_total_matches_entry_count(self):
+        """The '# Total: N files' header must match the real entry count.
+
+        A stale header is the canary for an add-without-counting edit —
+        the omission that left the L4 family (#12907) out for so long.
+        """
+        text = INSTALLER_MANIFEST.read_text(encoding="utf-8")
+        m = re.search(r"#\s*Total:\s*(\d+)\s*files", text)
+        assert m, "installer-files.txt is missing a '# Total: N files' header"
+        declared = int(m.group(1))
+        actual = sum(
+            1 for line in text.splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        )
+        assert declared == actual, (
+            f"installer-files.txt header says {declared} files but lists "
+            f"{actual} — update the '# Total:' line when adding/removing entries"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## #12907 — installer manifest missing all 9 l4_*.py scripts

Closes #12907.

### What
The L4 customization + file-watch subsystem was entirely absent from `references/installer-files.txt`, so fresh installs never received it. `harness.py` imports `l4_file_watcher` (`start_l4_watcher`) and the L4 customization pipeline (parser / op-processor / audit-gate / mini-cq / removal / write-commit / conflict-preempt / compose-dryrun) runs at runtime — a fresh install's harness would hit ImportError on the watcher and `l4-curation` would fail.

### Change
- Add all 9 `references/scripts/l4_*.py` to the manifest (alphabetical, in the scripts block).
- Reconcile the header: `# Total: 206 files` → `# Total: 215 files`.
- New regression tests in `tests/test_installer_wiring.py::TestInstallerFileManifest`:
  - `test_l4_subsystem_scripts_listed` — every `l4_*.py` on disk is in the manifest (locks this fix).
  - `test_header_total_matches_entry_count` — the `# Total: N` header matches the real entry count (catches add-without-counting drift, the canary for this class of omission).

### Scope
Focused on the demonstrably harness-imported l4 family. A broader disk-vs-manifest diff found **17 other** `scripts/*.py` missing (incl. the critical `event_poll.py`); those need per-script runtime-vs-dev triage and are filed separately as **#12909** (with a curated-allowlist completeness test).

### Tests
Static gate: 4637 passed, 0 fail. AC1 (manifest updated) ✓ AC-test (completeness lock) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
