### PR TITLE
skill: #13197 serialize l4_file_watcher freshen (index.lock collision)

### DIFF
--- a/references/scripts/l4_file_watcher.py
+++ b/references/scripts/l4_file_watcher.py
@@ -192,6 +192,19 @@ def emit_results(results, *, emit_event):
         )
 
 
+# #13197: serialize the freshen across debounce callbacks. Each role-class key
+# fires its debounce callback on its OWN threading.Timer thread (see _Debouncer),
+# so a burst that touches N role-classes runs N _default_ensure_fresh_source
+# calls CONCURRENTLY against the SAME harness clone. Concurrent `git pull`
+# invocations then collide on `.git/index.lock` and most return pull-failed — an
+# N-way compose-failed storm to PM (the all-fail-at-once #13197 pattern), NOT the
+# "fast already-up-to-date no-op" the docstring assumed. A module-level lock
+# serializes the git freshen so the first call does the real pull and the rest
+# run as genuine fast no-ops. Scoped to this process's watcher threads (the
+# collision source); a threading.Lock is the right primitive.
+_FRESHEN_LOCK = threading.Lock()
+
+
 def _default_ensure_fresh_source(*, repo_root):
     """Put the harness clone on ``main`` + pull origin before a recompose.
 
@@ -207,13 +220,20 @@ def _default_ensure_fresh_source(*, repo_root):
     Lives behind ``ensure_fresh_source=`` injection (same pattern as
     ``run_compose=``) so unit tests never shell out to git. Returns
     ``(ok, detail)``.
+
+    #13197: the git freshen runs under ``_FRESHEN_LOCK`` so a burst of
+    per-role-class debounce callbacks (each on its own Timer thread) cannot
+    fire concurrent ``git`` against the shared clone and collide on
+    ``.git/index.lock``. Serialized, the first pull does the work and the rest
+    are fast no-ops.
     """
     try:
         import git_ops
     except Exception as exc:  # noqa: BLE001 — import failure must not crash watch
         return False, f"git_ops import failed: {exc!r}"
     try:
-        return git_ops.ensure_main_and_pull(role="harness")
+        with _FRESHEN_LOCK:
+            return git_ops.ensure_main_and_pull(role="harness")
     except Exception as exc:  # noqa: BLE001 — guard must never crash the watch
         return False, f"ensure_main_and_pull raised: {exc!r}"
 

--- a/tests/test_l4_file_watcher_e3.py
+++ b/tests/test_l4_file_watcher_e3.py
@@ -825,12 +825,26 @@ class TestFreshenSerialized13197:
         import git_ops
         state = {"now": 0, "max": 0}
         guard = threading.Lock()
+        N = 11
+        # All threads rendezvous INSIDE fake_ensure before the concurrency
+        # measurement, so a missing _FRESHEN_LOCK is exposed deterministically
+        # (not dependent on a sleep window): without the lock all N reach the
+        # barrier together → max==N; with it, only one can be inside at a time
+        # so the (N-1)th never arrives and the barrier would deadlock — hence a
+        # short timeout that, when it trips, PROVES serialization.
+        barrier = threading.Barrier(N)
 
         def fake_ensure(role=None):
+            try:
+                barrier.wait(timeout=0.5)
+            except threading.BrokenBarrierError:
+                # Expected WITH the lock: serialized → barrier never fills →
+                # times out. That is the serialization signal, not a failure.
+                pass
             with guard:
                 state["now"] += 1
                 state["max"] = max(state["max"], state["now"])
-            time.sleep(0.02)  # widen the race window so a missing lock shows
+            time.sleep(0.02)
             with guard:
                 state["now"] -= 1
             return True, "on-main-synced"

--- a/tests/test_l4_file_watcher_e3.py
+++ b/tests/test_l4_file_watcher_e3.py
@@ -807,6 +807,55 @@ class TestEnsureMainAndPull12906:
         assert "unexpected" in detail
 
 
+class TestFreshenSerialized13197:
+    """#13197: each per-role-class debounce callback fires
+    _default_ensure_fresh_source on its OWN Timer thread, all against the SAME
+    harness clone. Without serialization, concurrent `git pull` collided on
+    `.git/index.lock` → an N-way pull-failed/compose-failed storm. _FRESHEN_LOCK
+    must single-flight the git freshen."""
+
+    def test_freshen_lock_exists(self):
+        assert isinstance(lfw._FRESHEN_LOCK, type(threading.Lock()))
+
+    def test_concurrent_freshens_are_serialized(self, monkeypatch, tmp_path):
+        """11 threads (the observed burst size) calling the freshen must never
+        run the underlying git op concurrently — the lock keeps max in-flight
+        at 1. Without _FRESHEN_LOCK this would observe up to 11-way concurrency
+        (the index.lock-collision regression)."""
+        import git_ops
+        state = {"now": 0, "max": 0}
+        guard = threading.Lock()
+
+        def fake_ensure(role=None):
+            with guard:
+                state["now"] += 1
+                state["max"] = max(state["max"], state["now"])
+            time.sleep(0.02)  # widen the race window so a missing lock shows
+            with guard:
+                state["now"] -= 1
+            return True, "on-main-synced"
+
+        monkeypatch.setattr(git_ops, "ensure_main_and_pull", fake_ensure)
+
+        results = []
+
+        def worker():
+            results.append(lfw._default_ensure_fresh_source(repo_root=tmp_path))
+
+        threads = [threading.Thread(target=worker) for _ in range(11)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(results) == 11
+        assert all(ok for ok, _ in results)  # all succeed (serialized no-ops)
+        assert state["max"] == 1, (
+            f"git freshen ran {state['max']}-way concurrent — _FRESHEN_LOCK is "
+            f"not serializing (the #13197 .git/index.lock-collision regression)"
+        )
+
+
 class TestPostMergeDeployFreshness12906:
     """AC1 — the OTHER harness-side recompose path (post-merge
     deploy-all) must also ensure-main + pull before composing. Static


### PR DESCRIPTION
Closes #13197.

## Problem
The harness L4 file-watcher emitted **11x `compose-failed`-to-pm** in a ~2s burst (`reason=freshen-source-failed`, `stderr="recompose for '<X>' aborted: pull-failed"`), one per role-class. The harness clone was **0-ahead/0-behind** origin/main, so a plain pull should have been an "Already up to date" no-op — yet all 11 failed.

## RCA (facts, confirmed)
Each per-role-class debounce callback fires `make_change_callback._on_change` → `_default_ensure_fresh_source` → `git_ops.ensure_main_and_pull` on its **own `threading.Timer` thread** (`_Debouncer._fire` runs the callback per-key, no cross-key serialization). A burst touching N role-classes therefore runs **N concurrent `git pull`** against the **same** harness clone → they collide on `.git/index.lock` → most return `pull-failed`. The all-fail-at-once pattern is lock contention, **not** staleness:
- **Divergence (#13158) ruled out**: clone was 0/0.
- **Dirty-tree ruled out**: `ensure_main_and_pull` skips `checkout main` when already on main; a 0/0 `git pull` is "Already up to date" even on a dirty tree.

The `_freshen_or_abort` docstring's "later pulls are fast already-up-to-date no-ops" assumption is only true *serially* — concurrent pulls collide before they can no-op.

## Fix
Module-level **`_FRESHEN_LOCK = threading.Lock()`** held around the `git_ops.ensure_main_and_pull` call in `_default_ensure_fresh_source`, so concurrent burst freshens **serialize** instead of colliding: the first does the real pull, the rest run as the fast no-ops the design assumed. Scoped to this process's watcher Timer threads (the collision source) — a `threading.Lock` is the right primitive.

## Tests
+2 in `TestFreshenSerialized13197`: lock-exists, and an **11-thread concurrency test** using a `threading.Barrier(N)` rendezvous so it deterministically exposes a missing lock (without the lock all N reach the barrier → max-in-flight==N; with it the barrier times out/breaks → max==1). File: 42 passed.

## Review (step:cycle/ds-review)
DeepSeek 402 → **Sonnet fallback**. **NO_BLOCKING_FINDINGS**; 1 MED + 4 LOW. MED + the test-flakiness LOW addressed; rest dispositioned no-change. Artifact: `.squidsquad/skill/planning/DS-REVIEW-13197.md` (on main).

## Known residual (documented, NOT silently dropped — review MED-1)
The post-merge deploy path (`harness.py`) calls `git_ops.ensure_main_and_pull("harness")` **directly**, outside `_FRESHEN_LOCK` — so a watcher burst concurrent with a post-merge deploy could still race on `.git/index.lock`. This is **out of scope for #13197** (watcher-burst-only); the comprehensive fix is to move the lock into `git_ops.ensure_main_and_pull` itself (covers all callers, higher blast radius — separate slice). Mitigant: the deploy path already serializes against other deploys via `harness._deploy_lock`; only the rare watcher-vs-deploy overlap remains. Flagged here so it isn't re-filed as a fresh mystery.

## Scope
Deterministic harness code → no CQ. No new/renamed files → no manifest update. Sibling fragility class: #13158 (deploy-pull divergence, shipped), #13030, #13036, #12906. Full static gate: see below.