### PR TITLE
--title

### DIFF
--- a/references/scripts/repo_scan.py
+++ b/references/scripts/repo_scan.py
@@ -386,7 +386,13 @@ def main():
     save = "--save" in args
 
     for i, a in enumerate(args):
-        if a == "--path" and i + 1 < len(args):
+        if a == "--path":
+            # #13145 F2: --path as the final token (no value) must be a usage
+            # error (exit 2 per the module docstring), not a silent fall-through
+            # that scans REPO_ROOT and returns 0.
+            if i + 1 >= len(args):
+                print("ERROR: --path requires an argument", file=sys.stderr)
+                return 2
             root = Path(args[i + 1])
             if not root.exists():
                 print(f"ERROR: Path does not exist: {root}", file=sys.stderr)
@@ -398,8 +404,15 @@ def main():
 
     if save:
         save_path = Path(root) / ".squidsquad" / ".repo-scan.json"
-        save_path.parent.mkdir(parents=True, exist_ok=True)
-        save_path.write_text(output + "\n", encoding="utf-8")
+        # #13145 F1: a read-only FS / permission error must exit 2 (docstring
+        # contract), not raise an unhandled OSError traceback — mirrors the
+        # try/except OSError guards on the sibling reads in this file.
+        try:
+            save_path.parent.mkdir(parents=True, exist_ok=True)
+            save_path.write_text(output + "\n", encoding="utf-8")
+        except OSError as e:
+            print(f"ERROR: Cannot save to {save_path}: {e}", file=sys.stderr)
+            return 2
         print(f"Saved to {save_path}", file=sys.stderr)
 
     return 0

--- a/tests/test_repo_scan.py
+++ b/tests/test_repo_scan.py
@@ -197,6 +197,26 @@ class TestCLI:
         code = repo_scan.main()
         assert code == 2
 
+    def test_path_without_value_is_usage_error(self, capsys):
+        """#13145 F2: --path as the final token (no value) must exit 2, not
+        silently fall through to scanning REPO_ROOT and returning 0."""
+        sys.argv = ["repo_scan.py", "--path"]
+        code = repo_scan.main()
+        assert code == 2
+        assert "--path requires an argument" in capsys.readouterr().err
+
+    def test_save_oserror_returns_exit_2(self, tmp_path, capsys):
+        """#13145 F1: an unwritable --save target must exit 2 (docstring
+        contract), not raise an unhandled OSError. Here .squidsquad exists as a
+        FILE, so mkdir(parents=True, exist_ok=True) on it raises FileExistsError
+        (an OSError subclass) — exercising the guard deterministically."""
+        (tmp_path / ".squidsquad").write_text("i am a file, not a dir")
+        (tmp_path / "app.py").write_text("")
+        sys.argv = ["repo_scan.py", "--path", str(tmp_path), "--save"]
+        code = repo_scan.main()
+        assert code == 2
+        assert "Cannot save" in capsys.readouterr().err
+
 
 class TestScanCurrentRepo:
     def test_detects_python_in_squidsquad(self):


### PR DESCRIPTION
#13145: repo_scan.py main() honors its documented exit-2 contract --body ## #13145 — two exit-code contract violations in `repo_scan.py main()`

The module docstring contracts exit **0 (success) / 2 (usage error)**, but `main()` violated it in two edge cases (both found by qa improvement-scan, verified by reading the code).

### F2 — `--path` with no value silently scans REPO_ROOT
`if a == "--path" and i + 1 < len(args):` — when `--path` is the final token, the guard is False, the block is skipped, `root` stays `REPO_ROOT`, and it returns 0. A typo'd `repo_scan.py --path` silently scanned the wrong directory. **Fix:** `--path` with no following argument now prints `ERROR: --path requires an argument` and returns 2.

### F1 — unguarded `--save` write
`save_path.parent.mkdir(...)` + `save_path.write_text(...)` were not wrapped → an unhandled `OSError` traceback on a read-only/permission-denied target, instead of the contracted exit 2. **Fix:** wrapped in `try/except OSError` → `ERROR: Cannot save to ...` + return 2, mirroring the sibling `try/except OSError` guards already in this file.

### Tests (`tests/test_repo_scan.py` TestCLI)
- `--path` as the final token → exit 2 + usage message.
- `--save` where `.squidsquad` exists as a FILE → `mkdir(parents=True, exist_ok=True)` raises `FileExistsError` (an `OSError` subclass) → exit 2 + "Cannot save" (deterministic, cross-platform, no monkeypatch).

### Gates
- Full static gate: **PASS 4858/0/0**.
- Deterministic utility script (not high-blast) with an exact pattern-mirroring fix → documented self-review per the #12846 precedent; no CQ (deterministic), no new installer-tracked files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)