### PR TITLE
#13162 Config-gated Verbose Mode (boot-read narration toggle) — skill lane

### DIFF
--- a/references/roles/SOUL.md
+++ b/references/roles/SOUL.md
@@ -84,14 +84,28 @@ You care about your own health and the team's health, and treat it as a first-cl
 
 ### User-Facing Communication
 
-The person reading your terminal output does not know the internals of the event system. When you wake on a forge event that needs **no action from you** — a false-positive wake that surfaces nothing, a real change that doesn't concern you, or a misrouted event you set aside — tell them in one short, plain sentence and keep watching. Show that line on **every** such no-action wake (including frequent false-positive wakes) so the person can see you checked rather than going dark.
+How much of SquidSquad's internals you narrate to the operator is set by **Verbose Mode**, a single posture you read **once at session boot** and hold for the whole session (the boot-read selector lives in your boot sequence; it is session-sticky — never re-checked mid-session). **Exactly one of the two postures below is live for the session — the boot-read selects it and the other does not apply** (never both at once). The shipped default is **quiet**:
 
-- Default one-liner (adapt the wording freely, but keep it jargon-free — never use `ack`/`acked`, `cursor`, `event id`, `GET`/`POST`, `no-op`, `care filter`, `nudge`, or `drain`, even where they read as natural English like "queue drained" or "it was a no-op"):
+#### Quiet posture (Verbose Mode OFF — the shipped default)
+
+Your operator-facing output exposes **zero internal SquidSquad mechanics, ever** — not only on no-action wakes, but in **all** output the operator reads. The operator never sees a word they would need SquidSquad-internal knowledge to parse.
+
+- **Banned in any operator-facing output** (no operator knows what these mean): `acknowledgment`/`acknowledge`/`ack`/`acked`, `cursor`, `event`/`event id`, `drain`/`drained`, `care filter`, `nudge`, `transition`, `GET`/`POST`, `no-op` — and any other term that requires internal knowledge — **even where they read as natural English** ("queue drained", "it was a no-op", "acknowledged the change").
+- **Substitute plain OUTCOME language** the operator understands. Describe *what happened for them*, not the mechanism: say "🦑 Activity detected — nothing needs my attention" rather than "acked 4 events / queue drained"; "Picked up the new task" rather than "cared the assigned-to event"; "Handed this to the verifier" rather than "transitioned to pending-test".
+- When you wake on something that needs **no action from you** — a wake that surfaces nothing, a change that doesn't concern you, or work you set aside — tell the operator in **one short, plain sentence** and keep watching. Show that line on **every** such no-action wake so the operator sees you checked rather than going dark. Default one-liner (adapt the wording freely, keep it jargon-free):
 
   `🦑 Checked the latest activity — nothing needs my attention right now.`
 
 - The line must read naturally to someone who knows nothing about how wakes work.
-- This is **wording only**: the underlying mechanics (advancing your place in the event stream, re-reading the forge, etc.) still happen exactly as before, and your own internal/working notes may still use precise terms. The rule governs only what the user sees.
+- This is **wording only**: the underlying mechanics (advancing your place in the event stream, re-reading the forge, etc.) still happen exactly as before, and your own internal/working notes may still use precise terms. The rule governs only what the operator sees.
+
+#### Verbose posture (Verbose Mode ON)
+
+The operator has explicitly opted into the full firehose — they **want** the internals. For the whole session, the quiet posture's jargon-ban and one-liner-brevity rule are **lifted**:
+
+- **Narrate every cycle step and every event in full internal detail** — each drained event, every acknowledgment / cursor advance, every care-filter decision, every status transition, and every cycle step (boot, pickup, work, checkpoint, cleanup, exit).
+- **Internal terms are allowed and expected** — `event`, `cursor`, `ack`, `drain`, `care filter`, `nudge`, `transition`, etc. — because the operator turned this on to see exactly how SquidSquad runs.
+- The token cost of this firehose is the operator's explicit, accepted tradeoff; it is off by default so no other deployment pays it.
 
 ### Universal Quality Gate
 

--- a/references/roles/instructions.md
+++ b/references/roles/instructions.md
@@ -101,7 +101,7 @@ sequenceDiagram
 
 A nudge wakes you. You then run the canonical eager loop documented in `docs/AGENT-RUNTIME.md` §8.1: fetch the next event past your cursor, apply the care filter, fire the cycle wrapper if cared (skip the wrapper if not), then POST `ack-cursor` for the event you just tended — and immediately re-check for the next event. The cursor advances **per event, not per batch**. When the queue drains, you optionally fire one improvement-subloop task (§4) if the cooldown is elapsed, then re-enter idle wait until the next nudge. Lost or missed nudges are harmless — your next nudge picks up the forge change. **If a new NUDGE arrives while you're mid-drain**, take no special action: note it in conversation context only — no file write, no queue, no flag. The next iteration's GET absorbs the new events naturally (see `docs/AGENT-RUNTIME.md` §8.5).
 
-> **Telling the user about a no-action wake.** When a whole wake resolves to nothing for you — the drain finds no events, every event in it is skipped by the care filter, or every cared event turns out to need no work — surface that to the user as a single short plain-language line per the **User-Facing Communication** rule in your Soul. One line **per wake, not per event**: a drain that skips three events still produces one line, emitted once the drain is complete. Emit it after any improvement-subloop task for this wake has finished or been skipped (§4); the line covers only the forge-event drain. Use plain language only — the prohibited internal terms and the template live in that Soul rule, and the mechanics still run unchanged underneath.
+> **Telling the user about a no-action wake.** When a whole wake resolves to nothing for you — the drain finds no events, every event in it is skipped by the care filter, or every cared event turns out to need no work — surface that to the user as a single short line per the **User-Facing Communication** rule in your Soul, in **whichever narration posture is live this session** (set by the Verbose Mode boot-read). One line **per wake, not per event**: a drain that skips three events still produces one line, emitted once the drain is complete. Emit it after any improvement-subloop task for this wake has finished or been skipped (§4); the line covers only the forge-event drain. **In quiet mode** (Verbose Mode OFF, the default) use plain language only — the prohibited internal terms and the one-liner template live in that Soul rule. **In verbose mode** (Verbose Mode ON) narrate the wake in full internal detail per the verbose posture instead. Either way the mechanics still run unchanged underneath.
 
 > **Care filter — what counts as "cared" vs "skipped"?** Per `docs/AGENT-RUNTIME.md` §8.4 the rule is simply: **does this event's `payload.target_alias` field equal my own alias?** If yes, you process it (pre-cycle → work → post-cycle) and POST `ack-cursor` to commit the tend. If no, you skip the cycle wrapper but still POST `ack-cursor` — finishing the event by deciding not to act on it IS the cursor commit (D1; finishing the event in either way advances the cursor). In normal operation the harness emits one `assigned-to` per target alias and the `/events/for/{role}` endpoint pre-filters before delivery, so your queue is already pre-filtered and almost every event is cared. The `else skipped` branch is the defensive escape hatch for race conditions (re-emit after EAD restart, cursor catch-up after eviction, future multi-instance scenarios) where a misrouted event lands in your queue — you ack past it without firing the cycle wrapper.
 
@@ -230,6 +230,21 @@ When you encounter one of these inside a runtime-loaded fragment, substitute it 
 #### Loaded mode is sticky
 
 Once the EVENT or POLLING block above completes, your wake-mode contract is fixed for this session. Do **not** re-check mode mid-session — operator-initiated mode flips take effect on the next agent restart, not mid-cycle.
+
+#### Verbose Mode — boot-read, session-sticky (#13162)
+
+Right after mode selection, read your **narration posture** for this session — once, at boot. Run:
+
+```bash
+python references/scripts/config.py get verbose-mode
+```
+
+- Output `yes` → adopt the **verbose** posture for the whole session.
+- Output `no` (the shipped default, and what an absent `## Verbose Mode` section returns) → adopt the **quiet** posture.
+
+The two postures are defined in your Soul's **User-Facing Communication** rule — quiet (default) bans all internal jargon and substitutes plain outcome language; verbose lifts that ban and narrates every cycle step and every event in full internal detail. Both contracts are carried in this one composed `CLAUDE.md`; this boot-read is the selector that picks which one is live.
+
+**Sticky — exactly like wake mode.** Read the flag **once** at boot and hold the posture for the entire session. Do **not** re-check `verbose-mode` mid-session; an operator's toggle (edit `config.md` + restart) takes effect on the next agent restart, never mid-cycle. (No recompose is needed to toggle — both postures already live in the composed instructions.)
 
 <!-- /sub-skill: boot-bootstrap -->
 

--- a/references/scripts/config.py
+++ b/references/scripts/config.py
@@ -91,6 +91,7 @@ FIELD_MAP = {
     "improvement-scanning": ("Improvement Scanning", "Enabled"),
     "improvement-scan-cool-down": ("Improvement Scanning", "Improvement Scan Cool-Down"),  # #11091
     "idle-scan-burst": ("Improvement Scanning", "Idle Scan Burst"),  # #12506
+    "verbose-mode": ("Verbose Mode", "Enabled"),  # #13162 — boot-read narration toggle
     "ship-threshold": ("Auto Versioning", "Ship Threshold"),
     "shipped-since-bump": ("Auto Versioning", "Shipped Since Last Bump"),
     "alias-skill": ("Aliases", "skill"),
@@ -209,6 +210,9 @@ _FIELD_DEFAULTS = {
     # #12506 — max idle improvement-scans per sustained-idle burst before the
     # event-mode periodic driver cancels itself (graceful default per §8.6.1).
     "idle-scan-burst": "3",
+    # #13162 — Verbose Mode narration toggle. Shipped default OFF; graceful
+    # default `no` so a config.md without the section reads as quiet (no sys.exit).
+    "verbose-mode": "no",
 }
 
 
@@ -294,6 +298,20 @@ def get_field(field):
 _DUAL_AWARE_CONFIG_FIELDS_6274 = {
     "workers": "dev-agents",
 }
+
+
+def is_verbose():
+    """Return True iff Verbose Mode is enabled in config.md (#13162).
+
+    Boot-read narration toggle: the agent calls this once at session boot to
+    select its narration posture for the whole session (verbose firehose vs.
+    quiet default). Graceful — returns False (quiet, the shipped default) when
+    the ``## Verbose Mode`` section is absent, since ``verbose-mode`` carries a
+    ``no`` default in ``_FIELD_DEFAULTS`` (so ``get_field`` never sys.exits here).
+    Mirrors the string-bool convention used elsewhere (e.g. ``pr-flow`` →
+    ``== "yes"`` in harness.py).
+    """
+    return (get_field("verbose-mode") or "").strip().lower() == "yes"
 
 
 def _harness_wake_port():

--- a/references/scripts/wizard.py
+++ b/references/scripts/wizard.py
@@ -1635,6 +1635,17 @@ def build_config_md(spec):
     lines.append("- **Idle Scan Burst**: 3")
     lines.append("")
 
+    # --- ## Verbose Mode ---
+    # #13162 — boot-read, session-sticky narration toggle. Shipped default OFF
+    # (quiet, jargon-free operator output). When ON, every agent narrates each
+    # cycle step + event with full internal detail (operator's accepted token
+    # tradeoff). Read once at boot via config.py is_verbose(); sticky for the
+    # session — toggling needs an edit + restart, no recompose.
+    lines.append("## Verbose Mode")
+    lines.append("")
+    lines.append("- **Enabled**: no")
+    lines.append("")
+
     # --- ## Git Branches ---
     lines.append("## Git Branches")
     lines.append("")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -230,6 +230,57 @@ class TestImprovementScanCoolDownDefault:
 
 
 # ---------------------------------------------------------------------------
+# Verbose Mode boot-read toggle (#13162)
+# ---------------------------------------------------------------------------
+
+class TestVerboseMode:
+    """#13162 — is_verbose() boot-read narration toggle; graceful default off."""
+
+    def test_enabled_yes_returns_true(self, tmp_path):
+        text = "## Verbose Mode\n\n- **Enabled**: yes\n"
+        f = tmp_path / "config.md"
+        f.write_text(text, encoding="utf-8")
+        with patch.object(config, "CONFIG_PATH", f):
+            assert config.is_verbose() is True
+
+    def test_enabled_no_returns_false(self, tmp_path):
+        text = "## Verbose Mode\n\n- **Enabled**: no\n"
+        f = tmp_path / "config.md"
+        f.write_text(text, encoding="utf-8")
+        with patch.object(config, "CONFIG_PATH", f):
+            assert config.is_verbose() is False
+
+    def test_section_absent_returns_false(self, tmp_path):
+        # Truly minimal install with no ## Verbose Mode section — graceful off.
+        f = tmp_path / "config.md"
+        f.write_text("# Config\n\n- **SquidSquad Version**: 0.0.0\n", encoding="utf-8")
+        with patch.object(config, "CONFIG_PATH", f):
+            assert config.is_verbose() is False
+
+    def test_get_field_default_off_when_absent(self, tmp_path):
+        # get_field must not sys.exit when the section is absent — default 'no'.
+        f = tmp_path / "config.md"
+        f.write_text("# Config\n\n- **SquidSquad Version**: 0.0.0\n", encoding="utf-8")
+        with patch.object(config, "CONFIG_PATH", f):
+            assert config.get_field("verbose-mode") == "no"
+
+    def test_case_and_whitespace_tolerant(self, tmp_path):
+        # Operator-typed 'YES' / stray spaces still read as enabled.
+        text = "## Verbose Mode\n\n- **Enabled**:   YES  \n"
+        f = tmp_path / "config.md"
+        f.write_text(text, encoding="utf-8")
+        with patch.object(config, "CONFIG_PATH", f):
+            assert config.is_verbose() is True
+
+    def test_field_in_defaults_registry(self):
+        # Lock the contract — _FIELD_DEFAULTS carries the verbose-mode key, off.
+        assert config._FIELD_DEFAULTS["verbose-mode"] == "no"
+
+    def test_field_map_registered(self):
+        assert config.FIELD_MAP["verbose-mode"] == ("Verbose Mode", "Enabled")
+
+
+# ---------------------------------------------------------------------------
 # set_field — happy path (#4879)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_config_functions.py
+++ b/tests/test_config_functions.py
@@ -72,6 +72,10 @@ SAMPLE_CONFIG = """# SquidSquad Config
 - **Improvement Scan Cool-Down**: 30m
 - **Idle Scan Burst**: 3
 
+## Verbose Mode
+
+- **Enabled**: no
+
 ## Vault Optimize
 
 - **Enabled**: yes

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -601,6 +601,7 @@ class TestBuildConfigMdStructure:
             "## Loop",
             "## Flags",
             "## Improvement Scanning",  # #11091
+            "## Verbose Mode",  # #13162
             "## Git Branches",
             "## Forge Backend",
             "## Model Routing",
@@ -611,6 +612,12 @@ class TestBuildConfigMdStructure:
         text = wizard.build_config_md(_minimal_spec())
         assert "## Improvement Scanning" in text
         assert "- **Improvement Scan Cool-Down**: 30" in text
+
+    def test_verbose_mode_section_defaults_off(self):
+        """#13162 — wizard emits Verbose Mode section, shipped default off."""
+        text = wizard.build_config_md(_minimal_spec())
+        assert "## Verbose Mode" in text
+        assert "- **Enabled**: no" in text
 
     def test_header_includes_version_and_architecture(self):
         text = wizard.build_config_md(_minimal_spec())


### PR DESCRIPTION
## #13162 — Config-gated Verbose Mode (boot-read, session-sticky narration toggle)

Implements the skill lane (AC1,2,3,4,5,9 + AC8 coverage) of the operator-approved Verbose Mode feature. Per PM design `.squidsquad/pm/planning/VERBOSE-MODE-DESIGN.md`.

### What changed (source-only; composed regen post-merge per #12853)
- **AC1 config schema** — `config.py`: `verbose-mode` in FIELD_MAP + `_FIELD_DEFAULTS` (`no`); new `is_verbose()` bool getter (graceful `False` when section absent). `wizard.py`: `config.md` template gains `## Verbose Mode → - **Enabled**: no`.
- **AC3 boot-read** — `instructions.md`: boot-read selector (`config.py get verbose-mode`) right after "Loaded mode is sticky"; session-sticky, no mid-session re-check (mirrors wake-mode stickiness). Composes into all 4 role boot blocks.
- **AC4 verbose ON / AC5 verbose OFF** — `SOUL.md` "User-Facing Communication" rewritten to carry BOTH postures, gated by the boot-read:
  - **Quiet (OFF, default)**: zero internal mechanics in ANY operator-facing output — comprehensive ban (`acknowledgment`/`ack`, cursor, event, drain, care-filter, nudge, transition, GET/POST, no-op) + positive plain-OUTCOME substitution. Strengthens today's L1 jargon-ban; **no default-install regression** (the `🦑 Checked the latest activity…` one-liner survives verbatim — PM's no-action-wake refinement stays intact).
  - **Verbose (ON)**: lifts the ban for the session; firehose every cycle step + event with internal terms allowed.
- **AC9 compose/installer hygiene** — `compose.py deploy-all` regenerates clean; no new `references/` files → no `installer-files.txt` change.

### Verification
- **AC1**: `tests/test_config.py::TestVerboseMode` (7: yes→True, no→False, absent→False, case/ws-tolerant, defaults registry, FIELD_MAP) + `test_config_functions` FIELD_MAP-coverage fixture + `test_wizard` section-order/default.
- **AC3 (consumption, not existence)**: composed `.squidsquad/{skill,qa}/CLAUDE.md` (post deploy-all) verified to contain the boot selector + BOTH posture contracts + the `config.py get verbose-mode` boot command.
- **Full static gate**: PASS 4916/0/0.
- **DS-review** (high-blast-radius; Sonnet fallback, DeepSeek 402): 1 BLOCKING + 1 LOW, both fixed (posture-gated the per-nudge no-action-wake callout; added exactly-one-posture-live preamble). `CODE-REVIEW-13162.md`.

### Coupled / cross-lane (land together)
- **AC2 (this install ON)**: `.squidsquad/config.md` set `Verbose Mode > Enabled: yes` committed **direct to main** (config.md is main-only per #11511 state-guard; takes effect next restart via the boot-read).
- **AC6 (AGENT-RUNTIME doc)**: PM lane. **AC7 (README operator section)**: DM lane.
- **AC8 (CQ)**: comprehension coverage is described in AC5/AC8 (both postures verifiable from composed instructions; explicit check that `acknowledg*` never appears in OFF-mode output). Per project practice (#13147) the `tests/comprehension/13162_spec.json` file is **verifier-derived** during verification — flagged to PM/verifier in the issue (lane split puts AC8 in skill; skill-cq rule says verifier authors the spec — I defaulted to verifier-derives; will author it if PM prefers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)