### PR TITLE
skill: #12363 kill process tree/group so event_poll sidecar is reaped

### DIFF
--- a/references/scripts/reboot_agent.py
+++ b/references/scripts/reboot_agent.py
@@ -67,8 +67,12 @@ def _kill_process(pid):
         return
     if sys.platform == "win32":
         try:
+            # #12363: /T terminates the process TREE, not just the claude PID,
+            # so the Monitor-spawned event_poll.py sidecar (a descendant of
+            # claude) dies with it instead of orphaning. Without /T the host
+            # accumulated ~13 claude + ~12 event_poll across respawns.
             subprocess.run(
-                ["taskkill", "/F", "/PID", str(pid)],
+                ["taskkill", "/F", "/T", "/PID", str(pid)],
                 check=False, capture_output=True,
             )
         except (OSError, FileNotFoundError):
@@ -76,14 +80,24 @@ def _kill_process(pid):
             # best-effort posture as the POSIX branch below.
             pass
     else:
+        # #12363: kill the process GROUP so the event_poll.py descendant dies
+        # with claude (a bare SIGKILL on the claude PID orphans it — the POSIX
+        # analogue of the Windows leak). SAFETY: never kill our OWN group — if a
+        # claude somehow shares the harness's group, killpg would take the
+        # harness down; fall back to a bare SIGKILL of the agent PID there (no
+        # regression vs the pre-#12363 behavior).
         try:
-            os.kill(pid, signal.SIGKILL)
-        except (ProcessLookupError, PermissionError, TypeError):
-            # Already dead (PLE), owned by a different UID (Permission),
-            # or a bad-type slipped past the guard (TypeError). All
-            # best-effort no-ops — the force-kill safety net in
-            # update_health will re-check on the next poll, and the
-            # operator can fall back to the harness API for diagnostics.
+            pgid = os.getpgid(pid)
+            if pgid != os.getpgid(0):
+                os.killpg(pgid, signal.SIGKILL)
+            else:
+                os.kill(pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, TypeError, OSError):
+            # Already dead (PLE), owned by a different UID (Permission), a
+            # bad-type past the guard (TypeError), or a getpgid/killpg failure
+            # (OSError, e.g. the group vanished mid-call). All best-effort
+            # no-ops — the force-kill safety net in update_health re-checks on
+            # the next poll, and the operator can fall back to the harness API.
             pass
 
 

--- a/tests/test_reboot_agent.py
+++ b/tests/test_reboot_agent.py
@@ -67,7 +67,7 @@ class TestReadClaudePid:
 class TestKillProcess:
     @pytest.mark.skipif(sys.platform != "win32",
                         reason="Windows-only — taskkill /F path")
-    def test_kill_windows_uses_taskkill_force(self):
+    def test_kill_windows_uses_taskkill_force_tree(self):
         with patch("reboot_agent.subprocess.run") as run:
             reboot_agent._kill_process(12345)
         run.assert_called_once()
@@ -75,36 +75,56 @@ class TestKillProcess:
         assert cmd[:2] == ["taskkill", "/F"], (
             "Windows kill must use taskkill /F for uninterruptible termination"
         )
+        # #12363: /T kills the process TREE so the event_poll.py sidecar dies too
+        assert "/T" in cmd, "Windows kill must pass /T to reap the child tree"
         assert "12345" in cmd
 
     @pytest.mark.skipif(sys.platform == "win32",
-                        reason="POSIX-only — SIGKILL path")
-    def test_kill_posix_uses_sigkill(self):
-        """SIGKILL is the only signal POSIX guarantees cannot be caught or
-        ignored — required to match Windows taskkill /F semantics in force
-        contexts (CONTEXT-4792.md §3.3 Q7)."""
+                        reason="POSIX-only — killpg path")
+    def test_kill_posix_kills_process_group(self):
+        """#12363: kill the process GROUP (SIGKILL) so the event_poll.py
+        descendant dies with claude instead of orphaning."""
         import signal
-        with patch("reboot_agent.os.kill") as kill:
+        with patch("reboot_agent.os.getpgid",
+                   side_effect=lambda p: 111 if p == 12345 else 222), \
+             patch("reboot_agent.os.killpg") as killpg, \
+             patch("reboot_agent.os.kill") as kill:
             reboot_agent._kill_process(12345)
+        killpg.assert_called_once_with(111, signal.SIGKILL)
+        kill.assert_not_called()
+
+    @pytest.mark.skipif(sys.platform == "win32",
+                        reason="POSIX-only — own-group fallback")
+    def test_kill_posix_falls_back_to_sigkill_for_own_group(self):
+        """#12363 SAFETY: if the target shares the harness's OWN group, killpg
+        would take the harness down — fall back to a bare SIGKILL of the PID."""
+        import signal
+        with patch("reboot_agent.os.getpgid", return_value=555), \
+             patch("reboot_agent.os.killpg") as killpg, \
+             patch("reboot_agent.os.kill") as kill:
+            reboot_agent._kill_process(12345)  # getpgid(pid)==getpgid(0)==555
+        killpg.assert_not_called()
         kill.assert_called_once_with(12345, signal.SIGKILL)
 
     @pytest.mark.skipif(sys.platform == "win32",
                         reason="POSIX-only — ProcessLookupError path")
     def test_kill_already_dead_pid_swallows_process_lookup_error(self):
-        """POSIX: killing a non-existent PID raises ProcessLookupError; the
-        helper must swallow it so callers don't crash on already-dead PIDs."""
-        with patch("reboot_agent.os.kill", side_effect=ProcessLookupError()):
-            # Must not raise
-            reboot_agent._kill_process(12345)
+        """POSIX: killing a non-existent PID raises ProcessLookupError (here from
+        getpgid); the helper must swallow it so callers don't crash on
+        already-dead PIDs."""
+        with patch("reboot_agent.os.getpgid", side_effect=ProcessLookupError()):
+            reboot_agent._kill_process(12345)  # must not raise
 
     @pytest.mark.skipif(sys.platform == "win32",
                         reason="POSIX-only — PermissionError path")
     def test_kill_permission_error_swallowed(self):
         """POSIX: a process owned by another UID raises PermissionError on
-        SIGKILL. The force-kill safety net runs inside update_health, which
+        killpg. The force-kill safety net runs inside update_health, which
         must NOT crash the harness on a permission denial — the next poll
         will re-evaluate."""
-        with patch("reboot_agent.os.kill", side_effect=PermissionError()):
+        with patch("reboot_agent.os.getpgid",
+                   side_effect=lambda p: 111 if p == 12345 else 222), \
+             patch("reboot_agent.os.killpg", side_effect=PermissionError()):
             reboot_agent._kill_process(12345)  # must not raise
 
 
@@ -143,9 +163,11 @@ class TestKillProcessPidValidation10530:
         """If a bad-type PID slips past the guard (e.g. a Mock object),
         os.kill raises TypeError. Mirror the ProcessLookupError /
         PermissionError swallow behavior so the harness doesn't crash."""
-        with patch("reboot_agent.os.kill", side_effect=TypeError("bad pid")):
-            # Pass a valid-shape int so the guard doesn't catch it before
-            # the stub gets to raise.
+        with patch("reboot_agent.os.getpgid", return_value=555), \
+             patch("reboot_agent.os.kill", side_effect=TypeError("bad pid")):
+            # getpgid(pid)==getpgid(0)==555 → own-group fallback reaches
+            # os.kill, whose TypeError must be swallowed. Pass a valid-shape int
+            # so the guard doesn't catch it before the stub raises.
             reboot_agent._kill_process(12345)  # must not raise
 
     @pytest.mark.skipif(sys.platform != "win32",


### PR DESCRIPTION
## #12363 — orphaned claude.exe / event_poll processes accumulate across respawns

`_kill_process` (the shared teardown helper for all three paths: poller-respawn, idle-restart, force-kill net) killed **only** the claude PID — `taskkill /F /PID` on Windows, a bare `SIGKILL` on POSIX. The Monitor-spawned `event_poll.py` sidecar is a *descendant* of claude, so it survived each kill and orphaned. Over a churny session the host reached ~13 claude + ~12 event_poll for 4 agents.

### Fix (RCA pinned by PM + skill)
Kill the whole tree/group via the shared helper (all three paths inherit it):
- **Windows**: `taskkill /F /T /PID <pid>` — `/T` reaps the child tree (claude → event_poll).
- **POSIX**: `os.killpg(os.getpgid(pid), SIGKILL)` so the group dies together, with a **safety fallback** to a bare `SIGKILL` of the PID when the target shares the harness's *own* group (`getpgid(pid) == getpgid(0)`) — killpg there would take the harness down. No regression vs prior behavior.

### Tests
- Full static gate: 0 failures. `test_reboot_agent.py`: Windows `/T`; POSIX killpg; POSIX own-group fallback; error swallows (ProcessLookup / Permission / Type / OSError). POSIX cases run on the qa CI host (skipped on the Windows dev box).

### Scope
Split from #12342 ask 3. The reaping gap is the fix here; #12282 (reboot-churn root cause) already shipped to reduce the churn that produced the orphans.

Closes #12363.