### PR TITLE
#13255: exclude self-emitted events from /events/for/{role} (stop agent self-wakes)

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -3542,14 +3542,24 @@ async def get_events_for_role(
     else:
         events = event_stream.get_recent(limit * 3)
 
-    # Filter: events targeted at this role OR matching the role's reaction types
+    # Filter: events targeted at this role OR matching the role's reaction types.
+    # #13255: a reacts-to match must EXCLUDE events the requesting role emitted
+    # itself — otherwise an agent's own git-commit / status-transition events
+    # come back through its own event_poll, wake it via Monitor, and drain to a
+    # guaranteed no-op (the care filter skips them: no target_alias). Explicit
+    # target_alias targeting still wins unconditionally (so a hypothetical
+    # self-assign via target_alias is preserved); only the broadcast reacts-to
+    # branch suppresses self-emitted events. Cross-agent awareness is unaffected:
+    # a verifier reject is qa-emitted, so the worker (different emitter) still
+    # sees it; assigned-to / deploy-signal are harness-emitted, never suppressed.
     filtered = []
     for e in events:
         target = e.get("payload", {}).get("target_alias", "")
         etype = e.get("event_type", "")
+        emitter = e.get("role", "")
         if target == role:
             filtered.append(e)
-        elif relevant_types and etype in relevant_types:
+        elif relevant_types and etype in relevant_types and emitter != role:
             filtered.append(e)
 
     # Same skim-then-advance rule as GET /events: oldest-first when the

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -3000,6 +3000,59 @@ class TestGetEventsForRole(unittest.TestCase):
         self.assertEqual(len(data["events"]), 1)
         self.assertEqual(data["events"][0]["id"], "e1")
 
+    def test_excludes_self_emitted_reacts_to_events_13255(self):
+        """#13255: a reacts-to match emitted BY the requesting role itself is
+        excluded — an agent must not self-wake on its own git-commit /
+        status-transition events (they always drain to a care-filter no-op).
+        Cross-agent reacts-to events (different emitter) are still delivered, and
+        explicit target_alias targeting always wins (even self-emitted)."""
+        from harness import event_stream
+
+        event_stream.append({  # self-emitted reacts-to -> EXCLUDED
+            "id": "own1", "event_type": "git-commit", "role": "skill",
+            "payload": {"result": "ok"},
+        })
+        event_stream.append({  # cross-agent reacts-to -> INCLUDED
+            "id": "other1", "event_type": "git-commit", "role": "qa",
+            "payload": {"result": "ok"},
+        })
+        event_stream.append({  # self-emitted BUT explicitly targeted -> INCLUDED
+            "id": "selftarget1", "event_type": "assigned-to", "role": "skill",
+            "payload": {"target_alias": "skill"},
+        })
+
+        with patch("harness._validate_role"), \
+             patch("config.get_event_filters_for_role",
+                   return_value=["git-commit", "status-transition"]):
+            resp = self.client.get("/events/for/skill")
+
+        self.assertEqual(resp.status_code, 200)
+        ids = [e["id"] for e in resp.json()["events"]]
+        self.assertNotIn("own1", ids, "self-emitted git-commit must be excluded (#13255)")
+        self.assertIn("other1", ids, "cross-agent git-commit must still be delivered")
+        self.assertIn("selftarget1", ids, "explicit target_alias must win over self-emitted exclusion")
+
+    def test_self_emit_filter_includes_event_with_missing_emitter_13255(self):
+        """#13255 (review LOW): an event with no top-level `role` field has
+        emitter "" — it cannot be attributed to the requesting role, so the
+        self-emit exclusion must NOT drop it (conservative-correct: include)."""
+        from harness import event_stream
+
+        event_stream.append({  # reacts-to match, NO emitter -> INCLUDED
+            "id": "noemit1", "event_type": "git-commit",
+            "payload": {"result": "ok"},
+        })
+
+        with patch("harness._validate_role"), \
+             patch("config.get_event_filters_for_role",
+                   return_value=["git-commit"]):
+            resp = self.client.get("/events/for/skill")
+
+        self.assertEqual(resp.status_code, 200)
+        ids = [e["id"] for e in resp.json()["events"]]
+        self.assertIn("noemit1", ids,
+                      "event with missing emitter must not be excluded (#13255)")
+
     def test_since_cursor_filters_events(self):
         """GET /events/for/skill?since=X returns only events after cursor."""
         from harness import event_stream


### PR DESCRIPTION
## #13255 — exclude self-emitted events from `GET /events/for/{role}`

(qa-filed improvement-scan; directly evidenced this session — I drained ~6 of these benign self-wakes while idle.)

### Root cause
`get_events_for_role` (harness.py) returned events where `payload.target_alias == role` **OR** `event_type` ∈ the role's reacts-to list — but never excluded events the requesting role **emitted itself**. An agent's own `git-commit` / `status-transition` events carry top-level `role=<that agent>` and no `target_alias`, are in its reacts-to list, so they came back through its own `event_poll`, woke it via Monitor, and drained to a guaranteed care-filter no-op. ~8 wasted wakes/session on a busy clone (each = a GET + ack round-trip + a slice of agent turn/context) — noise against AGENT-RUNTIME §8.4's "queue is pre-filtered, almost every event is cared" contract.

### Fix
Add `and emitter != role` (where `emitter = e.get("role", "")`) to the **reacts-to branch only**:
- Explicit `target_alias == role` still wins **unconditionally** (preserves any self-assign-via-target case).
- Self-emitted **broadcast** reacts-to events are suppressed → no self-wake.

### Why it's safe (no cross-agent regression)
- A **verifier reject** is qa-emitted → a worker (different emitter) still receives it.
- `assigned-to` / `deploy-signal` are **harness-emitted** (`role="harness"`) → never excluded for any agent.
- A **missing emitter** (`""`) → `"" != role` → always included (conservative: an unattributable event can't be ascribed to the requester).

### Verification
- +2 tests: self-emitted excluded / cross-agent included / explicit-target-self included; missing-emitter included.
- Full static gate: **4969 passed, 0 failures, 0 errors** (nothing relied on self-emitted delivery).
- Review: model_router/DeepSeek returned a degenerate sub-threshold output → **Sonnet fallback** (per the auto-fallback rule): **NO_BLOCKING_FINDINGS** + 1 LOW (missing-emitter test) addressed. DS-REVIEW-13255.md on main.
- No CQ (deterministic harness code, not LLM-consumed). No manifest (no new files).
