### PR TITLE
#12846: wizard cmd_scan_summary fails closed on malformed .repo-scan.json

### DIFF
--- a/references/scripts/wizard.py
+++ b/references/scripts/wizard.py
@@ -3432,10 +3432,17 @@ def cmd_scan_summary(args):
     """
     target = args[0] if args else "."
     scan_path = Path(target) / ".squidsquad" / ".repo-scan.json"
+    scan_data = None
     if scan_path.exists():
-        scan_data = json.loads(scan_path.read_text(encoding="utf-8"))
-    else:
-        # Run scan on the fly
+        # #12846: a malformed/unreadable cache must NOT crash the command —
+        # fall back to a fresh scan below (matches the guarded reads in
+        # cmd_generate_defaults / scaffold_install).
+        try:
+            scan_data = json.loads(scan_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            scan_data = None
+    if scan_data is None:
+        # No usable cached scan (absent, malformed, or unreadable) — run on the fly.
         try:
             sys.path.insert(0, str(SCRIPT_DIR))
             from repo_scan import scan

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -2411,6 +2411,41 @@ class TestScanSummary:
         assert "Frameworks" not in result  # empty list not shown
 
 
+class TestCmdScanSummaryMalformed12846:
+    """#12846: a malformed/unreadable .repo-scan.json must NOT crash
+    cmd_scan_summary — it falls back to a fresh on-the-fly scan (matching the
+    guarded reads in cmd_generate_defaults / scaffold_install)."""
+
+    def test_malformed_cache_falls_back_not_crash(self, tmp_path, capsys, monkeypatch):
+        import repo_scan
+        monkeypatch.setattr(repo_scan, "scan", lambda target: {
+            "languages": ["python"], "frameworks": [], "test_frameworks": []})
+        ss = tmp_path / ".squidsquad"
+        ss.mkdir()
+        (ss / ".repo-scan.json").write_text("{not valid json", encoding="utf-8")
+        # Pre-fix: uncaught JSONDecodeError. Post-fix: clean fallback, rc 0.
+        rc = wizard.cmd_scan_summary([str(tmp_path)])
+        assert rc == 0
+        assert "python" in capsys.readouterr().out  # fell back to fresh scan
+
+    def test_valid_cache_used_not_rescanned(self, tmp_path, capsys, monkeypatch):
+        import json as _json
+        import repo_scan
+        called = []
+        monkeypatch.setattr(repo_scan, "scan",
+                            lambda target: called.append(1) or {})
+        ss = tmp_path / ".squidsquad"
+        ss.mkdir()
+        (ss / ".repo-scan.json").write_text(
+            _json.dumps({"languages": ["rust"], "frameworks": [],
+                         "test_frameworks": []}),
+            encoding="utf-8")
+        rc = wizard.cmd_scan_summary([str(tmp_path)])
+        assert rc == 0
+        assert "rust" in capsys.readouterr().out
+        assert not called  # valid cache used — no wasteful rescan
+
+
 # ---------------------------------------------------------------------------
 # Default Spec Generation (#13)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #12846 (low severity; surfaced by #12450 S2 DeepSeek review).

`cmd_scan_summary` (wizard.py) read an existing `.repo-scan.json` via `json.loads(scan_path.read_text())` with **no try/except** — a malformed or unreadable cache crashed the command with an uncaught `JSONDecodeError`/`OSError`, inconsistent with every other `.repo-scan.json` read in the file (`cmd_generate_defaults`, `scaffold_install`, `_write_l4_project_files` all guard with `(json.JSONDecodeError, OSError)`).

## Fix
Wrap the cached read in `try/except (json.JSONDecodeError, OSError)`; on failure leave `scan_data=None` and fall through to the existing on-the-fly `repo_scan.scan()` branch (better UX than an empty summary). The `None` sentinel unifies the absent-file and bad-file paths.

## Tests
+2 deterministic cases (monkeypatch `repo_scan.scan`): malformed cache → clean fallback (rc 0, fresh-scan output, no crash); valid cache → used as-is with no wasteful rescan. Full `run_tests.py static` → **PASS (4858 / 0 / 0)**.

DS code-review: external model degenerate → documented self-review (the 6-line guard mirrors 4 existing call sites; subagent review disproportionate). Deterministic code — no CQ, no manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)