### PR TITLE
#13213: wire UserPromptSubmit activity hook -> activity_hook.py (close freeze-after-prompt liveness gap)

### DIFF
--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -1836,10 +1836,11 @@ def _session_end_hook_group() -> dict:
     }
 
 
-# #12443 — activity-heartbeat hooks (HARNESS-ARCH §15.1). PostToolUse /
-# PostToolUseFailure fire on EVERY tool call, so they MUST NOT block or delay
-# the agent (AC2). Native `type: http` hooks are SYNCHRONOUS (they block the
-# tool call; default timeout 600s) and only `type: command` hooks support
+# #12443/#13213 — activity-heartbeat hooks (HARNESS-ARCH §15.1). UserPromptSubmit
+# fires at prompt-receipt and PostToolUse / PostToolUseFailure fire on EVERY tool
+# call, so they MUST NOT block or delay the agent (AC2). Native `type: http` hooks
+# are SYNCHRONOUS (they block the tool call; default timeout 600s) and only
+# `type: command` hooks support
 # `async` — verified against the Claude Code hook API (#12443) — so these are
 # async command hooks: Claude Code backgrounds them and ignores exit/output,
 # giving true zero-latency fire-and-forget. (SessionEnd, slice a, stays http: a
@@ -1912,13 +1913,24 @@ def _ensure_session_end_hook(settings_path) -> bool:
 
 
 def _ensure_activity_hooks(settings_path) -> bool:
-    """#12443/#12458 — ensure the per-tool-call hooks are present in
-    ``.claude/settings.json`` (see ``_ensure_hook_entries``). All three are
-    async command hooks (NEVER block the tool call): PostToolUse/
-    PostToolUseFailure are the #12443 activity heartbeat; PreToolUse (#12458)
+    """#12443/#12458/#13213 — ensure the activity-heartbeat hooks are present in
+    ``.claude/settings.json`` (see ``_ensure_hook_entries``). All are async
+    command hooks (NEVER block/delay the agent's turn): PostToolUse/
+    PostToolUseFailure are the #12443 per-tool-call heartbeat; PreToolUse (#12458)
     additionally opens the in-flight window so a long tool call isn't mistaken
-    for a wedge (the harness sets in_flight_until on the PreToolUse event)."""
+    for a wedge (the harness sets in_flight_until on the PreToolUse event).
+
+    #13213 adds **UserPromptSubmit** as a prompt-receipt heartbeat: it stamps
+    last_activity_at the moment a prompt is submitted (nudge tick, idle-driver
+    tick, or inline operator turn), closing the freeze-after-prompt-before-first-
+    tool-call gap (a sibling of the #12271 wedge class). It is a PLAIN heartbeat
+    by design — the harness /hooks/activity handler sets in_flight_until ONLY on
+    PreToolUse, so UserPromptSubmit advances last_activity_at without opening an
+    in-flight window. That is deliberate: an in-flight window would MASK the very
+    freeze-after-prompt window this signal exists to expose. (HARNESS-ARCH §15.1/
+    §16; the prompt-receipt heartbeat does not set in-flight.)"""
     return _ensure_hook_entries(settings_path, {
+        "UserPromptSubmit": _activity_hook_group(),
         "PreToolUse": _activity_hook_group(),
         "PostToolUse": _activity_hook_group(),
         "PostToolUseFailure": _activity_hook_group(),
@@ -2264,9 +2276,9 @@ def main():
         se_settings = REPO_ROOT / ".claude" / "settings.json"
         if _ensure_session_end_hook(se_settings):
             print(f"  SessionEnd hook -> {se_settings.relative_to(REPO_ROOT)}")
-        # #12443/#12458 — ensure the per-tool-call hooks (PreToolUse +
-        # PostToolUse + PostToolUseFailure) are present too (same idempotent
-        # settings.json integration).
+        # #12443/#12458/#13213 — ensure the activity-heartbeat hooks
+        # (UserPromptSubmit + PreToolUse + PostToolUse + PostToolUseFailure) are
+        # present too (same idempotent settings.json integration).
         if _ensure_activity_hooks(se_settings):
             print(f"  Activity hooks -> {se_settings.relative_to(REPO_ROOT)}")
         # #12458 — ensure the pause-aware lifecycle hooks (Notification /

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -563,10 +563,10 @@ class TestEnsureSessionEndHook12418:
 
 
 class TestEnsureActivityHooks12443:
-    """#12443 AC1: the pipeline places PostToolUse + PostToolUseFailure
-    activity-heartbeat hooks in .claude/settings.json — async command hooks (NOT
-    blocking http), idempotently, preserving everything else (incl. slice-a's
-    SessionEnd hook)."""
+    """#12443/#13213 AC1: the pipeline places the activity-heartbeat hooks
+    (UserPromptSubmit + PreToolUse + PostToolUse + PostToolUseFailure) in
+    .claude/settings.json — async command hooks (NOT blocking http),
+    idempotently, preserving everything else (incl. slice-a's SessionEnd hook)."""
 
     def _load(self, p):
         import json
@@ -578,10 +578,12 @@ class TestEnsureActivityHooks12443:
         assert changed is True
         hooks = self._load(p)["hooks"]
         # #12458: PreToolUse joins the per-tool-call async command hooks.
-        for name in ("PreToolUse", "PostToolUse", "PostToolUseFailure"):
+        # #13213: UserPromptSubmit joins as the prompt-receipt heartbeat.
+        for name in ("UserPromptSubmit", "PreToolUse", "PostToolUse",
+                     "PostToolUseFailure"):
             assert name in hooks, f"{name} hook missing"
             hook = hooks[name][0]["hooks"][0]
-            # AC2: must be a non-blocking async COMMAND hook, not a blocking
+            # AC2/AC4: must be a non-blocking async COMMAND hook, not a blocking
             # native http hook.
             assert hook["type"] == "command"
             assert hook["async"] is True
@@ -590,6 +592,19 @@ class TestEnsureActivityHooks12443:
             assert hook["args"] == [
                 "${CLAUDE_PROJECT_DIR}/references/scripts/activity_hook.py"]
             assert isinstance(hook["timeout"], int)
+
+    def test_user_prompt_submit_heartbeat_13213(self, tmp_path):
+        """#13213 AC1: UserPromptSubmit is emitted as an async command hook
+        invoking activity_hook.py — same group shape as the other heartbeats
+        (it is a PLAIN heartbeat; the in-flight distinction is harness-side, on
+        event name, not in the settings group)."""
+        p = tmp_path / ".claude" / "settings.json"
+        assert compose._ensure_activity_hooks(p) is True
+        hook = self._load(p)["hooks"]["UserPromptSubmit"][0]["hooks"][0]
+        assert hook["type"] == "command"
+        assert hook["async"] is True
+        assert hook["args"] == [
+            "${CLAUDE_PROJECT_DIR}/references/scripts/activity_hook.py"]
 
     def test_idempotent_no_rewrite(self, tmp_path):
         p = tmp_path / ".claude" / "settings.json"
@@ -659,9 +674,9 @@ class TestEnsurePauseHooks12458:
         assert compose._ensure_activity_hooks(p) is True
         assert compose._ensure_pause_hooks(p) is True
         hooks = self._load(p)["hooks"]
-        for name in ("SessionEnd", "PreToolUse", "PostToolUse",
-                     "PostToolUseFailure", "Notification", "PreCompact",
-                     "PostCompact", "StopFailure"):
+        for name in ("SessionEnd", "UserPromptSubmit", "PreToolUse",
+                     "PostToolUse", "PostToolUseFailure", "Notification",
+                     "PreCompact", "PostCompact", "StopFailure"):
             assert name in hooks, f"{name} missing"
 
 

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -4910,6 +4910,37 @@ class TestPauseHook12458(unittest.TestCase):
                          json={"event": "PostToolUse"})
         self.assertIsNone(self._agent().in_flight_until)
 
+    def test_userpromptsubmit_records_heartbeat_no_in_flight_13213(self):
+        """#13213 AC2/AC4/AC5: a UserPromptSubmit heartbeat advances
+        last_activity_at and records the event (so progress_liveness/the shadow
+        verdict sees the agent received input), but is a PLAIN heartbeat — it
+        does NOT open an in-flight window. That is deliberate: an in-flight
+        window would MASK the freeze-after-prompt-before-first-tool-call gap this
+        signal exists to expose."""
+        r = self.client.post("/hooks/activity", headers=self._hdr(),
+                             json={"event": "UserPromptSubmit"})
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue(r.json().get("ok"))
+        agent = self._agent()
+        # AC2: heartbeat recorded — last_activity_at advanced, event stamped.
+        self.assertIsInstance(agent.last_activity_at, float)
+        self.assertEqual(agent.last_activity["event"], "UserPromptSubmit")
+        # AC4: plain heartbeat — NOT an in-flight opener (only PreToolUse opens).
+        self.assertIsNone(agent.in_flight_until)
+
+    def test_userpromptsubmit_does_not_disturb_open_in_flight_13213(self):
+        """A UserPromptSubmit arriving while a tool call is in flight must not
+        clear the in-flight window (it is neither the PreToolUse opener nor the
+        Post* closer) — only a real tool-call boundary moves that window."""
+        self.client.post("/hooks/activity", headers=self._hdr(),
+                         json={"event": "PreToolUse"})
+        opened = self._agent().in_flight_until
+        self.assertIsNotNone(opened)
+        self.client.post("/hooks/activity", headers=self._hdr(),
+                         json={"event": "UserPromptSubmit"})
+        # in-flight window untouched; only Post* closes it.
+        self.assertEqual(self._agent().in_flight_until, opened)
+
     def test_activity_clears_waiting(self):
         # set waiting via a Notification, then any activity clears it
         self.client.post("/hooks/pause", headers=self._hdr(),


### PR DESCRIPTION
## #13213 — Wire UserPromptSubmit activity hook → activity_hook.py

Closes the **freeze-after-prompt-before-first-tool-call** liveness gap (sibling of the #12271 wedge class). Today the activity heartbeat fires only on tool-call boundaries (PreToolUse opens an in-flight window; Post* closes it). An agent that receives a prompt and then freezes *before* its first tool call emits no new heartbeat — `last_activity_at` stays frozen and the harness can't distinguish "received input, now wedged at prompt-processing" from "legitimately idle". `UserPromptSubmit` stamps activity at prompt-receipt (nudge tick, idle-driver tick, or inline operator turn).

### Design decision (the "skill's call" in the issue scope)
`UserPromptSubmit` is wired as a **PLAIN heartbeat** — it advances `last_activity_at` but does **NOT** open an in-flight window. The harness `/hooks/activity` handler already sets `in_flight_until` only on `PreToolUse` (harness.py:2975), so the new event falls through as a passthrough heartbeat with **no harness change required**. This is deliberate: arming an in-flight "work-should-follow" window on UserPromptSubmit would *mask* the very freeze-after-prompt window this signal exists to expose. Documented in the `_ensure_activity_hooks` docstring (HARNESS-ARCH §15.1/§16).

### Wiring-only (no rewrite)
`activity_hook.py` is already event-generic (reads `hook_event_name` from stdin) and `/hooks/activity` already ingests any event → the change is a compose-template addition plus tests, exactly as the issue predicted.

### Acceptance criteria
- **AC1** — `compose._ensure_activity_hooks` emits `UserPromptSubmit` as an async command hook → `activity_hook.py` (same group as the other three). Tests: `test_user_prompt_submit_heartbeat_13213`, updated `test_adds_both_hooks_to_missing_file`. ✅
- **AC2** — On a prompt submission the harness records a heartbeat: `last_activity` shows `event: "UserPromptSubmit"` and `last_activity_at` advances. Test: `test_userpromptsubmit_records_heartbeat_no_in_flight_13213`. ✅
- **AC3** — Existing PreToolUse/PostToolUse/PostToolUseFailure + SessionEnd hooks unaffected. Test: updated `test_coexists_with_activity_and_session_end` (all 9 hooks coexist). ✅
- **AC4** — Fail-open preserved (async command hook, never blocks/delays the turn; harness always 200). Verified in compose group assertions + harness handler. ✅
- **AC5** — Integration test covering UserPromptSubmit → heartbeat, incl. that it does not disturb an open in-flight window (`test_userpromptsubmit_does_not_disturb_open_in_flight_13213`) so progress_liveness/shadow verdict sees the signal. ✅
- **AC6** — Coordination with #12271/#12492: lands **before** the cutover; the shadow `progress_liveness()` verdict (harness.py:731, reads `last_activity_at`) automatically includes the new signal with **no verdict-semantics change**. Noted on #12271. ✅

### Verification
- Full static gate (post merge of origin/main): **4963 passed, 0 failures, 0 errors**.
- DS code-review: **NO_FINDINGS** (DS-REVIEW-13213.md on main).
- No CQ spec: change is deterministic config/code (compose template + harness passthrough), not LLM-consumed agent instructions ([[feedback_cq_applies_to_llm_consumed_not_composed_files]]).
- No manifest update: no new tracked files (activity_hook.py already tracked).
- `.claude/settings.json` is per-clone state (stripped from the PR by the #11511 guard); the compose source in this PR regenerates it on every clone.
