### PR TITLE
#13158 — deploy-pull merges (--no-rebase) not --ff-only (fixes recurring deploy-error stage=pull)

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -4532,12 +4532,21 @@ def _run_deploy_sequence(role, deploy_signal_event_id=None):
         scripts = clone_path / "references" / "scripts"
 
         try:
-            # 1. ensure-main + fast-forward-only pull. Non-ff / conflict → §11.
+            # 1. ensure-main + MERGE pull (never rebase). A prior deploy whose
+            #    push was rejected leaves this clone with an unpushed compose
+            #    commit; if origin/main has since advanced, the branch is
+            #    DIVERGED — `git pull --ff-only` would FATAL on every such deploy
+            #    (#13158, recurring `deploy-error stage=pull`). `--no-rebase`
+            #    merges the divergence instead (consistent with the team's
+            #    always-merge-never-rebase rule + the #12526 launcher fix);
+            #    `--no-edit` keeps it non-interactive. A genuine merge CONFLICT
+            #    still fails the pull → §11 recovery (the rare case the old
+            #    --ff-only conflated with benign divergence).
             co = _git_in_clone(clone_path, ["checkout", "main"])
             if co.returncode != 0:
                 _deploy_recover_and_respawn(role, "checkout-main", co.stderr.strip()[:300])
                 return
-            pull = _git_in_clone(clone_path, ["pull", "--ff-only", "origin", "main"])
+            pull = _git_in_clone(clone_path, ["pull", "--no-rebase", "--no-edit", "origin", "main"])
             if pull.returncode != 0:
                 _deploy_recover_and_respawn(role, "pull", pull.stderr.strip()[:300])
                 return
@@ -4570,13 +4579,13 @@ def _run_deploy_sequence(role, deploy_signal_event_id=None):
             push = _git_in_clone(clone_path, ["push", "origin", "main"])
             if push.returncode != 0:
                 # DS-12912 iter-3 Finding 3: no retry loop. A rejected push means
-                # origin/main advanced (a concurrent clone pushed) — but this clone
-                # now holds a local compose commit, so `git pull --ff-only` cannot
-                # fast-forward the diverged branch, making a retry futile. The
-                # sequential _deploy_lock makes genuine concurrent pushes rare
-                # anyway. Go straight to §11 recovery: respawn on the existing
-                # CLAUDE.md + file deploy-error; the unadvanced checksum re-triggers
-                # a fresh deploy-signal on the next drift-check.
+                # origin/main advanced (a concurrent clone pushed) and this clone
+                # now holds an unpushed local compose commit (diverged). We do NOT
+                # retry-in-place; the sequential _deploy_lock makes genuine
+                # concurrent pushes rare, and §11 recovery handles it cleanly:
+                # respawn on the existing CLAUDE.md + file deploy-error; the
+                # unadvanced checksum re-triggers a fresh deploy-signal whose
+                # merge-pull (#13158, step 1) reconciles the divergence next pass.
                 _deploy_recover_and_respawn(role, "push", push.stderr.strip()[:300])
                 return
 

--- a/tests/test_harness_deploy_12912.py
+++ b/tests/test_harness_deploy_12912.py
@@ -302,6 +302,26 @@ class TestRunDeploySequence(unittest.TestCase):
         self.assertEqual(len(r["bumped"]), 1)
         self.assertEqual(r["emitted"], [])
 
+    def test_deploy_pull_merges_not_ff_only_13158(self):
+        """#13158: the deploy-pull must MERGE (--no-rebase), not --ff-only — else
+        a diverged main (an unpushed compose commit from a prior push-rejected
+        deploy + an advanced origin) FATALS every deploy with deploy-error
+        stage=pull. Merge reconciles benign divergence; a real conflict still
+        fails the pull → §11 recovery."""
+        calls = []
+
+        def _capturing_router(clone_path, args, timeout=120):
+            calls.append(list(args))
+            return _CP(returncode=0)
+
+        self._run(_capturing_router)
+        pull_calls = [a for a in calls if a and a[0] == "pull"]
+        self.assertEqual(len(pull_calls), 1, f"expected exactly one pull: {calls}")
+        pull = pull_calls[0]
+        self.assertIn("--no-rebase", pull, f"deploy-pull must merge (#13158): {pull}")
+        self.assertNotIn("--ff-only", pull,
+                         f"deploy-pull must not be --ff-only (#13158): {pull}")
+
     def test_pull_failure_recovers_without_checksum_bump(self):
         def router(clone_path, args, timeout=120):
             if args[0] == "pull":


### PR DESCRIPTION
## #13158 — deploy-sequence `git pull` merges (--no-rebase), not --ff-only

**Bug (live, recurring fleet-wide)**: `_run_deploy_sequence`'s pull used `["pull","--ff-only","origin","main"]`. When a prior deploy's push was rejected (leaving an unpushed local compose commit) and origin/main has since advanced, `main` is DIVERGED — `--ff-only` FATALS → `deploy-error stage=pull`, every deploy pass.

**Fix** (`references/scripts/harness.py`): `["pull","--no-rebase","--no-edit","origin","main"]` — merge the divergence (consistent with the team's always-merge-never-rebase rule + the #12526 launcher fix); `--no-edit` keeps it non-interactive in the headless subprocess. A genuine merge **conflict** still fails the pull (non-zero) → §11 recovery (`_deploy_recover_and_respawn`), the rare case the old `--ff-only` conflated with benign divergence. Updated the push-failure comment to match (the next deploy's merge-pull reconciles, no retry-in-place).

**Test**: `tests/test_harness_deploy_12912.py::TestRunDeploySequence::test_deploy_pull_merges_not_ff_only_13158` (captures the deploy-pull args via the existing mock router; asserts `--no-rebase` present, `--ff-only` absent). Gate PASS 4887/0/0.

**Review**: DeepSeek down (HTTP 402) → Claude/Sonnet fallback per the auto-fallback rule. NO_FINDINGS — merge-commit is benign for the downstream compose/`_stage_composed_outputs`(named files, not `add -A`)/commit/push; conflict→§11 correct; `--no-edit` safe under `capture_output=True` (no editor hang); push no-retry path unchanged. Artifact: `.squidsquad/skill/planning/DS-REVIEW-13158.md`.