### PR TITLE
#13077: harness actively force-kills deploy-halted agent (cannot self-/quit)

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -4210,10 +4210,12 @@ def _await_pid_death(pid, timeout_s, poll_s=0.5):
 
 def _respawn_agent_process(role):
     """Explicitly respawn a deploy-halted agent's claude process (DS-12912
-    Finding 2). The agent's PID is already dead (it halted on the deploy-signal),
-    and after a deploy its status is "deploying" — which is NOT in the health
-    poller's is_dead set, so the poller will NEVER auto-respawn it. We therefore
-    boot it directly and stamp fresh-spawn state, mirroring the auto-start path.
+    Finding 2). The agent's old claude PID is typically still ALIVE — it halted
+    on the deploy-signal but an LLM cannot self-/quit (#13077) — so we force-kill
+    it and confirm death before booting. After a deploy its status is "deploying"
+    — which is NOT in the health poller's is_dead set, so the poller will NEVER
+    auto-respawn it. We therefore boot it directly and stamp fresh-spawn state,
+    mirroring the auto-start path.
 
     Returns True iff the respawn succeeded — a fresh process was spawned OR the
     agent was already alive (boot_agent action="skip"); i.e. the agent is now
@@ -4375,8 +4377,11 @@ def _bump_compose_checksum(clone_path):
 
 def _respawn_after_deploy(role):
     """Successful deploy: respawn the halted agent against the freshly-committed
-    CLAUDE.md. The PID is dead and status is "deploying" (not in is_dead), so the
-    health poller will not do it — respawn explicitly (DS-12912 Finding 2).
+    CLAUDE.md. The old PID is typically still alive (halted but not exited — an
+    LLM cannot self-/quit, #13077) and status is "deploying" (not in is_dead), so
+    the health poller will not do it — respawn explicitly via
+    _respawn_agent_process, which force-kills the old process and boots the
+    replacement (DS-12912 Finding 2).
 
     #13032 (DS-13032-B F1/F2): this success path owns the deploy-error emit for a
     respawn failure. Previously a respawn that no-op'd here was SILENT (the agent

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -4177,16 +4177,14 @@ _DEPLOY_COMPOSED_FILES = ("CLAUDE.md", "SOUL.md", "CLAUDE.linked.md")
 # deploy sequence respawns explicitly and clears it well before this elapses.
 _DEPLOY_WINDOW_SECONDS = 300
 
-# #13032: how long the deploy respawn waits for a deploy-halted agent's OWN
-# claude process to exit (it `/quit`s itself per the event-mode Case E contract)
-# before booting its replacement. boot_agent's singleton guard refuses to spawn
-# over a live process, so booting too early no-ops the respawn and the agent
-# keeps running the stale pre-recompose CLAUDE.md. Kept SHORT because it is only
-# a tail-cover: the agent /quits the instant it emits ack-stop, and the deploy's
-# own cursor-advance + pull + compose (+ commit + push) already ran before we
-# get here, so the PID is normally already dead and the wait returns
-# immediately. A still-alive agent after this short window almost certainly did
-# not /quit at all (un-upgraded / wedged) → abort fast rather than block the
+# #13077: how long the deploy respawn waits for the deploy-halted agent's OWN
+# claude process to be reaped by the OS AFTER the harness force-kills it (the
+# agent cannot self-/quit, so the harness terminates it actively — see
+# _respawn_agent_process). boot_agent's singleton guard refuses to spawn over a
+# live process, so we confirm the killed PID is gone before booting its
+# replacement. Kept SHORT because a force-kill is near-instant — this only
+# covers OS reap latency. Still alive after this window means the force-kill
+# itself failed (permission / un-killable) → abort fast rather than block the
 # serialized _deploy_lock for long (DS-13032-B F3: a full fix moves the respawn
 # outside _deploy_lock so the wait never blocks other clones' deploys — tracked
 # follow-up).
@@ -4232,33 +4230,48 @@ def _respawn_agent_process(role):
     surfaced, and a success-without-spawn to "starting"."""
     agent = state.get_agent(role) or AgentState(role)
 
-    # #13032: wait for the deploy-halted agent's OWN claude process to exit
-    # before booting its replacement. The Case E contract now has the agent
-    # `/quit` itself on a deploy-halt, but the exit is asynchronous — if we boot
-    # while the old process is still alive, boot_agent's singleton guard returns
-    # action="skip" and the respawn no-ops, leaving the agent on the stale
-    # pre-recompose CLAUDE.md (the original #13032 bug). If the old PID does not
-    # die within the window the agent failed to exit (didn't /quit, or wedged):
-    # do NOT silently proceed to a no-op respawn — fail HONEST (status=error,
-    # which is in is_dead) and surface a deploy-error so the operator sees a real
-    # failure rather than a stale agent masquerading as healthy. (Image-verified
-    # force-kill auto-recovery is a #12294-dependent follow-up.)
+    # #13077: actively terminate the deploy-halted agent's OWN claude process
+    # before booting its replacement. The #13032 code WAITED for a cooperative
+    # self-exit ("the agent /quits itself per Case E"), but an LLM agent CANNOT
+    # execute /quit — it can only stop emitting output (operator-confirmed,
+    # inline 2026-06-21: "agent cannot kill itself, it doesnt work. so the
+    # harness has to act"). The old process therefore never exits on its own, so
+    # the passive wait always timed out to status=error and deploy-halt →
+    # recompose → respawn never completed. The deploy path also gets NO help from
+    # the 60s force-kill safety net (that net only fires on intent STOPPING /
+    # RESTARTING; a deploy-halted agent sits at status="deploying"), so this is
+    # the one respawn path that must force-kill the old process itself.
+    #
+    # Force-kill the old process tree (reaps the Monitor-spawned event_poll
+    # sidecar too, #12363), then CONFIRM death before booting — boot_agent's
+    # singleton guard refuses to spawn over a live PID, which would no-op the
+    # respawn and strand the agent on the stale pre-recompose CLAUDE.md (the
+    # original #13032 failure mode). _DEPLOY_RESPAWN_PID_WAIT_S now bounds the
+    # post-kill OS-reap confirm (force-kill is near-instant), not a self-exit.
     old_pid = agent.claude_pid
-    if old_pid and not _await_pid_death(old_pid, _DEPLOY_RESPAWN_PID_WAIT_S):
-        agent.status = "error"
-        agent.intent = AgentState.INTENT_RUNNING
-        agent.intent_set_at = None
-        agent.reboot_blocked_until = None
-        agent.bootup_complete = False
-        state.set_agent(role, agent)
-        state.save_state()
-        _log(f"{role}: deploy respawn ABORTED — old claude PID {old_pid} still "
-             f"alive after {_DEPLOY_RESPAWN_PID_WAIT_S}s (agent did not exit on "
-             f"the deploy-halt /quit) — left status=error")
-        # The deploy-error emit is owned by the caller (DS-13032-B F1: avoids a
-        # double-emit when called from _deploy_recover_and_respawn, which emits
-        # its own stage failure).
-        return False
+    if old_pid and boot_remote._is_process_alive(old_pid):
+        _log(f"{role}: deploy respawn — force-killing deploy-halted claude PID "
+             f"{old_pid} (agent cannot self-/quit, #13077)")
+        try:
+            reboot_agent._kill_process(old_pid)
+        except Exception as e:
+            _log(f"{role}: deploy respawn force-kill of PID {old_pid} raised "
+                 f"{type(e).__name__}: {e}")
+        if not _await_pid_death(old_pid, _DEPLOY_RESPAWN_PID_WAIT_S):
+            agent.status = "error"
+            agent.intent = AgentState.INTENT_RUNNING
+            agent.intent_set_at = None
+            agent.reboot_blocked_until = None
+            agent.bootup_complete = False
+            state.set_agent(role, agent)
+            state.save_state()
+            _log(f"{role}: deploy respawn ABORTED — claude PID {old_pid} still "
+                 f"alive {_DEPLOY_RESPAWN_PID_WAIT_S}s after force-kill — "
+                 f"left status=error")
+            # The deploy-error emit is owned by the caller (DS-13032-B F1:
+            # avoids a double-emit when called from _deploy_recover_and_respawn,
+            # which emits its own stage failure).
+            return False
 
     agent.reboot_blocked_until = None
     agent.intent = AgentState.INTENT_RUNNING

--- a/tests/test_harness_deploy_12912.py
+++ b/tests/test_harness_deploy_12912.py
@@ -345,14 +345,19 @@ class TestRespawnAgentProcess(unittest.TestCase):
     """DS-12912 Finding 2: the deploy respawn boots the agent explicitly (the
     health poller never would — status='deploying' is not in is_dead)."""
 
-    def _respawn(self, boot_side_effect, *, claude_pid=None, pid_dies=True):
+    def _respawn(self, boot_side_effect, *, claude_pid=None, pid_dies=True,
+                 pid_alive=True):
         import harness
         agent = AgentState("skill", "")
         agent.intent = AgentState.INTENT_DEPLOYING
         agent.status = "deploying"
         agent.claude_pid = claude_pid
         emitted = []
+        self.killed = []  # PIDs the harness force-killed (#13077)
         with patch.object(harness.boot_remote, "boot_agent", side_effect=boot_side_effect), \
+             patch.object(harness.boot_remote, "_is_process_alive", return_value=pid_alive), \
+             patch.object(harness.reboot_agent, "_kill_process",
+                          side_effect=lambda p: self.killed.append(p)), \
              patch.object(harness, "_await_pid_death", return_value=pid_dies), \
              patch.object(harness, "_emit_event",
                           side_effect=lambda *a, **k: emitted.append((a, k))), \
@@ -400,28 +405,43 @@ class TestRespawnAgentProcess(unittest.TestCase):
         self.assertEqual(agent.status, "error")
         self.assertEqual(emitted, [])                  # caller owns the emit
 
-    def test_old_pid_still_alive_aborts_respawn(self):
-        """#13032: if the deploy-halted agent's process never exits (didn't
-        /quit, or wedged), do NOT boot over it (singleton would no-op) — abort
-        and leave is_dead 'error'. boot_agent must NOT even be called; the
-        deploy-error is the caller's to emit (DS-13032-B F1)."""
+    def test_force_kills_old_pid_since_agent_cannot_self_quit(self):
+        """#13077: the agent CANNOT self-/quit, so the harness actively
+        force-kills the deploy-halted process before booting. With the old PID
+        alive, _kill_process MUST be called with it; once it dies the respawn
+        boots fresh."""
+        agent, ok, emitted = self._respawn(
+            lambda r: {"success": True, "action": "spawn", "message": "ok"},
+            claude_pid=4242, pid_alive=True, pid_dies=True)
+        self.assertTrue(ok)
+        self.assertEqual(self.killed, [4242])           # harness actively killed it
+        self.assertEqual(agent.status, "starting")
+        self.assertEqual(emitted, [])
+
+    def test_old_pid_survives_force_kill_aborts_respawn(self):
+        """#13077: if the force-kill itself fails (PID still alive after it),
+        do NOT boot over the live process (singleton would no-op) — abort and
+        leave is_dead 'error'. boot_agent must NOT be called; the deploy-error
+        is the caller's to emit (DS-13032-B F1)."""
         called = []
         agent, ok, emitted = self._respawn(
             lambda r: called.append(r) or {"success": True, "action": "spawn"},
-            claude_pid=4242, pid_dies=False)
+            claude_pid=4242, pid_alive=True, pid_dies=False)
         self.assertFalse(ok)
+        self.assertEqual(self.killed, [4242])           # we DID try to kill it
         self.assertEqual(called, [])                    # never booted over a live process
         self.assertEqual(agent.status, "error")
         self.assertEqual(agent.intent, AgentState.INTENT_RUNNING)
         self.assertEqual(emitted, [])                  # caller owns the emit
 
-    def test_old_pid_dies_then_boots_fresh(self):
-        """#13032: once the old PID dies within the wait, the respawn boots a
-        fresh process normally."""
+    def test_old_pid_already_dead_skips_kill_and_boots(self):
+        """#13077: if the old PID is already gone (rare — the deploy's own
+        steps ran first), no force-kill is needed and the respawn boots fresh."""
         agent, ok, emitted = self._respawn(
             lambda r: {"success": True, "action": "spawn", "message": "ok"},
-            claude_pid=4242, pid_dies=True)
+            claude_pid=4242, pid_alive=False, pid_dies=True)
         self.assertTrue(ok)
+        self.assertEqual(self.killed, [])               # nothing to kill
         self.assertEqual(agent.status, "starting")
         self.assertEqual(emitted, [])
 

--- a/tests/test_harness_deploy_12912.py
+++ b/tests/test_harness_deploy_12912.py
@@ -491,9 +491,15 @@ class TestRespawnAgentProcess(unittest.TestCase):
         respawn failure during recovery does not double-emit."""
         import harness
         agent = AgentState("skill", "")
-        agent.claude_pid = 4242  # still-alive → respawn aborts inside the call
+        # Old PID alive AND survives the force-kill (pid_dies=False) → respawn
+        # aborts inside the call. Mock _is_process_alive/_kill_process so the
+        # #13077 force-kill block actually executes (not the real OS — #13077
+        # DS Finding 1) rather than falling through to the boot_agent path.
+        agent.claude_pid = 4242
         emitted = []
         with patch.object(harness, "state", _DeployFakeState(agent)), \
+             patch.object(harness.boot_remote, "_is_process_alive", return_value=True), \
+             patch.object(harness.reboot_agent, "_kill_process", side_effect=lambda p: None), \
              patch.object(harness, "_await_pid_death", return_value=False), \
              patch.object(harness.boot_remote, "boot_agent",
                           side_effect=AssertionError("must not boot over live PID")), \


### PR DESCRIPTION
Fixes #13077. The deploy-halt → recompose → respawn path was broken because it waited for the agent to self-`/quit`, but an LLM agent cannot execute `/quit` (operator-confirmed inline 2026-06-21). Operator ruling LOCKED: "the harness has to act."

## RCA
`_respawn_agent_process` (the #13032 code) called `_await_pid_death(old_pid)` and failed to `status=error` on timeout. Since the agent never exits on its own, the wait always timed out → deploy-recompose-respawn never completed. The deploy path gets **no** help from the 60s force-kill safety net either — that net only fires on intent `STOPPING`/`RESTARTING`, while a deploy-halted agent sits at `status="deploying"`. So this is the one respawn path that had to terminate the process itself.

## Fix
`_respawn_agent_process` now actively force-kills the old process tree via `reboot_agent._kill_process` (reaps the Monitor `event_poll` sidecar too, #12363) when `_is_process_alive(old_pid)`, confirms death, then boots the replacement. `_DEPLOY_RESPAWN_PID_WAIT_S` now bounds the post-kill OS reap (force-kill is near-instant), not a self-exit. Consistent with the existing 60s-net kill (plain `_kill_process`, no image-verify needed — the deploy-halted PID is known-live).

## Verification
- Tests: force-kill-called, survives-kill→abort, already-dead→skip-kill; fixed an under-patched recovery test (DS Finding 1 — was falling through + a real-kill hazard). Suite 43/43; full static gate 53/0.
- DS review (DS-REVIEW-13077.md): 4 findings — Finding 1 (error, test under-patch) + Findings 2/3 (stale docstrings) folded; Finding 4 (test-mock fragility) DS-deemed not-a-bug.

## Scope / follow-ups (for PM/verifier)
- exit-42 / `stop-requested` share the self-`/quit` assumption but DO get the 60s force-kill net (functional, just slower) — **accelerating those to immediate force-kill is a separate decision**, flagged for PM.
- Doc-side reconcile (HARNESS-ARCH §7.1/§7.4, AGENT-RUNTIME §5.2, event-mode-contract Case E, self-restart.md) is PM-side per the issue — those docs still instruct the agent to "invoke /quit", which doesn't work.

Deterministic harness code — no CQ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)