### PR TITLE
#13236: harden harness.py main() stdout against cp1252 crash (banner art)

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -5400,6 +5400,19 @@ def _build_uvicorn_config(app_, host, port, log_level="warning"):
 
 
 def main():
+    # #13236 — crash-proof our own stdout/stderr first thing, before any print
+    # (banner, port-in-use notice, status lines). harness.py was named in the
+    # #13198 cp1252 crash-class list but left unwired: its banner is intentional
+    # box-drawing ASCII-art (U+2588 et al.) that cannot encode on a strict cp1252
+    # console, so a bare `python harness.py` launch (start.ps1:57, no PYTHONUTF8)
+    # would raise UnicodeEncodeError on the banner. harden_stdio() uses
+    # errors="backslashreplace" — the art degrades to escapes on a legacy console
+    # (no crash) and renders normally on UTF-8. In-process parity with the rest
+    # of the fleet (#13198); the banner literals are deliberately NOT ASCII-swept
+    # (unlike the agent-facing CLIs) — they are decorative art, not messages.
+    from cli_stdio import harden_stdio
+    harden_stdio()
+
     # On Windows, the default ProactorEventLoop's cleanup path
     # (_ProactorBasePipeTransport._call_connection_lost) does not handle
     # ConnectionResetError gracefully — when a client (uvicorn keepalive,

--- a/tests/test_cli_stdio_13198.py
+++ b/tests/test_cli_stdio_13198.py
@@ -90,6 +90,31 @@ class TestFleetWiring13198:
         assert (SCRIPTS / "cli_stdio.py").exists()
 
 
+class TestHarnessWiring13236:
+    """#13236 — harness.py was named in #13198's cp1252 crash-class list but
+    left unwired (out of #13198's agent-facing-CLI scope). It is the
+    long-running server, not a fire-and-exit CLI, so the harm is a crash+respawn
+    on its banner rather than a false-failure double-emit — but a strict cp1252
+    console still raises UnicodeEncodeError on the box-drawing banner art.
+    harness.py main() must invoke harden_stdio(); its banner literals are
+    intentional ASCII-art and are deliberately NOT in the #13198 print-sweep
+    guard (TestNoDecorativeNonAsciiInPrints13198.SWEPT)."""
+
+    def test_harness_main_invokes_harden_stdio(self):
+        src = (SCRIPTS / "harness.py").read_text(encoding="utf-8")
+        assert "from cli_stdio import harden_stdio" in src
+        assert "harden_stdio()" in src, (
+            "harness.py main() must invoke harden_stdio() (#13236) — the "
+            "cp1252 banner crash-proofing was dropped"
+        )
+
+    def test_harness_not_in_ascii_sweep_guard(self):
+        """harness.py's banner is intentional box-drawing art — it must stay out
+        of the print-literal ASCII sweep (which would flag/destroy the logo).
+        harden_stdio() crash-proofs it instead."""
+        assert "harness" not in TestNoDecorativeNonAsciiInPrints13198.SWEPT
+
+
 def _print_string_literals(src):
     """Yield (lineno, text) for every str literal passed to a `print(...)` call.
 


### PR DESCRIPTION
## #13236 — harden harness.py main() stdout against cp1252 crash

Follow-up to #13185 / #13198 (qa-filed during #13198 re-verification). `harness.py` was named in #13198's cp1252 crash-class list but left unwired — it was out of #13198's *agent-facing-CLI* scope.

### Root cause
`harness.py main()` did not reconfigure its own stdout, and `start.ps1:57` launches it via bare `python references/scripts/harness.py` with no `PYTHONUTF8`/`PYTHONIOENCODING`. An AST scan of its `print()` literals found **33 non-cp1252 chars** — all in the intentional box-drawing **banner art** (`_print_banner`: U+2588 FULL BLOCK ×16, half/quadrant blocks, the U+1F991 SQUID). On a strict cp1252 console the banner raises `UnicodeEncodeError`. (Unlike the agent-facing CLIs' fire-and-exit double-emit harm in #13185, the harness is a long-running server — a stdout crash dies + respawns rather than false-failing after a side effect; hence Low severity.)

### Fix
Call `cli_stdio.harden_stdio()` as the first action in `main()` — in-process parity with the #13198 fleet. `errors="backslashreplace"` means the banner art degrades to escapes on a legacy console (**no crash**) and renders normally on UTF-8 (the common case).

### Deliberately NOT swept
The banner literals are **intentional decorative art**, not operational messages — they are correctly left out of the #13198 print-literal ASCII-sweep guard (sweeping would flag/destroy the squid logo). The "4 decorative chars" qa's scan counted are em-dashes (U+2014), which **are** cp1252-encodable (0x97) and never crashed — no sweep value, so not touched (no gold-plating).

### Verification
- +2 regression tests (`TestHarnessWiring13236`): `main()` invokes `harden_stdio()`; harness stays out of the ASCII-sweep `SWEPT` set.
- Full static gate: **4962 passed, 0 failures, 0 errors**.
- No DS-review: deterministic stdout-hardening with comprehensive regression tests (same class as #13185, where DS-review was skipped) — not agent-instructions/compose/sub-skills.
- No CQ (deterministic code, not LLM-consumed). No manifest (no new tracked files; test file already tracked from #13198).
