### PR TITLE
#13212: stage verifier-authored comprehension specs in post-cycle commit

### DIFF
--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -872,7 +872,15 @@ def _role_owned_patterns(role):
             "SKILL.md",
             ".squidsquad/config.md",
         ],
-        # qa: nothing beyond common
+        # qa (verifier) authors comprehension specs under tests/comprehension/
+        # (#9184 — the verifier derives CQ specs; skill never self-authors them).
+        # These are permanent regression assets that MUST land in the repo, but
+        # tests/comprehension/ is outside .squidsquad/ so it matched no pattern
+        # and commit_role_scoped classified every new spec as "foreign" — leaving
+        # it untracked until a manual "recover N-behind" rescue commit (#13212).
+        # Adding it here lets the verifier's normal post-cycle commit stage its
+        # own specs. Scoped to qa only: no other role authors comprehension specs.
+        "qa": ["tests/comprehension/"],
     }
     return common + role_specific.get(role, [])
 

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -823,14 +823,27 @@ class TestRoleOwnedPatterns:
         assert "SKILL.md" in pats
         assert ".squidsquad/config.md" in pats
 
-    def test_qa_has_no_extras_beyond_common(self):
+    def test_qa_extras(self):
+        """#13212: qa (verifier) owns tests/comprehension/ — it authors the
+        comprehension regression specs (#9184) and must be able to stage them
+        in its own post-cycle commit (they live outside .squidsquad/, so they
+        matched no pattern before and were left untracked as 'foreign')."""
         pats = git_ops._role_owned_patterns("qa")
-        # QA must NOT pick up config or delivery docs
+        assert "tests/comprehension/" in pats
+        # QA must still NOT pick up config or delivery docs / SKILL.md —
+        # the new extra does not loosen the rest of the boundary.
         assert ".squidsquad/config.md" not in pats
         assert "README.md" not in pats
-        # #9474 sanity check: QA also must NOT pick up SKILL.md —
-        # the DM-extras additions don't bleed into other roles.
         assert "SKILL.md" not in pats
+
+    def test_comprehension_specs_are_qa_only(self):
+        """#13212: only the verifier authors comprehension specs — the
+        tests/comprehension/ ownership must NOT bleed into other roles (else a
+        non-verifier cycle could stage a half-written spec)."""
+        for role in ("pm", "dm", "skill"):
+            assert "tests/comprehension/" not in git_ops._role_owned_patterns(role), (
+                f"{role} must not own tests/comprehension/ (#13212 — verifier-only)"
+            )
 
     def test_pm_does_not_pick_up_dm_extras(self):
         """#9474: PM and DM co-own .squidsquad/config.md, but PM must
@@ -1050,6 +1063,41 @@ class TestCommitRoleScoped:
         assert ".squidsquad/qa/working-state.md" in staged
         assert ".squidsquad/config.md" not in staged
         assert ".squidsquad/config.md" in capsys.readouterr().err
+
+    @patch("git_ops.commit", return_value=True)
+    @patch("git_ops.push", return_value=True)
+    @patch("git_ops._get_working_branch", return_value="main")
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_qa_stages_untracked_comprehension_spec_13212(
+        self, mock_run, mock_run_list, mock_working_branch,
+        mock_push, mock_commit, capsys,
+    ):
+        """#13212: the exact bug — an UNTRACKED comprehension spec (porcelain
+        '??') authored by the verifier must be staged by its post-cycle commit,
+        not classified foreign and left to rot until a manual recovery commit."""
+        def _run_side(cmd, *a, **kw):
+            if "branch --show-current" in cmd:
+                return _mock_result(stdout="main\n")
+            return _mock_result(stdout=(
+                " M .squidsquad/qa/working-state.md\n"
+                "?? tests/comprehension/13250_spec.json\n"
+            ))
+        mock_run.side_effect = _run_side
+        mock_run_list.return_value = _mock_result()
+
+        result = git_ops.commit_role_scoped("qa", "qa cycle")
+
+        staged = [c[0][0][-1] for c in mock_run_list.call_args_list
+                  if c[0][0][:2] == ["git", "add"]]
+        assert "tests/comprehension/13250_spec.json" in staged, (
+            "qa post-cycle must stage untracked comprehension specs (#13212) — "
+            "they were silently left foreign before this fix"
+        )
+        assert ".squidsquad/qa/working-state.md" in staged
+        # not left in the foreign-skip warning
+        assert "tests/comprehension/13250_spec.json" not in capsys.readouterr().err
+        assert result is True
 
     @patch("git_ops._run")
     def test_returns_false_when_no_own_files(self, mock_run, capsys):


### PR DESCRIPTION
## #13212 — stage verifier-authored comprehension specs in the post-cycle commit

(qa-filed improvement-scan; cluster root, front-loaded plan on the issue.)

### RCA — two distinct findings, disentangled
1. **DURABLE BUG (fixed here):** `git_ops._role_owned_patterns` had **no** entry matching `tests/comprehension/`. `commit_role_scoped` reads `git status --porcelain` (which *does* list untracked `??` files) and stages by role pattern — so every new comprehension spec was classified **foreign** and left untracked, landing only via qa's manual "recover N-behind" rescue commits (e.g. `304a0990e`). These are verifier-authored **permanent regression assets** (#9184) that must land automatically.
2. **NOT a staging bug (out of this slice):** the `.squidsquad/qa/planning/` accumulation + 99-behind clone. Those paths **already** match `.squidsquad/qa/`, so they stage fine *when post-cycle runs*. Their accumulation = post-cycle **did not run** during the qa wedge (a liveness symptom tracked by **#12271**, recovered manually) — out of `cycle_post`'s control. Folding a liveness fix into this commit would be scope-creep.

### Fix
Add `tests/comprehension/` to the **qa (verifier)** `role_specific` patterns. Scoped to qa only — the verifier authors comprehension specs; skill never self-authors them (skill-cq). Purely **additive**: only expands what qa stages; foreign-file skip, the #11083 branch-guard, and push-role propagation are untouched.

### Verification
- +3 tests: `test_qa_extras` (positive + boundary), `test_comprehension_specs_are_qa_only` (qa-only isolation across pm/dm/skill), `test_qa_stages_untracked_comprehension_spec_13212` (behavioral — the exact `??` untracked porcelain status staged, not foreign-warned).
- Full static gate: **4965 passed, 0 failures, 0 errors**.
- DS code-review: **NO_FINDINGS** (DS-REVIEW-13212.md on main).
- No CQ (deterministic code, not LLM-consumed). No manifest (no new tracked files).

### Cluster context
Part of the deploy-path-fragility cluster (#13212 ⊃ #13215; #13211 separate). Sibling slices (per the strategy posted on this issue): **#13215** = make deploy-pull robust to a *pre-existing* dirty tree (belt to this fix's suspenders); **#13211** = move `_FRESHEN_LOCK` into `git_ops.ensure_main_and_pull`. Shipped as independent slices, not batched.
