### PR TITLE
--title

### DIFF
--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -288,8 +288,25 @@ def pull(role=None):
         return False
     stashed = _stash_top_ref() != pre_stash_ref
 
-    retry = _run("git pull", check=False)
+    # #13261: pin the retry to a MERGE pull (never rebase). The recovery below
+    # cleans up a failed retry with `git merge --abort`, which only clears a
+    # MERGING state — under a clone-local `pull.rebase=true` the retry would
+    # rebase and leave a REBASE state the abort cannot clear. `--no-rebase`
+    # guarantees the abort verb matches what a failed retry leaves behind, and
+    # matches the project's "always merge, never rebase" rule.
+    retry = _run("git pull --no-rebase", check=False)
     if retry.returncode != 0:
+        # #13261: the retry pull may have STARTED a merge and hit a
+        # committed-divergence conflict, leaving the clone MERGING (MERGE_HEAD +
+        # conflict markers). Abort that merge FIRST — otherwise (a) the markers
+        # break the next compose, (b) _safe_stash_pop below misreads the merge's
+        # unmerged paths as a stash-pop conflict and DROPS our stash, and (c) a
+        # lingering MERGE_HEAD makes the next op needing a clean tree fail. The
+        # abort is a harmless no-op (non-zero, ignored) when no merge is in
+        # progress (the pull failed before merging). Mirrors the same fix in the
+        # deploy path's _safe_pull_in_clone (#13215). The pull still FAILED →
+        # report failure after restoring our stash.
+        _run("git merge --abort", check=False)
         # Restore OUR stashed changes (only if we actually created one) and
         # report failure. Use the marker-safe pop (#13045), never a raw pop.
         if stashed:

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -81,10 +81,38 @@ class TestPull:
             _mock_result(),                      # git stash (no-op)
             _mock_result(stdout="oldsha"),       # post: unchanged → stashed=False
             _mock_result(returncode=1),          # pull retry ALSO fails
+            _mock_result(returncode=1),          # #13261: git merge --abort (no merge → no-op)
         ]
         assert git_ops.pull() is False
         calls = [c[0][0] for c in mock_run.call_args_list]
         assert "git stash pop" not in calls
+
+    @patch("git_ops._run")
+    def test_pull_retry_fail_aborts_merge_before_pop(self, mock_run):
+        """#13261: a genuine-divergence conflict on the retry pull leaves the
+        clone MERGING (MERGE_HEAD + conflict markers). pull() MUST `git merge
+        --abort` BEFORE restoring our stash — otherwise _safe_stash_pop misreads
+        the merge's unmerged paths as a stash-pop conflict and DROPS our stash,
+        and a lingering MERGE_HEAD breaks the next clean-tree op. Mirrors the
+        deploy-path fix in _safe_pull_in_clone (#13215)."""
+        mock_run.side_effect = [
+            _mock_result(returncode=1),          # pull fails
+            _mock_result(returncode=1),          # _stash_top_ref pre → ""
+            _mock_result(),                      # git stash (creates entry)
+            _mock_result(stdout="newsha"),       # _stash_top_ref post → stashed=True
+            _mock_result(returncode=1),          # pull retry FAILS (left MERGING)
+            _mock_result(),                      # git merge --abort
+            _mock_result(),                      # _safe_stash_pop: git stash pop (clean)
+        ]
+        assert git_ops.pull() is False
+        calls = [c[0][0] for c in mock_run.call_args_list]
+        assert "git merge --abort" in calls, "must abort the in-progress merge"
+        assert "git stash pop" in calls, "must restore our genuinely-created stash"
+        assert calls.index("git merge --abort") < calls.index("git stash pop"), \
+            "merge --abort MUST precede stash pop so the pop sees a clean tree"
+        # #13261: the retry must be a MERGE pull so `git merge --abort` is the
+        # correct cleanup verb (never a rebase, which the abort cannot clear).
+        assert "git pull --no-rebase" in calls, "retry pull must be pinned to merge"
 
     @patch("git_ops._run_list")
     @patch("git_ops._run")


### PR DESCRIPTION
#13261: git_ops.pull — abort merge before stash restore on genuine-conflict retry --body ## #13261 — git_ops.pull() leaves clone MERGING and drops stash on a genuine-conflict retry

### Root cause
`pull()`'s recovery path stashes, retries `git pull`, then pops. When the **retry** pull fails on a committed-divergence merge conflict, git leaves the clone **MERGING** (MERGE_HEAD + conflict markers in files). The old code went straight to `_safe_stash_pop()`, which:
- (a) leaves merge conflict markers that break the next `compose.py` run,
- (b) makes `_safe_stash_pop` misread the **merge's** unmerged paths (`git diff --diff-filter=U`) as a stash-pop conflict and **DROP our genuinely-stashed local changes** (data loss),
- (c) leaves a lingering MERGE_HEAD that fails the next op needing a clean tree.

### Fix
- `git merge --abort` (check=False) immediately after the retry-fail check and **before** `if stashed: _safe_stash_pop()`. Harmless no-op when no merge is in progress. Mirrors the already-shipped deploy-path fix in `_safe_pull_in_clone` (#13215).
- Pin the retry to `git pull --no-rebase` so the abort verb matches what a failed retry leaves behind (a clone-local `pull.rebase=true` would otherwise leave a REBASE state the abort can't clear). Aligns with the project's always-merge-never-rebase rule.

### Tests
- New `test_pull_retry_fail_aborts_merge_before_pop`: asserts `git merge --abort` precedes `git stash pop`, the stash is restored, and the retry uses `--no-rebase`.
- Updated `test_pull_clean_tree_pull_fail_does_not_pop_preexisting` for the extra `_run` call (#13167 guard preserved).

### Verification
- Full static gate: PASS — 5006 gated tests, 0 failures, 0 errors.
- DS-review (Sonnet fallback): no HIGH/MEDIUM; fix correct, ordering locked, #13167 + #13045 guards preserved, consistent with #13215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)