### PR TITLE
#12861: sub-skill manifest-completeness gate

### DIFF
--- a/tests/test_installer_wiring.py
+++ b/tests/test_installer_wiring.py
@@ -17,14 +17,31 @@ a rename or path change in any one file is caught immediately.
 """
 
 import re
+import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SKILL_MD = REPO_ROOT / "SKILL.md"
 WIZARD_MD = REPO_ROOT / "references" / "wizard" / "WIZARD.md"
 CLI_JS = REPO_ROOT / "packages" / "cli" / "index.js"
+
+# #12861: the sub-skill marker-completeness gate reuses the SAME catalog
+# resolver the compose catalog gate runs at deploy time (compose.py:1217),
+# so a `→ run sub-skill: <name>` reference resolves to its source path
+# exactly as runtime does.
+sys.path.insert(0, str(REPO_ROOT / "references" / "scripts"))
+import catalog_parser as _catalog_parser  # noqa: E402
+
+# Backtick-tolerant marker matcher. v2_catalog_gate._REF_RE matches only
+# BARE names — fine for composed output (the link stage emits markers
+# bare), but markers hand-authored INSIDE a sub-skill body are styled
+# with backticks (e.g. git-commit.md's ``→ run sub-skill: `pr-protocol` ``).
+# The completeness gate must follow those chained references, so it
+# tolerates the optional backticks the shared regex does not.
+_SUBSKILL_MARKER_RE = re.compile(r"→\s+run\s+sub-skill:\s+`?([a-z][a-z0-9/_-]*)`?")
 
 
 @pytest.fixture(scope="module")
@@ -355,6 +372,104 @@ class TestInstallerFileManifest:
         )
         assert not missing, (
             f"MANIFEST_EXCLUDED_SCRIPTS lists non-existent files: {missing}"
+        )
+
+    # #12861: the script-completeness gate above (#12909) protects
+    # references/scripts/*.py. The two tests below are its sub-skill
+    # analogue — they close the class that silently un-shipped
+    # l4-curation / pr-protocol / tracker-protocol / task-pickup: a
+    # sub-skill that an agent Reads at runtime (or that compose inlines)
+    # but that installer-files.txt never lists, so a fresh `npx
+    # squidsquad` install never fetches it and the reference dangles.
+
+    def test_every_marker_referenced_subskill_listed(self, manifest_entries):
+        """Every sub-skill reachable from a composed CLAUDE.md via
+        `→ run sub-skill: <name>` markers — directly OR through a chain of
+        sub-skill bodies — must resolve via the catalog to a source path
+        that IS in installer-files.txt.
+
+        Reactive/runtime-loaded sub-skills (l4-curation, pr-protocol,
+        harness-restart, the per-role issue-filing variants, …) are NOT
+        inlined — the agent Reads the source file from disk when it hits
+        the marker. Markers also CHAIN: a composed CLAUDE.md references
+        `git-commit`, whose body references `pr-protocol`. So the gate
+        walks the transitive closure, not just the top-level references.
+        Any file in that closure missing from the manifest would never be
+        fetched by a fresh `npx squidsquad` install → the marker dangles.
+
+        Unresolved names (no catalog row) are intentionally skipped here —
+        catalog completeness is a separate concern owned by the compose
+        catalog gate (test_v2_catalog_gate_d3), and skipping them also
+        ignores illustrative markers inside sub-skill bodies (e.g. the
+        `security-smoke` example op-block in l4-curation.md, which is never
+        a real runtime reference).
+        """
+        catalog = _catalog_parser.parse_catalog(
+            REPO_ROOT / "docs" / "sub-skill-catalog.md"
+        )
+        composed = sorted((REPO_ROOT / ".squidsquad").glob("*/CLAUDE.md"))
+        assert composed, (
+            "no composed .squidsquad/<alias>/CLAUDE.md found — expected the "
+            "self-hosted install's deployed agent files"
+        )
+
+        def markers(text):
+            return _SUBSKILL_MARKER_RE.findall(text)
+
+        # Seed the closure with every marker in every composed CLAUDE.md,
+        # then walk resolved sub-skill bodies until no new names appear.
+        queue = []
+        for path in composed:
+            queue.extend(markers(path.read_text(encoding="utf-8")))
+        resolved = {}  # name -> source_path
+        seen = set()
+        while queue:
+            name = queue.pop()
+            if name in seen:
+                continue
+            seen.add(name)
+            source_path = catalog.get(name)
+            if source_path is None:
+                continue  # catalog-resolution is a separate gate's job
+            resolved[name] = source_path
+            body = REPO_ROOT / source_path
+            if body.is_file():
+                queue.extend(markers(body.read_text(encoding="utf-8")))
+
+        listed = set(manifest_entries)
+        dangling = sorted(sp for sp in set(resolved.values()) if sp not in listed)
+        assert not dangling, (
+            "sub-skills reachable from composed CLAUDE.md via `→ run "
+            "sub-skill:` markers (incl. chained references) but NOT in "
+            "installer-files.txt — a fresh npx install would never fetch "
+            f"them, so the markers dangle: {dangling}"
+        )
+
+    def test_every_includes_yml_subskill_listed(self, manifest_entries):
+        """Every sub-skill inlined at compose time via a role's
+        includes.yml must be in installer-files.txt AND exist on disk.
+
+        The wizard composes each agent from the FETCHED source on a fresh
+        install (deploy_role_v2). A compose-time include that was never
+        fetched fails the install's compose step — the same un-shipped
+        class, surfaced at compose rather than at runtime.
+        """
+        listed = set(manifest_entries)
+        problems = []  # (name, source_path, reason)
+        for inc_yml in sorted((REPO_ROOT / "references" / "roles").glob("*/includes.yml")):
+            data = yaml.safe_load(inc_yml.read_text(encoding="utf-8")) or {}
+            for name in (data.get("includes") or []):
+                source_path = f"references/sub-skills/{name}.md"
+                if not (REPO_ROOT / source_path).is_file():
+                    problems.append((source_path, inc_yml.parent.name, "missing-on-disk"))
+                elif source_path not in listed:
+                    problems.append((source_path, inc_yml.parent.name, "not-in-manifest"))
+        assert not problems, (
+            "includes.yml sub-skills not shippable on a fresh install: "
+            + ", ".join(
+                f"{sp} ({reason}, from roles/{role}/includes.yml)"
+                for sp, role, reason in sorted(problems)
+            )
         )
 
 


### PR DESCRIPTION
Closes #12861. Adds the durable regression gate that prevents sub-skills referenced at runtime (or compose time) from silently un-shipping on a fresh `npx squidsquad` install.

## Context
Part (1) of the bug (4 missing manifest entries) was **already resolved** — facts check confirms all 34 marker-referenced sub-skills are in installer-files.txt. This PR delivers part (2): the completeness TEST, the sub-skill analogue of the #12909 `test_every_runtime_script_listed_or_excluded` script gate.

## Tests (tests/test_installer_wiring.py)
- **test_every_marker_referenced_subskill_listed** — walks the TRANSITIVE closure of `→ run sub-skill:` markers from all composed CLAUDE.md (seed) through resolved sub-skill bodies (chain), resolving each via the same catalog parser the deploy-time gate uses (compose.py:1217), and asserts every resolved source path is in the manifest. Catches chained refs (composed→git-commit→pr-protocol). Backtick-tolerant matcher (body-authored markers are styled `name`; the shared `_REF_RE` is bare-only). Unresolved names skipped (owned by the compose catalog gate).
- **test_every_includes_yml_subskill_listed** — every compose-time include in a role includes.yml must be manifested AND exist on disk.

## Verification
- 29/29 in test_installer_wiring.py; full static gate 53/0.
- **Negative-verified**: dropping any closure member (e.g. pr-protocol) fails the gate.
- DS review: NO_FINDINGS.

## Follow-up filed
- **#13052** — latent `v2_catalog_gate._REF_RE` bare-only gap (misses backtick-wrapped chained markers at compose time); kept out of scope.

No CQ — deterministic Python test, not LLM-consumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)