### PR TITLE
#13172: fail-closed on wrong-type additional_includes in v2 manifest loader

### DIFF
--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -291,7 +291,23 @@ def _load_manifest_v2_from_file(
             sys.exit(1)
         additional = data.get("additional_includes", []) or []
         if not isinstance(additional, list):
-            additional = []
+            # #13172 — fail CLOSED to match the sibling schema-error paths in
+            # THIS (base_role / variant) branch: base_role-missing and a
+            # missing sub-skill file both sys.exit(1). (The base-manifest
+            # `includes` wrong-type path below returns None instead — a
+            # different branch with a different contract; not the precedent
+            # here.) A bare-string additional_includes (e.g.
+            # `additional_includes: common/cycle-runner` instead of a list) was
+            # silently reset to [] — the variant's sub-skills then vanished from
+            # the composed CLAUDE.md with zero diagnostic. A schema typo must
+            # surface, not yield silently-incomplete agent instructions.
+            print(
+                f"ERROR: {manifest_path.name} for {role_name}: "
+                f"`additional_includes` is {type(additional).__name__}, "
+                f"expected list",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         for inc_path in additional:
             full_path = SUB_SKILLS_DIR / f"{inc_path}.md"
             if not full_path.exists():

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -709,6 +709,69 @@ class TestResolveVariant:
         assert compose._resolve_variant("skill") is None
 
 
+class TestManifestV2AdditionalIncludesWrongType13172:
+    """#13172: a wrong-TYPE additional_includes (e.g. a bare string instead of
+    a list) must fail CLOSED — matching every sibling schema-error path in
+    _load_manifest_v2_from_file — not silently reset to [] (which dropped the
+    variant's sub-skills from the composed CLAUDE.md with zero diagnostic)."""
+
+    def _write(self, tmp_path, additional):
+        import yaml as _yaml
+        p = tmp_path / "includes.yml"
+        p.write_text(
+            _yaml.safe_dump({"base_role": "worker",
+                             "additional_includes": additional}),
+            encoding="utf-8",
+        )
+        return p
+
+    def test_string_additional_includes_exits(self, tmp_path, capsys):
+        """The exact typo from the report: a bare string -> sys.exit(1)."""
+        p = self._write(tmp_path, "common/cycle-runner")
+        # Base-role recursion is isolated — we only exercise the type guard.
+        with patch.object(compose, "_load_manifest_v2",
+                          return_value=["common/boot-bootstrap"]):
+            with pytest.raises(SystemExit) as exc:
+                compose._load_manifest_v2_from_file(p, "worker-skill")
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "additional_includes" in err
+        assert "expected list" in err
+
+    def test_dict_additional_includes_exits(self, tmp_path):
+        """Any non-list type fails closed, not just str."""
+        p = self._write(tmp_path, {"oops": 1})
+        with patch.object(compose, "_load_manifest_v2",
+                          return_value=["common/boot-bootstrap"]):
+            with pytest.raises(SystemExit):
+                compose._load_manifest_v2_from_file(p, "worker-skill")
+
+    def test_valid_list_additional_includes_still_resolves(self, tmp_path):
+        """Regression guard: a correctly-typed list is unaffected by the fix —
+        base + additional are concatenated. Isolated from the live sub-skill
+        tree (stub file + patched SUB_SKILLS_DIR) so a future rename of any real
+        sub-skill can't make this fail with a misleading missing-file exit."""
+        subskills = tmp_path / "sub-skills"
+        (subskills / "common").mkdir(parents=True)
+        (subskills / "common" / "cycle-runner.md").write_text("x", encoding="utf-8")
+        p = self._write(tmp_path, ["common/cycle-runner"])
+        with patch.object(compose, "_load_manifest_v2",
+                          return_value=["common/boot-bootstrap"]), \
+             patch.object(compose, "SUB_SKILLS_DIR", subskills):
+            result = compose._load_manifest_v2_from_file(p, "worker-skill")
+        assert result == ["common/boot-bootstrap", "common/cycle-runner"]
+
+    def test_null_additional_includes_is_valid(self, tmp_path):
+        """Regression guard for the `... or []` idiom: an explicit YAML null
+        (or absent key) normalizes to [] and must NOT fail closed — only a
+        wrong NON-empty type does (#13172)."""
+        p = self._write(tmp_path, None)
+        with patch.object(compose, "_load_manifest_v2",
+                          return_value=["common/boot-bootstrap"]):
+            result = compose._load_manifest_v2_from_file(p, "worker-skill")
+        assert result == ["common/boot-bootstrap"]
+
+
 class TestAssembleSoul:
     """Test _assemble_soul produces L1 base + role SOUL flat output."""
 


### PR DESCRIPTION
## #13172 — fail-closed on wrong-type `additional_includes` in the v2 manifest loader

(skill-filed improvement-scan finding, triaged into the work queue.)

### Root cause
`compose._load_manifest_v2_from_file` silently reset a wrong-TYPE `additional_includes` (e.g. a bare string `additional_includes: common/cycle-runner` instead of a list) to `[]`. The variant's sub-skills then vanished from the composed `CLAUDE.md` with **zero diagnostic** — a manifest schema typo yields silently-incomplete agent instructions. This was the **only** swallowed case in the function: every sibling schema error in the same base_role/variant branch (`base_role` missing, a listed sub-skill file missing) does `sys.exit(1)`.

### Fix
Make the wrong-type case fail **closed** — `print(ERROR ... expected list, file=sys.stderr); sys.exit(1)` — matching its same-branch siblings. (The `isinstance` guard itself was already correct; it just must not be silent.)

### Verification
- +4 tests: bare-string→exit(1) with diagnostic, dict→exit, valid-list→resolves (isolated from the live sub-skill tree via stub + patched `SUB_SKILLS_DIR`), null/absent→valid (regression guard for the `… or []` idiom).
- Full static gate: **4971 passed, 0 failures, 0 errors**.
- Review: Sonnet (model_router/DeepSeek degenerate this session → auto-fallback): **NO_BLOCKING_FINDINGS**; 1 MEDIUM (an inline comment miscounted the siblings — the base `includes` wrong-type path returns `None`, not `sys.exit(1)`) + 2 LOW (null-case test, test isolation) all addressed. DS-REVIEW-13172.md on main.
- No CQ (deterministic code). No manifest (no new files).

### Out-of-scope note (on the issue)
The reviewer found `_load_manifest_v2` is **unreachable from the production deploy path** post-E6 (#10685) — deploy/deploy-all/wizard route through `v2_link_stage.emit_v2_linked`, not this loader. Retiring/tombstoning it is a separate triage decision; this guard is correct + cheap if the path is ever re-wired, and even on deploy-all each alias is wrapped in `except SystemExit` so a bad manifest fails one alias, never the fleet.
