### PR TITLE
#13043: vault doc-alignment code fixes (#10838)

### DIFF
--- a/references/scripts/cycle_pre.py
+++ b/references/scripts/cycle_pre.py
@@ -638,8 +638,12 @@ def _read_config_flags():
     return {
         "pr_flow": _config_get("pr-flow").lower() in _YES,
         "improvement_scanning": _config_get("improvement-scanning").lower() in _YES,
-        "vault_remember": _config_get("vault-remember").lower() in _YES,
-        "vault_optimize": _config_get("vault-optimize").lower() in _YES,
+        # Vault remember/optimize are always-on — no enable/disable toggle
+        # (#13043). Activation is gated by quiet-cycle + note-count + cooldown,
+        # not config. Hardcoded True so cycle-input reflects always-on rather
+        # than reading a now-removed config field (which returns '' → False).
+        "vault_remember": True,
+        "vault_optimize": True,
     }
 
 

--- a/references/scripts/vault_check.py
+++ b/references/scripts/vault_check.py
@@ -22,7 +22,11 @@ VAULT_DIR = REPO_ROOT / ".squidsquad" / "vault"
 
 PARAG_DIRS = ["projects", "areas", "resources", "archives", "galaxy"]
 VALID_GALAXY_PREFIXES = ("decision-", "pattern-", "learning-", "style-")
-REQUIRED_FM_FIELDS = {"type", "tags", "created", "updated", "owner", "status", "confidence"}
+REQUIRED_FM_FIELDS = {"type", "tags", "created", "updated", "owner", "status", "confidence", "source"}
+# Galaxy notes over this many lines are flagged for splitting (#13043 /
+# VAULT-ARCH §4.3 + vault-protocol Level-1 check 5). Galaxy only — areas/
+# projects/resources are exempt.
+GALAXY_MAX_LINES = 500
 VALID_CONFIDENCE = {"high", "medium", "low"}
 VALID_SOURCES = {"conversation", "code", "review", "observation", "research"}
 
@@ -129,6 +133,36 @@ def check_frontmatter():
     else:
         print("OK: All galaxy note frontmatter valid")
     return issues
+
+
+def check_galaxy_size():
+    """Warn on galaxy notes exceeding GALAXY_MAX_LINES — suggest splitting.
+
+    Level-1 check 5 (vault-protocol.md): galaxy notes only; areas/projects/
+    resources are exempt (those legitimately grow). Advisory — returns a
+    warning list but does NOT fail validation, since an oversized note is a
+    split-suggestion, not a structural error (#13043).
+    """
+    warnings = []
+    galaxy_dir = VAULT_DIR / "galaxy"
+    if not galaxy_dir.exists():
+        return warnings
+
+    for note in sorted(galaxy_dir.glob("*.md")):
+        if note.name == ".gitkeep":
+            continue
+        line_count = note.read_text(encoding="utf-8").count("\n") + 1
+        if line_count > GALAXY_MAX_LINES:
+            warnings.append(
+                f"{note.name}: {line_count} lines (> {GALAXY_MAX_LINES}) — "
+                "consider splitting into focused notes"
+            )
+
+    for w in warnings:
+        print(f"[vault-check] WARN: {w}")
+    if not warnings:
+        print(f"OK: All galaxy notes within {GALAXY_MAX_LINES} lines")
+    return warnings
 
 
 def check_wikilinks():
@@ -330,6 +364,9 @@ def validate():
     all_issues.extend(check_structure())
     all_issues.extend(check_frontmatter())
     all_issues.extend(check_wikilinks())
+    # Galaxy size is advisory (split-suggestion) — surfaced but not counted
+    # toward the pass/fail total (#13043).
+    check_galaxy_size()
     list_orphans()
 
     total = len(all_issues)
@@ -358,6 +395,10 @@ def main():
     elif cmd == "check-wikilinks":
         issues = check_wikilinks()
         sys.exit(1 if issues else 0)
+    elif cmd == "check-size":
+        # Advisory: always exits 0 (warnings, not failures).
+        check_galaxy_size()
+        sys.exit(0)
     elif cmd == "list-orphans":
         list_orphans()
     elif cmd == "dedup-check":

--- a/references/scripts/vault_check.py
+++ b/references/scripts/vault_check.py
@@ -7,6 +7,7 @@ Usage:
     python scripts/vault_check.py validate           # Full vault validation
     python scripts/vault_check.py check-frontmatter   # Validate frontmatter in galaxy notes
     python scripts/vault_check.py check-wikilinks     # Find broken wikilinks
+    python scripts/vault_check.py check-size           # Warn on galaxy notes >500 lines (advisory)
     python scripts/vault_check.py check-structure      # Validate PARAG directory structure
     python scripts/vault_check.py list-orphans         # Notes not linked from anywhere
     python scripts/vault_check.py --help

--- a/references/scripts/vault_optimize.py
+++ b/references/scripts/vault_optimize.py
@@ -5,7 +5,7 @@ Covers 5 areas: prune (auto-archive stale+orphan), consolidate candidates,
 reindex (links), confidence decay, relevance scoring.
 
 Usage:
-    python scripts/vault_optimize.py full-sweep [--dry-run]       # Full optimize pass
+    python scripts/vault_optimize.py run [--dry-run]              # Full optimize pass (alias: full-sweep)
     python scripts/vault_optimize.py prune-scan [--dry-run]       # Archive stale+orphan notes
     python scripts/vault_optimize.py consolidate-scan [--dry-run]  # Detect merge candidates
     python scripts/vault_optimize.py decay-apply [--dry-run]       # Confidence decay
@@ -571,7 +571,10 @@ def main():
     cmd = args[0]
     dry_run = "--dry-run" in args
 
-    if cmd == "full-sweep":
+    if cmd in ("full-sweep", "run"):
+        # `run` is the canonical name in VAULT-ARCH §7.3/§8.3 and the
+        # vault-optimize sub-skill (~7 references); `full-sweep` is kept as
+        # the historical alias (#13043).
         results = run_optimize(dry_run=dry_run)
         print(json.dumps(results, indent=2, default=str))
 

--- a/references/scripts/vault_optimize.py
+++ b/references/scripts/vault_optimize.py
@@ -94,17 +94,14 @@ def _count_notes():
 
 
 def _is_config_enabled():
-    """Check if vault optimize is enabled in config.md."""
-    if not CONFIG_PATH.exists():
-        return True  # Default enabled
-    try:
-        text = CONFIG_PATH.read_text(encoding="utf-8")
-        m = re.search(r"Vault Optimize.*?Enabled.*?:\s*(yes|no)", text, re.IGNORECASE | re.DOTALL)
-        if m:
-            return m.group(1).lower() == "yes"
-    except Exception:
-        pass
-    return True  # Default enabled
+    """Vault optimize is always-on — there is no enable/disable toggle (#13043).
+
+    Activation is controlled by the quiet-cycle gate + the 20-note threshold
+    + the cooldown, not by config. Retained as a function (rather than deleting
+    the call sites) so the activation contract stays in one named place; it now
+    unconditionally returns True.
+    """
+    return True
 
 
 def _acquire_lock():

--- a/references/sub-skills/common/vault-optimize.md
+++ b/references/sub-skills/common/vault-optimize.md
@@ -31,4 +31,4 @@ Questions use plain language — never expose vault internals (galaxy, frontmatt
 
 **Status bar**: The pending question count is shown in the status bar. PM mentions it in check-in. Human responds when ready.
 
-If the vault is too small (<20 notes) or optimize is disabled, the script exits cleanly with no output.
+If the vault is too small (<20 notes), the script exits cleanly with no output.

--- a/references/sub-skills/common/vault-optimize.md
+++ b/references/sub-skills/common/vault-optimize.md
@@ -7,9 +7,7 @@ ordinal: 10
 
 During quiet cycles, check if vault optimization is needed. This step runs AFTER the improvement scan check — if the scan ran this cycle, skip optimization.
 
-**Config gate**: Check `Vault Optimize > Enabled` in `config.md`. If `no`, skip entirely.
-
-**Activation**: Only run when the vault has 20+ notes AND this is a quiet cycle with no other work.
+**Activation**: Vault-optimize is **always-on** — there is no enable/disable toggle. Only run when the vault has 20+ notes AND this is a quiet cycle with no other work (these gates are the activation control, #13043).
 
 Run the optimizer:
 

--- a/references/sub-skills/common/vault-protocol.md
+++ b/references/sub-skills/common/vault-protocol.md
@@ -91,7 +91,7 @@ Runs **automatically after every vault-create or vault-update**. Checks the writ
 
 For each note checked:
 
-1. **Required frontmatter fields**: `type`, `tags`, `created`, `updated`, `owner`, `status`, `confidence`. Warn if any are missing or empty.
+1. **Required frontmatter fields**: `type`, `tags`, `created`, `updated`, `owner`, `status`, `confidence`, `source`. Warn if any are missing or empty.
 2. **Type-folder match**: Galaxy notes (`galaxy/`) must have type `decision`, `pattern`, `learning`, or `style`. Area notes (`areas/`) must have type `area`. Project notes (`projects/`) must have type `project`. Warn on mismatch.
 3. **Wikilink resolution**: Parse all `[[note-name]]` in the body. For each, verify a file named `note-name.md` exists somewhere in `.squidsquad/vault/`. Warn for each unresolved wikilink.
 4. **Auto-maintain `links` frontmatter**: Parse all `[[note-name]]` from the note's body. Update the `links` field in frontmatter to match (bare names, YAML list). This is automatic — agents do not manually curate the `links` field.

--- a/references/sub-skills/common/vault-remember.md
+++ b/references/sub-skills/common/vault-remember.md
@@ -80,6 +80,8 @@ python references/scripts/vault_remember.py inc-writes [ROLE]
 1. Decisions (architectural choices compound)
 2. Learnings (failure lessons prevent repeat mistakes)
 3. Patterns (useful but can wait a cycle)
+4. Styles (convention drift is costly, but a single style note rarely can't wait)
+5. Project context (usually a BRIEFING.md update, not a budget-consuming write)
 
 Remaining candidates beyond the write budget are noted in the iteration log's Notes field: `Vault-worthy but deferred (budget): [description]`.
 

--- a/references/sub-skills/common/vault-remember.md
+++ b/references/sub-skills/common/vault-remember.md
@@ -10,11 +10,7 @@ Print: `[🦑 HH:MM:SS] Reflecting on cycle...`
 **Per-role write lane** (see [[vault-protocol]] for the full lane discipline). Each role writes patterns from its own lane only: PM = coordination/decision patterns; worker = implementation patterns; **verifier = testing/verification patterns ONLY — never debate PM or worker decisions in vault writes**; DM = delivery patterns. If a candidate learning is outside your lane, file it on the owning role's tracker as a `learning` note request instead of writing it yourself.
 
 
-**Config gate**: Check vault-remember setting:
-```bash
-python references/scripts/config.py get vault-remember
-```
-If `no`, skip this step entirely.
+Vault-remember is **always-on** — there is no enable/disable toggle. Activation is controlled by the quiet-cycle gate and the per-cycle write budget below (#13043).
 
 **BRIEFING.md staleness check** (runs every cycle — not gated by quiet check):
 
@@ -46,6 +42,8 @@ python references/scripts/vault_remember.py reset-writes [ROLE]
    → If yes: vault-create `galaxy/learning-*.md`
 4. **PROJECT CONTEXT**: Did project goals, constraints, or architecture change?
    → If yes: vault-update `projects/<name>.md` or `BRIEFING.md`
+5. **STYLES**: Did a coding/writing/process style convention get established or confirmed this cycle?
+   → If yes: vault-create `galaxy/style-*.md`
 
 For each candidate, apply these **deterministic gates IN ORDER**:
 

--- a/tests/test_cycle_pre.py
+++ b/tests/test_cycle_pre.py
@@ -474,7 +474,8 @@ class TestReadConfigFlags:
         result = cycle_pre._read_config_flags()
         assert result["pr_flow"] is False
         assert result["improvement_scanning"] is True
-        assert result["vault_remember"] is False
+        # Vault remember/optimize are always-on (#13043) — independent of config.
+        assert result["vault_remember"] is True
         assert result["vault_optimize"] is True
 
     def test_accepts_true_and_1_as_truthy(self, monkeypatch):
@@ -489,8 +490,23 @@ class TestReadConfigFlags:
         result = cycle_pre._read_config_flags()
         assert result["pr_flow"] is True
         assert result["improvement_scanning"] is True
+        # Always-on regardless of config value (#13043).
         assert result["vault_remember"] is True
-        assert result["vault_optimize"] is False
+        assert result["vault_optimize"] is True
+
+    def test_vault_flags_always_on_regardless_of_config(self, monkeypatch):
+        """#13043: vault remember/optimize have no enable/disable toggle —
+        cycle-input reports them on even when config says 'no' (or the field
+        is absent entirely)."""
+        monkeypatch.setattr(cycle_pre, "_config_get", lambda f: "no")
+        result = cycle_pre._read_config_flags()
+        assert result["vault_remember"] is True
+        assert result["vault_optimize"] is True
+        # And with the field absent (empty) — the post-removal config.md state:
+        monkeypatch.setattr(cycle_pre, "_config_get", lambda f: "")
+        result = cycle_pre._read_config_flags()
+        assert result["vault_remember"] is True
+        assert result["vault_optimize"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_vault_check.py
+++ b/tests/test_vault_check.py
@@ -167,6 +167,59 @@ class TestCheckFrontmatter:
             issues = vault_check.check_frontmatter()
         assert issues == []
 
+    def test_missing_source_flagged(self, tmp_path):
+        """#13043 item 4: `source` is a REQUIRED field (VAULT-ARCH §4.3).
+        A note with every other field but no `source` must be flagged.
+        """
+        vault = self._setup_galaxy(tmp_path, {
+            "decision-no-source.md": (
+                "---\ntype: decision\ntags: [test]\ncreated: 2026-01-01\n"
+                "updated: 2026-01-01\nowner: skill\nstatus: active\n"
+                "confidence: high\nlinks: []\n---\n\n## Content"
+            ),
+        })
+        with patch.object(vault_check, "VAULT_DIR", vault):
+            issues = vault_check.check_frontmatter()
+        assert any("missing fields" in i and "source" in i for i in issues), (
+            f"expected a missing-source flag, got: {issues}"
+        )
+
+
+class TestCheckGalaxySize:
+    """#13043 item 5 / vault-protocol Level-1 check 5: galaxy notes over
+    GALAXY_MAX_LINES are warned (advisory); areas/projects/resources exempt."""
+
+    def _vault_with_galaxy_note(self, tmp_path, line_count):
+        vault = tmp_path / "vault"
+        galaxy = vault / "galaxy"
+        galaxy.mkdir(parents=True)
+        body = "\n".join(f"line {i}" for i in range(line_count))
+        (galaxy / "decision-big.md").write_text(body, encoding="utf-8")
+        return vault
+
+    def test_oversized_galaxy_note_warns(self, tmp_path):
+        vault = self._vault_with_galaxy_note(tmp_path, vault_check.GALAXY_MAX_LINES + 50)
+        with patch.object(vault_check, "VAULT_DIR", vault):
+            warnings = vault_check.check_galaxy_size()
+        assert any("decision-big.md" in w for w in warnings)
+
+    def test_small_galaxy_note_ok(self, tmp_path):
+        vault = self._vault_with_galaxy_note(tmp_path, 10)
+        with patch.object(vault_check, "VAULT_DIR", vault):
+            warnings = vault_check.check_galaxy_size()
+        assert warnings == []
+
+    def test_oversized_area_note_exempt(self, tmp_path):
+        """Areas legitimately grow — never warned."""
+        vault = tmp_path / "vault"
+        areas = vault / "areas"
+        areas.mkdir(parents=True)
+        body = "\n".join(f"line {i}" for i in range(vault_check.GALAXY_MAX_LINES + 50))
+        (areas / "human-profile.md").write_text(body, encoding="utf-8")
+        with patch.object(vault_check, "VAULT_DIR", vault):
+            warnings = vault_check.check_galaxy_size()
+        assert warnings == []
+
 
 class TestCheckWikilinks:
     def test_valid_links(self, tmp_path):

--- a/tests/test_vault_optimize.py
+++ b/tests/test_vault_optimize.py
@@ -370,15 +370,19 @@ class TestCliRunAlias:
 # ---------------------------------------------------------------------------
 
 class TestGuards:
-    def test_config_disabled(self, patched_vault):
+    def test_config_enabled_field_is_ignored_always_on(self, patched_vault):
+        """#13043: vault-optimize is always-on — there is no enable/disable
+        toggle. A stale `Enabled: no` in config.md must NOT block the guards
+        (activation is gated by note-count + quiet-cycle + cooldown, not config)."""
         config = patched_vault.parent / "config.md"
         config.write_text(
             "# SquidSquad Config\n\n## Vault Optimize\n\n- **Enabled**: no\n",
             encoding="utf-8",
         )
         ok, reason = vault_optimize._check_guards()
-        assert not ok
-        assert "disabled" in reason
+        # patched_vault has 25 notes (above threshold), so guards pass despite
+        # the stale Enabled: no.
+        assert ok, f"always-on guards should pass; blocked with: {reason}"
 
     def test_vault_too_small(self, tmp_path, monkeypatch):
         small_vault = tmp_path / ".squidsquad" / "vault" / "galaxy"

--- a/tests/test_vault_optimize.py
+++ b/tests/test_vault_optimize.py
@@ -346,6 +346,26 @@ class TestPendingQuestions:
 
 
 # ---------------------------------------------------------------------------
+# CLI dispatch
+# ---------------------------------------------------------------------------
+
+class TestCliRunAlias:
+    def test_run_is_alias_for_full_sweep(self, patched_vault, monkeypatch, capsys):
+        """#13043 item 2: `vault_optimize.py run` must dispatch the same
+        full optimize pass as `full-sweep` (VAULT-ARCH §7.3/§8.3 and the
+        vault-optimize sub-skill reference `run`, which previously errored
+        with 'Unknown command: run')."""
+        monkeypatch.setattr(sys, "argv", ["vault_optimize.py", "run", "--dry-run"])
+        rc = vault_optimize.main()
+        out = capsys.readouterr().out
+        assert rc in (0, None)
+        # full-sweep/run print the run_optimize() result as JSON — not the
+        # "Unknown command" error path.
+        assert "Unknown command" not in out
+        assert json.loads(out)  # parses as JSON (the optimize result)
+
+
+# ---------------------------------------------------------------------------
 # Guards
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Implements #13043 (code-side bucket of the #10838 VAULT-ARCH alignment). 5 items.

## Items
1. **Always-on vault remember/optimize** (operator decision 'a'). Removed the config Enabled-gate from the sub-skills AND the code that enforced it:
   - vault-remember.md / vault-optimize.md: gate prose removed (always-on; quiet-cycle + note-count + cooldown remain the activation control).
   - cycle_pre.py `_read_config_flags`: hardcode `vault_remember`/`vault_optimize` = True (reading the removed field returns '' → False, the opposite of always-on).
   - vault_optimize.py `_is_config_enabled()`: unconditionally True (no toggle).
   - config.md `Vault Remember/Optimize > Enabled` fields removed **direct to main** (state file, guard-stripped from feature branches per #11511).
2. **`run` CLI alias** for vault_optimize.py (`cmd in ('full-sweep','run')`) — docs referenced `run` in ~7 places but only `full-sweep` existed.
3. **STYLES** added as the 5th reflection category in vault-remember.md (+ write-priority rank) → enables `galaxy/style-*.md`.
4. **`source` required**: added to vault_check `REQUIRED_FM_FIELDS` + aligned vault-protocol.md Level-1 list. ⚠️ This surfaced broad pre-existing frontmatter debt (~14 notes missing source/other fields) + a source-taxonomy mismatch (agents author `incident`/`operator-directive`/etc. outside VALID_SOURCES) — filed separately as **#13066** (not backfilled here; Level-1 runs per-note-written so new notes are enforced without per-cycle noise).
5. **Galaxy 500-line size warning** (`check_galaxy_size` + `check-size` subcommand; advisory, galaxy-only, doesn't fail validation) — vault-protocol Level-1 check 5.

## Verification
- Tests +6 (source-required, 3× size, run-alias, always-on flags/guards). Affected suites 202/202; full static gate 53/0.
- DS review pass 1 (DS-REVIEW-13043.md): 3 prose warnings folded. DS review pass 2 (DS-REVIEW-13043b.md, code gates): NO_FINDINGS (confirmed no other vault enable/disable code path; wizard already hardcodes vault_remember True).

## Notes for verifier
- Items 1 + 3 touch LLM-consumed sub-skills → **comprehension-coverage AC needed** (verifier-authored per #9184); #13043 body has no CQ AC yet.
- config.md edit + the #13066 frontmatter backfill land on main / separately, not in this PR's diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)