### PR TITLE
--title

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -345,6 +345,30 @@ class AgentState:
         # judged dead. None until the first dispatch.
         self.last_dispatch_at = None
 
+    def reset_session_telemetry(self):
+        """Clear per-session activity + pause telemetry on a fresh (re)spawn.
+
+        #13113: the spawn paths already reset claude_pid / bootup_complete /
+        last_session_end / last_dispatch_at, but left these per-session fields
+        carrying the OLD session's values across the PID boundary. A respawned
+        record then showed the dead session's last_activity_at (frozen at the
+        pre-kill timestamp) until the new session landed its first heartbeat —
+        making a healthy fresh agent read as wedged, and (via a stale
+        in_flight_until) holding off death-detection in active_pause(). Reset
+        them to their fresh-AgentState defaults so a respawned record is
+        indistinguishable from a first boot.
+
+        Scope: only the per-session activity/pause telemetry. Crash-loop and
+        backoff bookkeeping (last_spawn_at, consecutive_fast_deaths,
+        reboot_history, reboot_blocked_until, last_stop_failure) is meant to
+        PERSIST across respawns by design and is deliberately not touched here.
+        """
+        self.last_activity_at = None
+        self.last_activity = None
+        self.in_flight_until = None
+        self.waiting_since = None
+        self.compacting_since = None
+
     def active_pause(self, now):
         """#12458 — return a short reason string if a hook currently explains
         this agent's silence/death (so the reboot decision should HOLD OFF), or
@@ -1175,6 +1199,11 @@ class HarnessState:
                             # baseline (a stale last_dispatch_at from before the
                             # death must not make the fresh agent read wedged).
                             agent.last_dispatch_at = None
+                            # #13113 — same rationale for the per-session activity
+                            # + pause telemetry: a stale last_activity_at / pause
+                            # flag from the dead session must not survive into the
+                            # fresh record (frozen-telemetry masquerade).
+                            agent.reset_session_telemetry()
                 elif result.get("action") == "error":
                     # #11640: boot_agent refused (e.g. unregistered/missing
                     # clone). Never spawned in REPO_ROOT — surface the refusal
@@ -2166,6 +2195,7 @@ async def lifespan(app: FastAPI):
                         agent_state.last_spawn_at = time.time()  # #12244 P2
                         agent_state.last_session_end = None  # #12418 F3
                         agent_state.last_dispatch_at = None  # #12271 slice d (DS-c1 F4)
+                        agent_state.reset_session_telemetry()  # #13113
                         agent_state.terminal_pid = result.get("terminal_pid")
                     state.set_agent(role, agent_state)
             state.save_state()
@@ -2496,6 +2526,7 @@ async def start_all():
                 agent_state.last_spawn_at = time.time()  # #12244 P2
                 agent_state.last_session_end = None  # #12418 F3
                 agent_state.last_dispatch_at = None  # #12271 slice d (DS-c1 F4)
+                agent_state.reset_session_telemetry()  # #13113
                 agent_state.terminal_pid = result.get("terminal_pid")
             state.set_agent(role, agent_state)
 
@@ -2610,6 +2641,7 @@ async def start_agent(role: str):
             agent_state.last_spawn_at = time.time()  # #12244 P2
             agent_state.last_session_end = None  # #12418 F3
             agent_state.last_dispatch_at = None  # #12271 slice d (DS-c1 F4)
+            agent_state.reset_session_telemetry()  # #13113
             agent_state.terminal_pid = result.get("terminal_pid")
             # #8695: spawning a fresh agent → bootup-complete must be re-asserted
             # by the new process before we'll dispatch any events to it.
@@ -4296,6 +4328,7 @@ def _respawn_agent_process(role):
         agent.last_spawn_at = time.time()
         agent.last_session_end = None
         agent.last_dispatch_at = None
+        agent.reset_session_telemetry()  # #13113
         agent.terminal_pid = result.get("terminal_pid")
         state.set_agent(role, agent)
         state.save_state()

--- a/tests/test_harness_telemetry_reset_13113.py
+++ b/tests/test_harness_telemetry_reset_13113.py
@@ -1,0 +1,110 @@
+"""Regression tests for #13113 — respawned-agent telemetry masquerade.
+
+The (re)spawn paths reset claude_pid / bootup_complete / last_session_end /
+last_dispatch_at, but historically left the per-session ACTIVITY + PAUSE
+telemetry (last_activity_at, last_activity, in_flight_until, waiting_since,
+compacting_since) carrying the dead session's values across the PID boundary.
+A respawned record then showed the old session's last_activity_at — frozen at
+the pre-kill timestamp — until the new session landed its first heartbeat,
+making a healthy fresh agent indistinguishable from a wedged one (and, via a
+stale in_flight_until, holding off death-detection in active_pause()).
+
+`AgentState.reset_session_telemetry()` clears that set on every spawn path so a
+respawned record is indistinguishable from a first boot. These tests lock the
+behavior, the deliberate scope boundary (backoff bookkeeping persists), and the
+structural pairing (no spawn path may clear last_dispatch_at without it).
+"""
+
+import inspect
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "references" / "scripts"))
+
+import harness  # noqa: E402
+from harness import AgentState  # noqa: E402
+
+
+# The per-session activity + pause fields the helper must reset.
+_SESSION_FIELDS = (
+    "last_activity_at",
+    "last_activity",
+    "in_flight_until",
+    "waiting_since",
+    "compacting_since",
+)
+
+# Backoff / crash-loop bookkeeping that MUST survive a respawn by design.
+_PERSIST_FIELDS = {
+    "last_spawn_at": 1_234_567.0,
+    "consecutive_fast_deaths": 3,
+    "reboot_history": [111.0, 222.0],
+    "reboot_blocked_until": 999_999.0,
+    "last_stop_failure": {"cause": "rate_limit", "at": 42.0},
+}
+
+
+def _staled():
+    """An agent record carrying a dead session's stale per-session telemetry."""
+    a = AgentState("skill", "/clone/skill")
+    a.last_activity_at = 22_060.0
+    a.last_activity = {"at": 22_060.0, "event": "PostToolUse", "tool": "Read"}
+    a.in_flight_until = 22_100.0
+    a.waiting_since = 22_050.0
+    a.compacting_since = 22_040.0
+    return a
+
+
+class TestResetSessionTelemetry:
+    def test_clears_all_session_fields(self):
+        a = _staled()
+        a.reset_session_telemetry()
+        for f in _SESSION_FIELDS:
+            assert getattr(a, f) is None, f"{f} not cleared by reset"
+
+    def test_respawned_record_matches_fresh_boot(self):
+        """After reset, the per-session telemetry is indistinguishable from a
+        first-boot AgentState — the whole point (no masquerade)."""
+        fresh = AgentState("skill", "/clone/skill")
+        a = _staled()
+        a.reset_session_telemetry()
+        for f in _SESSION_FIELDS:
+            assert getattr(a, f) == getattr(fresh, f)
+
+    def test_preserves_backoff_bookkeeping(self):
+        """Scope boundary: crash-loop / backoff fields persist across respawns
+        by design and must NOT be touched."""
+        a = _staled()
+        for f, v in _PERSIST_FIELDS.items():
+            setattr(a, f, v)
+        a.reset_session_telemetry()
+        for f, v in _PERSIST_FIELDS.items():
+            assert getattr(a, f) == v, f"{f} wrongly reset (must persist)"
+
+    def test_idempotent_on_fresh_agent(self):
+        """Calling it on an already-fresh record is a harmless no-op."""
+        a = AgentState("skill")
+        a.reset_session_telemetry()
+        for f in _SESSION_FIELDS:
+            assert getattr(a, f) is None
+
+
+class TestSpawnPathPairing:
+    def test_every_spawn_path_resets_session_telemetry(self):
+        """Structural guard (mirrors the DS-c1 F4 last_dispatch_at pairing):
+        every spawn site that clears last_dispatch_at must also call
+        reset_session_telemetry(), so a future spawn path cannot reintroduce
+        the masquerade. last_dispatch_at = None appears once in __init__ plus
+        once per spawn path; the reset is called once per spawn path."""
+        src = inspect.getsource(harness)
+        ld_total = src.count("last_dispatch_at = None")
+        spawn_dispatch_clears = ld_total - 1  # exclude the __init__ default
+        reset_calls = src.count(".reset_session_telemetry()")
+        assert spawn_dispatch_clears >= 1, "no spawn-path dispatch clears found"
+        assert reset_calls >= spawn_dispatch_clears, (
+            f"reset_session_telemetry() called {reset_calls}x but "
+            f"{spawn_dispatch_clears} spawn paths clear last_dispatch_at — a "
+            f"spawn path clears the dispatch reference without resetting the "
+            f"per-session telemetry (#13113 masquerade regression)"
+        )


### PR DESCRIPTION
#13113: reset per-session telemetry on respawn (frozen-telemetry masquerade) --body ## #13113 — respawned-agent telemetry frozen, defeating health diagnosis

### Root cause
The 5 (re)spawn paths in `harness.py` reset `claude_pid` / `bootup_complete` / `last_session_end` / `last_dispatch_at`, but left the per-session **activity + pause** telemetry (`last_activity_at`, `last_activity`, `in_flight_until`, `waiting_since`, `compacting_since`) carrying the **dead session's** values across the PID boundary. A respawned record then displayed the old session's `last_activity_at` — frozen at the pre-kill timestamp — until the new session landed its first heartbeat: a healthy fresh agent reads as wedged, and a stale `in_flight_until` holds off death-detection in `active_pause()`.

RCA also ruled out the report's PID-guard hypothesis: both telemetry write paths (`bootup-complete` handler, `hook_activity`) key the agent record by role and write **unconditionally** — no PID/intent/already-booted guard. A *delivered* POST always lands; the issue is the stale record between respawn and the first new POST. Live `/status` cross-check confirmed the report's subject (qa) self-recovered once its new session landed a heartbeat — consistent with the masquerade, not a permanent drop.

### Fix
- Add `AgentState.reset_session_telemetry()` clearing the 5 per-session fields to their fresh-`AgentState` defaults.
- Call it from **all 5** spawn paths: auto-reboot (`update_health`), `_deferred_init` auto-start, `POST /agents/all/start`, `POST /agents/{role}/start`, deploy respawn.
- **Scope boundary**: crash-loop / backoff bookkeeping (`last_spawn_at`, `consecutive_fast_deaths`, `reboot_history`, `reboot_blocked_until`, `last_stop_failure`) persists across respawns by design — deliberately untouched.

### Tests
`tests/test_harness_telemetry_reset_13113.py` — behavioral (clears session fields; respawned record matches a fresh boot; preserves backoff bookkeeping; idempotent) + a **structural pairing guard** mirroring the DS-c1 F4 `last_dispatch_at` test: every spawn path clearing `last_dispatch_at` must also reset, so a future spawn path can't reintroduce the masquerade.

### Gates
- Full static gate: **PASS 4861/0/0**.
- DeepSeek code-review: **NO_FINDINGS** (traced all 5 spawn paths, scope, persistence, thread-safety, tests).
- Deterministic harness code — no CQ; new test file isn't installer-tracked — no manifest update.

### Not in scope (filed separately)
`#13142` (role:pm) — a live incident where dm is **genuinely** wedged alive-but-idle (its telemetry is *correct*); needs a manual reap. The deeper "harness should auto-detect wedged-alive agents" is noted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)