### PR TITLE
#13156 — harness POST /events fails closed (400) on malformed body

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -3072,7 +3072,19 @@ async def receive_event(request: Request):
       auto-assigned (#11404 AC1) so the event cannot be silently skipped by
       id-tracking consumers (``event_poll`` skips id-less events).
     """
-    body = await request.json()
+    # #13156: fail CLOSED on a malformed body. stdlib json.loads (strict=True,
+    # used by Starlette's request.json()) raises JSONDecodeError on a raw
+    # (unescaped) control character in a string field — e.g. a hand-built /
+    # curl body or an emit path that serializes multi-line text without
+    # JSON-escaping. Unguarded, that propagated to the global handler as a 500
+    # (47x in harness-errors.log, a fixed-position retry loop). Reject cleanly
+    # with 400 instead so the bad event is dropped, not crashed-on. (ValueError
+    # covers JSONDecodeError + UnicodeDecodeError, both ValueError subclasses.)
+    try:
+        body = await request.json()
+    except (json.JSONDecodeError, ValueError) as e:
+        _log(f"DROPPED malformed event body (400): {e}")
+        raise HTTPException(status_code=400, detail=f"malformed JSON body: {e}")
 
     # Validate minimal fields
     event_type = body.get("event_type")

--- a/tests/test_13156_malformed_event_body.py
+++ b/tests/test_13156_malformed_event_body.py
@@ -1,0 +1,78 @@
+"""Regression: harness `POST /events` must fail CLOSED (400) on a malformed
+body, not crash with a 500 (#13156).
+
+Before the fix, `receive_event` called `await request.json()` unguarded; a raw
+(unescaped) control character in a JSON string field made stdlib `json.loads`
+(strict=True) raise `JSONDecodeError`, which propagated to the global exception
+handler as a 500 — observed 47x in harness-errors.log, a fixed-position retry
+loop. The endpoint must reject malformed input cleanly with 400 instead.
+"""
+
+import sys
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "references" / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+try:
+    from fastapi.testclient import TestClient
+    import harness  # noqa: F401
+    from harness import app, state
+    _HTTP_OK = True
+except Exception:  # pragma: no cover - import guard
+    _HTTP_OK = False
+
+
+@unittest.skipUnless(_HTTP_OK, "fastapi / harness not importable")
+class TestMalformedEventBody(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        state.start_time = time.time()
+        state.port = 7373
+        cls.client = TestClient(app, raise_server_exceptions=False)
+
+    def test_raw_control_char_body_returns_400_not_500(self):
+        """A raw newline (0x0a) inside a JSON string field is invalid per strict
+        JSON. The handler must return 400 (fail closed), NOT 500 (crash)."""
+        # Literal newline byte inside the "detail" string — the exact shape the
+        # bug hit (multi-line text serialized without JSON-escaping).
+        raw = b'{"event_type":"booted","role":"skill","payload":{"detail":"line1\nline2"}}'
+        with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+             patch("harness._persist_harness_error") as mock_persist:
+            resp = self.client.post(
+                "/events", content=raw,
+                headers={"content-type": "application/json"},
+            )
+        self.assertEqual(resp.status_code, 400, f"expected 400, got {resp.status_code}")
+        # The 400 is an intentional HTTPException — it must NOT be captured as a
+        # 500 by the global exception handler (#12824).
+        mock_persist.assert_not_called()
+
+    def test_raw_control_char_other_position_also_400(self):
+        """A different raw control char (0x01) in a string also fails closed."""
+        raw = b'{"event_type":"booted","role":"skill","x":"a\x01b"}'
+        with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+             patch("harness._persist_harness_error") as mock_persist:
+            resp = self.client.post(
+                "/events", content=raw,
+                headers={"content-type": "application/json"},
+            )
+        self.assertEqual(resp.status_code, 400)
+        mock_persist.assert_not_called()
+
+    def test_well_formed_body_still_accepted(self):
+        """Control: a properly-escaped body (multi-line via \\n escape) is still
+        accepted — the guard rejects only genuinely malformed JSON."""
+        with patch("harness.boot_remote._get_all_roles", return_value=["skill"]):
+            resp = self.client.post(
+                "/events",
+                json={"event_type": "booted", "role": "skill",
+                      "payload": {"detail": "line1\nline2"}},  # json= escapes the \n
+            )
+        # Valid body: stored (200). Not a 400/500.
+        self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
## #13156 — harness `POST /events` fails closed (400), not 500, on a malformed body

**Bug (live, recurring 47x)**: `receive_event` called `await request.json()` unguarded. A raw (unescaped) control character in a JSON string field made stdlib `json.loads` (strict) raise `JSONDecodeError`, which propagated to the global exception handler as a **500** — a fixed-position retry loop spinning indefinitely.

**Fix** (`references/scripts/harness.py`): wrap the body parse in `try/except (json.JSONDecodeError, ValueError)` → `raise HTTPException(400)` + `_log` the drop. Fail-closed: a malformed POST is rejected cleanly instead of crashing the handler. Consistent with the existing missing-fields 400; per #12824 the global handler intentionally passes 4xx through (not captured as 500).

**Root-cause note**: `event_bus.emit` (the main Python emit path) already serializes via `json.dumps(...).encode()`, which escapes control chars — so it is **safe**. The bad bytes come from a hand-built / curl caller (an agent POST or external script), exactly what the 400 now rejects. The new `_log("DROPPED malformed event body")` line converts the silent 500-loop into a logged 400 that **identifies the offending caller** for any future targeted emit-path fix.

**Regression test** (`tests/test_13156_malformed_event_body.py`, 3 cases): raw newline in a string → 400 (not 500); raw 0x01 control char → 400; well-formed multi-line body (escaped `\n`) → still 200 (guard rejects only malformed JSON).

**DS review**: NO_FINDINGS (try wraps only `request.json()`; 400 passes through; empty/non-UTF-8 bodies → 400). DS noted one **pre-existing, out-of-scope** edge: a valid-but-non-dict JSON body (`[1,2,3]`/`null`) still reaches `body.get()` → 500 (AttributeError). That is outside #13156's "malformed body parse" framing (non-dict parses fine) — flagged here so it can be a tiny follow-on if desired; not fixed in this PR to keep scope to the observed live bug.

**Gate**: `run_tests.py static` PASS — 4886/0/0.