### PR TITLE
#13264: tombstone the unreachable v2 manifest loader (dead code post-E6)

### DIFF
--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -187,6 +187,17 @@ _V2_MANIFEST_FILENAME = "includes.yml"
 def _load_manifest_v2(role_name: str) -> list | None:
     """Load the role's v2 mode-agnostic manifest (PRD-D D5 #10676, PRD-E E6 #10685).
 
+    .. note:: TOMBSTONE (#13264) — UNREACHABLE from production post-E6 (#10685).
+       The deploy entrypoints (``deploy_role_v2`` / deploy-all / wizard) route
+       through ``v2_link_stage.emit_v2_linked`` → ``atomic_emit.assemble_and_emit``,
+       NOT this loader. The only callers are this function pair's own ``base_role``
+       recursion and the unit tests. It is RETAINED (not deleted) so the
+       ``base_role`` + ``additional_includes`` schema reader — and the #13172
+       fail-closed guard hardening it — survive intact should the manifest-loader
+       path ever be re-wired. Remove (with its tests) only after confirming the
+       path is permanently retired. Do not add new production callers without
+       re-deciding this tombstone.
+
     Reads ``references/roles/<role>/includes.yml`` for base roles via the
     ``_V2_MANIFEST_FILENAME`` constant and follows the
     ``base_role`` + ``additional_includes`` schema. Variant Layer-3
@@ -257,6 +268,10 @@ def _load_manifest_v2(role_name: str) -> list | None:
 def _load_manifest_v2_from_file(
         manifest_path: Path, role_name: str) -> list | None:
     """Parse a v2 manifest file (or a variant ``includes.yml``).
+
+    .. note:: TOMBSTONE (#13264) — UNREACHABLE from production post-E6; see
+       ``_load_manifest_v2`` above for the full rationale. Called only from
+       ``_load_manifest_v2`` (and the unit tests); retained, not deleted.
 
     Shared body for ``_load_manifest_v2`` — keeps base-role and variant
     paths reading from a single YAML loader + schema dispatcher. Resolves

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -709,6 +709,37 @@ class TestResolveVariant:
         assert compose._resolve_variant("skill") is None
 
 
+class TestManifestV2TombstoneUnreachable13264:
+    """#13264: `_load_manifest_v2` / `_load_manifest_v2_from_file` are dead code
+    post-E6 (#10685) — the deploy path routes through `v2_link_stage.emit_v2_linked`,
+    not this loader. They are TOMBSTONED (retained for the schema reader + #13172
+    guard, in case the manifest path is ever re-wired), NOT removed. This guard
+    locks the tombstone: if a production script (re)wires `_load_manifest_v2`, this
+    fails → forcing a re-decision rather than silently reviving dead code."""
+
+    def test_symbol_only_referenced_within_compose(self):
+        scripts = Path(__file__).resolve().parent.parent / "references" / "scripts"
+        offenders = []
+        for py in scripts.glob("*.py"):
+            if py.name == "compose.py":
+                continue  # the def-site + own recursion live here, by design
+            if "_load_manifest_v2" in py.read_text(encoding="utf-8"):
+                offenders.append(py.name)
+        assert not offenders, (
+            "_load_manifest_v2 is tombstoned/unreachable (#13264) but is now "
+            f"referenced by production script(s): {offenders} — re-decide the "
+            "tombstone (remove it, or drop the dead-code marker) before wiring "
+            "a new caller"
+        )
+
+    def test_tombstone_marker_present(self):
+        """The tombstone rationale must stay in the source so a future reader
+        knows the function is intentionally-retained dead code, not live."""
+        src = (Path(__file__).resolve().parent.parent / "references" / "scripts"
+               / "compose.py").read_text(encoding="utf-8")
+        assert "TOMBSTONE (#13264)" in src
+
+
 class TestManifestV2AdditionalIncludesWrongType13172:
     """#13172: a wrong-TYPE additional_includes (e.g. a bare string instead of
     a list) must fail CLOSED — matching every sibling schema-error path in


### PR DESCRIPTION
## #13264 — tombstone the unreachable v2 manifest loader (dead code post-E6)

(verifier-filed, from my #13172 review; the tombstone-vs-remove decision I flagged but hadn't filed.)

### Finding
`compose._load_manifest_v2` / `_load_manifest_v2_from_file` have **zero production callers** post-E6 (#10685). The deploy entrypoints (`deploy_role_v2` / deploy-all / wizard) route through `v2_link_stage.emit_v2_linked` → `atomic_emit.assemble_and_emit`, not this loader. Independently grep-confirmed: the only references are the pair's own `base_role` recursion + the unit tests.

### Decision: tombstone, not remove
Added an explicit **unreachable-post-E6 docstring marker** to both functions. Retained (not deleted) because:
- it preserves the `base_role`/`additional_includes` schema reader **and the #13172 fail-closed guard** in case the manifest-loader path is ever re-wired;
- removing a recursive function pair + its tests from the fleet-critical `compose.py` would warrant heavier review than a low-priority dead-code item justifies.

Removal (with tests) is the follow-on once the path is confirmed permanently retired — the marker says so.

### Verification
- +2 guard tests (`TestManifestV2TombstoneUnreachable13264`): the symbol stays referenced **only** within `compose.py` (a new production caller fails the test → forces re-deciding the tombstone rather than silently reviving dead code), and the marker stays present.
- Doc-only + guards, **zero behavior change** → no DS-review, no CQ, no manifest.
- Full static gate: **5002 passed, 0 failures, 0 errors**.
