### PR TITLE
#13052: v2_catalog_gate regex tolerates backtick-wrapped sub-skill markers

### DIFF
--- a/references/scripts/v2_catalog_gate.py
+++ b/references/scripts/v2_catalog_gate.py
@@ -41,8 +41,17 @@ import catalog_parser as _cp
 # (slash-bearing catalog names like `roles/dm/events/pr-merge-wait`
 # are valid per D1). Capture only the name; trailing whitespace and
 # the optional comment tail are not part of the lookup key.
+#
+# #13052: the name may be wrapped in backticks. The v2 link stage emits
+# top-level markers BARE, but markers hand-authored INSIDE sub-skill bodies
+# are styled `→ run sub-skill: \`pr-protocol\`` (see git-commit.md). Tolerate
+# the optional surrounding backticks so chained references are visible to
+# find_references. (A transitive-closure compose gate that walks resolved
+# sub-skill bodies would need this too, but that Part-2 enhancement is
+# DEFERRED — the naive closure walk false-positives on illustrative example
+# markers such as l4-curation.md's `security-smoke`; see #13052.)
 _REF_RE = re.compile(
-    r"→\s+run\s+sub-skill:\s+([a-z][a-z0-9/_-]*)"
+    r"→\s+run\s+sub-skill:\s+`?([a-z][a-z0-9/_-]*)`?"
 )
 
 

--- a/tests/test_v2_catalog_gate_d3.py
+++ b/tests/test_v2_catalog_gate_d3.py
@@ -95,6 +95,24 @@ class TestFindReferences:
             "boot-bootstrap", "boot-bootstrap",
         ]
 
+    def test_finds_backtick_wrapped_name_13052(self):
+        # #13052: markers hand-authored INSIDE sub-skill bodies are styled
+        # with backticks (e.g. git-commit.md → `pr-protocol`). The name must
+        # be captured WITHOUT the surrounding backticks.
+        text = "→ run sub-skill: `pr-protocol`"
+        assert gate.find_references(text) == ["pr-protocol"]
+
+    def test_finds_backtick_wrapped_slash_name_13052(self):
+        text = "→ run sub-skill: `roles/dm/events/pr-merge-wait`"
+        assert gate.find_references(text) == ["roles/dm/events/pr-merge-wait"]
+
+    def test_bare_and_backtick_forms_both_captured_13052(self):
+        text = (
+            "→ run sub-skill: cycle-runner\n"
+            "→ run sub-skill: `pr-protocol`"
+        )
+        assert gate.find_references(text) == ["cycle-runner", "pr-protocol"]
+
 
 # ---------------------------------------------------------------------------
 # AC6(a) clean compose -> no issues


### PR DESCRIPTION
Fixes #13052 (Part 1; low severity).

`v2_catalog_gate._REF_RE` matched only **bare** `→ run sub-skill: <name>` markers, so `find_references()` returned `[]` for backtick-styled markers authored inside sub-skill bodies (e.g. `git-commit.md` → `` `pr-protocol` ``).

## Fix (Part 1 — the titled defect)
Broadened `_REF_RE` to tolerate optional surrounding backticks (`` `?([a-z]…)`? ``); the name is captured **without** them. Bare + slash-bearing forms unchanged. The existing top-level compose gate is unaffected (the v2 link stage emits composed markers bare). +3 regression tests (backtick name / backtick slash-name / mixed bare+backtick).

## Part 2 DEFERRED (unsafe as specified)
The issue also proposed extending `validate_v2_compose` to walk the **transitive closure** of sub-skill bodies. An empirical closure check (now possible with the fixed regex) found a **real false-positive dangler**: `security-smoke`, referenced inside an `l4-curation.md` **worked-EXAMPLE** block (`### append` demo), not a live marker. A naive closure walk would abort compose on such illustrative markers — and distinguishing live vs example markers (same `→ run sub-skill:` syntax) is a separate design problem. The issue's premise ("today every chained marker resolves") was wrong. Recommend rescoping Part 2 (or closing #13052 at the find_references level) — see the pending-test comment.

## Verification
Full `run_tests.py static` → **PASS (4859 / 0 / 0)**. DS code-review (real DeepSeek): 1 finding (stale forward-ref comment) **fixed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)