### PR TITLE
#13215: deploy-pull survives a dirty agent clone (stash-around-merge)

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -4553,6 +4553,105 @@ def _git_in_clone(clone_path, args, timeout=120):
     )
 
 
+def _safe_stash_pop_in_clone(clone_path):
+    """Clone-aware mirror of ``git_ops._safe_stash_pop`` (#13045): pop the top
+    stash leaving NO conflict markers. On a pop conflict, restore each unmerged
+    path to the pulled ``HEAD`` and drop the now-applied stash — the just-pulled
+    state is authoritative for the state files clone-sync touches (e.g.
+    config.md's ship counter). Returns True on a clean pop, False if it
+    conflicted and was force-resolved (or popped nothing)."""
+    pop = _git_in_clone(clone_path, ["stash", "pop"])
+    if pop.returncode == 0:
+        return True
+    conflicted = _git_in_clone(
+        clone_path, ["diff", "--name-only", "--diff-filter=U"])
+    unmerged = [p.strip() for p in conflicted.stdout.splitlines() if p.strip()]
+    if not unmerged:
+        # Pop failed for a NON-conflict reason (no stash entry / unrelated git
+        # error) — the stash was NOT applied. Do NOT drop it (that would discard
+        # un-applied work). Leave it intact and report the pop did not succeed.
+        return False
+    for path in unmerged:
+        _git_in_clone(clone_path, ["checkout", "HEAD", "--", path])
+    _git_in_clone(clone_path, ["stash", "drop"])
+    return False
+
+
+def _safe_pull_in_clone(clone_path):
+    """Merge-pull ``origin/main`` into a clone, surviving a DIRTY working tree.
+
+    Mirrors ``git_ops.pull``'s stash-around-merge (#13167/#13045) but operates
+    on an arbitrary clone via ``_git_in_clone`` (``git_ops.pull`` only knows the
+    harness process cwd, so the deploy sequence — which runs against another
+    agent's clone — cannot reuse it). #13215: a clone carrying an uncommitted
+    change to a file the incoming commit also touches makes a bare
+    ``git pull --no-rebase`` ABORT (``local changes would be overwritten by
+    merge``) → deploy-sync silently skipped, the clone drifts from shipped
+    source. Stashing the dirty change lets the merge land, then the change is
+    re-applied — or, if it conflicts with the pulled content, resolved to the
+    pulled ``HEAD`` and dropped (same authoritative-pulled-state rule as
+    ``_safe_stash_pop_in_clone``).
+
+    A genuine MERGE conflict (committed divergence that truly conflicts) still
+    fails the retry pull → returns ``(False, …)`` so the caller routes to §11
+    recovery; only a DIRTY-TREE abort is newly survived.
+
+    Returns ``(ok: bool, detail: str)``.
+    """
+    pull_args = ["pull", "--no-rebase", "--no-edit", "origin", "main"]
+    first = _git_in_clone(clone_path, pull_args)
+    if first.returncode == 0:
+        return True, "pulled"
+    combined = (first.stdout + first.stderr).lower()
+    if "already up to date" in combined or "up to date" in combined:
+        return True, "already-up-to-date"
+
+    # First pull failed. Stash any dirty change and retry: a dirty-tree abort
+    # then merges cleanly; a genuine merge conflict fails the retry the same way
+    # and routes to recovery.
+    def _stash_ref():
+        r = _git_in_clone(
+            clone_path, ["rev-parse", "--quiet", "--verify", "refs/stash"])
+        return r.stdout.strip() if r.returncode == 0 else ""
+
+    pre_ref = _stash_ref()
+    stash = _git_in_clone(clone_path, ["stash"])
+    if stash.returncode != 0:
+        return False, f"stash-failed: {(stash.stderr or first.stderr).strip()[:200]}"
+    # #13167: `git stash` on a CLEAN tree is a no-op that still exits 0 — only
+    # pop a stash we actually created (ref changed), else a pop would splatter a
+    # pre-existing/ancient stash tree-wide and break compose.
+    stashed = _stash_ref() != pre_ref
+
+    retry = _git_in_clone(clone_path, pull_args)
+    if retry.returncode != 0:
+        # Genuine merge conflict (committed divergence) or other failure. If the
+        # retry STARTED a merge and hit a conflict, the clone is now in MERGING
+        # state (.git/MERGE_HEAD + conflict markers in the tree). Abort that
+        # merge FIRST — otherwise (a) the markers break the next compose, (b)
+        # _safe_stash_pop_in_clone would misread the merge's unmerged paths as a
+        # stash-pop conflict and DROP our stash, and (c) a lingering MERGE_HEAD
+        # makes the NEXT deploy's `checkout main` fail ("you have not concluded
+        # your merge") → a recurring deploy-error loop until manually cleared.
+        # `git merge --abort` exits non-zero (harmlessly ignored) when no merge
+        # is in progress (the pre-merge dirty-tree-abort case). After the abort
+        # the tree is back at the post-stash clean state, so restoring our stash
+        # lands our dirty change correctly. The pull itself still FAILED (origin
+        # not synced) → report failure so the caller routes to §11 recovery.
+        _git_in_clone(clone_path, ["merge", "--abort"])
+        if stashed:
+            _safe_stash_pop_in_clone(clone_path)
+        return False, f"pull-failed: {retry.stderr.strip()[:200]}"
+
+    if not stashed:
+        # Clean tree — the first failure was transient and nothing of ours was
+        # stashed, so there is nothing to pop.
+        return True, "pulled (no local changes to stash)"
+    if _safe_stash_pop_in_clone(clone_path):
+        return True, "pulled (stashed and popped)"
+    return True, "pulled (stash pop conflict — resolved to pulled state)"
+
+
 def _bump_compose_checksum(clone_path):
     """Advance last_compose_checksum to the just-deployed source state (§7.6).
     Best-effort: a checksum-compute failure must not fail an otherwise-good
@@ -4703,16 +4802,21 @@ def _run_deploy_sequence(role, deploy_signal_event_id=None):
             #    (#13158, recurring `deploy-error stage=pull`). `--no-rebase`
             #    merges the divergence instead (consistent with the team's
             #    always-merge-never-rebase rule + the #12526 launcher fix);
-            #    `--no-edit` keeps it non-interactive. A genuine merge CONFLICT
-            #    still fails the pull → §11 recovery (the rare case the old
-            #    --ff-only conflated with benign divergence).
+            #    `--no-edit` keeps it non-interactive. #13215: a DIRTY working
+            #    tree (uncommitted change to a file the incoming commit touches)
+            #    made even the merge-pull ABORT ("local changes would be
+            #    overwritten") → deploy-sync silently skipped; _safe_pull_in_clone
+            #    stashes-around-merge (mirroring git_ops.pull) so the dirty case
+            #    survives. A genuine merge CONFLICT still fails → §11 recovery
+            #    (the rare case the old --ff-only conflated with benign
+            #    divergence).
             co = _git_in_clone(clone_path, ["checkout", "main"])
             if co.returncode != 0:
                 _deploy_recover_and_respawn(role, "checkout-main", co.stderr.strip()[:300])
                 return
-            pull = _git_in_clone(clone_path, ["pull", "--no-rebase", "--no-edit", "origin", "main"])
-            if pull.returncode != 0:
-                _deploy_recover_and_respawn(role, "pull", pull.stderr.strip()[:300])
+            pull_ok, pull_detail = _safe_pull_in_clone(clone_path)
+            if not pull_ok:
+                _deploy_recover_and_respawn(role, "pull", pull_detail[:300])
                 return
 
             # 2. compose the alias using the CLONE's own compose.py (so its repo

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -3047,6 +3047,169 @@ class TestCompleteEventEndpoint(unittest.TestCase):
         self.assertEqual(resp.status_code, 410)
 
 
+class TestSafePullInClone13215(unittest.TestCase):
+    """#13215: the deploy sequence's clone pull must survive a DIRTY working
+    tree (uncommitted change to a file the incoming commit touches) by
+    stashing-around-merge, instead of aborting and silently skipping the
+    deploy-sync. _safe_pull_in_clone mirrors git_ops.pull (#13167/#13045) over
+    an arbitrary clone via _git_in_clone. Driven entirely by a scripted
+    _git_in_clone responder (no real git)."""
+
+    def _resp(self, rc=0, out="", err=""):
+        from types import SimpleNamespace
+        return SimpleNamespace(returncode=rc, stdout=out, stderr=err)
+
+    def _responder(self, scripted):
+        """Return a _git_in_clone side_effect. `scripted` maps a command key to
+        a LIST of responses consumed in order; unscripted commands default to
+        rc=0. Keys: 'pull','stash','stash pop','stash drop','rev-parse','diff',
+        'checkout'."""
+        def _key(args):
+            if args[:2] == ["stash", "pop"]:
+                return "stash pop"
+            if args[:2] == ["stash", "drop"]:
+                return "stash drop"
+            return args[0]
+
+        def _side(clone_path, args, **kw):
+            k = _key(list(args))
+            q = scripted.get(k)
+            if q:
+                return q.pop(0)
+            return self._resp(0)
+        return _side
+
+    def test_clean_pull_succeeds(self):
+        import harness
+        with patch.object(harness, "_git_in_clone",
+                          side_effect=self._responder({"pull": [self._resp(0)]})):
+            ok, detail = harness._safe_pull_in_clone("/clone")
+        self.assertTrue(ok)
+        self.assertEqual(detail, "pulled")
+
+    def test_already_up_to_date_succeeds(self):
+        import harness
+        with patch.object(harness, "_git_in_clone", side_effect=self._responder(
+                {"pull": [self._resp(1, err="Already up to date.")]})):
+            ok, detail = harness._safe_pull_in_clone("/clone")
+        self.assertTrue(ok)
+        self.assertEqual(detail, "already-up-to-date")
+
+    def test_dirty_tree_stashes_pulls_and_pops(self):
+        """The exact #13215 bug: first pull aborts (dirty), stash creates an
+        entry, retry pull succeeds, clean pop -> success."""
+        import harness
+        scripted = {
+            "pull": [self._resp(1, err="local changes would be overwritten by merge"),
+                     self._resp(0)],
+            # rev-parse: pre (no stash) then post (stash exists)
+            "rev-parse": [self._resp(1, out=""), self._resp(0, out="abc123")],
+            "stash": [self._resp(0)],
+            "stash pop": [self._resp(0)],
+        }
+        with patch.object(harness, "_git_in_clone",
+                          side_effect=self._responder(scripted)):
+            ok, detail = harness._safe_pull_in_clone("/clone")
+        self.assertTrue(ok)
+        self.assertEqual(detail, "pulled (stashed and popped)")
+
+    def test_genuine_merge_conflict_fails_after_stash(self):
+        """A committed-divergence conflict: retry pull also fails -> (False, ...)
+        so the caller routes to §11 recovery. The merge is aborted (clears
+        MERGE_HEAD + markers) BEFORE the stash is restored, so the clone is not
+        left in MERGING state (which would loop the next deploy's checkout)."""
+        import harness
+        calls = []
+        scripted = {
+            "pull": [self._resp(1, err="conflict A"),
+                     self._resp(1, err="CONFLICT (content): merge conflict in x")],
+            "rev-parse": [self._resp(1, out=""), self._resp(0, out="abc123")],
+            "stash": [self._resp(0)],
+            "stash pop": [self._resp(0)],  # restore after merge --abort
+        }
+        responder = self._responder(scripted)
+
+        def _tracking(clone_path, args, **kw):
+            calls.append(list(args))
+            return responder(clone_path, args, **kw)
+        with patch.object(harness, "_git_in_clone", side_effect=_tracking):
+            ok, detail = harness._safe_pull_in_clone("/clone")
+        self.assertFalse(ok)
+        self.assertIn("pull-failed", detail)
+        # #13215 review MED: the merge is aborted before restoring the stash, and
+        # the abort precedes the stash pop (so MERGING state is cleared first).
+        self.assertIn(["merge", "--abort"], calls)
+        self.assertLess(calls.index(["merge", "--abort"]),
+                        calls.index(["stash", "pop"]),
+                        "merge --abort must precede the stash restore")
+
+    def test_clean_tree_transient_first_failure_no_pop(self):
+        """First pull fails but the tree is CLEAN (stash creates nothing) — the
+        retry succeeds and there is nothing to pop (#13167 no-op-stash guard)."""
+        import harness
+        scripted = {
+            "pull": [self._resp(1, err="transient"), self._resp(0)],
+            "rev-parse": [self._resp(1, out=""), self._resp(1, out="")],  # unchanged
+            "stash": [self._resp(0)],
+        }
+        with patch.object(harness, "_git_in_clone",
+                          side_effect=self._responder(scripted)):
+            ok, detail = harness._safe_pull_in_clone("/clone")
+        self.assertTrue(ok)
+        self.assertEqual(detail, "pulled (no local changes to stash)")
+
+    def test_stash_command_failure_returns_false(self):
+        import harness
+        scripted = {
+            "pull": [self._resp(1, err="dirty")],
+            "rev-parse": [self._resp(1, out="")],
+            "stash": [self._resp(1, err="stash boom")],
+        }
+        with patch.object(harness, "_git_in_clone",
+                          side_effect=self._responder(scripted)):
+            ok, detail = harness._safe_pull_in_clone("/clone")
+        self.assertFalse(ok)
+        self.assertIn("stash-failed", detail)
+
+    def test_stash_pop_conflict_resolves_to_pulled_state(self):
+        """Retry pull succeeds but the stashed local change conflicts on pop ->
+        force-resolved to HEAD, still reported as a successful pull (the
+        CLAUDE.md sync landed; the stale local change is discarded)."""
+        import harness
+        scripted = {
+            "pull": [self._resp(1, err="dirty"), self._resp(0)],
+            "rev-parse": [self._resp(1, out=""), self._resp(0, out="abc123")],
+            "stash": [self._resp(0)],
+            "stash pop": [self._resp(1, err="conflict")],
+            "diff": [self._resp(0, out="config.md\n")],  # unmerged path
+            "checkout": [self._resp(0)],
+            "stash drop": [self._resp(0)],
+        }
+        with patch.object(harness, "_git_in_clone",
+                          side_effect=self._responder(scripted)):
+            ok, detail = harness._safe_pull_in_clone("/clone")
+        self.assertTrue(ok)
+        self.assertIn("resolved to pulled state", detail)
+
+    def test_safe_stash_pop_in_clone_no_unmerged_does_not_drop(self):
+        """A pop that fails for a NON-conflict reason (no unmerged paths) must
+        NOT drop the stash (would discard un-applied work)."""
+        import harness
+        calls = []
+
+        def _side(clone_path, args, **kw):
+            calls.append(list(args))
+            if list(args)[:2] == ["stash", "pop"]:
+                return self._resp(1, err="no stash")
+            if list(args)[0] == "diff":
+                return self._resp(0, out="")  # no unmerged
+            return self._resp(0)
+        with patch.object(harness, "_git_in_clone", side_effect=_side):
+            result = harness._safe_stash_pop_in_clone("/clone")
+        self.assertFalse(result)
+        self.assertNotIn(["stash", "drop"], calls)
+
+
 # ---------------------------------------------------------------------------
 # Thin-harness invariants — #8914
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## #13215 — deploy-pull survives a dirty agent clone (stash-around-merge)

(pm-filed; deploy-path-fragility cluster, sibling of the shipped #13212.)

### Root cause
`_run_deploy_sequence` pulled `origin/main` into a target agent's clone with a bare `git pull --no-rebase --no-edit` (via `_git_in_clone(clone_path, …)`). A **dirty** working tree — an uncommitted change to a file the incoming commit also touches — makes the merge **abort** (`local changes would be overwritten by merge`). The deploy's CLAUDE.md sync is then silently skipped and the clone drifts from shipped source. (`#12906` keeps agents on a working CLAUDE.md, so no outage — hence Low — but the drift is real.) `git_ops.pull` already solves this with a stash-around-merge (#13167/#13045), but it only operates on the harness's own cwd, so the deploy sequence (which runs against *another* clone) couldn't reuse it.

### Fix — Option A (blast-radius containment)
Add clone-aware helpers `_safe_pull_in_clone(clone_path)` + `_safe_stash_pop_in_clone(clone_path)` mirroring `git_ops.pull` / `_safe_stash_pop` over `_git_in_clone`, and call `_safe_pull_in_clone` at the deploy-pull site. Stashes-around-merge so the dirty case survives; a genuine merge conflict still returns `(False, …)` → §11 recovery. **Chosen over** parameterizing `git_ops.pull` with a cwd (Option B) to keep a regression **off the every-agent pull path** — a deploy-path bug stays contained to the deploy sequence.

### Review (Sonnet; DeepSeek degenerate all session → auto-fallback)
- **NO_BLOCKING_FINDINGS.** Verified faithful to git_ops: #13167 no-op-stash guard, #13045 marker-free conflict handling, genuine-conflict-still-fails.
- **MEDIUM (FIXED):** the genuine-conflict retry left the clone MERGING (MERGE_HEAD + markers) → `_safe_stash_pop_in_clone` would misread the merge's unmerged files as a stash-pop conflict, drop our stash, and the lingering MERGE_HEAD would loop the next deploy's `checkout main`. Added `git merge --abort` before the stash-restore (harmless no-op when no merge is in progress); test asserts the abort precedes the pop.
- **LOW (accepted):** replication drift risk vs git_ops — docstring-mitigated.
- **Follow-up noted on the issue:** the identical MERGING gap exists in `git_ops.pull` (every-agent path), pre-existing — a separate higher-blast-radius slice, not folded here.

### Verification
- +8 tests (clean / already-up-to-date / dirty→stash→pop / genuine-conflict→abort-then-fail / clean-tree-no-pop / stash-fail / pop-conflict→resolve-to-pulled / no-unmerged→no-drop).
- Full static gate: **4975 passed, 0 failures, 0 errors**.
- No CQ (deterministic). No manifest (no new files). Pairs with #13212 (shipped — reduces how often the tree is dirty in the first place).
