### PR TITLE
#13211: hoist freshen serialization into git_ops.ensure_main_and_pull (cover deploy path)

### DIFF
--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -34,8 +34,21 @@ import io
 import json
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
+
+# #13211 — serialize ensure_main_and_pull across ALL in-process callers (the
+# L4 watcher's per-role-class freshen bursts AND the post-merge deploy-all path,
+# both in the harness process). Concurrent main-checkout + pull on the SAME
+# clone collide on .git/index.lock (#13197 fixed this for the watcher-only case
+# via a watcher-local lock; the deploy path called ensure_main_and_pull outside
+# it). Hoisting the lock here covers every caller from one place. ensure_main_
+# and_pull never re-enters itself (it calls _run/pull only), so a plain
+# non-reentrant Lock cannot self-deadlock. Threading-scoped (not cross-process):
+# the racing callers are threads in the one harness process; the CLI caller is a
+# separate process not part of that race.
+_ENSURE_MAIN_LOCK = threading.Lock()
 
 # Ensure stdout/stderr can handle UTF-8 on Windows (cp1252 consoles choke on em dashes etc.)
 if sys.stdout.encoding and sys.stdout.encoding.lower() != "utf-8":
@@ -324,21 +337,28 @@ def ensure_main_and_pull(role=None):
     until a later recompose succeeds.
     """
     try:
-        result = _run("git branch --show-current", check=False)
-        branch = result.stdout.strip() if result.returncode == 0 else ""
-        if branch != "main":
-            sw = _run_list(["git", "checkout", "main"], check=False)
-            if sw.returncode != 0:
-                detail = (sw.stderr or sw.stdout or "").strip()[:200]
-                print(
-                    f"WARNING: ensure_main_and_pull could not switch to main "
-                    f"from {branch!r}: {detail}",
-                    file=sys.stderr,
-                )
-                return False, f"checkout-main-failed (on {branch!r})"
-        if not pull(role=role):
-            return False, "pull-failed"
-        return True, "on-main-synced"
+        # #13211 — single-flight the checkout+pull across every in-process
+        # caller (watcher freshen bursts + post-merge deploy-all) so concurrent
+        # git on the shared clone can't collide on .git/index.lock. Held across
+        # the subprocess git calls below — exactly the serialization #13197
+        # established (it just lived in the watcher before, missing the deploy
+        # path). Inside the try so the "Never raises" contract still holds.
+        with _ENSURE_MAIN_LOCK:
+            result = _run("git branch --show-current", check=False)
+            branch = result.stdout.strip() if result.returncode == 0 else ""
+            if branch != "main":
+                sw = _run_list(["git", "checkout", "main"], check=False)
+                if sw.returncode != 0:
+                    detail = (sw.stderr or sw.stdout or "").strip()[:200]
+                    print(
+                        f"WARNING: ensure_main_and_pull could not switch to main "
+                        f"from {branch!r}: {detail}",
+                        file=sys.stderr,
+                    )
+                    return False, f"checkout-main-failed (on {branch!r})"
+            if not pull(role=role):
+                return False, "pull-failed"
+            return True, "on-main-synced"
     except Exception as exc:  # noqa: BLE001 — "Never raises" is the contract
         print(
             f"WARNING: ensure_main_and_pull raised unexpectedly: {exc!r}",

--- a/references/scripts/l4_file_watcher.py
+++ b/references/scripts/l4_file_watcher.py
@@ -192,17 +192,17 @@ def emit_results(results, *, emit_event):
         )
 
 
-# #13197: serialize the freshen across debounce callbacks. Each role-class key
-# fires its debounce callback on its OWN threading.Timer thread (see _Debouncer),
-# so a burst that touches N role-classes runs N _default_ensure_fresh_source
-# calls CONCURRENTLY against the SAME harness clone. Concurrent `git pull`
-# invocations then collide on `.git/index.lock` and most return pull-failed — an
-# N-way compose-failed storm to PM (the all-fail-at-once #13197 pattern), NOT the
-# "fast already-up-to-date no-op" the docstring assumed. A module-level lock
-# serializes the git freshen so the first call does the real pull and the rest
-# run as genuine fast no-ops. Scoped to this process's watcher threads (the
-# collision source); a threading.Lock is the right primitive.
-_FRESHEN_LOCK = threading.Lock()
+# #13197/#13211: the freshen must be single-flighted — each role-class debounce
+# callback fires on its OWN threading.Timer thread (see _Debouncer), so a burst
+# touching N role-classes runs N concurrent git freshens against the SAME harness
+# clone and collides on `.git/index.lock` (an N-way compose-failed storm to PM).
+# #13197 originally added a watcher-local lock here, but the post-merge deploy-all
+# path called git_ops.ensure_main_and_pull OUTSIDE it, so a watcher burst could
+# still race the deploy. #13211 HOISTED the serialization into
+# git_ops.ensure_main_and_pull (git_ops._ENSURE_MAIN_LOCK) so EVERY in-process
+# caller — this freshen AND the deploy path — shares one lock. The watcher-local
+# lock is therefore retired; serialization now lives at the single shared
+# implementation, not at each call site.
 
 
 def _default_ensure_fresh_source(*, repo_root):
@@ -221,19 +221,20 @@ def _default_ensure_fresh_source(*, repo_root):
     ``run_compose=``) so unit tests never shell out to git. Returns
     ``(ok, detail)``.
 
-    #13197: the git freshen runs under ``_FRESHEN_LOCK`` so a burst of
-    per-role-class debounce callbacks (each on its own Timer thread) cannot
-    fire concurrent ``git`` against the shared clone and collide on
-    ``.git/index.lock``. Serialized, the first pull does the work and the rest
-    are fast no-ops.
+    #13197/#13211: a burst of per-role-class debounce callbacks (each on its own
+    Timer thread) must not fire concurrent ``git`` against the shared clone and
+    collide on ``.git/index.lock``. Serialization now lives inside
+    ``git_ops.ensure_main_and_pull`` (``git_ops._ENSURE_MAIN_LOCK``, #13211) so it
+    covers this freshen AND the post-merge deploy-all path from one place — no
+    watcher-local lock needed here. Serialized, the first call does the real pull
+    and the rest are fast no-ops.
     """
     try:
         import git_ops
     except Exception as exc:  # noqa: BLE001 — import failure must not crash watch
         return False, f"git_ops import failed: {exc!r}"
     try:
-        with _FRESHEN_LOCK:
-            return git_ops.ensure_main_and_pull(role="harness")
+        return git_ops.ensure_main_and_pull(role="harness")
     except Exception as exc:  # noqa: BLE001 — guard must never crash the watch
         return False, f"ensure_main_and_pull raised: {exc!r}"
 

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -2296,3 +2296,75 @@ class TestEnsureHooksDispatch11511:
         monkeypatch.setattr(sys, "argv", ["git_ops.py", "has-changes"])
         git_ops.main()
         mock_ensure.assert_called_once()
+
+
+class TestEnsureMainAndPullSerialized13211:
+    """#13211: ensure_main_and_pull single-flights its checkout+pull via the
+    module-level _ENSURE_MAIN_LOCK so concurrent in-process callers (the L4
+    watcher freshen bursts AND the post-merge deploy-all path) cannot collide on
+    `.git/index.lock`. #13197 first added this serialization in the watcher; this
+    hoists it to the shared implementation so every caller is covered."""
+
+    def test_lock_is_a_threading_lock(self):
+        import threading
+        assert isinstance(git_ops._ENSURE_MAIN_LOCK, type(threading.Lock()))
+
+    def test_contract_preserved_on_main_synced(self):
+        """Behaviour unchanged for the happy path: on main + pull ok -> (True,
+        'on-main-synced'). The lock wrap must not alter the return contract."""
+        with patch.object(git_ops, "_run") as mrun, \
+             patch.object(git_ops, "pull", return_value=True):
+            mrun.return_value = MagicMock(returncode=0, stdout="main\n", stderr="")
+            ok, detail = git_ops.ensure_main_and_pull(role="harness")
+        assert ok is True
+        assert detail == "on-main-synced"
+
+    def test_pull_failure_still_reported(self):
+        """The lock must not swallow a pull failure."""
+        with patch.object(git_ops, "_run") as mrun, \
+             patch.object(git_ops, "pull", return_value=False):
+            mrun.return_value = MagicMock(returncode=0, stdout="main\n", stderr="")
+            ok, detail = git_ops.ensure_main_and_pull(role="harness")
+        assert ok is False
+        assert detail == "pull-failed"
+
+    def test_concurrent_calls_are_serialized(self):
+        """N threads calling ensure_main_and_pull directly must never run the
+        underlying git op concurrently — max in-flight stays 1."""
+        import threading
+        import time as _time
+        state = {"now": 0, "max": 0}
+        guard = threading.Lock()
+        N = 11
+        barrier = threading.Barrier(N)
+
+        def fake_pull(role=None):
+            try:
+                barrier.wait(timeout=0.5)  # serialized -> never fills -> times out
+            except threading.BrokenBarrierError:
+                pass
+            with guard:
+                state["now"] += 1
+                state["max"] = max(state["max"], state["now"])
+            _time.sleep(0.02)
+            with guard:
+                state["now"] -= 1
+            return True
+
+        def fake_run(cmd, check=False):
+            return MagicMock(returncode=0, stdout="main\n", stderr="")
+
+        with patch.object(git_ops, "_run", side_effect=fake_run), \
+             patch.object(git_ops, "pull", side_effect=fake_pull):
+            threads = [threading.Thread(
+                target=lambda: git_ops.ensure_main_and_pull("harness"))
+                for _ in range(N)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        assert state["max"] == 1, (
+            f"ensure_main_and_pull ran {state['max']}-way concurrent — "
+            f"_ENSURE_MAIN_LOCK is not serializing (#13211)"
+        )

--- a/tests/test_l4_file_watcher_e3.py
+++ b/tests/test_l4_file_watcher_e3.py
@@ -807,39 +807,33 @@ class TestEnsureMainAndPull12906:
         assert "unexpected" in detail
 
 
-class TestFreshenSerialized13197:
-    """#13197: each per-role-class debounce callback fires
-    _default_ensure_fresh_source on its OWN Timer thread, all against the SAME
-    harness clone. Without serialization, concurrent `git pull` collided on
-    `.git/index.lock` → an N-way pull-failed/compose-failed storm. _FRESHEN_LOCK
-    must single-flight the git freshen."""
+class TestFreshenSerialized13197And13211:
+    """#13197 + #13211: concurrent freshens against the same clone must be
+    single-flighted to avoid `.git/index.lock` collisions (an N-way
+    pull-failed/compose-failed storm). #13197 originally put a watcher-local
+    `_FRESHEN_LOCK` here; #13211 RELOCATED the serialization into
+    `git_ops.ensure_main_and_pull` (`git_ops._ENSURE_MAIN_LOCK`) so it also
+    covers the post-merge deploy-all path, which called ensure_main_and_pull
+    outside the watcher lock. These tests measure concurrency INSIDE the real
+    git_ops.ensure_main_and_pull (via a mocked git layer), validating the
+    relocated lock rather than a watcher-local one."""
 
-    def test_freshen_lock_exists(self):
-        assert isinstance(lfw._FRESHEN_LOCK, type(threading.Lock()))
+    def _make_measuring_git(self, state, guard, barrier):
+        """Return (fake_run, fake_pull): _run reports branch==main (so
+        ensure_main_and_pull skips checkout and goes straight to pull), and pull
+        measures max concurrency — it runs INSIDE _ENSURE_MAIN_LOCK."""
+        from types import SimpleNamespace
 
-    def test_concurrent_freshens_are_serialized(self, monkeypatch, tmp_path):
-        """11 threads (the observed burst size) calling the freshen must never
-        run the underlying git op concurrently — the lock keeps max in-flight
-        at 1. Without _FRESHEN_LOCK this would observe up to 11-way concurrency
-        (the index.lock-collision regression)."""
-        import git_ops
-        state = {"now": 0, "max": 0}
-        guard = threading.Lock()
-        N = 11
-        # All threads rendezvous INSIDE fake_ensure before the concurrency
-        # measurement, so a missing _FRESHEN_LOCK is exposed deterministically
-        # (not dependent on a sleep window): without the lock all N reach the
-        # barrier together → max==N; with it, only one can be inside at a time
-        # so the (N-1)th never arrives and the barrier would deadlock — hence a
-        # short timeout that, when it trips, PROVES serialization.
-        barrier = threading.Barrier(N)
+        def fake_run(cmd, check=False):
+            return SimpleNamespace(returncode=0, stdout="main\n", stderr="")
 
-        def fake_ensure(role=None):
+        def fake_pull(role=None):
             try:
+                # Serialized → only one thread is ever inside the lock, so the
+                # barrier never fills and times out. The timeout IS the
+                # serialization proof (without the lock all N rendezvous → max==N).
                 barrier.wait(timeout=0.5)
             except threading.BrokenBarrierError:
-                # Expected WITH the lock: serialized → barrier never fills →
-                # times out. That is the serialization signal, not a failure.
                 pass
             with guard:
                 state["now"] += 1
@@ -847,26 +841,77 @@ class TestFreshenSerialized13197:
             time.sleep(0.02)
             with guard:
                 state["now"] -= 1
-            return True, "on-main-synced"
+            return True
 
-        monkeypatch.setattr(git_ops, "ensure_main_and_pull", fake_ensure)
+        return fake_run, fake_pull
+
+    def test_lock_relocated_to_git_ops_13211(self):
+        import git_ops
+        assert isinstance(git_ops._ENSURE_MAIN_LOCK, type(threading.Lock()))
+        # the watcher-local lock is retired (serialization now shared in git_ops)
+        assert not hasattr(lfw, "_FRESHEN_LOCK")
+
+    def test_concurrent_freshens_are_serialized(self, monkeypatch, tmp_path):
+        """11 threads through the watcher freshen never run the git op
+        concurrently — the relocated lock keeps max in-flight at 1."""
+        import git_ops
+        state = {"now": 0, "max": 0}
+        N = 11
+        fake_run, fake_pull = self._make_measuring_git(
+            state, threading.Lock(), threading.Barrier(N))
+        monkeypatch.setattr(git_ops, "_run", fake_run)
+        monkeypatch.setattr(git_ops, "pull", fake_pull)
 
         results = []
 
         def worker():
             results.append(lfw._default_ensure_fresh_source(repo_root=tmp_path))
 
-        threads = [threading.Thread(target=worker) for _ in range(11)]
+        threads = [threading.Thread(target=worker) for _ in range(N)]
         for t in threads:
             t.start()
         for t in threads:
             t.join()
 
-        assert len(results) == 11
+        assert len(results) == N
         assert all(ok for ok, _ in results)  # all succeed (serialized no-ops)
         assert state["max"] == 1, (
-            f"git freshen ran {state['max']}-way concurrent — _FRESHEN_LOCK is "
-            f"not serializing (the #13197 .git/index.lock-collision regression)"
+            f"git freshen ran {state['max']}-way concurrent — _ENSURE_MAIN_LOCK "
+            f"is not serializing (the #13197/#13211 .git/index.lock regression)"
+        )
+
+    def test_watcher_and_deploy_paths_share_the_lock_13211(self, monkeypatch, tmp_path):
+        """The #13211 fix: the post-merge deploy path calls
+        git_ops.ensure_main_and_pull DIRECTLY (harness.py:4221), previously
+        outside the watcher lock. With the lock in git_ops, running the watcher
+        freshen AND the direct deploy call concurrently still keeps max
+        in-flight at 1 — both callers share one lock."""
+        import git_ops
+        state = {"now": 0, "max": 0}
+        N = 10
+        fake_run, fake_pull = self._make_measuring_git(
+            state, threading.Lock(), threading.Barrier(N))
+        monkeypatch.setattr(git_ops, "_run", fake_run)
+        monkeypatch.setattr(git_ops, "pull", fake_pull)
+
+        def watcher_worker():
+            lfw._default_ensure_fresh_source(repo_root=tmp_path)
+
+        def deploy_worker():
+            git_ops.ensure_main_and_pull("harness")  # the post-merge deploy path
+
+        threads = (
+            [threading.Thread(target=watcher_worker) for _ in range(N // 2)]
+            + [threading.Thread(target=deploy_worker) for _ in range(N - N // 2)]
+        )
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert state["max"] == 1, (
+            f"watcher + deploy paths ran {state['max']}-way concurrent — the "
+            f"relocated lock does not cover both callers (#13211)"
         )
 
 


### PR DESCRIPTION
## #13211 — hoist freshen serialization into `git_ops.ensure_main_and_pull`

(verifier-filed; the last deploy-path-fragility cluster sibling, completing #13212/#13215/#13211.)

### Root cause
`#13197` added a watcher-local `_FRESHEN_LOCK` in `l4_file_watcher._default_ensure_fresh_source` to single-flight per-role-class freshen bursts (separate Timer threads colliding on `.git/index.lock`). But the **post-merge deploy-all** path (`harness.py:4221`) calls `git_ops.ensure_main_and_pull` **directly**, outside that watcher lock — so a watcher burst could still race the deploy on the same clone's `.git/index.lock`.

### Fix
**Relocate** the serialization into `git_ops` itself: a module-level `_ENSURE_MAIN_LOCK` wraps `ensure_main_and_pull`'s body (inside the existing `try`, so the "Never raises" contract holds). Now **every in-process caller** — the watcher freshen *and* the deploy path — shares one lock. The redundant watcher-local `_FRESHEN_LOCK` is removed.

- **Non-reentrant Lock is safe:** `ensure_main_and_pull` never re-enters itself (it calls `_run`/`_run_list`/`pull` only; `pull` never calls back).
- **Threading-scoped (correct):** the racing callers are threads in the one harness process; the CLI caller is a separate process, not part of that race.

### Review (Sonnet; DeepSeek degenerate all session → auto-fallback)
- **NO_BLOCKING_FINDINGS.** Verified: no reentrancy/deadlock (flat call tree), complete coverage (both callers acquire the same `sys.modules`-shared lock instance), `_FRESHEN_LOCK` fully removed (threading still used by `_Debouncer`), `with`-inside-`try` releases on every path, tests prove serialization deterministically.
- **LOW (follow-up, not folded):** the git subprocesses inside the lock have no `timeout=`, so a hung git starves both callers (was: just the watcher) — a **pre-existing** gap whose scope is slightly widened. Hardening (`timeout=` on the fleet-wide `_run` helpers, or a watchdog) is a separate slice; noted on the issue for triage.

### Verification
- + git_ops tests: 11-thread barrier-timeout serialization proof, contract-preserved, pull-failure-still-reported, lock-is-a-Lock.
- + l4 tests rewritten to validate the **relocated** lock (mock the git layer so the real `ensure_main_and_pull` lock runs) + a new test proving **watcher AND deploy paths share the lock** + assert `_FRESHEN_LOCK` retired.
- Full static gate: **4975 passed, 0 failures, 0 errors**.
- No CQ (deterministic). No manifest (no new files).
