### PR TITLE
#12854: flag stale current-state so frozen content isn't read as current activity

### DIFF
--- a/references/scripts/health_check.py
+++ b/references/scripts/health_check.py
@@ -225,6 +225,7 @@ def check_agent_health(role, clone_root, interval_minutes, now=None):
         "clone_path": str(clone_root),
         "current_state_phase": "",
         "current_state_desc": "",
+        "current_state_stale": False,
         "task": "unknown",
         "last_active_minutes_ago": None,
         "reason": "",
@@ -257,6 +258,21 @@ def check_agent_health(role, clone_root, interval_minutes, now=None):
         result["last_active_minutes_ago"] = int((now - state_mtime) / 60)
 
     stale_threshold = interval_minutes * 2
+
+    # #12854: flag whether the current-state CONTENT can still be trusted as
+    # *current* activity. A still-alive agent that stopped/stalled mid-cycle
+    # never reaches cycle_post's "idle" write, so its current-state freezes on
+    # the last in-flight phase/desc (e.g. "implementing — #X running suite").
+    # Past the staleness window that frozen content is no longer "what the
+    # agent is doing" — but it reads as authoritative and seeds wrong root-cause
+    # theories (the #12854 incident: a frozen "running full suite" sent PM down
+    # a hung-suite theory). The agent cannot self-correct it (it's stopped), so
+    # this reader-side flag is the reliable signal; consumers (PM health checks,
+    # operator, pipeline-sentinel) must treat phase/desc as last-known-stale,
+    # not current, when it is set. (current-state is gitignored, so its mtime is
+    # never spuriously refreshed by git — the staleness measure is sound.)
+    if state_mtime is not None:
+        result["current_state_stale"] = (now - state_mtime) / 60 > stale_threshold
 
     # --- Primary: PID-liveness via .claude-pid ---
     pid = _read_claude_pid_file(squid)
@@ -371,7 +387,13 @@ def format_table(report):
             if a["last_active_minutes_ago"] is not None
             else "n/a"
         )
-        phase = a["current_state_phase"][:15] if a["current_state_phase"] else "-"
+        phase = a["current_state_phase"] if a["current_state_phase"] else "-"
+        # #12854: a leading "~" marks the phase as last-known-stale, not current,
+        # so the table never presents frozen content as live activity. The
+        # authoritative signal is the `current_state_stale` JSON field.
+        if a.get("current_state_stale") and a["current_state_phase"]:
+            phase = "~" + phase
+        phase = phase[:15]
         task = a["task"][:20] if a["task"] else "-"
         lines.append(
             f"{a['role']:<{w_role}}  {emoji:<7} {source:<8} {last:<8} {phase:<16} {task}"

--- a/references/scripts/health_check.py
+++ b/references/scripts/health_check.py
@@ -207,6 +207,9 @@ def check_agent_health(role, clone_root, interval_minutes, now=None):
             "clone_path": str,
             "current_state_phase": str,
             "current_state_desc": str,
+            "current_state_stale": bool,  # #12854: phase/desc is past the
+                                          # staleness window — treat as
+                                          # last-known, NOT current activity
             "task": str,
             "last_active_minutes_ago": int | None,
             "reason": str,

--- a/tests/test_12854_current_state_stale_flag.py
+++ b/tests/test_12854_current_state_stale_flag.py
@@ -1,0 +1,110 @@
+"""#12854 — current-state CONTENT must not be read as *current* when stale.
+
+A still-alive agent that stops/stalls mid-cycle never reaches cycle_post's
+"idle" write, so its `current-state` freezes on the last in-flight phase/desc
+(e.g. "implementing|#12142 running full suite"). Past the staleness window that
+frozen content is no longer what the agent is doing — but it reads as
+authoritative and seeds wrong root-cause theories (the incident: a frozen
+"running full suite" sent PM down a hung-suite theory before the operator
+supplied the real cause).
+
+The agent cannot self-correct frozen content (it's stopped), so health_check
+exposes a reader-side `current_state_stale` flag: True iff the current-state
+mtime is older than the staleness threshold. Consumers (PM health checks,
+operator, pipeline-sentinel) must treat phase/desc as last-known-stale, not
+current, when it is set. The human table marks a stale phase with a leading "~".
+
+(current-state is gitignored, so git never spuriously refreshes its mtime — the
+staleness measure is sound. The residual case — distinguishing "stopped mid-suite"
+from "genuinely running a suite" *within* the threshold window — needs the
+progress-liveness heartbeat from #12271 and is out of scope here.)
+"""
+
+import time
+from unittest.mock import patch
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "references" / "scripts"))
+import health_check
+
+
+def _setup_agent(tmp_path, role, state_text=None, state_age_seconds=0, claude_pid=None):
+    import os as _os
+    squid = tmp_path / ".squidsquad" / role
+    squid.mkdir(parents=True, exist_ok=True)
+    if state_text is not None:
+        state_file = squid / "current-state"
+        state_file.write_text(state_text)
+        if state_age_seconds > 0:
+            mtime = time.time() - state_age_seconds
+            _os.utime(state_file, (mtime, mtime))
+    if claude_pid is not None:
+        (squid / ".claude-pid").write_text(str(claude_pid))
+    return tmp_path
+
+
+class TestCurrentStateStaleFlag:
+    @patch.object(health_check, "_is_process_alive", return_value=True)
+    def test_fresh_content_not_stale(self, _alive, tmp_path):
+        clone = _setup_agent(tmp_path, "skill",
+                             state_text="implementing|#42 writing tests",
+                             state_age_seconds=5, claude_pid=12345)
+        r = health_check.check_agent_health("skill", clone, 30)
+        assert r["current_state_stale"] is False
+        assert r["health"] == "healthy"
+
+    @patch.object(health_check, "_is_process_alive", return_value=True)
+    def test_alive_agent_with_frozen_content_is_flagged_stale(self, _alive, tmp_path):
+        """The #12854 incident shape: PID alive, but content frozen past the
+        window — the flag must fire so the frozen desc isn't read as current."""
+        clone = _setup_agent(tmp_path, "skill",
+                             state_text="implementing|#12142 running full suite",
+                             state_age_seconds=3700, claude_pid=12345)
+        r = health_check.check_agent_health("skill", clone, 30)
+        assert r["current_state_stale"] is True
+        # content is preserved (not blanked) so diagnosis keeps the last-known
+        # info — but it is now explicitly marked stale.
+        assert r["current_state_phase"] == "implementing"
+        assert r["current_state_desc"] == "#12142 running full suite"
+
+    def test_no_state_file_is_not_stale(self, tmp_path):
+        """Absent state is 'unknown', not 'stale' — staleness needs an mtime."""
+        clone = _setup_agent(tmp_path, "skill", claude_pid=None)
+        r = health_check.check_agent_health("skill", clone, 30)
+        assert r["current_state_stale"] is False
+
+    def test_mtime_fallback_stale_sets_flag(self, tmp_path):
+        clone = _setup_agent(tmp_path, "skill",
+                             state_text="implementing|#7", state_age_seconds=3700)
+        r = health_check.check_agent_health("skill", clone, 30)
+        assert r["current_state_stale"] is True
+        assert r["health"] == "stalled"
+
+    @patch.object(health_check, "_is_process_alive", return_value=True)
+    def test_table_marks_stale_phase_with_tilde(self, _alive, tmp_path):
+        clone = _setup_agent(tmp_path, "skill",
+                             state_text="implementing|#12142 running full suite",
+                             state_age_seconds=3700, claude_pid=12345)
+        report = {
+            "agents": [health_check.check_agent_health("skill", clone, 30)],
+            "interval_minutes": 30, "all_healthy": False,
+            "timestamp": "2026-06-21T00:00:00",
+        }
+        table = health_check.format_table(report)
+        assert "~implementing" in table
+
+    @patch.object(health_check, "_is_process_alive", return_value=True)
+    def test_table_does_not_mark_fresh_phase(self, _alive, tmp_path):
+        clone = _setup_agent(tmp_path, "skill",
+                             state_text="implementing|#42",
+                             state_age_seconds=5, claude_pid=12345)
+        report = {
+            "agents": [health_check.check_agent_health("skill", clone, 30)],
+            "interval_minutes": 30, "all_healthy": True,
+            "timestamp": "2026-06-21T00:00:00",
+        }
+        table = health_check.format_table(report)
+        assert "~implementing" not in table
+        assert "implementing" in table


### PR DESCRIPTION
## What & why

#12854 — `current-state` is a primary health-diagnosis signal (statusline + PM/operator health checks). When it goes stale it actively **misleads**: a frozen `implementing|#12142 running full suite` sent PM down a hung-suite theory before the operator supplied the real cause (a behavioral mid-cycle stop).

## RCA

- `current-state` is **gitignored** (`.gitignore: .squidsquad/*/current-state`) → git never spuriously refreshes its mtime, so the mtime-based staleness measure is **sound** (rules out a git-touch confound).
- `cycle_post.py` already writes `idle` on **clean** cycle end (covers the "idles" and "changes task" cases). The uncovered case is a **mid-cycle stop/stall** (the "QA tangent" behavioral stop): the agent never reaches `cycle_post`, so current-state freezes on the last in-flight phase/desc.
- A stopped agent **cannot self-correct** its own status file → the fix must be **reader-side**.
- health_check already flips `health: stalled` once mtime passes the window, but it still reports the frozen `current_state_phase/desc` with no staleness qualifier — so the *content* ("running full suite") keeps reading as authoritative and seeds specific wrong theories.

## Fix (reader-side, complete-as-achievable)

- `health_check.check_agent_health` now sets **`current_state_stale`** (True iff current-state mtime > staleness threshold). Content is **kept** (not blanked) so diagnosis retains the last-known info — now explicitly marked stale.
- `format_table` prefixes a stale phase with **`~`** so the human table never presents frozen content as live activity.
- Consumers (PM health checks, pipeline-sentinel, operator) get a structured signal to treat phase/desc as last-known-stale, not current.

## Residual (out of scope — dependency surfaced)

Distinguishing "stopped mid-suite" from "genuinely running a suite" **within** the threshold window is *not* resolvable from current-state mtime alone — both look identical (PID alive, recent mtime, same content). That needs the **progress-liveness heartbeat from #12271** (PostToolUse activity / `should_advance_dispatch`), which is currently gated (on #12492's observation window). This PR removes the **past-window** misread; the in-window case should be closed with/after #12271. Sibling: #13113 (harness in-memory telemetry frozen across respawn — same meta-problem, different surface).

## Verification

- New `tests/test_12854_current_state_stale_flag.py` — 6 cases incl. the incident shape (PID-alive + frozen content → flagged stale; content preserved; table marks `~`). Existing `test_health_check.py` 41/41 (no regression from the added field).
- Full gate `run_tests.py` → OK; static gate auto-discovers the new file.

Deterministic script + test — no LLM-consumed instructions, so no CQ/DS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
