### PR TITLE
--title

### DIFF
--- a/references/scripts/run_comprehension_test.py
+++ b/references/scripts/run_comprehension_test.py
@@ -31,6 +31,29 @@ CACHE_DIR = REPO_ROOT / "tests" / "comprehension" / ".cache"
 
 
 # ---------------------------------------------------------------------------
+# Result-id canonicalization (#13169)
+# ---------------------------------------------------------------------------
+
+def _normalize_result_id(raw_id):
+    """Canonicalize a judge-emitted question id to the spec's bare id.
+
+    The eval prompt presents questions as ``### Q-<id>`` headers, so the judge
+    LLM frequently echoes the visible label (e.g. ``"Q-1"``) as the result id
+    instead of the bare spec id (``"1"``). The spec questions and every
+    ``test_comprehension_*`` file key on the bare id, so a ``Q-`` echo makes
+    ``_get_result`` and ``test_all_questions_answered`` fail even when the
+    answer PASSED — the #13169 spurious-failure-when-run-live symptom. Strip a
+    single leading ``Q-``/``q-`` (and surrounding whitespace) so the stored id
+    matches the spec regardless of which form the judge emitted. A bare id that
+    has no ``Q-`` prefix is returned unchanged.
+    """
+    s = str(raw_id).strip()
+    if len(s) >= 2 and s[0] in ("Q", "q") and s[1] == "-":
+        return s[2:].strip()
+    return s
+
+
+# ---------------------------------------------------------------------------
 # Content-hash caching
 # ---------------------------------------------------------------------------
 
@@ -349,11 +372,11 @@ If you cannot find a question's answer in the listed files, write `NOT FOUND IN 
 - FAIL = the answer contradicts the expected behavior, is missing, or says `NOT FOUND IN FILES`.
 
 ## Required output (your final assistant message — nothing else)
-Respond with a raw JSON array. No code fences, no preamble, no closing remarks. One object per question id in this shape:
+Respond with a raw JSON array. No code fences, no preamble, no closing remarks. One object per question id in this shape — use the BARE question id (the part after `Q-`, e.g. `1` for a `### Q-1` heading), not the `Q-` label:
 
 [
-  {{"id": "<question-id>", "pass": true, "reason": "<brief explanation>"}},
-  {{"id": "<question-id>", "pass": false, "reason": "<brief explanation>"}}
+  {{"id": "1", "pass": true, "reason": "<brief explanation>"}},
+  {{"id": "2", "pass": false, "reason": "<brief explanation>"}}
 ]
 
 The runner parses your reply directly as JSON.
@@ -392,6 +415,14 @@ The runner parses your reply directly as JSON.
         print(f"  Content: {raw[:500]}", file=sys.stderr)
         sys.exit(1)
 
+    # #13169: the judge often echoes the prompt's ``Q-<id>`` label as the result
+    # id; canonicalize to the bare spec id so the per-question asserts and
+    # test_all_questions_answered match regardless of which form it emitted.
+    if isinstance(results, list):
+        for r in results:
+            if isinstance(r, dict) and "id" in r:
+                r["id"] = _normalize_result_id(r["id"])
+
     results_path.write_text(json.dumps(results, indent=2), encoding="utf-8")
 
     if not results:
@@ -406,7 +437,9 @@ The runner parses your reply directly as JSON.
     print(f"\nResults: {passed}/{total} passed")
     for r in results:
         status = "PASS" if r.get("pass") else "FAIL"
-        print(f"  Q-{r['id']}: {status} — {r.get('reason', '')}")
+        # #13169: ids are already canonicalized (bare spec id, e.g. "1"/"CQ1");
+        # print as-is rather than re-prefixing "Q-" (which produced "Q-CQ1").
+        print(f"  Q[{r['id']}]: {status} — {r.get('reason', '')}")
 
     # Write cache only on PASS — failed runs must not update cache
     if all_pass:

--- a/tests/test_9574_comprehension_runner_write_contract.py
+++ b/tests/test_9574_comprehension_runner_write_contract.py
@@ -535,5 +535,103 @@ class TestFindClaudeWindowsPreference(unittest.TestCase):
         self.assertTrue(got.lower().endswith(".cmd"))
 
 
+class TestResultIdNormalization13169(unittest.TestCase):
+    """#13169: the eval prompt presents questions as ``### Q-<id>`` headers, so
+    the judge LLM echoes ``"Q-1"`` as the result id while the spec questions and
+    every ``test_comprehension_*`` file key on the bare id ``"1"``. The
+    ``_get_result`` lookup and ``test_all_questions_answered`` then fail even
+    when the answer PASSED. The runner must canonicalize result ids to the bare
+    form before writing results.json so file-order / judge-echo cannot turn a
+    correct answer into a spurious red."""
+
+    def setUp(self):
+        self.runner = _load_runner()
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="cq13169-"))
+        self.spec_path = self.tmpdir / "fake_spec.json"
+        self.spec_path.write_text(
+            json.dumps({
+                "issue": 13169,
+                "title": "fake spec for id-normalization test",
+                "files": ["README.md"],
+                "questions": [
+                    {"id": "1", "question": "q1?", "expected": "a"},
+                    {"id": "2", "question": "q2?", "expected": "b"},
+                ],
+            }),
+            encoding="utf-8",
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_normalize_strips_q_prefix(self):
+        n = self.runner._normalize_result_id
+        self.assertEqual(n("Q-1"), "1")
+        self.assertEqual(n("q-2"), "2")
+        self.assertEqual(n(" Q-3 "), "3")
+
+    def test_normalize_leaves_bare_id_unchanged(self):
+        n = self.runner._normalize_result_id
+        self.assertEqual(n("1"), "1")
+        self.assertEqual(n("q1"), "q1")        # no hyphen → not a Q- label
+        self.assertEqual(n(7), "7")            # non-string id coerced
+        self.assertEqual(n("Question-1"), "Question-1")  # only a single Q- prefix
+
+    def test_normalize_strips_only_one_prefix(self):
+        # A pathological double label keeps everything after the first ``Q-``.
+        self.assertEqual(self.runner._normalize_result_id("Q-Q-1"), "Q-1")
+
+    def test_runner_normalizes_judge_echoed_ids_end_to_end(self):
+        """The decisive regression: the eval agent returns ``Q-1``/``Q-2`` ids
+        (the #13169 echo); results.json on disk and the returned list must carry
+        the bare ``1``/``2`` so the per-question asserts match."""
+        output_dir = self.tmpdir / ".out"
+        answers_md = "### Q-1\nfoo\n### Q-2\nbar\n"
+        results_json = (
+            '[{"id":"Q-1","pass":true,"reason":"ok"},'
+            '{"id":"Q-2","pass":true,"reason":"ok"}]'
+        )
+        call_outputs = iter([
+            (answers_md, _make_proc(returncode=0)),
+            (results_json, _make_proc(returncode=0)),
+        ])
+        with mock.patch.object(
+            self.runner, "_run_agent",
+            side_effect=lambda *a, **kw: next(call_outputs),
+        ), mock.patch.object(
+            self.runner, "_find_claude", return_value="/fake/claude",
+        ), mock.patch.dict(os.environ, {"FORCE_CQ": "1"}):
+            results, _ = self.runner.run_test(
+                self.spec_path, output_dir=output_dir
+            )
+
+        ids = {r["id"] for r in results}
+        self.assertEqual(
+            ids, {"1", "2"},
+            msg="runner must canonicalize judge-echoed Q-<id> to the bare id",
+        )
+        on_disk = json.loads((output_dir / "results.json").read_text(encoding="utf-8"))
+        self.assertEqual(
+            {r["id"] for r in on_disk}, {"1", "2"},
+            msg="results.json on disk must carry the normalized ids",
+        )
+
+    def test_eval_prompt_instructs_bare_id(self):
+        """Belt-and-suspenders: the eval prompt BODY (not a docstring/comment)
+        must tell the judge to emit the bare id, reducing the echo at source.
+        Scoped to the extracted ``eval_prompt`` f-string so it cannot pass
+        vacuously against ``_normalize_result_id``'s docstring (DS-review MED)."""
+        source = RUNNER_PATH.read_text(encoding="utf-8")
+        m = re.search(r'\beval_prompt\s*=\s*f?"""(.*?)"""', source, re.DOTALL)
+        self.assertIsNotNone(
+            m, msg="eval_prompt assignment not found — if renamed, update test."
+        )
+        body = m.group(1).lower()
+        self.assertIn(
+            "bare", body,
+            msg="eval_prompt must instruct the judge to emit the BARE id (#13169)",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#13169: comprehension live tests — canonicalize judge-echoed Q-<id> result ids --body ## #13169 — comprehension live tests fail (not skip) when run together

### Root cause (QA-confirmed 2026-06-27)
The eval prompt in `run_comprehension_test.py` presents questions to the judge LLM as `### Q-<id>` headers, then asks for a JSON array of `{"id": "<question-id>", ...}`. The judge **echoes the visible label** `"Q-1"`, but the spec questions and every `test_comprehension_*.py` file key on the **bare** id `"1"`:
- `_get_result(results, "1")` returns `None` for `{"id": "Q-1", "pass": true}` → `"Q-1 result not found"`.
- `test_all_questions_answered` compares `{1..7}` (spec) vs `{Q-1..Q-7}` (results) → fails.

Both fail **even when the model answered correctly**. This is the real cause of the QA full-run reds (118s live runs that fail on the id lookup); the "cross-file skip leak" only governs skip-vs-run, not pass-vs-fail (isolated runs cache-hit→skip, so the mismatch never surfaces alone).

### Fix
- **Deterministic seam (load-bearing):** new `_normalize_result_id()` strips a single leading `Q-`/`q-`; applied to every parsed result id before `results.json` is written, so the stored id matches the spec regardless of judge echo. The prompt prefixes **every** id with `Q-`, so stripping exactly one is the precise inverse for all id formats (ints, `CQ`-slugs, etc.).
- **Prompt tweak (belt-and-suspenders):** the eval prompt now requests the bare id and uses bare-id examples.

### Tests
- `_normalize_result_id` unit cases: `Q-`/`q-`/whitespace/bare/numeric/double-prefix.
- End-to-end through `run_test()` with a mocked eval agent returning `Q-1`/`Q-2` — asserts both the returned list and `results.json` on disk carry bare ids.
- DS-review (Sonnet) fixes applied: prompt-instruction test scoped to the `eval_prompt` body (was vacuous); summary print no longer re-prefixes `Q-` onto canonicalized ids.

### Verification
- Full static gate: PASS — 5012 gated tests, 0 failures, 0 errors.
- DS-review (Sonnet fallback): no HIGH; MEDIUM (vacuous prompt test) + NIT (print) fixed; LOW (prospective `Q-`-prefixed spec id) is non-applicable — the prompt always prefixes, so the unconditional single-strip is the matched inverse (documented in the helper).

### Note for verifier
The prompt change is LLM-consumed, but correctness is guaranteed by the deterministic normalization (unit + e2e tested), not by the judge following the instruction. Full live-CQ confirmation needs a live model (no-live-model env here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)