### PR TITLE
skill: #13179 (#12271 Slice A) bound progress_liveness booting escape

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -174,6 +174,15 @@ STOP_FAILURE_RECENT_SECONDS = 180    # a StopFailure older than this is stale
 #     PreToolUse fires) or model latency never false-positives; tunable from the
 #     shadow-mode divergence data this slice gathers.
 ACTIVITY_GRACE_SECONDS = 600         # 10m
+#   #13179 (#12271 Slice A) — boot-completion grace. A not-yet-booted agent
+#     (bootup_complete=False) is legitimately mid-boot only for so long; past
+#     this window with no bootup-complete it is a wedged boot, not a slow one
+#     (the #12271 qa incident sat bootup_complete=False ~54m at intent=deploying).
+#     Bounds the otherwise-unbounded "booting" escape in progress_liveness so a
+#     never-completing boot reads wedged in the SHADOW verdict (does NOT drive
+#     reboot until the #12492 cutover). Generous so a slow first boot never
+#     false-positives; tunable from the same shadow-mode divergence data.
+BOOT_GRACE_SECONDS = 600             # 10m
 
 # #9242: Diagnostic escape hatch. When True (set by `main()` from
 # `--no-auto-start` or `SQUIDSQUAD_HARNESS_NO_AUTO_START=1`), the
@@ -452,9 +461,21 @@ class AgentState:
         (``update_health``) already holds it when it reads agent state for the
         PID check, so wiring this in there satisfies the contract for free.
         """
-        # A not-yet-booted agent has no heartbeat baseline — never judge it dead
-        # by activity silence (it may be mid-boot). Treat as alive.
+        # A not-yet-booted agent has no heartbeat baseline — within a generous
+        # boot-grace it may legitimately be mid-boot, so treat it as alive. But
+        # the escape is BOUNDED (#13179 / #12271 Slice A): a boot that never
+        # completes is a wedge, not a slow boot (the qa incident sat
+        # bootup_complete=False ~54m). Age it from the most recent spawn
+        # (last_spawn_at; fall back to boot_time) — past BOOT_GRACE_SECONDS with
+        # no bootup-complete it reads wedged. If we have no spawn reference we
+        # cannot age it, so stay conservative and report booting (never
+        # false-positive a death we cannot time). Shadow-only: this changes the
+        # logged verdict, not the reboot decision (cutover is #12492).
         if not self.bootup_complete:
+            boot_ref = (self.last_spawn_at
+                        if self.last_spawn_at is not None else self.boot_time)
+            if boot_ref is not None and now - boot_ref > BOOT_GRACE_SECONDS:
+                return False, "wedged-boot-timeout"
             return True, "booting"
         # An explained pause (in-flight tool call / compacting / waiting) means
         # the silence is accounted for — alive. Reuses the slice-c guard so the

--- a/tests/test_12460_progress_liveness.py
+++ b/tests/test_12460_progress_liveness.py
@@ -22,7 +22,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "references" / "scripts"))
 
 import harness  # noqa: E402
-from harness import AgentState, ACTIVITY_GRACE_SECONDS  # noqa: E402
+from harness import AgentState, ACTIVITY_GRACE_SECONDS, BOOT_GRACE_SECONDS  # noqa: E402
 
 
 NOW = 1_000_000.0  # fixed epoch for deterministic math
@@ -42,6 +42,47 @@ class TestProgressLiveness:
     def test_not_booted_is_alive(self):
         a = AgentState("skill")  # bootup_complete = False
         a.last_dispatch_at = NOW - 10 * ACTIVITY_GRACE_SECONDS  # stale dispatch
+        # No spawn reference (boot_time/last_spawn_at both None) → cannot age the
+        # boot → conservatively "booting" (#13179: never false-positive a death
+        # we cannot time).
+        alive, reason = a.progress_liveness(NOW)
+        assert alive is True
+        assert reason == "booting"
+
+    # -- #13179 (#12271 Slice A): bound the unbounded "booting" escape ---------
+
+    def test_not_booted_within_boot_grace_is_alive(self):
+        """A fresh boot still within BOOT_GRACE_SECONDS reads booting (alive)."""
+        a = AgentState("skill")  # bootup_complete = False
+        a.last_spawn_at = NOW - (BOOT_GRACE_SECONDS - 1)  # just inside grace
+        alive, reason = a.progress_liveness(NOW)
+        assert alive is True
+        assert reason == "booting"
+
+    def test_not_booted_past_boot_grace_is_wedged(self):
+        """THE qa-wedge catch (#13179 AC1/AC3): bootup_complete=False past the
+        boot-grace → wedged, not booting. The unbounded escape returned alive
+        forever here (qa sat bootup_complete=False ~54m)."""
+        a = AgentState("skill")  # bootup_complete = False
+        a.last_spawn_at = NOW - (BOOT_GRACE_SECONDS + 100)  # grace elapsed
+        alive, reason = a.progress_liveness(NOW)
+        assert alive is False
+        assert reason == "wedged-boot-timeout"
+
+    def test_not_booted_boot_time_fallback_when_no_spawn(self):
+        """When last_spawn_at is absent, age the boot from boot_time."""
+        a = AgentState("skill")  # bootup_complete = False
+        a.last_spawn_at = None
+        a.boot_time = NOW - (BOOT_GRACE_SECONDS + 100)
+        alive, reason = a.progress_liveness(NOW)
+        assert alive is False
+        assert reason == "wedged-boot-timeout"
+
+    def test_not_booted_at_grace_boundary_is_alive(self):
+        """Exactly at the boundary (== grace, not >) is still booting — the
+        wedge verdict requires STRICTLY exceeding the grace."""
+        a = AgentState("skill")
+        a.last_spawn_at = NOW - BOOT_GRACE_SECONDS  # exactly at the ceiling
         alive, reason = a.progress_liveness(NOW)
         assert alive is True
         assert reason == "booting"


### PR DESCRIPTION
Closes #13179. Parent: #12271 (progress-based liveness) — **Slice A**, PM-greenlit.

## Problem
`AgentState.progress_liveness(now)` (harness.py:457) returned `(True, "booting")` whenever `bootup_complete` is False, with **no time bound**. A wedged agent that never completes bootup read as alive-forever in the shadow verdict — the opposite of #12271's requirement "bootup never completed must trigger reboot." Real instance: qa sat `bootup_complete:false` for ~54 min (wedged at `intent=deploying`, blocked on an AskUserQuestion modal) and would have read alive the entire time.

## Fix (shadow-only — zero reboot blast radius)
- Add `BOOT_GRACE_SECONDS = 600` named module constant (same pattern as `ACTIVITY_GRACE_SECONDS` — AC2), with a generous-default comment + tunable-from-shadow-data note.
- Bound the booting escape: age a not-yet-booted agent from `last_spawn_at` (fall back to `boot_time`); past the grace → verdict `wedged-boot-timeout` (alive=False); within it → `booting` (alive). **No spawn reference** (both None) → stay `booting` (never false-positive a death we cannot time).
- **Verdict-only**: changes what the shadow `progress_liveness` reports; does NOT drive reboot. The existing poller divergence log (harness.py:731) already surfaces the new verdict (PID-alive vs progress-dead → "candidate-zombie"), so the #12492 cutover decision sees sharper data (AC5). PID-liveness remains authoritative until #12492 (AC4).

## ACs
- **AC1** ✓ `wedged-boot-timeout` (non-alive) past grace; `booting` within grace. **AC2** ✓ config-tunable named constant, ~600s default. **AC3** ✓ regression test of the qa-wedge shape (>grace not-yet-booted → non-alive). **AC4** ✓ no reboot-behavior change (shadow verdict-only). **AC5** ✓ surfaced via existing divergence logging.

## Tests / gates
+5 boundary regression tests in `test_12460_progress_liveness.py` (within-grace / over-grace [qa shape] / exactly-at-boundary / boot_time-fallback / no-spawn-reference). File: 28 passed. Full static gate: see below.

## Scope discipline
DS-review skipped per PM's #12271 structuring comment (Slice A is "shadow-only, zero reboot blast radius"; DS-review reserved for Slice B). Deterministic harness code → no CQ. No new/renamed files → no manifest update. **Slice B** (intent=deploying force-kill backstop) is a separate, higher-blast-radius slice (DS-review + PM doc-pairing) — filed/built next, not folded here.