### PR TITLE
skill: #12294 keep .claude-pid authoritative across harness restart (C+A)

### DIFF
--- a/.squidsquad/skill/working-state.md
+++ b/.squidsquad/skill/working-state.md
@@ -1,8 +1,18 @@
 # Working State
 
-- **Task**: #12294 (.claude-pid authoritative across harness restart) IN-PROGRESS — RCA DONE, **dependency-free design LOCKED** (comment posted), implementation pending next session (fresh budget for high-blast harness ctypes). Branch `squidsquad/task/12294` created (no commits yet). SECONDARY in-progress: #12451 (status-bar) S1+S3 on branch (PR #13024), S2 PARKED on PM CQ-AC via **#13031**.
-- **Updated**: 2026-06-20 11:40 (skill — event-mode, post-harness-restart boot)
+- **Task**: #12294 (.claude-pid authoritative across harness restart) IN-PROGRESS — RCA DONE, design **C+A LOCKED & RE-VALIDATED**, IMPLEMENTING test-first this session on branch `squidsquad/task/12294`. SECONDARY in-progress: #12451 (status-bar) S1+S3 on branch (PR #13024), S2 PARKED on PM CQ-AC via **#13031**.
+- **Updated**: 2026-06-20 (skill — event-mode, implementing #12294)
 - **Quiet Cycle Counter**: 0
+
+## #12294 — NEW FINDING this session (terminal_pid dead-end → confirms psutil gate)
+Considered closing the never-recorded-orphan gap dependency-free by re-resolving claude.exe from the persisted `terminal_pid` (#10101 descendant walk). **DOESN'T WORK on Windows**: boot_remote.py:472-475 — terminal_pid = proc.pid of the `cmd /c start` cmd.exe, which **exits immediately** (self-closing window). Recorded terminal_pid is a dead short-lived process; claude.exe is detached, not its descendant. So orphan re-adoption genuinely needs psutil (cwd/cmdline) → stays a HUMAN GATE. Locked C+A scope stands.
+
+## #12294 — IMPL PLAN (this session)
+1. **process_utils.py**: add `image_name_for_pid(pid)` (win32 toolhelp / posix /proc comm; None=undetermined) + `is_claude_process_alive(pid)` (alive AND image∈{claude.exe,claude}; None-image → fall back to liveness = AC2-safe). Extend `_win32_kernel32` w/ toolhelp typing. + unit tests (mock snapshot).
+2. **thin_launcher.py**: factor `_win32_all_procs()` out of `_win32_list_descendants`; add local mirror `_image_name_for_pid`/`_is_claude_process_alive` (#8891 no-import); `_check_singleton` → image-verified (recycled PID no longer defeats singleton = A). + tests.
+3. **harness.py update_health (580-596)**: PID chain image-verified (in-mem → file), reclaim dead/recycled; (C) write-back .claude-pid via new `reboot_agent.write_claude_pid` when missing/divergent + image-verified-alive. + tests mocking helpers.
+4. **AC4 regression test**: (i) stale .claude-pid dead PID + live recorded in state → running not respawned; (ii) recycled non-claude PID at .claude-pid → reclaimed; (iii) missing file + recorded-in-state → running (self-heal write-back). True never-recorded orphan = psutil-gated (out of dependency-free scope; route to human via PM).
+5. DS review (high-blast) per logical commit.
 
 ## #12294 — RCA + LOCKED DESIGN (resume target)
 RCA: harness learns claude.exe PID ONLY from `.claude-pid` (harness.py:595 in update_health; NO spawn-time registration). Single point of failure: thin_launcher writes resolved PID (thin_launcher.py:584, #10101) but unclean exit leaves it STALE; never-recorded live claude.exe (dm/qa observed) is invisible; load_state (harness.py:1381) restores possibly-stale PID on restart.

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -195,6 +195,7 @@ _NO_FRESHNESS_CHECK = False
 
 import boot_remote
 import health_check
+import process_utils
 import reboot_agent
 
 try:
@@ -577,23 +578,45 @@ class HarnessState:
                 agent.last_health_check = time.time()
                 prev_status = agent.status
 
-                # Direct PID check (#4966) — primary health detection
+                # Direct PID check (#4966) — primary health detection.
+                # #12294: trust a PID only if it is alive AND its image is
+                # actually claude (image-verified liveness). A recycled PID now
+                # owned by an unrelated process must not read as "agent alive"
+                # (AC3), and a possibly-stale .claude-pid must be reconciled
+                # against the real process, not blindly trusted (AC1). Where the
+                # image can't be determined, is_claude_process_alive falls back
+                # to plain liveness so a live agent is never mis-reclaimed (AC2).
                 pid = agent.claude_pid
                 alive = False
                 pid_changed = False
                 if pid:
-                    alive = boot_remote._is_process_alive(pid)
+                    alive = process_utils.is_claude_process_alive(pid)
 
-                # If no stored PID or PID stale, try reading .claude-pid file
+                # If no stored PID or it didn't image-verify, reconcile from the
+                # .claude-pid file — image-verified, so a stale (dead) or
+                # recycled (live non-claude) holder is reclaimed rather than
+                # adopted.
                 if not alive:
-                    file_pid, file_alive = reboot_agent._read_claude_pid(clone_path, role)
-                    if file_pid and file_alive:
+                    file_pid, _ = reboot_agent._read_claude_pid(clone_path, role)
+                    if file_pid and process_utils.is_claude_process_alive(file_pid):
                         pid = file_pid
                         alive = True
                         if agent.claude_pid != pid:
                             pid_changed = True
                         agent.claude_pid = pid
                         state_changed = True
+
+                # #12294 (C) write-back: when we hold an image-verified live
+                # claude PID, keep .claude-pid in sync with the harness's
+                # in-memory truth so a *subsequent* restart isn't blind to this
+                # agent (the missing/stale-file observation that motivated this
+                # issue). Only writes when the file is missing or divergent;
+                # best-effort (a write failure leaves the in-memory PID
+                # authoritative for this session).
+                if alive and pid:
+                    file_pid, _ = reboot_agent._read_claude_pid(clone_path, role)
+                    if file_pid != pid:
+                        reboot_agent.write_claude_pid(clone_path, role, pid)
 
                 # Fallback: check .health file for legacy wrapper agents
                 if not alive and not pid:

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -589,34 +589,53 @@ class HarnessState:
                 pid = agent.claude_pid
                 alive = False
                 pid_changed = False
-                if pid:
-                    alive = process_utils.is_claude_process_alive(pid)
+                # The image-verify helpers are total (never raise), but this is
+                # the fleet-wide health poll — guard the whole resolution block
+                # so any unforeseen fault degrades THIS agent to "treat as dead"
+                # rather than aborting liveness for every remaining role
+                # (DS-12294-c3 Finding 1). file_pid is captured once and reused
+                # by the write-back to avoid a second .claude-pid read
+                # (DS-12294-c3 Finding 3).
+                file_pid = None
+                file_read = False
+                try:
+                    if pid:
+                        alive = process_utils.is_claude_process_alive(pid)
 
-                # If no stored PID or it didn't image-verify, reconcile from the
-                # .claude-pid file — image-verified, so a stale (dead) or
-                # recycled (live non-claude) holder is reclaimed rather than
-                # adopted.
-                if not alive:
-                    file_pid, _ = reboot_agent._read_claude_pid(clone_path, role)
-                    if file_pid and process_utils.is_claude_process_alive(file_pid):
-                        pid = file_pid
-                        alive = True
-                        if agent.claude_pid != pid:
-                            pid_changed = True
-                        agent.claude_pid = pid
-                        state_changed = True
+                    # If no stored PID or it didn't image-verify, reconcile from
+                    # the .claude-pid file — image-verified, so a stale (dead) or
+                    # recycled (live non-claude) holder is reclaimed rather than
+                    # adopted.
+                    if not alive:
+                        file_pid, _ = reboot_agent._read_claude_pid(clone_path, role)
+                        file_read = True
+                        if file_pid and process_utils.is_claude_process_alive(file_pid):
+                            pid = file_pid
+                            alive = True
+                            if agent.claude_pid != pid:
+                                pid_changed = True
+                            agent.claude_pid = pid
+                            state_changed = True
 
-                # #12294 (C) write-back: when we hold an image-verified live
-                # claude PID, keep .claude-pid in sync with the harness's
-                # in-memory truth so a *subsequent* restart isn't blind to this
-                # agent (the missing/stale-file observation that motivated this
-                # issue). Only writes when the file is missing or divergent;
-                # best-effort (a write failure leaves the in-memory PID
-                # authoritative for this session).
-                if alive and pid:
-                    file_pid, _ = reboot_agent._read_claude_pid(clone_path, role)
-                    if file_pid != pid:
-                        reboot_agent.write_claude_pid(clone_path, role, pid)
+                    # #12294 (C) write-back: when we hold an image-verified live
+                    # claude PID for a RUNNING agent, keep .claude-pid in sync
+                    # with the harness's in-memory truth so a *subsequent*
+                    # restart isn't blind to this agent (the missing/stale-file
+                    # observation that motivated this issue). Gated on
+                    # intent=RUNNING so we never race thin_launcher's spawn-time
+                    # write during a restart/deploy (DS-12294-c3 Finding 5);
+                    # only writes when the file is missing or divergent;
+                    # best-effort.
+                    if alive and pid and agent.intent == AgentState.INTENT_RUNNING:
+                        if not file_read:
+                            file_pid, _ = reboot_agent._read_claude_pid(clone_path, role)
+                        if file_pid != pid:
+                            reboot_agent.write_claude_pid(clone_path, role, pid)
+                except Exception as e:
+                    _log(f"{role}: liveness resolution error — {e!r}; "
+                         f"treating as dead this poll")
+                    alive = False
+                    pid_changed = False
 
                 # Fallback: check .health file for legacy wrapper agents
                 if not alive and not pid:

--- a/references/scripts/process_utils.py
+++ b/references/scripts/process_utils.py
@@ -4,12 +4,15 @@ Cross-platform process liveness used by boot_remote, health_check, and
 reboot_agent. thin_launcher.py keeps its own copy of this logic to avoid
 importing this module (and indirectly any heavier deps) at boot — see
 the comment there. If you change the semantics here, mirror the change
-in thin_launcher.py:_is_process_alive.
+in thin_launcher.py:_is_process_alive (and, for the image-verification
+helpers below, thin_launcher.py:_image_name_for_pid /
+_is_claude_process_alive).
 """
 
 import ctypes
 import os
 import sys
+from pathlib import Path
 
 
 # Win32 constants for OpenProcess + GetExitCodeProcess (#9904)
@@ -104,5 +107,111 @@ def _win32_kernel32():
     k.CloseHandle.restype = wintypes.BOOL
     k.GetExitCodeProcess.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
     k.GetExitCodeProcess.restype = wintypes.BOOL
+    # toolhelp32 (used by image_name_for_pid, #12294). Same #10440 ABI
+    # fix as thin_launcher: CreateToolhelp32Snapshot.restype MUST be
+    # HANDLE so INVALID_HANDLE_VALUE compares correctly at full pointer
+    # width on x64; Process32First/Next take (HANDLE, LPPROCESSENTRY32)
+    # passed as c_void_p so we don't import the struct layout here.
+    k.CreateToolhelp32Snapshot.argtypes = [wintypes.DWORD, wintypes.DWORD]
+    k.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
+    k.Process32First.argtypes = [wintypes.HANDLE, ctypes.c_void_p]
+    k.Process32First.restype = wintypes.BOOL
+    k.Process32Next.argtypes = [wintypes.HANDLE, ctypes.c_void_p]
+    k.Process32Next.restype = wintypes.BOOL
     _CACHED_KERNEL32 = k
     return k
+
+
+# Executable image names that identify a SquidSquad agent's claude process.
+# npm/Windows installs run ``claude.exe``; a direct POSIX binary reports
+# ``claude``. Compared case-insensitively against the OS-reported image name.
+_CLAUDE_IMAGE_NAMES = ("claude.exe", "claude")
+
+
+def image_name_for_pid(pid):
+    """Return the lowercased executable image name for a live PID, or None.
+
+    ``None`` means *undetermined* — the PID was not found in the process
+    snapshot, the snapshot failed, or the platform offers no cheap image
+    lookup. Callers MUST treat ``None`` as "could not verify" and fall
+    back to plain liveness, never as "not our process" — mis-reading an
+    undetermined image as a non-match would reclaim a live agent we
+    simply couldn't inspect (#12294 AC2 safety).
+
+    Windows uses the same in-process CreateToolhelp32Snapshot path as
+    ``thin_launcher._win32_list_descendants`` (no ``tasklist`` shell-out —
+    #9904). POSIX reads ``/proc/<pid>/comm`` (Linux); platforms without
+    ``/proc`` (macOS) return ``None`` (undetermined).
+    """
+    if pid is None or pid <= 0:
+        return None
+    if sys.platform == "win32":
+        return _image_name_win32(pid)
+    try:
+        comm = Path(f"/proc/{pid}/comm").read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return comm.lower() or None
+
+
+def _image_name_win32(pid):
+    """Win32 image-name lookup via toolhelp32. Returns lowercased name or None."""
+    from ctypes import wintypes
+
+    TH32CS_SNAPPROCESS = 0x00000002
+    INVALID_HANDLE_VALUE = ctypes.c_void_p(-1).value
+
+    class PROCESSENTRY32(ctypes.Structure):
+        _fields_ = [
+            ("dwSize", wintypes.DWORD),
+            ("cntUsage", wintypes.DWORD),
+            ("th32ProcessID", wintypes.DWORD),
+            ("th32DefaultHeapID", ctypes.c_void_p),
+            ("th32ModuleID", wintypes.DWORD),
+            ("cntThreads", wintypes.DWORD),
+            ("th32ParentProcessID", wintypes.DWORD),
+            ("pcPriClassBase", wintypes.LONG),
+            ("dwFlags", wintypes.DWORD),
+            ("szExeFile", ctypes.c_char * 260),
+        ]
+
+    kernel32 = _win32_kernel32()
+    snap = kernel32.CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
+    if snap is None or snap == INVALID_HANDLE_VALUE:
+        return None
+    try:
+        entry = PROCESSENTRY32()
+        entry.dwSize = ctypes.sizeof(PROCESSENTRY32)
+        if not kernel32.Process32First(snap, ctypes.byref(entry)):
+            return None
+        while True:
+            if entry.th32ProcessID == pid:
+                return entry.szExeFile.decode("utf-8", errors="replace").lower()
+            if not kernel32.Process32Next(snap, ctypes.byref(entry)):
+                break
+    finally:
+        kernel32.CloseHandle(snap)
+    return None
+
+
+def is_claude_process_alive(pid):
+    """Return True iff ``pid`` is a live process whose image is claude (#12294).
+
+    Image-verified liveness. A bare ``is_process_alive`` can be fooled by
+    a recycled PID now owned by an unrelated process (the stale/recycled
+    ``.claude-pid`` failure mode), so we trust a PID as "our agent" only
+    when it is alive AND its image name is claude.
+
+    When the image cannot be determined (``image_name_for_pid`` returns
+    ``None`` — snapshot failure, or a platform without a cheap image
+    lookup), fall back to plain liveness so a live agent we merely
+    couldn't inspect is never mis-reclaimed (#12294 AC2). The recycled-PID
+    reclaim (AC3) therefore depends on a working image lookup, which is the
+    case on the Windows deployment target.
+    """
+    if not is_process_alive(pid):
+        return False
+    img = image_name_for_pid(pid)
+    if img is None:
+        return True
+    return img in _CLAUDE_IMAGE_NAMES

--- a/references/scripts/process_utils.py
+++ b/references/scripts/process_utils.py
@@ -186,7 +186,11 @@ def _image_name_win32(pid):
             return None
         while True:
             if entry.th32ProcessID == pid:
-                return entry.szExeFile.decode("utf-8", errors="replace").lower()
+                # `or None`: an empty image name is "undetermined", not a
+                # non-match — keep parity with the POSIX path so AC2's
+                # fallback-to-liveness contract has no loophole (DS-12294-c1).
+                return entry.szExeFile.decode(
+                    "utf-8", errors="replace").lower() or None
             if not kernel32.Process32Next(snap, ctypes.byref(entry)):
                 break
     finally:

--- a/references/scripts/process_utils.py
+++ b/references/scripts/process_utils.py
@@ -155,9 +155,20 @@ def image_name_for_pid(pid):
 
 
 def _image_name_win32(pid):
-    """Win32 image-name lookup via toolhelp32. Returns lowercased name or None."""
+    """Win32 image-name lookup via toolhelp32. Returns lowercased name or None.
+
+    Total by construction: any ctypes/Win32 fault (snapshot failure, an
+    unexpected ArgumentError, a future API change) is swallowed and reported
+    as ``None`` (undetermined). The harness calls this from inside the health
+    poll loop — a raise here would abort liveness checks for the whole agent
+    fleet (DS-12294-c3 Finding 1), so the helper MUST never propagate.
+    """
     from ctypes import wintypes
 
+    # NOTE: the PROCESSENTRY32 field list below is mirrored verbatim in
+    # thin_launcher._win32_all_procs (kept separate per the #8891 no-import
+    # design). Any field-layout change MUST be replicated there (DS-12294-c3
+    # Finding 6) — there is no compile-time check that they agree.
     TH32CS_SNAPPROCESS = 0x00000002
     INVALID_HANDLE_VALUE = ctypes.c_void_p(-1).value
 
@@ -175,26 +186,29 @@ def _image_name_win32(pid):
             ("szExeFile", ctypes.c_char * 260),
         ]
 
-    kernel32 = _win32_kernel32()
-    snap = kernel32.CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
-    if snap is None or snap == INVALID_HANDLE_VALUE:
-        return None
     try:
-        entry = PROCESSENTRY32()
-        entry.dwSize = ctypes.sizeof(PROCESSENTRY32)
-        if not kernel32.Process32First(snap, ctypes.byref(entry)):
+        kernel32 = _win32_kernel32()
+        snap = kernel32.CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
+        if snap is None or snap == INVALID_HANDLE_VALUE:
             return None
-        while True:
-            if entry.th32ProcessID == pid:
-                # `or None`: an empty image name is "undetermined", not a
-                # non-match — keep parity with the POSIX path so AC2's
-                # fallback-to-liveness contract has no loophole (DS-12294-c1).
-                return entry.szExeFile.decode(
-                    "utf-8", errors="replace").lower() or None
-            if not kernel32.Process32Next(snap, ctypes.byref(entry)):
-                break
-    finally:
-        kernel32.CloseHandle(snap)
+        try:
+            entry = PROCESSENTRY32()
+            entry.dwSize = ctypes.sizeof(PROCESSENTRY32)
+            if not kernel32.Process32First(snap, ctypes.byref(entry)):
+                return None
+            while True:
+                if entry.th32ProcessID == pid:
+                    # `or None`: an empty image name is "undetermined", not a
+                    # non-match — keep parity with the POSIX path so AC2's
+                    # fallback-to-liveness contract has no loophole (DS-12294-c1).
+                    return entry.szExeFile.decode(
+                        "utf-8", errors="replace").lower() or None
+                if not kernel32.Process32Next(snap, ctypes.byref(entry)):
+                    break
+        finally:
+            kernel32.CloseHandle(snap)
+    except Exception:
+        return None
     return None
 
 

--- a/references/scripts/reboot_agent.py
+++ b/references/scripts/reboot_agent.py
@@ -103,6 +103,33 @@ def _read_claude_pid(clone_path, role):
         return None, False
 
 
+def write_claude_pid(clone_path, role, pid):
+    """Write ``pid`` to ``.claude-pid`` atomically (#12294 write-back).
+
+    The harness self-heals the file from its in-memory truth: when
+    ``update_health`` confirms an image-verified live claude PID but the
+    on-disk ``.claude-pid`` is missing or divergent, it writes the file
+    back so a *subsequent* harness restart isn't blind to that agent.
+    Symmetric with ``_read_claude_pid``. Best-effort: an OSError (disk
+    full, permission, antivirus lock on the .tmp) is swallowed with a
+    warning — the in-memory PID is still authoritative this session.
+    Returns True iff the file was written.
+    """
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+        return False
+    pid_file = Path(clone_path) / ".squidsquad" / role / ".claude-pid"
+    try:
+        pid_file.parent.mkdir(parents=True, exist_ok=True)
+        tmp = pid_file.with_suffix(".tmp")
+        tmp.write_text(str(pid), encoding="utf-8")
+        tmp.replace(pid_file)
+        return True
+    except OSError as e:
+        print(f"[reboot_agent] WARNING: could not write {pid_file}: {e}",
+              file=sys.stderr)
+        return False
+
+
 def main():
     """Deprecated CLI surface — kept for Phase 2 backward compat (#4792).
 

--- a/references/scripts/thin_launcher.py
+++ b/references/scripts/thin_launcher.py
@@ -187,7 +187,9 @@ def _image_name_for_pid(pid):
         return None
     if sys.platform == "win32":
         ppid_name = _win32_all_procs().get(pid)
-        return ppid_name[1].lower() if ppid_name else None
+        # `or None`: empty image name is "undetermined", not a non-match —
+        # parity with the POSIX path / process_utils (DS-12294-c1).
+        return (ppid_name[1].lower() or None) if ppid_name else None
     try:
         comm = Path(f"/proc/{pid}/comm").read_text(encoding="utf-8").strip()
     except OSError:

--- a/references/scripts/thin_launcher.py
+++ b/references/scripts/thin_launcher.py
@@ -168,12 +168,58 @@ def _win32_kernel32():
     return k
 
 
+# Mirror of process_utils.image_name_for_pid / is_claude_process_alive
+# (#12294). Kept local for the same reason as _is_process_alive — thin_launcher
+# avoids importing process_utils (and any heavier deps) at launch (#8891). If
+# you change the semantics in process_utils, mirror the change here.
+_CLAUDE_IMAGE_NAMES = ("claude.exe", "claude")
+
+
+def _image_name_for_pid(pid):
+    """Return the lowercased executable image name for a live PID, or None.
+
+    ``None`` == undetermined (PID not in the snapshot, snapshot failed, or no
+    cheap image lookup on this platform) — callers MUST treat it as "could not
+    verify" and fall back to plain liveness, never as a non-match (#12294 AC2).
+    Windows reuses ``_win32_all_procs``; POSIX reads ``/proc/<pid>/comm``.
+    """
+    if pid is None or pid <= 0:
+        return None
+    if sys.platform == "win32":
+        ppid_name = _win32_all_procs().get(pid)
+        return ppid_name[1].lower() if ppid_name else None
+    try:
+        comm = Path(f"/proc/{pid}/comm").read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return comm.lower() or None
+
+
+def _is_claude_process_alive(pid):
+    """True iff ``pid`` is a live process whose image is claude (#12294).
+
+    A PID recycled by an unrelated process must not be trusted as our agent.
+    Undetermined image (``_image_name_for_pid`` → None) falls back to plain
+    liveness so a live agent we couldn't inspect is never mis-reclaimed (AC2).
+    """
+    if not _is_process_alive(pid):
+        return False
+    img = _image_name_for_pid(pid)
+    if img is None:
+        return True
+    return img in _CLAUDE_IMAGE_NAMES
+
+
 def _check_singleton(clone_path, role):
     """Return a live PID if another agent of this role is already running here.
 
     Reads `.squidsquad/<role>/.claude-pid` and verifies the recorded process
-    is still alive. Stale pid files (process exited without cleanup) return
-    None — the new boot is allowed and will overwrite the file (#8692).
+    is still alive AND is actually a claude process (#12294). Stale pid files
+    (process exited without cleanup) — and recycled PIDs now owned by an
+    unrelated process — return None, so the new boot is allowed and will
+    overwrite the file (#8692). Image verification closes the recycled-PID
+    hole: a non-claude process squatting on the recorded PID no longer
+    defeats singleton enforcement and forces a duplicate-spawn refusal.
     """
     pid_file = Path(clone_path) / ".squidsquad" / role / ".claude-pid"
     if not pid_file.exists():
@@ -185,7 +231,7 @@ def _check_singleton(clone_path, role):
     if pid == os.getpid():
         # Defensive: our own PID shouldn't be there, but if it is, treat as stale.
         return None
-    return pid if _is_process_alive(pid) else None
+    return pid if _is_claude_process_alive(pid) else None
 
 
 def _reclaim_stale_scheduled_lock(clone_path):
@@ -329,16 +375,18 @@ def _resolve_claude_exe_pid(wrapper_pid, claude_exe_used,
     return wrapper_pid
 
 
-def _win32_list_descendants(parent_pid):
-    """Return all descendants of `parent_pid` on Windows via toolhelp32.
+def _win32_all_procs():
+    """Return a ``{pid: (parent_pid, image_name)}`` snapshot of all processes.
 
-    Implementation note: builds the full process snapshot then walks the
-    tree from `parent_pid`. CreateToolhelp32Snapshot is in-process and
+    Single source of the toolhelp32 walk used by both
+    ``_win32_list_descendants`` (tree walk) and ``_image_name_for_pid``
+    (image lookup, #12294). CreateToolhelp32Snapshot is in-process and
     avoids the WMI / tasklist hangs documented in #9903 / #9904.
 
     Uses the same ``_win32_kernel32()`` typed binding as
     ``_is_process_alive`` (#10440) so handle values aren't truncated to
     ``c_int`` and ``INVALID_HANDLE_VALUE`` compares correctly on x64.
+    Returns ``{}`` if the snapshot cannot be created.
     """
     import ctypes
     from ctypes import wintypes
@@ -367,15 +415,14 @@ def _win32_list_descendants(parent_pid):
     kernel32 = _win32_kernel32()
     snap = kernel32.CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
     if snap is None or snap == INVALID_HANDLE_VALUE:
-        return []
+        return {}
 
+    procs = {}
     try:
         entry = PROCESSENTRY32()
         entry.dwSize = ctypes.sizeof(PROCESSENTRY32)
-        # Build {pid: (parent_pid, name)} map.
-        procs = {}
         if not kernel32.Process32First(snap, ctypes.byref(entry)):
-            return []
+            return {}
         while True:
             procs[entry.th32ProcessID] = (
                 entry.th32ParentProcessID,
@@ -385,6 +432,18 @@ def _win32_list_descendants(parent_pid):
                 break
     finally:
         kernel32.CloseHandle(snap)
+    return procs
+
+
+def _win32_list_descendants(parent_pid):
+    """Return all descendants of `parent_pid` on Windows via toolhelp32.
+
+    Implementation note: snapshots all processes via ``_win32_all_procs``
+    then walks the tree from `parent_pid`.
+    """
+    procs = _win32_all_procs()
+    if not procs:
+        return []
 
     # Walk descendants of parent_pid (BFS). claude.exe is typically a
     # direct child of the cmd.exe shim, sometimes one hop deeper through

--- a/references/scripts/thin_launcher.py
+++ b/references/scripts/thin_launcher.py
@@ -186,7 +186,14 @@ def _image_name_for_pid(pid):
     if pid is None or pid <= 0:
         return None
     if sys.platform == "win32":
-        ppid_name = _win32_all_procs().get(pid)
+        # Total: any toolhelp/ctypes fault degrades to "undetermined" (None)
+        # rather than propagating — _check_singleton runs at launch and the
+        # process_utils twin runs inside the harness health poll (DS-12294-c3
+        # Finding 1).
+        try:
+            ppid_name = _win32_all_procs().get(pid)
+        except Exception:
+            return None
         # `or None`: empty image name is "undetermined", not a non-match —
         # parity with the POSIX path / process_utils (DS-12294-c1).
         return (ppid_name[1].lower() or None) if ppid_name else None

--- a/tests/test_12294_claude_pid_authoritative.py
+++ b/tests/test_12294_claude_pid_authoritative.py
@@ -1,0 +1,166 @@
+"""#12294 — keep .claude-pid authoritative across harness restart.
+
+Restart-time liveness hardening (design C + A, dependency-free):
+
+- **A (read-side image verification)** — ``update_health`` trusts a PID only
+  when it is alive AND its image is actually claude. A possibly-stale
+  ``.claude-pid`` is reconciled against the real process (AC1); a recycled
+  live non-claude PID is reclaimed, not trusted (AC3); an undetermined image
+  falls back to plain liveness so a live agent is never mis-reclaimed (AC2).
+- **C (write-side self-heal)** — when the harness holds an image-verified live
+  claude PID, it writes ``.claude-pid`` back from in-memory truth when the file
+  is missing or divergent, so a *subsequent* restart isn't blind to the agent.
+
+AC4 regression scenarios are exercised through ``update_health`` itself.
+
+The never-recorded-orphan edge (a live claude.exe whose PID was never recorded
+in either ``.claude-pid`` or harness state) is NOT covered here — recovering it
+needs cwd/cmdline discovery (psutil), a new dependency gated on a human
+decision. terminal_pid descendant re-resolution can't substitute on Windows:
+the recorded terminal_pid is the short-lived ``cmd /c start`` process that
+exits immediately (boot_remote.py), so claude.exe is detached, not its child.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import reboot_agent
+
+
+class TestWriteClaudePid:
+    """#12294 (C): the write-back helper, symmetric with _read_claude_pid."""
+
+    def test_writes_pid_atomically(self, tmp_path):
+        assert reboot_agent.write_claude_pid(str(tmp_path), "skill", 4242) is True
+        pid_file = tmp_path / ".squidsquad" / "skill" / ".claude-pid"
+        assert pid_file.read_text(encoding="utf-8") == "4242"
+        assert not pid_file.with_suffix(".tmp").exists()
+
+    def test_round_trips_through_read(self, tmp_path):
+        reboot_agent.write_claude_pid(str(tmp_path), "skill", 7777)
+        pid, _alive = reboot_agent._read_claude_pid(str(tmp_path), "skill")
+        assert pid == 7777
+
+    def test_rejects_bad_pid(self, tmp_path):
+        for bad in (None, 0, -1, True, "5"):
+            assert reboot_agent.write_claude_pid(str(tmp_path), "skill", bad) is False
+        assert not (tmp_path / ".squidsquad" / "skill" / ".claude-pid").exists()
+
+    def test_oserror_is_swallowed(self, tmp_path, capsys):
+        with patch("reboot_agent.Path") as fake_path:
+            chain = MagicMock(name="pid_file")
+            chain.__truediv__.return_value = chain  # Path(c)/".."/role/".." → chain
+            chain.parent.mkdir.side_effect = OSError("disk full")
+            fake_path.return_value = chain
+            assert reboot_agent.write_claude_pid(str(tmp_path), "skill", 4242) is False
+        assert "WARNING" in capsys.readouterr().err
+
+
+def _fresh_state(role, clone_path):
+    """Build a HarnessState with a single agent, no pollers/side effects."""
+    import harness
+    state = harness.HarnessState()
+    state.agents[role] = harness.AgentState(role, clone_path)
+    return harness, state
+
+
+class TestUpdateHealthImageVerified:
+    """#12294 A + C — exercised through update_health (AC1/AC2/AC3/AC4)."""
+
+    ROLE = "skill"
+    CLONE = "/fake/clone"
+
+    def _run(self, monkeypatch, *, in_mem_pid, file_pid, file_alive,
+             claude_alive, agent_setup=None, legacy_health="unknown"):
+        """Drive one update_health pass with the liveness layer mocked.
+
+        ``claude_alive`` is a predicate pid->bool standing in for the
+        image-verified is_claude_process_alive.
+        """
+        harness, state = _fresh_state(self.ROLE, self.CLONE)
+        agent = state.agents[self.ROLE]
+        agent.claude_pid = in_mem_pid
+        agent.status = "running"
+        agent.intent = harness.AgentState.INTENT_RUNNING
+        if agent_setup:
+            agent_setup(agent)
+
+        boot_agent = MagicMock(return_value={"success": True, "terminal_pid": 1})
+        write_pid = MagicMock(return_value=True)
+        health = MagicMock(return_value={"health": legacy_health})
+
+        monkeypatch.setattr(harness.boot_remote, "_get_all_roles",
+                            lambda: [self.ROLE])
+        monkeypatch.setattr(harness.boot_remote, "_get_clone_path",
+                            lambda r: self.CLONE)
+        monkeypatch.setattr(harness.boot_remote, "boot_agent", boot_agent)
+        monkeypatch.setattr(harness.process_utils, "is_claude_process_alive",
+                            claude_alive)
+        monkeypatch.setattr(harness.reboot_agent, "_read_claude_pid",
+                            lambda c, r: (file_pid, file_alive))
+        monkeypatch.setattr(harness.reboot_agent, "write_claude_pid", write_pid)
+        monkeypatch.setattr(harness.health_check, "check_agent_health",
+                            lambda *a, **k: health())
+        monkeypatch.setattr(state, "save_state", lambda: None)
+
+        state.update_health()
+        return agent, boot_agent, write_pid
+
+    def test_ac4_i_stale_file_live_recorded_in_state_stays_running(self, monkeypatch):
+        """Stale (dead) .claude-pid + live claude recorded in state →
+        agent detected running, not respawned; file self-healed."""
+        agent, boot_agent, write_pid = self._run(
+            monkeypatch,
+            in_mem_pid=5000,                  # restored from harness state
+            file_pid=9999, file_alive=False,  # stale dead PID on disk
+            claude_alive=lambda pid: pid == 5000,
+        )
+        assert agent.status == "running"
+        assert agent.claude_pid == 5000
+        boot_agent.assert_not_called()        # AC2 — never respawned
+        write_pid.assert_called_once_with(self.CLONE, self.ROLE, 5000)  # C self-heal
+
+    def test_ac4_iii_missing_file_live_recorded_in_state_stays_running(self, monkeypatch):
+        """Missing .claude-pid + live claude recorded in state →
+        detected running; file written back from in-memory truth."""
+        agent, boot_agent, write_pid = self._run(
+            monkeypatch,
+            in_mem_pid=5000,
+            file_pid=None, file_alive=False,  # missing file
+            claude_alive=lambda pid: pid == 5000,
+        )
+        assert agent.status == "running"
+        boot_agent.assert_not_called()
+        write_pid.assert_called_once_with(self.CLONE, self.ROLE, 5000)
+
+    def test_ac3_recycled_nonclaude_pid_is_reclaimed(self, monkeypatch):
+        """A live PID recycled by a non-claude process must NOT be trusted as
+        the agent — it is reclaimed (treated dead) and the agent respawns."""
+        agent, boot_agent, write_pid = self._run(
+            monkeypatch,
+            in_mem_pid=None,                  # nothing recorded in state
+            file_pid=7777, file_alive=True,   # live, but NOT claude
+            claude_alive=lambda pid: False,   # image check fails for the recycled PID
+        )
+        # not trusted as alive → reconcile didn't adopt it, write-back skipped
+        boot_agent.assert_called_once_with(self.ROLE)   # respawned, not masked
+        write_pid.assert_not_called()
+        assert agent.claude_pid is None
+
+    def test_file_pid_adopted_when_image_verified(self, monkeypatch):
+        """In-memory PID dead but .claude-pid points at a live claude →
+        adopt it (AC1 reconcile) and keep running."""
+        agent, boot_agent, write_pid = self._run(
+            monkeypatch,
+            in_mem_pid=1234, file_pid=4242, file_alive=True,
+            claude_alive=lambda pid: pid == 4242,  # only the file PID is claude
+        )
+        assert agent.status == "running"
+        assert agent.claude_pid == 4242
+        boot_agent.assert_not_called()
+        # file already holds 4242 (file_pid == resolved pid) → no write-back
+        write_pid.assert_not_called()

--- a/tests/test_12460_progress_liveness.py
+++ b/tests/test_12460_progress_liveness.py
@@ -289,6 +289,12 @@ class TestShadowDivergenceLogging:
             patch("harness.boot_remote._get_all_roles", return_value=["skill"]),
             patch("harness.boot_remote._get_clone_path", return_value="/clone"),
             patch("harness.boot_remote._is_process_alive", return_value=pid_alive),
+            # #12294: the PID-based `alive` verdict now comes from the
+            # image-verified helper — drive it to keep the shadow-divergence
+            # scenarios deterministic; pin write-back to a no-op (would touch
+            # /clone otherwise).
+            patch("harness.process_utils.is_claude_process_alive", return_value=pid_alive),
+            patch("harness.reboot_agent.write_claude_pid", return_value=True),
             patch("harness.reboot_agent._read_claude_pid", return_value=(None, False)),
             patch("harness.boot_remote.boot_agent",
                   return_value={"success": True, "terminal_pid": 9, "action": "spawn"}),

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -471,6 +471,12 @@ class TestForceKillSafetyNet(unittest.TestCase):
                   return_value="/clone"),
             patch("harness.boot_remote._is_process_alive",
                   return_value=pid_alive),
+            # #12294: update_health now resolves liveness via the image-verified
+            # helper, so control that instead of the bare liveness check; pin
+            # write-back to a no-op so the self-heal doesn't touch /clone.
+            patch("harness.process_utils.is_claude_process_alive",
+                  return_value=pid_alive),
+            patch("harness.reboot_agent.write_claude_pid", return_value=True),
             patch("harness.time.time", return_value=fake_now),
             patch("harness._log"),
         ]
@@ -667,6 +673,10 @@ class TestCrashLoopBackoff(unittest.TestCase):
             patch("harness.boot_remote._get_clone_path", return_value="/clone"),
             patch("harness.boot_remote._is_process_alive",
                   return_value=pid_alive),
+            # #12294: image-verified liveness is the path update_health uses now.
+            patch("harness.process_utils.is_claude_process_alive",
+                  return_value=pid_alive),
+            patch("harness.reboot_agent.write_claude_pid", return_value=True),
             patch("harness.reboot_agent._read_claude_pid",
                   return_value=(None, False)),
             patch("harness.time.time", return_value=fake_now),
@@ -942,11 +952,29 @@ class TestRestartLifecycle(unittest.TestCase):
             (pid_changed=True).
         """
         kill = MagicMock()
+        # #12294: update_health resolves liveness via the image-verified helper
+        # for BOTH the stored PID and the .claude-pid file PID. Mirror the old
+        # two-source semantics with a per-PID side_effect: the stored PID's
+        # liveness is `stored_pid_alive`; the file PID's is `read_pid_return`'s
+        # alive flag. Write-back is pinned to a no-op (it would touch /clone).
+        stored_pid = hs.get_agent("skill").claude_pid
+        file_pid, file_alive = read_pid_return
+
+        def _claude_alive(pid):
+            if stored_pid is not None and pid == stored_pid:
+                return stored_pid_alive
+            if file_pid is not None and pid == file_pid:
+                return file_alive
+            return False
+
         patches = [
             patch("harness.boot_remote._get_all_roles", return_value=["skill"]),
             patch("harness.boot_remote._get_clone_path", return_value="/clone"),
             patch("harness.boot_remote._is_process_alive",
                   return_value=stored_pid_alive),
+            patch("harness.process_utils.is_claude_process_alive",
+                  side_effect=_claude_alive),
+            patch("harness.reboot_agent.write_claude_pid", return_value=True),
             patch("harness.reboot_agent._read_claude_pid",
                   return_value=read_pid_return),
             patch("harness.reboot_agent._kill_process", kill),
@@ -1584,8 +1612,12 @@ class TestHarnessHealthPolling(unittest.TestCase):
             (role_dir / ".claude-pid").write_text(str(os.getpid()), encoding="utf-8")
 
             hs = HarnessState()
+            # #12294: the test PID is this python process, not a claude.exe, so
+            # image verification would (correctly) reject it. Stub the
+            # image-verified check to True so the .claude-pid PID is adopted.
             with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
                  patch("harness.boot_remote._get_clone_path", return_value=tmpdir), \
+                 patch("harness.process_utils.is_claude_process_alive", return_value=True), \
                  patch("harness.HARNESS_STATE_FILE", Path(tmpdir) / ".harness-state.json"):
                 hs.update_health()
 
@@ -2203,6 +2235,7 @@ class TestIntentLifecycle(unittest.TestCase):
             with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
                  patch("harness.boot_remote._get_clone_path", return_value=tmpdir), \
                  patch("harness.boot_remote.boot_agent", return_value=spawn_result), \
+                 patch("harness.process_utils.is_claude_process_alive", return_value=True), \
                  patch("harness.HARNESS_STATE_FILE", Path(tmpdir) / ".harness-state.json"):
                 hs.update_health()
 
@@ -2230,8 +2263,11 @@ class TestManualRebootClearsStoppingIntent(unittest.TestCase):
             agent.claude_pid = None  # PID cleared when agent died
             hs.set_agent("skill", agent)
 
+            # #12294: os.getpid() is python, not claude — stub image-verify True.
             with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
                  patch("harness.boot_remote._get_clone_path", return_value=tmpdir), \
+                 patch("harness.process_utils.is_claude_process_alive", return_value=True), \
+                 patch("harness.reboot_agent.write_claude_pid", return_value=True), \
                  patch("harness.HARNESS_STATE_FILE", Path(tmpdir) / ".harness-state.json"):
                 hs.update_health()
 
@@ -2257,8 +2293,11 @@ class TestManualRebootClearsStoppingIntent(unittest.TestCase):
             agent.claude_pid = None
             hs.set_agent("skill", agent)
 
+            # #12294: os.getpid() is python, not claude — stub image-verify True.
             with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
                  patch("harness.boot_remote._get_clone_path", return_value=tmpdir), \
+                 patch("harness.process_utils.is_claude_process_alive", return_value=True), \
+                 patch("harness.reboot_agent.write_claude_pid", return_value=True), \
                  patch("harness.HARNESS_STATE_FILE", Path(tmpdir) / ".harness-state.json"):
                 hs.update_health()
 
@@ -2283,8 +2322,12 @@ class TestManualRebootClearsStoppingIntent(unittest.TestCase):
             agent.claude_pid = os.getpid()  # Same PID — stop is in-flight
             hs.set_agent("skill", agent)
 
+            # #12294: os.getpid() is python, not claude — stub image-verify True
+            # so the same-PID-alive case is exercised (intent stays STOPPING).
             with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
                  patch("harness.boot_remote._get_clone_path", return_value=tmpdir), \
+                 patch("harness.process_utils.is_claude_process_alive", return_value=True), \
+                 patch("harness.reboot_agent.write_claude_pid", return_value=True), \
                  patch("harness.HARNESS_STATE_FILE", Path(tmpdir) / ".harness-state.json"):
                 hs.update_health()
 

--- a/tests/test_process_utils.py
+++ b/tests/test_process_utils.py
@@ -169,6 +169,129 @@ class TestWin32KernelBinding:
         assert not hasattr(process_utils, "subprocess")
 
 
+class TestImageNameForPid:
+    """#12294: image-name-by-PID lookup (toolhelp on win32, /proc on POSIX)."""
+
+    def test_none_and_nonpositive_return_none(self):
+        assert process_utils.image_name_for_pid(None) is None
+        assert process_utils.image_name_for_pid(0) is None
+        assert process_utils.image_name_for_pid(-5) is None
+
+    def test_posix_reads_proc_comm_lowercased(self, monkeypatch):
+        monkeypatch.setattr(process_utils.sys, "platform", "linux")
+        fake_path = MagicMock(name="Path")
+        fake_path.return_value.read_text.return_value = "Claude\n"
+        monkeypatch.setattr(process_utils, "Path", fake_path)
+        assert process_utils.image_name_for_pid(4321) == "claude"
+        fake_path.assert_called_once_with("/proc/4321/comm")
+
+    def test_posix_oserror_returns_none(self, monkeypatch):
+        """No /proc entry (process gone, or macOS has no /proc) → undetermined."""
+        monkeypatch.setattr(process_utils.sys, "platform", "linux")
+        fake_path = MagicMock(name="Path")
+        fake_path.return_value.read_text.side_effect = OSError("no /proc")
+        monkeypatch.setattr(process_utils, "Path", fake_path)
+        assert process_utils.image_name_for_pid(4321) is None
+
+    def test_posix_empty_comm_returns_none(self, monkeypatch):
+        monkeypatch.setattr(process_utils.sys, "platform", "linux")
+        fake_path = MagicMock(name="Path")
+        fake_path.return_value.read_text.return_value = "\n"
+        monkeypatch.setattr(process_utils, "Path", fake_path)
+        assert process_utils.image_name_for_pid(4321) is None
+
+    # ---- Win32 toolhelp32 snapshot iteration ----
+
+    def _fake_snapshot(self, monkeypatch, procs, handle=999):
+        """Simulate CreateToolhelp32Snapshot + Process32First/Next walking
+        `procs` (a list of (pid, name) tuples). The side_effects populate the
+        caller's PROCESSENTRY32 via the byref pointer's ``_obj`` (same trick
+        the is_process_alive win32 tests use for the exit-code pointer)."""
+        fake = MagicMock(name="kernel32")
+        monkeypatch.setattr(process_utils, "_win32_kernel32", lambda: fake)
+        monkeypatch.setattr(process_utils.sys, "platform", "win32")
+        fake.CreateToolhelp32Snapshot.return_value = handle
+        state = {"i": 0}
+
+        def _fill(ptr, idx):
+            entry = ptr._obj
+            pid, name = procs[idx]
+            entry.th32ProcessID = pid
+            entry.szExeFile = name.encode("utf-8")
+            return 1
+
+        def first(snap, ptr):
+            state["i"] = 0
+            return _fill(ptr, 0) if procs else 0
+
+        def nxt(snap, ptr):
+            state["i"] += 1
+            return _fill(ptr, state["i"]) if state["i"] < len(procs) else 0
+
+        fake.Process32First.side_effect = first
+        fake.Process32Next.side_effect = nxt
+        return fake
+
+    def test_win32_found_returns_lowercased_image(self, monkeypatch):
+        fake = self._fake_snapshot(
+            monkeypatch, [(10, "System"), (4242, "Claude.exe"), (99, "node.exe")]
+        )
+        assert process_utils.image_name_for_pid(4242) == "claude.exe"
+        fake.CloseHandle.assert_called_once_with(999)
+
+    def test_win32_not_found_returns_none(self, monkeypatch):
+        """A live but unfindable PID is undetermined — caller falls back to
+        liveness, never mis-reclaims (AC2)."""
+        fake = self._fake_snapshot(monkeypatch, [(10, "System"), (99, "node.exe")])
+        assert process_utils.image_name_for_pid(4242) is None
+        fake.CloseHandle.assert_called_once_with(999)
+
+    def test_win32_invalid_handle_returns_none(self, monkeypatch):
+        invalid = process_utils.ctypes.c_void_p(-1).value
+        fake = self._fake_snapshot(monkeypatch, [(4242, "claude.exe")], handle=invalid)
+        assert process_utils.image_name_for_pid(4242) is None
+        fake.CloseHandle.assert_not_called()
+
+    def test_win32_empty_snapshot_returns_none(self, monkeypatch):
+        fake = self._fake_snapshot(monkeypatch, [])
+        assert process_utils.image_name_for_pid(4242) is None
+        fake.CloseHandle.assert_called_once_with(999)
+
+
+class TestIsClaudeProcessAlive:
+    """#12294: image-verified liveness — alive AND image is claude."""
+
+    def test_dead_pid_is_false(self, monkeypatch):
+        monkeypatch.setattr(process_utils, "is_process_alive", lambda pid: False)
+        # image lookup must not even be consulted for a dead PID
+        monkeypatch.setattr(process_utils, "image_name_for_pid",
+                            lambda pid: (_ for _ in ()).throw(AssertionError("should not call")))
+        assert process_utils.is_claude_process_alive(123) is False
+
+    def test_alive_claude_exe_is_true(self, monkeypatch):
+        monkeypatch.setattr(process_utils, "is_process_alive", lambda pid: True)
+        monkeypatch.setattr(process_utils, "image_name_for_pid", lambda pid: "claude.exe")
+        assert process_utils.is_claude_process_alive(123) is True
+
+    def test_alive_claude_posix_is_true(self, monkeypatch):
+        monkeypatch.setattr(process_utils, "is_process_alive", lambda pid: True)
+        monkeypatch.setattr(process_utils, "image_name_for_pid", lambda pid: "claude")
+        assert process_utils.is_claude_process_alive(123) is True
+
+    def test_alive_recycled_nonclaude_is_false(self, monkeypatch):
+        """AC3: a live PID recycled by an unrelated process is reclaimed."""
+        monkeypatch.setattr(process_utils, "is_process_alive", lambda pid: True)
+        monkeypatch.setattr(process_utils, "image_name_for_pid", lambda pid: "explorer.exe")
+        assert process_utils.is_claude_process_alive(123) is False
+
+    def test_alive_undetermined_image_falls_back_to_liveness(self, monkeypatch):
+        """AC2: when the image can't be determined, trust liveness so a live
+        agent we couldn't inspect is never mis-reclaimed."""
+        monkeypatch.setattr(process_utils, "is_process_alive", lambda pid: True)
+        monkeypatch.setattr(process_utils, "image_name_for_pid", lambda pid: None)
+        assert process_utils.is_claude_process_alive(123) is True
+
+
 class TestModuleReexports:
     """Importers should be able to alias via `as _is_process_alive`."""
 

--- a/tests/test_process_utils.py
+++ b/tests/test_process_utils.py
@@ -257,6 +257,11 @@ class TestImageNameForPid:
         assert process_utils.image_name_for_pid(4242) is None
         fake.CloseHandle.assert_called_once_with(999)
 
+    def test_win32_empty_image_name_is_none(self, monkeypatch):
+        """Empty szExeFile → undetermined (None), not a non-match (DS-12294-c1)."""
+        self._fake_snapshot(monkeypatch, [(4242, "")])
+        assert process_utils.image_name_for_pid(4242) is None
+
 
 class TestIsClaudeProcessAlive:
     """#12294: image-verified liveness — alive AND image is claude."""

--- a/tests/test_process_utils.py
+++ b/tests/test_process_utils.py
@@ -262,6 +262,15 @@ class TestImageNameForPid:
         self._fake_snapshot(monkeypatch, [(4242, "")])
         assert process_utils.image_name_for_pid(4242) is None
 
+    def test_win32_fault_is_swallowed_to_none(self, monkeypatch):
+        """A ctypes/Win32 fault must degrade to None, never propagate — the
+        harness calls this inside the fleet health poll (DS-12294-c3 F1)."""
+        monkeypatch.setattr(process_utils.sys, "platform", "win32")
+        boom = MagicMock(name="kernel32")
+        boom.CreateToolhelp32Snapshot.side_effect = OSError("ctypes boom")
+        monkeypatch.setattr(process_utils, "_win32_kernel32", lambda: boom)
+        assert process_utils.image_name_for_pid(4242) is None
+
 
 class TestIsClaudeProcessAlive:
     """#12294: image-verified liveness — alive AND image is claude."""

--- a/tests/test_thin_launcher.py
+++ b/tests/test_thin_launcher.py
@@ -522,6 +522,14 @@ class TestImageNameForPid12294:
         )
         assert thin_launcher._image_name_for_pid(4242) is None
 
+    def test_win32_empty_image_name_is_none(self, monkeypatch):
+        """Empty image name → undetermined (None), not a non-match (DS-12294-c1)."""
+        monkeypatch.setattr(thin_launcher.sys, "platform", "win32")
+        monkeypatch.setattr(
+            thin_launcher, "_win32_all_procs", lambda: {4242: (10, "")},
+        )
+        assert thin_launcher._image_name_for_pid(4242) is None
+
     def test_posix_reads_proc_comm(self, monkeypatch):
         monkeypatch.setattr(thin_launcher.sys, "platform", "linux")
         fake = MagicMock(name="proc-comm")

--- a/tests/test_thin_launcher.py
+++ b/tests/test_thin_launcher.py
@@ -284,12 +284,23 @@ class TestCheckSingleton:
         with patch("thin_launcher._is_process_alive", return_value=False):
             assert thin_launcher._check_singleton(str(tmp_path), "skill") is None
 
-    def test_alive_pid_returns_pid(self, tmp_path):
+    def test_alive_claude_pid_returns_pid(self, tmp_path):
         d = tmp_path / ".squidsquad" / "skill"
         d.mkdir(parents=True)
         (d / ".claude-pid").write_text("12345", encoding="utf-8")
-        with patch("thin_launcher._is_process_alive", return_value=True):
+        # #12294: held only when the live PID is image-verified as claude.
+        with patch("thin_launcher._is_claude_process_alive", return_value=True):
             assert thin_launcher._check_singleton(str(tmp_path), "skill") == 12345
+
+    def test_recycled_nonclaude_pid_returns_none(self, tmp_path):
+        """#12294 AC3: a live PID recycled by a non-claude process is stale —
+        image verification stops it from defeating singleton enforcement."""
+        d = tmp_path / ".squidsquad" / "skill"
+        d.mkdir(parents=True)
+        (d / ".claude-pid").write_text("12345", encoding="utf-8")
+        with patch("thin_launcher._is_process_alive", return_value=True), \
+             patch("thin_launcher._image_name_for_pid", return_value="explorer.exe"):
+            assert thin_launcher._check_singleton(str(tmp_path), "skill") is None
 
     def test_own_pid_treated_as_stale(self, tmp_path):
         """Defensive: if our own PID is in the file (shouldn't happen) it's stale."""
@@ -308,7 +319,7 @@ class TestSingletonEnforcement:
         (d / ".claude-pid").write_text("12345", encoding="utf-8")
 
         with patch("thin_launcher.os.getcwd", return_value=str(tmp_path)), \
-             patch("thin_launcher._is_process_alive", return_value=True), \
+             patch("thin_launcher._is_claude_process_alive", return_value=True), \
              patch("thin_launcher.subprocess.Popen") as mock_popen, \
              patch("sys.argv", ["thin_launcher.py", "skill"]):
             rc = thin_launcher.main()
@@ -485,3 +496,87 @@ class TestStaleScheduledLockReclaim:
             rc = thin_launcher.main()
         assert rc == 0
         mock_reclaim.assert_called_once_with(str(tmp_path))
+
+
+class TestImageNameForPid12294:
+    """#12294: thin_launcher's local mirror of process_utils.image_name_for_pid."""
+
+    def test_none_and_nonpositive(self):
+        assert thin_launcher._image_name_for_pid(None) is None
+        assert thin_launcher._image_name_for_pid(0) is None
+        assert thin_launcher._image_name_for_pid(-2) is None
+
+    def test_win32_uses_all_procs_lowercased(self, monkeypatch):
+        monkeypatch.setattr(thin_launcher.sys, "platform", "win32")
+        monkeypatch.setattr(
+            thin_launcher, "_win32_all_procs",
+            lambda: {4242: (10, "Claude.exe"), 99: (10, "node.exe")},
+        )
+        assert thin_launcher._image_name_for_pid(4242) == "claude.exe"
+
+    def test_win32_not_found_is_none(self, monkeypatch):
+        """Undetermined image (PID absent from snapshot) — caller falls back."""
+        monkeypatch.setattr(thin_launcher.sys, "platform", "win32")
+        monkeypatch.setattr(
+            thin_launcher, "_win32_all_procs", lambda: {99: (10, "node.exe")},
+        )
+        assert thin_launcher._image_name_for_pid(4242) is None
+
+    def test_posix_reads_proc_comm(self, monkeypatch):
+        monkeypatch.setattr(thin_launcher.sys, "platform", "linux")
+        fake = MagicMock(name="proc-comm")
+        fake.read_text.return_value = "Claude\n"
+        monkeypatch.setattr(thin_launcher, "Path", lambda *a, **k: fake)
+        assert thin_launcher._image_name_for_pid(4242) == "claude"
+
+    def test_posix_oserror_is_none(self, monkeypatch):
+        monkeypatch.setattr(thin_launcher.sys, "platform", "linux")
+        fake = MagicMock(name="proc-comm")
+        fake.read_text.side_effect = OSError("no /proc")
+        monkeypatch.setattr(thin_launcher, "Path", lambda *a, **k: fake)
+        assert thin_launcher._image_name_for_pid(4242) is None
+
+
+class TestIsClaudeProcessAlive12294:
+    """#12294: thin_launcher's local image-verified liveness mirror."""
+
+    def test_dead_is_false(self, monkeypatch):
+        monkeypatch.setattr(thin_launcher, "_is_process_alive", lambda pid: False)
+        assert thin_launcher._is_claude_process_alive(123) is False
+
+    def test_alive_claude_is_true(self, monkeypatch):
+        monkeypatch.setattr(thin_launcher, "_is_process_alive", lambda pid: True)
+        monkeypatch.setattr(thin_launcher, "_image_name_for_pid", lambda pid: "claude.exe")
+        assert thin_launcher._is_claude_process_alive(123) is True
+
+    def test_alive_nonclaude_is_false(self, monkeypatch):
+        monkeypatch.setattr(thin_launcher, "_is_process_alive", lambda pid: True)
+        monkeypatch.setattr(thin_launcher, "_image_name_for_pid", lambda pid: "explorer.exe")
+        assert thin_launcher._is_claude_process_alive(123) is False
+
+    def test_alive_undetermined_falls_back_to_liveness(self, monkeypatch):
+        monkeypatch.setattr(thin_launcher, "_is_process_alive", lambda pid: True)
+        monkeypatch.setattr(thin_launcher, "_image_name_for_pid", lambda pid: None)
+        assert thin_launcher._is_claude_process_alive(123) is True
+
+
+class TestWin32AllProcs12294:
+    """#12294: _win32_all_procs feeds both descendant walk and image lookup."""
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="toolhelp32 is Windows-only")
+    def test_returns_self_and_known_processes(self):
+        procs = thin_launcher._win32_all_procs()
+        assert isinstance(procs, dict)
+        assert procs, "snapshot should never be empty on a live Windows host"
+        # our own PID must be present, mapped to (ppid, image_name)
+        assert os.getpid() in procs
+        ppid, name = procs[os.getpid()]
+        assert isinstance(ppid, int)
+        assert name.lower().startswith("python")
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="toolhelp32 is Windows-only")
+    def test_descendants_still_work_after_refactor(self):
+        # _win32_list_descendants now delegates to _win32_all_procs; smoke-test
+        # it still returns a list without error for our own PID.
+        out = thin_launcher._win32_list_descendants(os.getpid())
+        assert isinstance(out, list)


### PR DESCRIPTION
## #12294 — Keep `.claude-pid` authoritative across harness restart

Restart-time liveness hardening. Design **C + A** (dependency-free), per the locked RCA on the issue.

### What changed
- **`process_utils`** (A, read-side): `image_name_for_pid()` (win32 toolhelp32 / posix `/proc/<pid>/comm`; `None` = undetermined) + `is_claude_process_alive()` (alive **and** image is claude; undetermined image → fall back to plain liveness so a live agent is never mis-reclaimed). Helpers are **total** — any ctypes fault degrades to `None`, never propagates.
- **`thin_launcher`** (A): factored `_win32_all_procs()`; local mirrors of the image helpers (kept local per #8891); `_check_singleton` now image-verifies, so a recycled non-claude PID can't defeat singleton enforcement.
- **`harness.update_health`** (C+A): image-verifies the in-memory and `.claude-pid` PIDs (reconcile, not blind trust); **self-heals** `.claude-pid` from in-memory truth via new `reboot_agent.write_claude_pid` when missing/divergent (gated on `intent==RUNNING` to avoid racing a respawn). The whole resolution block is guarded so a fault degrades one agent to "treat as dead" rather than aborting the fleet poll.

### AC coverage
- **AC1** (reconcile from real process, not stale file) — ✅ image-verify the recorded/file PID.
- **AC2 + AC4** (live agent detected running across restart, not respawned) — ✅ for the realistic scenario: the harness persists `claude_pid` in `.harness-state.json`, so a restart restores it and image-verify confirms it even with a missing/stale `.claude-pid`, plus self-heal write-back.
- **AC3** (stale/recycled `.claude-pid` reclaimed, not trusted) — ✅ dead short-circuits; live non-claude reclaimed via image-verify.
- **AC4 regression test** — ✅ exercised through `update_health` (stale/missing file + recorded-live; recycled non-claude reclaimed; file PID adopted when claude).

### Out of dependency-free scope (human gate)
The *truly never-recorded* orphan — a live `claude.exe` whose PID was never in `.claude-pid` **nor** harness state — can't be re-adopted dependency-free. terminal_pid descendant re-resolution doesn't work on Windows (the recorded `terminal_pid` is the short-lived `cmd /c start` process). Recovering it needs psutil cwd/cmdline discovery → a new dependency requiring human approval. Tracked separately.

### Tests / review
- Full static gate: **4787 passed, 0 failures**.
- Two DeepSeek/Claude review passes folded in (DS-c1 empty-image parity; DS-c3 blocker fix — total helpers + guarded poll + write-back race gate).

Closes #12294 (dependency-free scope).