### PR TITLE
--title

### DIFF
--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -34,6 +34,7 @@ import io
 import json
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 # Ensure stdout/stderr can handle UTF-8 on Windows (cp1252 consoles choke on em dashes etc.)
@@ -489,12 +490,21 @@ def pr_ready(pr_number):
     return True
 
 
-def pr_merge(pr_number, strategy="squash"):
+def pr_merge(pr_number, strategy="squash", _max_base_retries=3, _base_retry_delay=2.0):
     """Merge a PR. Uses forge adapter for non-GitHub backends,
     gh CLI for GitHub. Returns (success, message).
 
     Checks PR state first — if already merged, returns success.
     On merge conflict or unexpected failure, returns failure with details.
+
+    #10540: "Base branch was modified" is a TRANSIENT batch-ship race (not a
+    real conflict) — when DM drains a deep ship queue, each successful merge
+    moves main's SHA, so PRs dispatched against the old base are rejected until
+    GitHub recomputes mergeability; the same PR retried alone succeeds. The
+    gh-CLI path retries that specific error up to ``_max_base_retries`` times
+    (``_base_retry_delay`` seconds apart, to let GitHub settle), while a real
+    ``merge conflict`` stays terminal (routed back to in-progress for rebase,
+    never retried). The retry knobs are parameters for deterministic testing.
     """
     try:
         from forge_adapter import get_adapter, _read_forge_config
@@ -539,33 +549,49 @@ def pr_merge(pr_number, strategy="squash"):
         except (json.JSONDecodeError, AttributeError):
             pass
 
-    # Attempt merge
+    # Attempt merge, retrying ONLY the transient "Base branch was modified"
+    # batch-ship race (#10540). A real merge conflict is terminal.
     merge_args = ["gh", "pr", "merge", str(pr_number), f"--{strategy}", "--delete-branch"]
-    result = _run_list(merge_args, check=False)
-    if result.returncode == 0:
-        # pr-merge event removed (#6126) — harness emits pr-merged instead
-        print(f"PR #{pr_number} merged ({strategy})")
-        # Extract linked issue number from branch name
-        branch_result = _run_list(
-            ["gh", "pr", "view", str(pr_number), "--json", "headRefName"],
-            check=False,
-        )
-        if branch_result.returncode == 0:
-            try:
-                branch_name = json.loads(branch_result.stdout.strip()).get("headRefName", "")
-                # Branch format: squidsquad/role/NUMBER
-                parts = branch_name.split("/")
-                if len(parts) >= 2 and parts[0] == "squidsquad" and parts[-1].isdigit():
-                    issue_num = parts[-1]
-                    print(f"PR linked to #{issue_num} -- GitHub auto-close will handle issue state")
-            except (json.JSONDecodeError, AttributeError, IndexError):
-                pass
-        return True, "merged"
-    else:
+    for attempt in range(_max_base_retries + 1):
+        result = _run_list(merge_args, check=False)
+        if result.returncode == 0:
+            # pr-merge event removed (#6126) — harness emits pr-merged instead
+            print(f"PR #{pr_number} merged ({strategy})")
+            # Extract linked issue number from branch name
+            branch_result = _run_list(
+                ["gh", "pr", "view", str(pr_number), "--json", "headRefName"],
+                check=False,
+            )
+            if branch_result.returncode == 0:
+                try:
+                    branch_name = json.loads(branch_result.stdout.strip()).get("headRefName", "")
+                    # Branch format: squidsquad/role/NUMBER
+                    parts = branch_name.split("/")
+                    if len(parts) >= 2 and parts[0] == "squidsquad" and parts[-1].isdigit():
+                        issue_num = parts[-1]
+                        print(f"PR linked to #{issue_num} -- GitHub auto-close will handle issue state")
+                except (json.JSONDecodeError, AttributeError, IndexError):
+                    pass
+            return True, "merged"
+
         error = result.stderr.strip()
-        if "merge conflict" in error.lower() or "not mergeable" in error.lower():
+        error_lower = error.lower()
+        # Real conflict — terminal, never retried (routes back for rebase).
+        if "merge conflict" in error_lower or "not mergeable" in error_lower:
             print(f"PR #{pr_number} has merge conflicts", file=sys.stderr)
             return False, "merge conflict"
+        # Transient batch-ship race — an earlier merge moved main's SHA. Retry
+        # after a short settle so GitHub recomputes mergeability against the new
+        # base (#10540). Checked AFTER the conflict guard so a real conflict
+        # never masquerades as the race.
+        if "base branch was modified" in error_lower and attempt < _max_base_retries:
+            print(
+                f"PR #{pr_number}: base branch moved (batch-ship race) — "
+                f"retry {attempt + 1}/{_max_base_retries} after {_base_retry_delay}s",
+                file=sys.stderr,
+            )
+            time.sleep(_base_retry_delay)
+            continue
         print(f"ERROR: PR #{pr_number} merge failed: {error}", file=sys.stderr)
         return False, f"merge failed: {error}"
 

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -410,6 +410,70 @@ class TestPrMerge:
         merge_call = mock_run.call_args_list[1]
         assert "--rebase" in merge_call[0][0]
 
+    # --- #10540: "Base branch was modified" batch-ship race retry ---
+
+    @patch("git_ops._run_list")
+    def test_base_modified_retries_then_succeeds(self, mock_run):
+        """The transient batch-ship race is retried and succeeds once the base
+        settles — distinct from a terminal failure."""
+        mock_run.side_effect = [
+            _mock_result(stdout='{"state": "OPEN"}'),                       # state check
+            _mock_result(stderr="GraphQL: Base branch was modified. Review and try the merge again.", returncode=1),  # attempt 1
+            _mock_result(stderr="GraphQL: Base branch was modified.", returncode=1),  # attempt 2
+            _mock_result(stdout=""),                                        # attempt 3 — success
+            _mock_result(stdout='{"headRefName": "squidsquad/skill/42"}'),  # branch lookup
+        ]
+        success, msg = git_ops.pr_merge(42, _base_retry_delay=0)
+        assert success is True
+        assert msg == "merged"
+        # 1 state check + 3 merge attempts + 1 branch lookup = 5 calls
+        assert mock_run.call_count == 5
+
+    @patch("git_ops._run_list")
+    def test_base_modified_exhausts_retries(self, mock_run):
+        """If the race never clears within the retry budget, it fails as a
+        merge-failed (not silently, not as a conflict)."""
+        mock_run.side_effect = [
+            _mock_result(stdout='{"state": "OPEN"}'),
+        ] + [
+            _mock_result(stderr="GraphQL: Base branch was modified.", returncode=1)
+            for _ in range(4)  # _max_base_retries=3 → 4 attempts (initial + 3 retries)
+        ]
+        success, msg = git_ops.pr_merge(42, _max_base_retries=3, _base_retry_delay=0)
+        assert success is False
+        assert "merge failed" in msg
+        assert "Base branch was modified" in msg
+        # 1 state check + 4 merge attempts = 5 calls (no branch lookup on failure)
+        assert mock_run.call_count == 5
+
+    @patch("git_ops._run_list")
+    def test_real_conflict_is_terminal_not_retried(self, mock_run):
+        """A real merge conflict must NOT be retried (it routes back for rebase)
+        — only ONE merge attempt, even though retries are available."""
+        mock_run.side_effect = [
+            _mock_result(stdout='{"state": "OPEN"}'),
+            _mock_result(stderr="failed to merge: merge conflict between base and head", returncode=1),
+        ]
+        success, msg = git_ops.pr_merge(42, _max_base_retries=3, _base_retry_delay=0)
+        assert success is False
+        assert msg == "merge conflict"
+        # 1 state check + exactly 1 merge attempt (no retry)
+        assert mock_run.call_count == 2
+
+    @patch("git_ops._run_list")
+    def test_base_modified_then_real_conflict(self, mock_run):
+        """A retry can surface a real conflict (base moved into a true conflict)
+        — once it does, it's terminal, not retried further."""
+        mock_run.side_effect = [
+            _mock_result(stdout='{"state": "OPEN"}'),
+            _mock_result(stderr="GraphQL: Base branch was modified.", returncode=1),  # race
+            _mock_result(stderr="not mergeable: merge conflict", returncode=1),        # now a real conflict
+        ]
+        success, msg = git_ops.pr_merge(42, _max_base_retries=3, _base_retry_delay=0)
+        assert success is False
+        assert msg == "merge conflict"
+        assert mock_run.call_count == 3  # state + race attempt + conflict attempt
+
     @patch("git_ops._run_list")
     def test_state_check_fails_still_attempts_merge(self, mock_run):
         # State check fails (non-zero), merge succeeds, branch lookup


### PR DESCRIPTION
#10540: retry transient 'Base branch was modified' batch-ship merge race --body ## #10540 — DM batch ship: 8 of 10 PR merges fail with 'Base branch was modified'

### Root cause
`git_ops.pr_merge`'s gh-CLI path distinguished a real `merge conflict`/`not mergeable` (terminal → route back for rebase) but let **`Base branch was modified`** fall into the generic terminal-failure branch. That error is a **transient batch-ship race**: when DM drains a deep ship queue, each successful merge moves `main`'s SHA, so PRs dispatched against the now-stale base are rejected until GitHub recomputes mergeability — the *same PR retried alone succeeds*. Lumping it with terminal failures drained the queue at ~20% success/cycle (the remaining 8 inherited by the next cycle, repeating the race).

### Fix
Bounded retry-on-base-modified loop in `pr_merge`:
- `_max_base_retries=3` (4 attempts total), `_base_retry_delay=2.0s` to let GitHub settle.
- The real-conflict guard is checked **first** — a `merge conflict` is terminal, never retried, still returns `"merge conflict"` so DM routes it back to in-progress.
- The base-modified guard is checked after, retries within budget, then falls through to `merge failed` if it never clears.
- Retry knobs are parameters for deterministic testing (no real sleeps in tests).

### Tests (`tests/test_git_ops.py`)
- retry-then-succeed (race clears on attempt 3)
- exhaust-retries → `merge failed` (not silent, not a conflict)
- real-conflict-not-retried (exactly 1 merge attempt despite budget)
- base-modified-then-real-conflict (a retry surfacing a true conflict is terminal)

### Gates
- Full static gate: **PASS 4860/0/0**.
- DeepSeek code-review: **NO_FINDINGS** (verified race-vs-conflict distinction, bounded loop, attempt counts, no merge-wrongly/loop path).
- Deterministic code — no CQ; no new installer-tracked files — no manifest update.

### Why now
The 6 currently-stranded pending-ship PRs (blocked on the wedged dm — see #13142) will hit exactly this race when dm resumes batch-shipping; this makes that recovery actually drain the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)