### PR TITLE
#13133: scan_index.rebuild() no longer double-counts findings across multi-file scans

### DIFF
--- a/references/scripts/scan_index.py
+++ b/references/scripts/scan_index.py
@@ -685,6 +685,9 @@ def rebuild(db_path=None):
             entries = _parse_scan_history(history_file)
 
             for entry in entries:
+                # Insert one scan row per file; remember each file's scan id so
+                # findings can be attributed without re-querying.
+                file_scan_ids = {}
                 for f in entry["files"]:
                     f = _normalize_path(f)
                     try:
@@ -701,17 +704,26 @@ def rebuild(db_path=None):
                         ).fetchone()
                         scan_id = row["id"] if row else None
 
-                    if scan_id is None:
-                        continue
+                    if scan_id is not None:
+                        file_scan_ids[f] = scan_id
 
-                    # Insert findings for this file
+                # #13133: insert each finding ONCE, attributed to the entry's
+                # first file — the scan-history format carries no per-finding
+                # file attribution, so this mirrors record_scan's `files[0]`
+                # default. The pre-fix code nested this INSERT inside the
+                # per-file loop, over-counting a single finding once per file.
+                if entry["findings"] and file_scan_ids:
+                    first_file = _normalize_path(entry["files"][0])
+                    first_sid = file_scan_ids.get(
+                        first_file, next(iter(file_scan_ids.values()))
+                    )
                     for finding in entry["findings"]:
                         conn.execute(
                             """INSERT INTO findings (scan_id, file_path, finding_type,
                                description, github_issue_number) VALUES (?, ?, ?, ?, ?)""",
                             (
-                                scan_id,
-                                f,
+                                first_sid,
+                                first_file,
                                 "issue",  # default from scan-history format
                                 finding.get("description", ""),
                                 finding.get("issue_number"),

--- a/tests/test_scan_index.py
+++ b/tests/test_scan_index.py
@@ -455,13 +455,34 @@ class TestRebuild:
         # 2 files in first skill scan + 1 in second + 1 in qa scan = 4
         assert scans == 4
 
+        # #13133: exactly 1 finding row — #100 is attributed ONCE to the first
+        # file of the scan, NOT duplicated across every scanned file (the
+        # pre-fix over-count produced 2 rows for this 2-file/1-finding scan).
         findings = conn.execute("SELECT COUNT(*) FROM findings").fetchone()[0]
-        # 1 finding (#100) appears in both files of the first scan = 2
-        assert findings >= 1
+        assert findings == 1
+        rows = conn.execute(
+            "SELECT file_path, github_issue_number FROM findings"
+        ).fetchall()
+        assert len(rows) == 1
+        assert rows[0]["github_issue_number"] == 100
+        # Attributed to files[0] (tracker.py), matching record_scan's default,
+        # since scan-history carries no per-finding file attribution.
+        assert rows[0]["file_path"] == "references/scripts/tracker.py"
 
         # Check file_coverage was populated
         cov = conn.execute("SELECT COUNT(*) FROM file_coverage").fetchone()[0]
         assert cov >= 3  # at least 3 unique file paths
+
+        # #13133 symptom: finding_count must not be inflated across the scan's
+        # files. Only the first file carries the finding; the others stay at 0
+        # (pre-fix, BOTH tracker.py and compose.py showed finding_count=1).
+        def _fc(path):
+            r = conn.execute(
+                "SELECT finding_count FROM file_coverage WHERE file_path=?", (path,)
+            ).fetchone()
+            return r["finding_count"] if r else None
+        assert _fc("references/scripts/tracker.py") == 1
+        assert _fc("references/scripts/compose.py") == 0
         conn.close()
 
     def test_rebuild_deletes_old_db(self, scan_history_dir, tmp_path):


### PR DESCRIPTION
Fixes #13133 (verifier improvement-scan, low severity).

`scan_index.rebuild()` nested its findings INSERT inside the per-file loop (`scan_index.py:688`), so an N-file / 1-finding scan-history entry inserted **N** finding rows — inflating `finding_count` / `finding_density` for every file in a multi-file scan and skewing `suggest_targets` prioritization. The live `record_scan` path does the opposite (loops findings once, attributes each to `files[0]` default), so `rebuild` and `record_scan` built divergent DBs.

## Fix
Hoist the findings INSERT out of the per-file loop: capture each file's `scan_id` in a dict during the per-file loop, then insert each finding **once** attributed to `entry['files'][0]` (scan-history carries no per-finding file attribution, so `files[0]` mirrors `record_scan`'s default). Edge cases (empty files, all-`IntegrityError`) skip findings, guarded by `file_scan_ids` truthiness.

## Tests
Tightened `test_rebuilds_from_scan_history` (was `assert findings >= 1`, which masked the over-count): now asserts **exactly 1** finding row, attributed to `references/scripts/tracker.py` (`files[0]`), with `file_coverage.finding_count` = 1 for tracker.py and **0** for compose.py (pre-fix both showed 1). 42 tests green; full `run_tests.py static` → **PASS (4856/0/0)**.

DS code-review (real DeepSeek): **NO_FINDINGS**. Deterministic code — no CQ, no manifest change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)