### PR TITLE
#13148 — align harness ack-stop handler to settled result enum (checkpointed/aborted/drained)

### DIFF
--- a/references/scripts/event_bus.py
+++ b/references/scripts/event_bus.py
@@ -189,12 +189,14 @@ def ack_cursor(event_id, role):
 def ack_stop(event_id, result, role=None):
     """Acknowledge a stop request from the harness (#9873-A D10 / AC-11).
 
-    Emits ``event_type="ack-stop"`` with payload ``{event_id, result}``. The
-    harness inline handler preserves the prior ``ack`` stop-confirmed
-    behavior at AC-12 — when ``result == "stop-confirmed"`` and the agent is
-    in ``INTENT_STOPPING``, the harness persists agent state without
-    resetting ``intent_set_at`` (which would extend the 60s force-kill
-    window per CONTEXT-4792 §3.3 Q7).
+    Emits ``event_type="ack-stop"`` with payload ``{event_id, result}``.
+    ``result`` is the settled stop-path enum — ``"checkpointed"`` /
+    ``"aborted"`` / ``"drained"`` (AGENT-RUNTIME §10 Q11, closed 2026-05-30) —
+    or ``"deploy-halted"`` for a deploy-signal halt. (The pre-#13148 value
+    ``"stop-confirmed"`` is obsolete and no longer recognized by the handler.)
+    When ``result`` is a stop-path value and the agent is in ``INTENT_STOPPING``,
+    the harness persists agent state without resetting ``intent_set_at`` (which
+    would extend the 60s force-kill window per CONTEXT-4792 §3.3 Q7).
 
     The agent's role is normally read from ``SQUIDSQUAD_ROLE`` (set by
     ``thin_launcher.py`` at spawn time). Callers may pass ``role`` explicitly

--- a/references/scripts/event_catalog.py
+++ b/references/scripts/event_catalog.py
@@ -95,7 +95,7 @@ EMITTED = {
         "payload_fields": ["event_id", "role"],
     },
     "ack-stop": {
-        "description": "Agent acknowledges a stop request — confirms the agent has accepted an intent=stopping transition. Result field carries the disposition (e.g. \"stop-confirmed\", or \"deploy-halted\" for a deploy-signal halt).",
+        "description": "Agent acknowledges a stop request — confirms the agent has accepted an intent=stopping transition. Result field carries the disposition: one of \"checkpointed\" / \"aborted\" / \"drained\" (the settled stop-path enum, AGENT-RUNTIME §10 Q11), or \"deploy-halted\" for a deploy-signal halt.",
         "source": "event_bus.py ack_stop()",
         "payload_fields": ["event_id", "result"],
     },

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -3198,14 +3198,30 @@ async def receive_event(request: Request):
             # §3.3 Q7). Also only fires when the agent is still in STOPPING:
             # any subsequent operator action (RUNNING / RESTARTING / STOPPED)
             # supersedes this ack, which is now stale.
-            if ack_payload.get("result") == "stop-confirmed":
+            #
+            # #13148: the stop-path ack-stop result enum is SETTLED to
+            # 'checkpointed' | 'aborted' | 'drained' (AGENT-RUNTIME §10 Q11,
+            # closed 2026-05-30). This branch previously keyed on the obsolete
+            # 'stop-confirmed' (NOT in the enum) — so a correctly-emitted stop
+            # ack would have silently missed it. Recognize the settled values:
+            # 'checkpointed'/'drained' = clean stop; 'aborted' = graceful stop
+            # FAILED → the existing 60s force-kill net is the escalation (logged
+            # for visibility). No agent-side emitter exists yet (event_bus
+            # .ack_stop has no callers); wiring one is the follow-on — this
+            # aligns the handler so it works correctly when that lands.
+            _stop_result = ack_payload.get("result")
+            if _stop_result in ("checkpointed", "aborted", "drained"):
+                if _stop_result == "aborted":
+                    _log(f"{role}: ack-stop result=aborted (graceful stop FAILED)"
+                         f" — 60s force-kill net will escalate")
                 with state._lock:
                     agent = state.agents.get(role)
                     if agent and agent.intent == AgentState.INTENT_STOPPING:
                         # Intent already STOPPING and intent_set_at already
-                        # recorded at request time — nothing to update here.
-                        # The save_state below is a no-op for these fields
-                        # but kept for parity with other ack paths.
+                        # recorded at request time — do NOT reset it (would
+                        # extend the 60s window). The save_state below is a
+                        # no-op for these fields but kept for parity with
+                        # other ack paths.
                         pass
                 # #9242: disk write off the asyncio event loop.
                 await asyncio.to_thread(state.save_state)

--- a/tests/test_13148_ack_stop_enum.py
+++ b/tests/test_13148_ack_stop_enum.py
@@ -1,0 +1,95 @@
+"""Regression: the harness `ack-stop` handler recognizes the SETTLED result
+enum — 'checkpointed' / 'aborted' / 'drained' (AGENT-RUNTIME §10 Q11, closed
+2026-05-30) — not the obsolete 'stop-confirmed' (#13148).
+
+Before the fix, `receive_event` keyed the stop-confirm branch on
+`result == "stop-confirmed"`, which is NOT in the settled enum — so a
+correctly-emitted stop ack would have silently missed it. These tests POST the
+settled values and assert the handler accepts them (200) without resetting
+`intent_set_at` (which would extend the 60s force-kill window).
+"""
+
+import sys
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "references" / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+try:
+    from fastapi.testclient import TestClient
+    import harness  # noqa: F401
+    from harness import app, state, AgentState
+    _HTTP_OK = True
+except Exception:  # pragma: no cover - import guard
+    _HTTP_OK = False
+
+
+@unittest.skipUnless(_HTTP_OK, "fastapi / harness not importable")
+class TestAckStopSettledEnum(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        state.start_time = time.time()
+        state.port = 7373
+        cls.client = TestClient(app, raise_server_exceptions=False)
+
+    def _stopping_agent(self, set_at=12345.0):
+        agent = AgentState("skill", "/p")
+        agent.intent = AgentState.INTENT_STOPPING
+        agent.intent_set_at = set_at
+        state.set_agent("skill", agent)
+        return agent
+
+    def _post(self, result):
+        with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+             patch.object(state, "save_state"):
+            return self.client.post(
+                "/events",
+                json={"event_type": "ack-stop", "role": "skill",
+                      "payload": {"event_id": "evt-1", "result": result}},
+            )
+
+    def test_checkpointed_accepted_without_clock_reset(self):
+        agent = self._stopping_agent(set_at=12345.0)
+        resp = self._post("checkpointed")
+        self.assertEqual(resp.status_code, 200)
+        # The clock must NOT be reset — intent_set_at is set at stop-REQUEST time.
+        self.assertEqual(agent.intent_set_at, 12345.0)
+        self.assertEqual(agent.intent, AgentState.INTENT_STOPPING)
+
+    def test_drained_accepted(self):
+        agent = self._stopping_agent(set_at=222.0)
+        resp = self._post("drained")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(agent.intent_set_at, 222.0)
+
+    def test_aborted_accepted_and_logged(self):
+        agent = self._stopping_agent(set_at=333.0)
+        with patch("harness.boot_remote._get_all_roles", return_value=["skill"]), \
+             patch.object(state, "save_state"), \
+             patch("harness._log") as mock_log:
+            resp = self.client.post(
+                "/events",
+                json={"event_type": "ack-stop", "role": "skill",
+                      "payload": {"event_id": "evt-1", "result": "aborted"}},
+            )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(agent.intent_set_at, 333.0)  # no clock reset
+        # 'aborted' (graceful stop failed) is logged for visibility.
+        logged = " ".join(str(c.args[0]) for c in mock_log.call_args_list if c.args)
+        self.assertIn("aborted", logged)
+
+    def test_obsolete_stop_confirmed_not_specially_handled(self):
+        """The obsolete 'stop-confirmed' value is no longer in the settled enum;
+        it is accepted as a generic ack-stop (200) but does not hit the
+        stop-path branch — proving the handler keys on the settled enum."""
+        agent = self._stopping_agent(set_at=444.0)
+        resp = self._post("stop-confirmed")
+        # Still a valid POST (200) — but it is not a settled stop-result, so it
+        # falls through (no special handling). intent_set_at unchanged either way.
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(agent.intent_set_at, 444.0)

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -299,19 +299,19 @@ class TestAckStop:
         port, events = mock_server
         (patch_dirs / ".harness-port").write_text(str(port))
         monkeypatch.setenv("SQUIDSQUAD_ROLE", "skill")
-        event_bus.ack_stop("evt-456", "stop-confirmed")
+        event_bus.ack_stop("evt-456", "checkpointed")
         time.sleep(0.05)
         assert len(events) == 1
         e = events[0]
         assert e["event_type"] == "ack-stop"
         assert e["role"] == "skill"
-        assert e["payload"] == {"event_id": "evt-456", "result": "stop-confirmed"}
+        assert e["payload"] == {"event_id": "evt-456", "result": "checkpointed"}
 
     def test_noop_on_empty_event_id(self, mock_server, patch_dirs, monkeypatch):
         port, events = mock_server
         (patch_dirs / ".harness-port").write_text(str(port))
         monkeypatch.setenv("SQUIDSQUAD_ROLE", "skill")
-        event_bus.ack_stop("", "stop-confirmed")
+        event_bus.ack_stop("", "checkpointed")
         time.sleep(0.05)
         assert events == []
 
@@ -329,7 +329,7 @@ class TestAckStop:
         port, events = mock_server
         (patch_dirs / ".harness-port").write_text(str(port))
         monkeypatch.delenv("SQUIDSQUAD_ROLE", raising=False)
-        event_bus.ack_stop("evt-456", "stop-confirmed")
+        event_bus.ack_stop("evt-456", "checkpointed")
         time.sleep(0.05)
         assert events == []
 
@@ -340,11 +340,11 @@ class TestAckStop:
         port, events = mock_server
         (patch_dirs / ".harness-port").write_text(str(port))
         monkeypatch.setenv("SQUIDSQUAD_ROLE", "skill")
-        event_bus.ack_stop("evt-789", "stop-confirmed", role="qa")
+        event_bus.ack_stop("evt-789", "checkpointed", role="qa")
         time.sleep(0.05)
         assert len(events) == 1
         assert events[0]["role"] == "qa"  # explicit kwarg wins
-        assert events[0]["payload"] == {"event_id": "evt-789", "result": "stop-confirmed"}
+        assert events[0]["payload"] == {"event_id": "evt-789", "result": "checkpointed"}
 
     def test_emits_when_env_unset_but_role_passed_9902(self, mock_server, patch_dirs, monkeypatch):
         """#9902 F3: env unset is no longer a silent no-op when the caller
@@ -353,7 +353,7 @@ class TestAckStop:
         port, events = mock_server
         (patch_dirs / ".harness-port").write_text(str(port))
         monkeypatch.delenv("SQUIDSQUAD_ROLE", raising=False)
-        event_bus.ack_stop("evt-101", "stop-confirmed", role="dm")
+        event_bus.ack_stop("evt-101", "checkpointed", role="dm")
         time.sleep(0.05)
         assert len(events) == 1
         assert events[0]["role"] == "dm"

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -397,27 +397,34 @@ class TestIntentSetAt(unittest.TestCase):
                 )
 
     def test_ack_stop_confirmed_guarded_by_stopping_intent(self):
-        """Iter-1 finding 4 + iter-2 findings 2/3: a stale stop-confirmed
-        ack must NOT overwrite intent when the agent has moved on to
-        RUNNING/RESTARTING/STOPPED, and must NOT reset intent_set_at when
-        intent is already STOPPING (which would extend the 60s force-kill
-        window indefinitely per CONTEXT-4792.md §3.3)."""
+        """Iter-1 finding 4 + iter-2 findings 2/3 (+ #13148): the stop-path
+        ack-stop handler recognizes the SETTLED result enum
+        ('checkpointed'/'aborted'/'drained' per AGENT-RUNTIME §10 Q11), not the
+        obsolete 'stop-confirmed'. A stale stop ack must NOT overwrite intent
+        when the agent has moved on to RUNNING/RESTARTING/STOPPED, and must NOT
+        reset intent_set_at when intent is already STOPPING (which would extend
+        the 60s force-kill window indefinitely per CONTEXT-4792.md §3.3)."""
         import inspect
         from harness import receive_event
         src = inspect.getsource(receive_event)
-        assert "stop-confirmed" in src
+        # #13148: settled enum recognized (replaces obsolete "stop-confirmed").
+        assert '"checkpointed"' in src and '"aborted"' in src and '"drained"' in src, (
+            "stop-path ack-stop handler must recognize the settled enum "
+            "(checkpointed/aborted/drained), not the obsolete 'stop-confirmed'"
+        )
         # The guard must be == STOPPING (the only state where ack is valid),
         # not the iter-1 weaker `!= RESTARTING`.
         assert "agent.intent == AgentState.INTENT_STOPPING" in src, (
-            "stop-confirmed handler must require intent == STOPPING"
+            "stop-path ack handler must require intent == STOPPING"
         )
         # And it must NOT contain a `intent_set_at = time.time()` inside the
         # ack branch — that would reset the force-kill clock on every ack.
-        # Locate the stop-confirmed block and assert no clock-reset inside.
-        idx = src.find("stop-confirmed")
-        block = src[idx:idx + 600]
+        # Locate the stop-enum block and assert no clock-reset inside.
+        idx = src.find("_stop_result in (")
+        assert idx != -1, "expected the settled-enum membership check"
+        block = src[idx:idx + 700]
         assert "intent_set_at = time.time()" not in block, (
-            "stop-confirmed ack must not reset intent_set_at — it is set "
+            "stop ack must not reset intent_set_at — it is set "
             "at stop-REQUEST time, not at ack time"
         )
 


### PR DESCRIPTION
## #13148 — align harness `ack-stop` handler to the settled result enum

**Bug**: `receive_event`'s stop-path branch keyed on the obsolete `result == "stop-confirmed"`, but the enum is SETTLED to `checkpointed` / `aborted` / `drained` (AGENT-RUNTIME §10 Q11, closed 2026-05-30). A correctly-emitted stop ack would have silently missed the branch (doubly-dead with the absent emitter, found in the #13136 RCA).

**Fix** (aligns every `stop-confirmed` surface):
- `harness.py` — branch now `_stop_result in ("checkpointed","aborted","drained")`; `aborted` (graceful-stop-failed) logged, the existing 60s force-kill net is the escalation; the no-reset-of-`intent_set_at` invariant preserved; `deploy-halted` branch untouched.
- `event_catalog.py` — ack-stop description example → settled enum.
- `event_bus.py` — `ack_stop` docstring (the emitter contract) → settled enum, notes `stop-confirmed` obsolete.
- `test_harness.py` — source-inspection test updated to the settled enum.
- `test_event_bus.py` — 6 emitter examples → `checkpointed`.

**Tests**: new `tests/test_13148_ack_stop_enum.py` (behavioral, 4): POST ack-stop with `checkpointed`/`drained` → 200 + `intent_set_at` unchanged; `aborted` → logged; obsolete `stop-confirmed` → not specially handled. Gate PASS 4887/0/0.

**Review**: DeepSeek (model_router) returned HTTP 402 (Insufficient Balance) → fell back to a Claude (Sonnet) subagent per the auto-fallback rule. Verdict: no functional regressions (deploy-halted reachable, no-clock-reset preserved, zero-emitter dead-path confirmed); its 1 warning (event_bus docstring still advertised `stop-confirmed`) is incorporated. Artifact: `.squidsquad/skill/planning/DS-REVIEW-13148.md`.

**Dead-path note**: no agent-side emitter exists yet (`event_bus.ack_stop` has zero callers) — this is hygiene that makes the handler correct WHEN an emitter is wired (the follow-on; full cooperative stop-confirm = handler + emitter + faster-than-60s escalation is a larger design vs. the working 60s net).

**Verifier note**: `tests/comprehension/9873_spec.json` (verifier-owned CQ) still describes the obsolete `stop-confirmed` handler behavior — now stale; needs reconciliation to the settled enum (same shape as #13134's 13032_spec.json note).