### PR TITLE
#13132: tracker.py gh-CLI fallback paths fail closed

### DIFF
--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -1212,7 +1212,12 @@ def _check_unread_feedback(number, caller_role):
         # Fail closed — if we can't read comments, block the transition
         return [("unknown (API error)", "unknown")]
 
-    data = json.loads(result.stdout)
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        # Malformed exit-0 response — fail closed (same sentinel) so the guard
+        # blocks rather than aborting transition() with an uncaught traceback.
+        return [("unknown (API error)", "unknown")]
     comments = data.get("comments", [])
     if not comments:
         return []
@@ -1592,9 +1597,21 @@ def get_labels(number):
         labels = [l["name"] for l in data.get("labels", [])] if data else []
         print(json.dumps(labels))
         return labels
-    result = _run_list(["gh", "issue", "view", str(number), "--json", "labels"])
-    data = json.loads(result.stdout)
-    labels = [l["name"] for l in data.get("labels", [])]
+    result = _run_list(
+        ["gh", "issue", "view", str(number), "--json", "labels"],
+        check=False,
+    )
+    # Fail closed: a gh blip or malformed exit-0 JSON yields [] (no labels)
+    # rather than a raw traceback — mirrors _get_issue_role_labels.
+    labels = []
+    if result.returncode == 0 and result.stdout.strip():
+        try:
+            data = json.loads(result.stdout)
+            # Drop label objects missing a "name" (would otherwise inject "");
+            # mirrors the startswith-filtering in _get_issue_*_labels.
+            labels = [n for n in (l.get("name", "") for l in data.get("labels", [])) if n]
+        except json.JSONDecodeError:
+            labels = []
     print(json.dumps(labels))
     return labels
 
@@ -1607,9 +1624,19 @@ def get_state(number):
         state = (data or {}).get("state") or "UNKNOWN"
         print(state)
         return state
-    result = _run_list(["gh", "issue", "view", str(number), "--json", "state"])
-    data = json.loads(result.stdout)
-    state = data["state"]
+    result = _run_list(
+        ["gh", "issue", "view", str(number), "--json", "state"],
+        check=False,
+    )
+    # Fail closed to "UNKNOWN" on gh failure / malformed exit-0 JSON / missing
+    # field — mirrors the adapter path's `(data or {}).get("state") or "UNKNOWN"`.
+    data = {}
+    if result.returncode == 0 and result.stdout.strip():
+        try:
+            data = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            data = {}
+    state = (data or {}).get("state") or "UNKNOWN"
     print(state)
     return state
 

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -320,6 +320,81 @@ class TestGetState:
         assert state == "UNKNOWN"
 
 
+class TestGetLabelsStateCliFallbackFailClosed13132:
+    """#13132: get_labels / get_state CLI-fallback paths must fail closed
+    (no raw traceback) on gh non-zero exit, empty stdout, or malformed exit-0
+    JSON — mirroring the adapter paths and _get_issue_role_labels."""
+
+    def _cli(self, monkeypatch, result):
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(tracker, "_run_list", lambda cmd, **kw: result)
+
+    def test_get_labels_nonzero_returns_empty(self, monkeypatch):
+        self._cli(monkeypatch, _mock_result(returncode=1, stderr="boom"))
+        assert tracker.get_labels(42) == []
+
+    def test_get_labels_empty_stdout_returns_empty(self, monkeypatch):
+        self._cli(monkeypatch, _mock_result(stdout="", returncode=0))
+        assert tracker.get_labels(42) == []
+
+    def test_get_labels_malformed_json_returns_empty(self, monkeypatch):
+        self._cli(monkeypatch, _mock_result(stdout="not json{", returncode=0))
+        assert tracker.get_labels(42) == []
+
+    def test_get_labels_drops_nameless_label_objects(self, monkeypatch):
+        # DS-review fold: a label dict missing "name" must be dropped, not
+        # injected as "" (matches _get_issue_*_labels filtering).
+        data = {"labels": [{"name": "role:skill"}, {}, {"name": "squidsquad"}]}
+        self._cli(monkeypatch, _mock_result(stdout=json.dumps(data), returncode=0))
+        assert tracker.get_labels(42) == ["role:skill", "squidsquad"]
+
+    def test_get_state_nonzero_returns_unknown(self, monkeypatch):
+        self._cli(monkeypatch, _mock_result(returncode=1, stderr="boom"))
+        assert tracker.get_state(42) == "UNKNOWN"
+
+    def test_get_state_empty_stdout_returns_unknown(self, monkeypatch):
+        self._cli(monkeypatch, _mock_result(stdout="", returncode=0))
+        assert tracker.get_state(42) == "UNKNOWN"
+
+    def test_get_state_malformed_json_returns_unknown(self, monkeypatch):
+        self._cli(monkeypatch, _mock_result(stdout="<html>500</html>", returncode=0))
+        assert tracker.get_state(42) == "UNKNOWN"
+
+    def test_get_state_missing_state_key_returns_unknown(self, monkeypatch):
+        # exit-0 JSON without a "state" field previously raised KeyError.
+        self._cli(monkeypatch, _mock_result(stdout='{"title": "x"}', returncode=0))
+        assert tracker.get_state(42) == "UNKNOWN"
+
+
+class TestCheckUnreadFeedbackFailClosed13132:
+    """#13132 Finding 2: _check_unread_feedback must return the fail-closed
+    sentinel on a malformed exit-0 response, not raise JSONDecodeError."""
+
+    _SENTINEL = [("unknown (API error)", "unknown")]
+
+    def test_malformed_exit0_returns_sentinel(self, monkeypatch):
+        monkeypatch.setattr(
+            tracker, "_run_list",
+            lambda cmd, **kw: _mock_result(stdout="not json{", returncode=0),
+        )
+        assert tracker._check_unread_feedback(42, "skill") == self._SENTINEL
+
+    def test_nonzero_still_returns_sentinel(self, monkeypatch):
+        monkeypatch.setattr(
+            tracker, "_run_list",
+            lambda cmd, **kw: _mock_result(returncode=1),
+        )
+        assert tracker._check_unread_feedback(42, "skill") == self._SENTINEL
+
+    def test_valid_no_comments_returns_empty(self, monkeypatch):
+        # Happy path still works: valid JSON, no comments → no unread feedback.
+        monkeypatch.setattr(
+            tracker, "_run_list",
+            lambda cmd, **kw: _mock_result(stdout='{"comments": []}', returncode=0),
+        )
+        assert tracker._check_unread_feedback(42, "skill") == []
+
+
 class TestCloseIssue:
     def test_calls_close(self, monkeypatch):
         calls = []


### PR DESCRIPTION
Fixes #13132 (qa improvement-scan, low severity).

tracker.py's gh-CLI **fallback** paths skipped the fail-closed error pattern the **adapter** paths and `_get_issue_role_labels`/`_get_issue_status_labels` already use → a gh blip or malformed exit-0 response surfaced as a raw traceback.

**Finding 1 — get_labels / get_state crash on gh failure**
- `get_labels`: `check=False` + returncode/empty guard + `try/except JSONDecodeError` → `[]`; drop nameless label objects (DS-review fold).
- `get_state`: same guard; `(data or {}).get("state") or "UNKNOWN"` (missing `state` key no longer KeyErrors).

**Finding 2 — _check_unread_feedback unguarded success-path json.loads**
- Wrapped in `try/except JSONDecodeError` → same fail-closed sentinel `[("unknown (API error)","unknown")]`, so the transition guard BLOCKS rather than aborting with a traceback. (Per the issue's verifier note: the old uncaught exception aborted the transition — it did NOT bypass the guard — so this is a contract/robustness fix, not a security fix.)

**Tests:** +11 regression cases in `tests/test_tracker.py` (62 total) covering nonzero / empty / malformed-JSON / missing-key branches on all three functions. Full `run_tests.py static` → PASS (4867/0/0).

**Review:** DeepSeek returned a degenerate response → Claude-sonnet fallback (per model-router auto-fallback). 1 LOW finding (empty-string label injection) folded; rest clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)