### PR TITLE
#13167 (P0): guard git_ops stash+pop against popping a pre-existing stash

### DIFF
--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -193,6 +193,20 @@ def _emit(event_type, payload=None, cycle_number=None, role=None):
         pass
 
 
+def _stash_top_ref():
+    """SHA of the top stash entry (``refs/stash``), or ``""`` if no stash exists.
+
+    Used to detect whether a ``git stash`` actually created a NEW entry: on a
+    CLEAN working tree ``git stash`` is a no-op that still exits 0, so a
+    subsequent pop would apply a PRE-EXISTING (possibly ancient) stash —
+    splattering ``<<<<<<<`` conflict markers tree-wide and breaking compose
+    (#13167). Callers compare this before/after their stash and only pop when
+    the ref changed (i.e. they created the stash they are about to pop).
+    """
+    r = _run("git rev-parse --quiet --verify refs/stash", check=False)
+    return r.stdout.strip() if r.returncode == 0 else ""
+
+
 def _safe_stash_pop():
     """Pop the most recent stash, leaving NO conflict markers behind (#13045).
 
@@ -250,21 +264,32 @@ def pull(role=None):
         _emit("git-pull", {"result": "ok"}, role=role)
         return True
 
-    # Try stash + pull + pop
+    # Try stash + pull + pop. #13167: guard against `git stash` being a no-op
+    # on a clean tree (exits 0 but creates nothing) — popping then would apply a
+    # PRE-EXISTING ancient stash and write conflict markers tree-wide, breaking
+    # compose. Only pop when our stash actually created a new entry.
+    pre_stash_ref = _stash_top_ref()
     stash_result = _run("git stash", check=False)
     if stash_result.returncode != 0:
         print("WARNING: git stash failed -- skipping pull", file=sys.stderr)
         return False
+    stashed = _stash_top_ref() != pre_stash_ref
 
     retry = _run("git pull", check=False)
     if retry.returncode != 0:
-        # Restore stashed changes and report failure
-        _run("git stash pop", check=False)
+        # Restore OUR stashed changes (only if we actually created one) and
+        # report failure. Use the marker-safe pop (#13045), never a raw pop.
+        if stashed:
+            _safe_stash_pop()
         print(f"WARNING: git pull failed after stash -- {retry.stderr.strip()}",
               file=sys.stderr)
         return False
 
-    if _safe_stash_pop():
+    if not stashed:
+        # Clean tree — `git stash` stashed nothing, so there is nothing of ours
+        # to pop. Do NOT pop a pre-existing stash (#13167).
+        print("Pulled (no local changes to stash)")
+    elif _safe_stash_pop():
         print("Pulled (stashed and popped)")
     else:
         # #13045: a conflicted pop is resolved to the pulled HEAD (markers
@@ -679,17 +704,25 @@ def _safe_checkout(target_branch):
     result = _run_list(["git", "checkout", target_branch], check=False)
     if result.returncode == 0:
         return True
-    # Unstaged changes blocking checkout — stash and retry
+    # Checkout failed (commonly unstaged changes, but possibly a non-dirty
+    # reason e.g. branch-not-found) — stash anything present and retry. #13167:
+    # guard the stash so a no-op stash (clean tree / non-dirty failure) never
+    # leads to popping a PRE-EXISTING ancient stash. Only pop what we stashed.
+    pre_stash_ref = _stash_top_ref()
     _run("git stash -q", check=False)
+    stashed = _stash_top_ref() != pre_stash_ref
     result = _run_list(["git", "checkout", target_branch], check=False)
     if result.returncode != 0:
         # Checkout failed — restore original branch state. Use the conflict-safe
         # pop so a conflict here never leaves `<<<<<<<` markers either (#13045).
-        _safe_stash_pop()
+        if stashed:
+            _safe_stash_pop()
         print(f"ERROR: could not switch to {target_branch}: {result.stderr}", file=sys.stderr)
         return False
-    # Checkout succeeded — pop stash on the target branch (conflict-safe, #13045).
-    _safe_stash_pop()
+    # Checkout succeeded — pop OUR stash on the target branch (conflict-safe,
+    # #13045) only if we created one (#13167).
+    if stashed:
+        _safe_stash_pop()
     return True
 
 

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -39,15 +39,52 @@ class TestPull:
 
     @patch("git_ops._run")
     def test_pull_stash_pop(self, mock_run):
-        """Dirty tree → stash, pull, pop succeeds."""
+        """Dirty tree → stash CREATES an entry (refs/stash changes), pull, pop."""
         mock_run.side_effect = [
-            _mock_result(returncode=1),  # pull fails
-            _mock_result(),              # stash
-            _mock_result(),              # pull (retry)
-            _mock_result(),              # stash pop
+            _mock_result(returncode=1),          # pull fails
+            _mock_result(returncode=1),          # _stash_top_ref pre: no refs/stash → ""
+            _mock_result(),                      # git stash
+            _mock_result(stdout="newsha"),       # _stash_top_ref post: new stash → "newsha"
+            _mock_result(),                      # pull (retry)
+            _mock_result(),                      # _safe_stash_pop: git stash pop (clean)
         ]
         assert git_ops.pull() is True
-        assert mock_run.call_count == 4
+        assert mock_run.call_count == 6
+        assert any(c[0][0] == "git stash pop" for c in mock_run.call_args_list)
+
+    @patch("git_ops._run")
+    def test_pull_clean_tree_does_not_pop_preexisting_stash(self, mock_run):
+        """#13167 ROOT-CAUSE: on a clean tree `git stash` is a no-op (refs/stash
+        UNCHANGED). The pop MUST be skipped — otherwise a PRE-EXISTING ancient
+        stash is applied, writing conflict markers tree-wide and breaking
+        compose. Asserts NO `git stash pop` (and no `_safe_stash_pop` machinery)
+        runs when the stash created nothing."""
+        mock_run.side_effect = [
+            _mock_result(returncode=1),          # pull fails
+            _mock_result(stdout="oldsha"),       # _stash_top_ref pre: pre-existing stash
+            _mock_result(),                      # git stash (no-op on clean tree)
+            _mock_result(stdout="oldsha"),       # _stash_top_ref post: UNCHANGED → stashed=False
+            _mock_result(),                      # pull (retry) succeeds
+        ]
+        assert git_ops.pull() is True
+        calls = [c[0][0] for c in mock_run.call_args_list]
+        assert "git stash pop" not in calls, "must NOT pop a pre-existing stash on a clean tree"
+        assert mock_run.call_count == 5  # no pop call
+
+    @patch("git_ops._run")
+    def test_pull_clean_tree_pull_fail_does_not_pop_preexisting(self, mock_run):
+        """#13167: even on the pull-fail branch, a no-op stash must not pop a
+        pre-existing stash (the raw-pop-on-failure path was a culprit too)."""
+        mock_run.side_effect = [
+            _mock_result(returncode=1),          # pull fails
+            _mock_result(stdout="oldsha"),       # pre
+            _mock_result(),                      # git stash (no-op)
+            _mock_result(stdout="oldsha"),       # post: unchanged → stashed=False
+            _mock_result(returncode=1),          # pull retry ALSO fails
+        ]
+        assert git_ops.pull() is False
+        calls = [c[0][0] for c in mock_run.call_args_list]
+        assert "git stash pop" not in calls
 
     @patch("git_ops._run_list")
     @patch("git_ops._run")
@@ -56,7 +93,9 @@ class TestPull:
         dropped, still returns True (#4829 + #13045)."""
         mock_run.side_effect = [
             _mock_result(returncode=1),                       # pull fails
+            _mock_result(returncode=1),                       # _stash_top_ref pre → ""
             _mock_result(),                                   # stash
+            _mock_result(stdout="newsha"),                    # _stash_top_ref post → stashed
             _mock_result(),                                   # pull (retry)
             _mock_result(returncode=1),                       # stash pop conflict
             _mock_result(stdout=".squidsquad/config.md\n"),   # diff --diff-filter=U
@@ -72,7 +111,9 @@ class TestPull:
         drop (no stash-entry leak)."""
         mock_run.side_effect = [
             _mock_result(returncode=1),                       # pull fails
+            _mock_result(returncode=1),                       # _stash_top_ref pre
             _mock_result(),                                   # stash
+            _mock_result(stdout="newsha"),                    # _stash_top_ref post
             _mock_result(),                                   # pull (retry)
             _mock_result(returncode=1),                       # stash pop conflict
             _mock_result(stdout=".squidsquad/config.md\n"),   # diff --diff-filter=U
@@ -93,7 +134,9 @@ class TestPull:
         conflicted config.md so compose never sees a corrupt file."""
         mock_run.side_effect = [
             _mock_result(returncode=1),                       # pull fails
+            _mock_result(returncode=1),                       # _stash_top_ref pre
             _mock_result(),                                   # stash
+            _mock_result(stdout="newsha"),                    # _stash_top_ref post
             _mock_result(),                                   # pull (retry)
             _mock_result(returncode=1),                       # stash pop conflict
             _mock_result(stdout=".squidsquad/config.md\nreferences/x.py\n"),  # diff -U
@@ -104,6 +147,20 @@ class TestPull:
         checkouts = [c[0][0] for c in mock_run_list.call_args_list]
         assert ["git", "checkout", "HEAD", "--", ".squidsquad/config.md"] in checkouts
         assert ["git", "checkout", "HEAD", "--", "references/x.py"] in checkouts
+
+
+class TestStashTopRef:
+    @patch("git_ops._run")
+    def test_returns_sha_when_stash_exists(self, mock_run):
+        mock_run.return_value = _mock_result(stdout="abc123\n", returncode=0)
+        assert git_ops._stash_top_ref() == "abc123"
+
+    @patch("git_ops._run")
+    def test_returns_empty_when_no_stash(self, mock_run):
+        # `git rev-parse --quiet --verify refs/stash` exits non-zero when there
+        # is no stash ref — must map to "" (not a spurious ref).
+        mock_run.return_value = _mock_result(stdout="", returncode=1)
+        assert git_ops._stash_top_ref() == ""
 
 
 # ---------------------------------------------------------------------------
@@ -1256,7 +1313,9 @@ class TestSafeCheckout:
         """On checkout failure after stash, pop restores original branch (#4362)."""
         mock_run.side_effect = [
             _mock_result(stdout="main\n"),      # git branch --show-current
+            _mock_result(returncode=1),          # _stash_top_ref pre → ""
             _mock_result(),                      # git stash -q
+            _mock_result(stdout="newsha"),       # _stash_top_ref post → stashed=True
             _mock_result(),                      # git stash pop -q (restore)
         ]
         # First checkout fails, second (after stash) also fails
@@ -1274,11 +1333,34 @@ class TestSafeCheckout:
 
     @patch("git_ops._run_list")
     @patch("git_ops._run")
+    def test_clean_checkout_failure_does_not_pop_preexisting(self, mock_run, mock_run_list):
+        """#13167: if checkout fails for a NON-dirty reason, `git stash -q` is a
+        no-op (refs/stash unchanged) and the recovery pop MUST be skipped — never
+        pop a pre-existing ancient stash."""
+        mock_run.side_effect = [
+            _mock_result(stdout="main\n"),      # branch --show-current
+            _mock_result(stdout="oldsha"),       # _stash_top_ref pre: pre-existing stash
+            _mock_result(),                      # git stash -q (no-op)
+            _mock_result(stdout="oldsha"),       # _stash_top_ref post: UNCHANGED → stashed=False
+        ]
+        mock_run_list.side_effect = [
+            _mock_result(returncode=1, stderr="no such branch"),  # direct checkout fails
+            _mock_result(returncode=1, stderr="no such branch"),  # stash+checkout fails
+        ]
+        result = git_ops._safe_checkout("feature-branch")
+        assert result is False
+        pop_calls = [c for c in mock_run.call_args_list if "stash pop" in str(c)]
+        assert not pop_calls, "must NOT pop a pre-existing stash when our stash was a no-op"
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
     def test_stash_pop_on_success_applies_to_target(self, mock_run, mock_run_list):
         """On checkout success after stash, pop applies on target branch."""
         mock_run.side_effect = [
             _mock_result(stdout="main\n"),      # git branch --show-current
+            _mock_result(returncode=1),          # _stash_top_ref pre → ""
             _mock_result(),                      # git stash -q
+            _mock_result(stdout="newsha"),       # _stash_top_ref post → stashed=True
             _mock_result(),                      # git stash pop -q
         ]
         mock_run_list.side_effect = [
@@ -1298,7 +1380,9 @@ class TestSafeCheckout:
         HEAD and the stash dropped (via _safe_stash_pop)."""
         mock_run.side_effect = [
             _mock_result(stdout="main\n"),                    # branch --show-current
+            _mock_result(returncode=1),                       # _stash_top_ref pre → ""
             _mock_result(),                                   # git stash -q
+            _mock_result(stdout="newsha"),                    # _stash_top_ref post → stashed=True
             _mock_result(returncode=1),                       # stash pop conflict
             _mock_result(stdout=".squidsquad/config.md\n"),   # diff --diff-filter=U
             _mock_result(),                                   # stash drop


### PR DESCRIPTION
## #13167 (P0) — git_ops stash+pull/checkout+pop popped a PRE-EXISTING stash on a clean tree

**RCA (confirmed from code):** `pull()` (and `_safe_checkout()`) ran `git stash` → … → `git stash pop` without checking whether `git stash` actually created an entry. On a **clean tree** `git stash` is a no-op that still exits 0 — so the pop applied a **pre-existing (ancient) stash**, writing `<<<<<<<` markers across ~20 files incl. `config.py` → SyntaxError → `compose.py` won't import → compose pipeline down (16 `compose-failed`). The clone's 26 accumulated ancient stashes made every clean-tree pull a landmine.

**Fix:**
- New `_stash_top_ref()` — top `refs/stash` SHA (`git rev-parse --quiet --verify refs/stash`), `""` if none.
- Both stash sites (`pull()`, `_safe_checkout()`) capture the ref **before** stashing and only pop (via the marker-safe `_safe_stash_pop`, #13045) when the ref **changed** — i.e. when *we* created the stash. A new stash always gets a new commit SHA, so the comparison reliably distinguishes created-stash from no-op.
- The raw `git stash pop` on the pull-fail branch → guarded `_safe_stash_pop`.
- All remaining edge cases **fail safe** (skip-pop/leak), never corruption.

**Tests:** +5 (clean-tree-no-pop on `pull` + pull-fail branch + `_safe_checkout`; `_stash_top_ref` both branches) + updated existing stash tests for the new `refs/stash` probes. 160 git_ops tests green; **full static gate PASS 4896/0/0**.

**Review:** Sonnet DS-audit (DeepSeek 402) → **NO_BLOCKING_FINDINGS** (verified the SHA-comparison soundness, all stash→pop sites guarded, all edge cases safe); applied the 1 LOW comment-accuracy finding. Artifact: `.squidsquad/skill/planning/CODE-REVIEW-13167.md`.

**Note (out of code scope):** the 26 accumulated ancient stashes are per-clone local state — this fix makes them harmless (never popped). Clearing them is an operator/maintenance action, not a code change.

No CQ (deterministic code). No manifest (no new shipped file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)