### PR TITLE
#12909: ship 14 more runtime scripts + manifest completeness gate

### DIFF
--- a/references/installer-files.txt
+++ b/references/installer-files.txt
@@ -1,7 +1,7 @@
 # SquidSquad installer file manifest
 # Every file the wizard needs, fetched by npx squidsquad before
 # launching Claude. One path per line, relative to repo root.
-# Total: 215 files
+# Total: 229 files
 #
 # Maintained alongside the wizard - when you add a new role,
 # capability, preset, or sub-skill, add its files here too.
@@ -20,10 +20,14 @@ references/VERSION
 references/migrations/README.md
 references/scripts/activity_hook.py
 references/scripts/add_role.py
+references/scripts/atomic_emit.py
 references/scripts/boot_remote.py
 references/scripts/capability_check.py
+references/scripts/catalog_drift.py
+references/scripts/catalog_parser.py
 references/scripts/comms_adapter.py
 references/scripts/compose.py
+references/scripts/compose_freshness.py
 references/scripts/config.py
 references/scripts/cycle.py
 references/scripts/cycle_post.py
@@ -31,6 +35,9 @@ references/scripts/cycle_pre.py
 references/scripts/diagnostics.py
 references/scripts/event_bus.py
 references/scripts/event_bus_reader.py
+references/scripts/event_catalog.py
+references/scripts/event_poll.py
+references/scripts/event_validator.py
 references/scripts/forge_adapter.py
 references/scripts/forgejo_setup.py
 references/scripts/git_ops.py
@@ -45,9 +52,12 @@ references/scripts/l4_op_processor.py
 references/scripts/l4_parser.py
 references/scripts/l4_removal.py
 references/scripts/l4_write_commit.py
+references/scripts/link_stage_validator.py
 references/scripts/manifest.py
 references/scripts/migrate_state_branch.py
 references/scripts/model_router.py
+references/scripts/orphan_cleanup.py
+references/scripts/process_utils.py
 references/scripts/reboot_agent.py
 references/scripts/repo_scan.py
 references/scripts/run_comprehension_test.py
@@ -55,13 +65,17 @@ references/scripts/scan_index.py
 references/scripts/shared_fs.py
 references/scripts/squidsquad_cli.py
 references/scripts/soul_adaptation.py
+references/scripts/source_frontmatter.py
 references/scripts/start_team.py
 references/scripts/state_bus.py
+references/scripts/statusline_data.py
 references/scripts/subloop_driver.py
 references/scripts/tc_coverage.py
 references/scripts/thin_launcher.py
 references/scripts/tracker.py
 references/scripts/triage.py
+references/scripts/v2_catalog_gate.py
+references/scripts/v2_link_stage.py
 references/scripts/vault_check.py
 references/scripts/vault_entity.py
 references/scripts/vault_optimize.py

--- a/tests/test_installer_wiring.py
+++ b/tests/test_installer_wiring.py
@@ -304,6 +304,59 @@ class TestInstallerFileManifest:
             f"{actual} — update the '# Total:' line when adding/removing entries"
         )
 
+    # #12909: every references/scripts/*.py must be either shipped (in the
+    # manifest) or explicitly excluded here with a reason. This is the
+    # general completeness gate — it would have caught both the l4 family
+    # (#12907) and this batch. Dev/CI/migration-only scripts that must NOT
+    # ship to fresh installs go here; adding a new runtime script without
+    # a manifest entry now fails CI instead of silently un-shipping a
+    # whole subsystem (as happened with event_poll.py, statusline_data.py).
+    MANIFEST_EXCLUDED_SCRIPTS = {
+        # one-time #6274 label-rename migration + its verifier — historical,
+        # never invoked at runtime; nothing to migrate on a fresh install.
+        "references/scripts/migrate_labels_6274.py",
+        "references/scripts/verify_dual_label_6274.py",
+        # smoke-test helper for the Monitor event poller — dev/CI only.
+        "references/scripts/monitor_smoke_poller.py",
+    }
+
+    def test_every_runtime_script_listed_or_excluded(self, manifest_entries):
+        scripts_dir = REPO_ROOT / "references" / "scripts"
+        on_disk = {
+            f"references/scripts/{p.name}"
+            for p in scripts_dir.glob("*.py")
+        }
+        listed = set(manifest_entries)
+        unaccounted = sorted(
+            s for s in on_disk
+            if s not in listed and s not in self.MANIFEST_EXCLUDED_SCRIPTS
+        )
+        assert not unaccounted, (
+            "references/scripts/*.py neither in installer-files.txt nor in "
+            f"MANIFEST_EXCLUDED_SCRIPTS: {unaccounted}. Add runtime scripts "
+            "to the manifest; add dev/CI/migration-only scripts to the "
+            "allowlist with a reason."
+        )
+
+    def test_excluded_scripts_are_not_also_listed(self, manifest_entries):
+        """An allowlisted script must not also be shipped (contradiction)."""
+        listed = set(manifest_entries)
+        both = sorted(self.MANIFEST_EXCLUDED_SCRIPTS & listed)
+        assert not both, (
+            f"scripts both allowlisted AND in the manifest: {both} — "
+            "decide: ship it (drop from allowlist) or not (drop from manifest)"
+        )
+
+    def test_excluded_scripts_exist_on_disk(self):
+        """Keep the allowlist honest — no stale entries for deleted scripts."""
+        missing = sorted(
+            s for s in self.MANIFEST_EXCLUDED_SCRIPTS
+            if not (REPO_ROOT / s).exists()
+        )
+        assert not missing, (
+            f"MANIFEST_EXCLUDED_SCRIPTS lists non-existent files: {missing}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## #12909 — ship 14 more runtime scripts + add a manifest completeness gate

Closes #12909.

### What
A full disk-vs-manifest audit of `references/scripts/` (after #12907 added the 9 l4 scripts) found **14 more runtime-required scripts** missing from `installer-files.txt` — so fresh installs were missing real functionality, most critically:
- **event_poll.py** — every event-mode agent runs it via Monitor; without it a fresh install has no event mode at all.
- **statusline_data.py** — `statusline.sh` shells out to it (`mode`/`phase`); without it the status line is dead.
- **process_utils.py** — imported by boot_remote / health_check / reboot_agent / thin_launcher.
- **compose_freshness.py** (← harness, squidsquad_cli), plus the compose pipeline's `catalog_drift/catalog_parser/event_catalog/event_validator/link_stage_validator/v2_catalog_gate/v2_link_stage/atomic_emit/source_frontmatter` (all imported by compose.py), and `orphan_cleanup` (← boot_remote, cycle_post).

### How (triage)
Built the import/invocation graph across shipped scripts + `statusline.sh` + sub-skills/roles. Each script classified runtime-required (→ ship) or dev-only (→ allowlist):
- **Added 14** runtime scripts (alphabetical), header `215 → 229`.
- **Allowlisted 3** dev/CI/migration-only with reasons: `migrate_labels_6274.py` + `verify_dual_label_6274.py` (one-time #6274 migration; the `cycle_pre.py` mention is a comment, not an invocation), `monitor_smoke_poller.py` (smoke-test helper).

### Completeness gate (prevents recurrence)
New tests in `TestInstallerFileManifest`:
- `test_every_runtime_script_listed_or_excluded` — every `references/scripts/*.py` is in the manifest OR in `MANIFEST_EXCLUDED_SCRIPTS`. Would have caught both #12907 and this.
- `test_excluded_scripts_are_not_also_listed` + `test_excluded_scripts_exist_on_disk` — keep the allowlist honest.

### Tests
Static gate: 4640 passed, 0 fail. All 66 `scripts/*.py` now accounted for (63 shipped + 3 allowlisted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
