### PR TITLE
skill: #13176 deploy stage=commit empty-detail + benign re-trigger

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -4595,17 +4595,35 @@ def _deploy_recover_and_respawn(role, stage, detail):
 def _stage_composed_outputs(clone_path, alias):
     """Stage ONLY the alias's composed outputs (CLAUDE.md / SOUL.md /
     CLAUDE.linked.md) — never the whole .squidsquad/<alias>/ dir, which also
-    holds working-state and other per-cycle churn. Returns True if anything was
-    staged. NB: per-alias `compose.py deploy` does NOT write .claude/settings.json
-    (AC11 / #12519) — that stays an installer-managed artifact, out of scope."""
-    staged_any = False
+    holds working-state and other per-cycle churn. Returns True only if a real
+    staged DIFF resulted. NB: per-alias `compose.py deploy` does NOT write
+    .claude/settings.json (AC11 / #12519) — that stays an installer-managed
+    artifact, out of scope.
+
+    #13176: keying on `add.returncode == 0` was wrong — `git add` of an
+    UNCHANGED file exits 0 while staging nothing, so this returned True whenever
+    the composed output already matched HEAD (the common no-net-change deploy).
+    The caller then ran `git commit`, which failed benignly with 'nothing to
+    commit, working tree clean' (written to STDOUT, exit non-zero, empty stderr)
+    → an undiagnosable deploy-error with empty detail AND §11 recovery that left
+    the checksum unadvanced, re-firing the deploy on the next pass. Keying on the
+    actual staged diff (`git diff --cached --quiet`) routes the no-net-change case
+    to the caller's clean no-op success path (checksum advanced, no deploy-error)."""
+    staged_paths = []
     for fn in _DEPLOY_COMPOSED_FILES:
         rel = f".squidsquad/{alias}/{fn}"
         if (clone_path / rel).exists():
             add = _git_in_clone(clone_path, ["add", "--", rel])
             if add.returncode == 0:
-                staged_any = True
-    return staged_any
+                staged_paths.append(rel)
+    if not staged_paths:
+        return False
+    # `git diff --cached --quiet` exits 0 when there is NO staged diff, non-zero
+    # when there IS one. Scope to the paths we staged so unrelated index state
+    # (there should be none after a clean pull) can't mask the result.
+    diff = _git_in_clone(
+        clone_path, ["diff", "--cached", "--quiet", "--", *staged_paths])
+    return diff.returncode != 0
 
 
 def _run_deploy_sequence(role, deploy_signal_event_id=None):
@@ -4699,7 +4717,16 @@ def _run_deploy_sequence(role, deploy_signal_event_id=None):
                  f"deploy: recompose {alias} CLAUDE.md (#12912 deploy-signal)"],
             )
             if commit.returncode != 0:
-                _deploy_recover_and_respawn(role, "commit", commit.stderr.strip()[:300])
+                # #13176: `git commit` writes some failures to STDOUT (e.g.
+                # 'nothing to commit, working tree clean'), so stderr alone can be
+                # empty — combine both streams (stderr first) so the deploy-error
+                # detail is never empty/undiagnosable. With the staged-diff guard
+                # in _stage_composed_outputs above, the benign 'nothing to commit'
+                # case no longer reaches here, so this branch now means a GENUINE
+                # commit failure whose detail the operator needs.
+                detail = (commit.stderr.strip() or commit.stdout.strip()
+                          or "git commit failed with no stdout/stderr")
+                _deploy_recover_and_respawn(role, "commit", detail[:300])
                 return
             push = _git_in_clone(clone_path, ["push", "origin", "main"])
             if push.returncode != 0:

--- a/tests/test_harness_deploy_12912.py
+++ b/tests/test_harness_deploy_12912.py
@@ -360,6 +360,84 @@ class TestRunDeploySequence(unittest.TestCase):
         self.assertEqual(len(r["emitted"]), 1)
         self.assertEqual(r["emitted"][0][1]["payload"]["stage"], "push")
 
+    def test_commit_failure_detail_combines_stdout_13176(self):
+        """#13176: a non-zero `git commit` whose failure text is on STDOUT (empty
+        stderr — e.g. 'nothing to commit, working tree clean') must still produce
+        a non-empty, diagnosable deploy-error detail. The old code sourced
+        commit.stderr only → empty detail."""
+        def router(clone_path, args, timeout=120):
+            if args[0] == "commit":
+                return _CP(returncode=1,
+                           stdout="nothing to commit, working tree clean",
+                           stderr="")
+            return _CP(returncode=0)
+        r = self._run(router)  # staged=True default → reaches the commit step
+        self.assertEqual(len(r["emitted"]), 1)
+        payload = r["emitted"][0][1]["payload"]
+        self.assertEqual(payload["stage"], "commit")
+        self.assertTrue(payload["detail"].strip(),
+                        "deploy-error detail must not be empty (#13176)")
+        self.assertIn("nothing to commit", payload["detail"])
+
+
+class TestStageComposedOutputs(unittest.TestCase):
+    """#13176: _stage_composed_outputs must return True only on an ACTUAL staged
+    diff, not merely on `git add` exit 0 — `git add` of an unchanged file exits 0
+    while staging nothing, so the old behavior surfaced a benign 'nothing to
+    commit' as a deploy-error (empty detail) + left the checksum unadvanced
+    (re-trigger risk)."""
+
+    def _make_clone(self, tmpdir, alias="skill"):
+        import harness
+        d = Path(tmpdir)
+        for fn in harness._DEPLOY_COMPOSED_FILES:
+            p = d / ".squidsquad" / alias / fn
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("x", encoding="utf-8")
+        return d
+
+    def test_returns_false_when_add_ok_but_no_staged_diff(self):
+        """The regression: add exits 0 but `git diff --cached --quiet` shows no
+        staged diff → False (routes to the caller's clean no-op success path)."""
+        import tempfile, harness
+        with tempfile.TemporaryDirectory() as tmp:
+            clone = self._make_clone(tmp)
+
+            def router(clone_path, args, timeout=120):
+                # add → 0; diff --cached --quiet → 0 (no staged diff)
+                return _CP(returncode=0)
+            with patch.object(harness, "_git_in_clone", side_effect=router), \
+                 patch.object(harness, "_log"):
+                self.assertFalse(harness._stage_composed_outputs(clone, "skill"))
+
+    def test_returns_true_when_real_staged_diff(self):
+        import tempfile, harness
+        with tempfile.TemporaryDirectory() as tmp:
+            clone = self._make_clone(tmp)
+
+            def router(clone_path, args, timeout=120):
+                if args and args[0] == "diff":
+                    return _CP(returncode=1)  # staged diff present
+                return _CP(returncode=0)
+            with patch.object(harness, "_git_in_clone", side_effect=router), \
+                 patch.object(harness, "_log"):
+                self.assertTrue(harness._stage_composed_outputs(clone, "skill"))
+
+    def test_returns_false_when_no_composed_files_exist(self):
+        import tempfile, harness
+        with tempfile.TemporaryDirectory() as tmp:
+            calls = []
+
+            def router(clone_path, args, timeout=120):
+                calls.append(list(args))
+                return _CP(returncode=0)
+            with patch.object(harness, "_git_in_clone", side_effect=router), \
+                 patch.object(harness, "_log"):
+                # no composed files created → nothing staged → False, and we never
+                # reach the diff probe.
+                self.assertFalse(harness._stage_composed_outputs(Path(tmp), "skill"))
+            self.assertFalse(any(a and a[0] == "diff" for a in calls))
+
 
 class TestRespawnAgentProcess(unittest.TestCase):
     """DS-12912 Finding 2: the deploy respawn boots the agent explicitly (the


### PR DESCRIPTION
Closes #13176.

## Problem
On a harness deploy/recompose, `_stage_composed_outputs` returned `True` whenever `git add` exited 0 — but **`git add` of an unchanged file exits 0 while staging nothing**. So when the composed output already matched HEAD (the common no-net-change deploy), it returned `True`, the caller ran `git commit`, which failed benignly with `nothing to commit, working tree clean` — written to **stdout**, exit non-zero, **empty stderr**. Two impacts (both confirmed):
1. **Undiagnosable**: the `deploy-error stage=commit` event sourced `commit.stderr` only → **empty `detail`** (PM observed `detail: ""`).
2. **Re-trigger risk**: that benign "failure" routed through §11 recovery, which by design does NOT advance the compose checksum → the deploy re-fires on the next pass (PM logged this as a recurring `stage=commit` pattern across boots).

## Root cause confirmed
`_stage_composed_outputs` keyed on `add.returncode == 0` rather than on whether an actual diff got staged. Verified by reading harness.py.

## Fix
**`references/scripts/harness.py`**
1. **Root** — `_stage_composed_outputs` returns `True` only if `git diff --cached --quiet -- <staged paths>` reports a real staged diff (exit non-zero). The no-net-change case now returns `False` → the caller's **existing clean no-op success path** (`_bump_compose_checksum` + `_respawn_after_deploy`) runs: checksum advanced, **no deploy-error, no re-trigger**.
2. **Defense-in-depth** — the commit-failure `detail` now combines `commit.stderr.strip() or commit.stdout.strip() or "<fallback>"`, so a *genuine* commit failure (now the only way to reach that branch) is never empty/undiagnosable.

**`tests/test_harness_deploy_12912.py`** — +4 regression tests: `TestStageComposedOutputs` (False on add-ok-but-no-staged-diff [the regression]; True on real diff; False + no diff-probe when no composed files exist) and `test_commit_failure_detail_combines_stdout_13176` (stdout-only commit failure → non-empty diagnosable detail).

## Review (step:cycle/ds-review)
DeepSeek 402 → **Sonnet fallback** (per `feedback_model_router_auto_fallback`). Verdict **NO_BLOCKING_FINDINGS**; 3 LOW, all dispositioned no-change (diff-probe error fallthrough is *safer* than aborting; coverage depth acceptable; the `add.returncode` add-failure-invisibility is pre-existing/out-of-scope). Artifact: `.squidsquad/skill/planning/DS-REVIEW-13176.md` (on `main`).

## Gates / scope
Full static gate **exit 0** (only baseline known-failures `test_agent_boundaries` + `test_compose_author_comments_11142`, both #10360-blocked). Deterministic harness code → **no CQ** (not LLM-consumed). **No manifest update** (no new/renamed files). Related (not duplicates): #13158 (deploy stage=pull benign-divergence, analogous prior fix), #13175 (deploy-signal boot-drain), #13036 (respawn hardening).