### PR TITLE
#13042: decay() must not rewrite updated: (VAULT-ARCH §4.4)

### DIFF
--- a/references/scripts/vault_optimize.py
+++ b/references/scripts/vault_optimize.py
@@ -382,18 +382,24 @@ def decay(dry_run=False):
                 decayed.append(f"[dry-run] {rel}: {confidence} -> {new_confidence}")
             else:
                 today = datetime.now().strftime("%Y-%m-%d")
-                # Scope rewrites to frontmatter only (#6514) — avoid corrupting body
+                # Scope rewrites to frontmatter only (#6514) — avoid corrupting body.
+                # Decay rewrites ONLY `confidence:`, never `updated:` (#13042):
+                # VAULT-ARCH §4.4 — "Decay steps do NOT modify `updated:`"; the
+                # decay clock keys off the last human/agent semantic edit, not the
+                # decay event. Bumping `updated:` here restarts the medium→low clock
+                # from the decay (so a note never reaches `low` on the 120-day-from-
+                # edit schedule) and hides just-decayed notes from the next
+                # decay-scan for ~60 days. The decay event is recorded by the
+                # changelog entry below, which is the correct audit trail.
                 fm_end = text.find("---", 3)
                 if fm_end != -1:
                     header = text[:fm_end + 3]
                     body = text[fm_end + 3:]
                     header = header.replace(f"confidence: {confidence}", f"confidence: {new_confidence}", 1)
-                    header = re.sub(r"updated: \S+", f"updated: {today}", header, count=1)
                     new_text = header + body
                 else:
                     # No frontmatter boundary — fall back to full-text (shouldn't happen)
                     new_text = text.replace(f"confidence: {confidence}", f"confidence: {new_confidence}", 1)
-                    new_text = re.sub(r"updated: \S+", f"updated: {today}", new_text, count=1)
 
                 # Append changelog entry
                 changelog_entry = f"- {today} — Confidence decayed by vault-optimize (staleness)."

--- a/tests/test_vault_optimize.py
+++ b/tests/test_vault_optimize.py
@@ -1,6 +1,7 @@
 """Tests for references/scripts/vault_optimize.py — fake vault corpus, no real git."""
 
 import json
+import re
 import sys
 import time
 from datetime import datetime, timedelta
@@ -230,6 +231,34 @@ class TestDecay:
         text = path.read_text(encoding="utf-8")
         assert "confidence: medium" in text
         assert "Confidence decayed by vault-optimize" in text
+
+    def test_decay_preserves_updated_field(self, patched_vault):
+        """#13042 / VAULT-ARCH §4.4: decay rewrites `confidence:` but must
+        NOT touch `updated:`. The decay clock keys off the last human/agent
+        semantic edit, not the decay event — bumping `updated:` to today
+        restarts the medium→low clock (so the note never reaches `low` on
+        the 120-day-from-edit schedule) and hides the just-decayed note from
+        the next decay-scan for ~60 days. The decay event is recorded by the
+        changelog entry instead.
+        """
+        path = patched_vault / "galaxy" / "decision-stale-high.md"
+        updated_before = re.search(
+            r"updated: (\S+)", path.read_text(encoding="utf-8")
+        ).group(1)
+
+        results = vault_optimize.decay(dry_run=False)
+        assert any("decision-stale-high" in r for r in results)
+
+        after = path.read_text(encoding="utf-8")
+        assert "confidence: medium" in after  # confidence did decay
+        updated_after = re.search(r"updated: (\S+)", after).group(1)
+        assert updated_after == updated_before, (
+            f"decay rewrote updated: {updated_before} -> {updated_after}; "
+            "VAULT-ARCH §4.4 requires it be preserved (the #13042 bug)"
+        )
+        assert updated_after != datetime.now().strftime("%Y-%m-%d"), (
+            "decay bumped updated: to today — the #13042 regression"
+        )
 
     def test_decay_does_not_corrupt_body_content(self, patched_vault):
         """#6514: Body containing 'confidence: high' must not be modified."""


### PR DESCRIPTION
Fixes #13042. The confidence-decay clock was broken: `vault_optimize.py decay()` rewrote a note's `updated:` to today in the same operation as the confidence change, so the medium→low clock restarted from the decay event (a note never reached `low` on the intended 120-day-from-last-edit schedule) and just-decayed notes were invisible to `decay-scan` for ~60 days.

VAULT-ARCH §4.4 (line 204): *"Decay steps do NOT modify `updated:`"*.

## Fix
- Remove both `updated:` `re.sub` rewrites from `decay()` (the frontmatter-scoped path + the no-frontmatter fallback). Keep the `confidence:` rewrite and the changelog body entry (which records the decay event with today's date — the correct audit trail).
- Regression test `test_decay_preserves_updated_field`: asserts `updated:` is unchanged after decay AND not bumped to today. **Negative-verified**: fails against the pre-fix code.

## Verification
- `tests/test_vault_optimize.py`: 30/30. Full static gate: 53/0.
- DS review: core fix confirmed correct; Integration/Regression check found no other consumer relied on the `updated:` bump (prune/relevance/decay all read it for staleness/recency — fix makes them MORE accurate). Two pre-existing findings adjacent to the diff (changelog heading-level mismatch + dead fallback) filed separately as **#13064**, kept out of scope.

Deterministic Python — no CQ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)