### PR TITLE
#13045: conflict-safe stash pop — never leave merge markers in config.md

### DIFF
--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -216,12 +216,17 @@ def _safe_stash_pop():
     if pop.returncode == 0:
         return True
     conflicted = _run("git diff --name-only --diff-filter=U", check=False)
-    for path in conflicted.stdout.splitlines():
-        path = path.strip()
-        if path:
-            _run_list(["git", "checkout", "HEAD", "--", path], check=False)
-    # The conflicted pop left the stash applied-but-retained; drop it now that
-    # the working tree is clean again.
+    unmerged = [p.strip() for p in conflicted.stdout.splitlines() if p.strip()]
+    if not unmerged:
+        # Pop failed for a NON-conflict reason (no stash entry, or an unrelated
+        # git error) — the stash, if any, was NOT applied. Do NOT drop it: that
+        # would discard un-applied stashed work. Leave it intact and report the
+        # pop did not succeed.
+        return False
+    for path in unmerged:
+        _run_list(["git", "checkout", "HEAD", "--", path], check=False)
+    # A real conflict: git applied the stash WITH markers and kept it. Now that
+    # the conflicted paths are restored to HEAD, drop the retained stash.
     _run("git stash drop", check=False)
     return False
 

--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -192,6 +192,40 @@ def _emit(event_type, payload=None, cycle_number=None, role=None):
         pass
 
 
+def _safe_stash_pop():
+    """Pop the most recent stash, leaving NO conflict markers behind (#13045).
+
+    A plain ``git stash pop`` that conflicts writes ``<<<<<<< / ======= /
+    >>>>>>>`` merge markers into the unmerged working-tree files and KEEPS the
+    stash. The old recovery only ran ``git stash drop`` — which removes the
+    stash entry but NOT the markers already written, so a state file like
+    ``config.md`` was left corrupt → ``compose.py`` failed on every recompose →
+    a fleet-wide compose-failed loop.
+
+    On conflict we instead restore every conflicted (unmerged) path to the
+    pulled ``HEAD`` version — the just-pulled/checked-out state is authoritative
+    for the state files clone-sync touches (e.g. config.md's ship counter, whose
+    live value lives on main) — then drop the now-applied stash. This discards
+    the stashed local version of the conflicting paths, which is exactly the
+    stale local change that caused the conflict.
+
+    Returns True if the pop applied cleanly, False if it conflicted and was
+    force-resolved to HEAD.
+    """
+    pop = _run("git stash pop", check=False)
+    if pop.returncode == 0:
+        return True
+    conflicted = _run("git diff --name-only --diff-filter=U", check=False)
+    for path in conflicted.stdout.splitlines():
+        path = path.strip()
+        if path:
+            _run_list(["git", "checkout", "HEAD", "--", path], check=False)
+    # The conflicted pop left the stash applied-but-retained; drop it now that
+    # the working tree is clean again.
+    _run("git stash drop", check=False)
+    return False
+
+
 def pull(role=None):
     """Pull with merge (#5378, #5445).
 
@@ -224,17 +258,19 @@ def pull(role=None):
               file=sys.stderr)
         return False
 
-    pop_result = _run("git stash pop", check=False)
-    if pop_result.returncode != 0:
-        _log_diagnostic("warning", "stash pop failed during pull — possible merge conflict")
-        # Drop the failed stash to prevent leak accumulation (#4829)
-        _run("git stash drop", check=False)
-        print("WARNING: stash pop failed -- dropped stale stash entry.", file=sys.stderr)
-        print("Pulled (stash pop conflict -- stale stash dropped)")
-        _emit("git-pull", {"result": "stash"}, role=role)
-    else:
+    if _safe_stash_pop():
         print("Pulled (stashed and popped)")
-        _emit("git-pull", {"result": "stash"}, role=role)
+    else:
+        # #13045: a conflicted pop is resolved to the pulled HEAD (markers
+        # removed) and the stash dropped (#4829 leak-prevention preserved),
+        # so config.md is never left with `<<<<<<<` markers that break compose.
+        _log_diagnostic("warning",
+                        "stash pop conflict during pull — restored conflicted "
+                        "paths to pulled HEAD and dropped stash (#13045)")
+        print("WARNING: stash pop conflict -- conflicts resolved to pulled "
+              "state, stash dropped.", file=sys.stderr)
+        print("Pulled (stash pop conflict -- resolved to pulled state)")
+    _emit("git-pull", {"result": "stash"}, role=role)
     return True
 
 
@@ -616,12 +652,13 @@ def _safe_checkout(target_branch):
     _run("git stash -q", check=False)
     result = _run_list(["git", "checkout", target_branch], check=False)
     if result.returncode != 0:
-        # Checkout failed — pop stash to restore original branch state
-        _run("git stash pop -q", check=False)
+        # Checkout failed — restore original branch state. Use the conflict-safe
+        # pop so a conflict here never leaves `<<<<<<<` markers either (#13045).
+        _safe_stash_pop()
         print(f"ERROR: could not switch to {target_branch}: {result.stderr}", file=sys.stderr)
         return False
-    # Checkout succeeded — pop stash on the target branch
-    _run("git stash pop -q", check=False)
+    # Checkout succeeded — pop stash on the target branch (conflict-safe, #13045).
+    _safe_stash_pop()
     return True
 
 

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -49,32 +49,61 @@ class TestPull:
         assert git_ops.pull() is True
         assert mock_run.call_count == 4
 
+    @patch("git_ops._run_list")
     @patch("git_ops._run")
-    def test_pull_stash_pop_conflict(self, mock_run):
-        """Stash pop fails → stash dropped, still returns True (#4829)."""
+    def test_pull_stash_pop_conflict(self, mock_run, mock_run_list):
+        """Stash pop conflict → conflicted paths restored to HEAD + stash
+        dropped, still returns True (#4829 + #13045)."""
         mock_run.side_effect = [
-            _mock_result(returncode=1),  # pull fails
-            _mock_result(),              # stash
-            _mock_result(),              # pull (retry)
-            _mock_result(returncode=1),  # stash pop fails
-            _mock_result(),              # stash drop (#4829)
+            _mock_result(returncode=1),                       # pull fails
+            _mock_result(),                                   # stash
+            _mock_result(),                                   # pull (retry)
+            _mock_result(returncode=1),                       # stash pop conflict
+            _mock_result(stdout=".squidsquad/config.md\n"),   # diff --diff-filter=U
+            _mock_result(),                                   # stash drop
         ]
+        mock_run_list.return_value = _mock_result()           # checkout HEAD -- path
         assert git_ops.pull() is True
-        assert mock_run.call_count == 5
 
+    @patch("git_ops._run_list")
     @patch("git_ops._run")
-    def test_pull_stash_pop_conflict_drops_stash(self, mock_run):
-        """Regression #4829: failed stash pop must call git stash drop."""
+    def test_pull_stash_pop_conflict_drops_stash(self, mock_run, mock_run_list):
+        """Regression #4829: a conflicted stash pop must still call git stash
+        drop (no stash-entry leak)."""
         mock_run.side_effect = [
-            _mock_result(returncode=1),  # pull fails
-            _mock_result(),              # stash
-            _mock_result(),              # pull (retry)
-            _mock_result(returncode=1),  # stash pop fails
-            _mock_result(),              # stash drop
+            _mock_result(returncode=1),                       # pull fails
+            _mock_result(),                                   # stash
+            _mock_result(),                                   # pull (retry)
+            _mock_result(returncode=1),                       # stash pop conflict
+            _mock_result(stdout=".squidsquad/config.md\n"),   # diff --diff-filter=U
+            _mock_result(),                                   # stash drop
         ]
+        mock_run_list.return_value = _mock_result()
         git_ops.pull()
-        drop_call = mock_run.call_args_list[4]
-        assert drop_call[0][0] == "git stash drop"
+        assert any(c[0][0] == "git stash drop" for c in mock_run.call_args_list), \
+            "conflicted pop must drop the retained stash"
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_pull_stash_pop_conflict_restores_conflicted_paths_to_head(
+            self, mock_run, mock_run_list):
+        """#13045: a conflicted stash pop must restore every unmerged path to
+        the pulled HEAD (removing the `<<<<<<<` markers git wrote) — NOT just
+        drop the stash. Asserts `git checkout HEAD -- <path>` is issued for the
+        conflicted config.md so compose never sees a corrupt file."""
+        mock_run.side_effect = [
+            _mock_result(returncode=1),                       # pull fails
+            _mock_result(),                                   # stash
+            _mock_result(),                                   # pull (retry)
+            _mock_result(returncode=1),                       # stash pop conflict
+            _mock_result(stdout=".squidsquad/config.md\nreferences/x.py\n"),  # diff -U
+            _mock_result(),                                   # stash drop
+        ]
+        mock_run_list.return_value = _mock_result()
+        git_ops.pull()
+        checkouts = [c[0][0] for c in mock_run_list.call_args_list]
+        assert ["git", "checkout", "HEAD", "--", ".squidsquad/config.md"] in checkouts
+        assert ["git", "checkout", "HEAD", "--", "references/x.py"] in checkouts
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1225,6 +1225,75 @@ class TestSafeCheckout:
         result = git_ops._safe_checkout("feature-branch")
         assert result is True
 
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_checkout_success_then_pop_conflict_resolves_to_head(
+            self, mock_run, mock_run_list):
+        """#13045: if the pop on the target branch conflicts, _safe_checkout
+        must NOT leave `<<<<<<<` markers — the conflicted paths are restored to
+        HEAD and the stash dropped (via _safe_stash_pop)."""
+        mock_run.side_effect = [
+            _mock_result(stdout="main\n"),                    # branch --show-current
+            _mock_result(),                                   # git stash -q
+            _mock_result(returncode=1),                       # stash pop conflict
+            _mock_result(stdout=".squidsquad/config.md\n"),   # diff --diff-filter=U
+            _mock_result(),                                   # stash drop
+        ]
+        mock_run_list.side_effect = [
+            _mock_result(returncode=1, stderr="error"),       # direct checkout fails
+            _mock_result(returncode=0),                       # stash+checkout succeeds
+            _mock_result(),                                   # checkout HEAD -- config.md
+        ]
+        result = git_ops._safe_checkout("feature-branch")
+        assert result is True
+        checkouts = [c[0][0] for c in mock_run_list.call_args_list]
+        assert ["git", "checkout", "HEAD", "--", ".squidsquad/config.md"] in checkouts
+        assert any(c[0][0] == "git stash drop" for c in mock_run.call_args_list)
+
+
+# ---------------------------------------------------------------------------
+# _safe_stash_pop (#13045)
+# ---------------------------------------------------------------------------
+
+class TestSafeStashPop:
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_clean_pop_returns_true_no_drop(self, mock_run, mock_run_list):
+        """A clean pop returns True and does NOT drop (the stash is consumed)."""
+        mock_run.side_effect = [_mock_result()]               # git stash pop (ok)
+        assert git_ops._safe_stash_pop() is True
+        assert not any("stash drop" in str(c) for c in mock_run.call_args_list)
+        mock_run_list.assert_not_called()
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_conflict_restores_to_head_and_drops(self, mock_run, mock_run_list):
+        """A conflicted pop restores unmerged paths to HEAD then drops (#13045)."""
+        mock_run.side_effect = [
+            _mock_result(returncode=1),                       # pop conflict
+            _mock_result(stdout=".squidsquad/config.md\n"),   # diff --diff-filter=U
+            _mock_result(),                                   # stash drop
+        ]
+        mock_run_list.return_value = _mock_result()
+        assert git_ops._safe_stash_pop() is False
+        mock_run_list.assert_called_once_with(
+            ["git", "checkout", "HEAD", "--", ".squidsquad/config.md"], check=False)
+        assert any(c[0][0] == "git stash drop" for c in mock_run.call_args_list)
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_non_conflict_pop_failure_does_not_drop(self, mock_run, mock_run_list):
+        """#13045 DS Finding 1: a pop that fails WITHOUT conflicts (no stash /
+        unrelated error → empty unmerged set) must NOT drop a possibly-unapplied
+        stash. No checkout, no drop, returns False."""
+        mock_run.side_effect = [
+            _mock_result(returncode=1),                       # pop fails
+            _mock_result(stdout=""),                          # diff: no unmerged paths
+        ]
+        assert git_ops._safe_stash_pop() is False
+        mock_run_list.assert_not_called()
+        assert not any("stash drop" in str(c) for c in mock_run.call_args_list)
+
 
 # ---------------------------------------------------------------------------
 # .gitignore volatile file coverage — regression #4829


### PR DESCRIPTION
Fixes #13045. A clone-sync `git stash` → pull → `git stash pop` left `<<<<<<<` conflict markers in `config.md` when the pop conflicted (stale stashed ship-counter vs pulled value), corrupting config so `compose.py` failed on every recompose → a fleet-wide compose-failed loop.

## RCA
`git_ops.pull()` (and `_safe_checkout`) handled a pop conflict with only `git stash drop` (#4829 leak-prevention) — which removes the stash *entry* but NOT the merge markers git had already written into the working tree. So `config.md` was left corrupt.

## Fix
New `_safe_stash_pop()` helper — on a pop conflict it restores every unmerged path to the pulled `HEAD` (`git diff --name-only --diff-filter=U` → `git checkout HEAD -- <path>`; main is authoritative for the state files clone-sync touches, e.g. the ship counter), then drops the now-applied stash. Wired into both stash/pop sites (`pull()` and the latent same-class `_safe_checkout` pop, which previously didn't handle conflicts at all). Only the *conflicting* paths are reset, so non-conflicting stashed work is preserved (not a `reset --hard`).

## Verification
- `tests/test_git_ops.py` 151/151 (mock-sequence): pull conflict-resolves + restores paths, `_safe_checkout` conflict path, `TestSafeStashPop` (clean/conflict/non-conflict-failure). Full static gate 53/0.
- **Real-git smoke**: induced an actual `config.md` stash-pop conflict → the fix removes all markers, restores the pulled value, clears the stash.
- DS review (DS-REVIEW-13045.md): 4 warnings folded — Finding 1 (gate drop on actual conflicts so a non-conflict pop failure never discards an un-applied stash) + Findings 2/4 (coverage) + Finding 3 (mitigated by the Finding-1 gate).

Deterministic Python — no CQ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)