### PR TITLE
--title

### DIFF
--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -71,22 +71,78 @@ def _get_working_branch():
         return "main"
 
 
-def _run(cmd, check=True):
+# #13262 — every git_ops subprocess gets a timeout so a hung `git` (network
+# stall, stuck index.lock, a credential-helper wedge — cf. the documented
+# `credential.helper=manager` silent hang) fails fast into the callers' existing
+# failure paths instead of blocking the thread (and, since #13211, the whole
+# in-process recompose surface behind `_ENSURE_MAIN_LOCK`) indefinitely. The
+# default is generous (git ops are normally sub-second; a slow network fetch/push
+# of a large pack is the worst legitimate case) so it fail-fasts a true hang
+# without false-tripping. Overridable per-call and fleet-wide via the
+# `SQUIDSQUAD_GIT_TIMEOUT` env var (no config-schema change → existing installs
+# keep the default).
+DEFAULT_GIT_TIMEOUT = 300
+
+
+def _git_timeout():
+    """Resolve the git subprocess timeout (seconds): ``SQUIDSQUAD_GIT_TIMEOUT``
+    env override if a positive int, else ``DEFAULT_GIT_TIMEOUT``.
+
+    Installs on very high-latency links or with very large packs (a `git pull`/
+    `git fetch` that legitimately runs minutes) can raise the cap via
+    ``SQUIDSQUAD_GIT_TIMEOUT=600`` without a code or config-schema change."""
+    import os
+    raw = os.environ.get("SQUIDSQUAD_GIT_TIMEOUT")
+    if raw:
+        try:
+            val = int(raw)
+            if val > 0:
+                return val
+        except (TypeError, ValueError):
+            pass
+    return DEFAULT_GIT_TIMEOUT
+
+
+def _timeout_failure(cmd, check, timeout):
+    """Translate a ``subprocess.TimeoutExpired`` into the failure shape the
+    caller already handles (#13262): raise ``CalledProcessError`` when
+    ``check=True`` (mirroring subprocess's own check-failure contract), else
+    return a synthetic non-zero ``CompletedProcess`` (rc=124, the conventional
+    timeout code) so ``check=False`` callers fall into their existing
+    ``returncode != 0`` / ``(False, ...)`` recovery."""
+    msg = f"git command timed out after {timeout}s: {cmd}"
+    print(f"WARNING: {msg}", file=sys.stderr)
+    if check:
+        raise subprocess.CalledProcessError(124, cmd, output=None, stderr=msg)
+    return subprocess.CompletedProcess(cmd, 124, stdout="", stderr=msg)
+
+
+def _run(cmd, check=True, timeout=None):
     """Run a shell command from repo root (only for static commands)."""
-    return subprocess.run(
-        cmd, shell=True, capture_output=True, text=True,
-        encoding="utf-8", errors="replace",
-        check=check, cwd=str(REPO_ROOT),
-    )
+    if timeout is None:
+        timeout = _git_timeout()
+    try:
+        return subprocess.run(
+            cmd, shell=True, capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
+            check=check, cwd=str(REPO_ROOT), timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return _timeout_failure(cmd, check, timeout)
 
 
-def _run_list(cmd_list, check=True):
+def _run_list(cmd_list, check=True, timeout=None):
     """Run a command from repo root using list form (safe for variable args)."""
-    return subprocess.run(
-        cmd_list, capture_output=True, text=True,
-        encoding="utf-8", errors="replace",
-        check=check, cwd=str(REPO_ROOT),
-    )
+    if timeout is None:
+        timeout = _git_timeout()
+    try:
+        return subprocess.run(
+            cmd_list, capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
+            check=check, cwd=str(REPO_ROOT), timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return _timeout_failure(cmd_list, check, timeout)
 
 
 _GH_AVAILABLE_CACHE = None
@@ -403,11 +459,9 @@ def commit(role, message):
     """Commit with role prefix and Co-Authored-By trailer."""
     alias = _get_alias(role)
     full_msg = f"{role}: {message}\n\nCo-Authored-By: {alias} <noreply@squidsquad>"
-    result = subprocess.run(
-        ["git", "commit", "-m", full_msg],
-        capture_output=True, text=True, encoding="utf-8", errors="replace",
-        check=False, cwd=str(REPO_ROOT),
-    )
+    # #13262: route through _run_list so the commit (and a hung pre-commit hook
+    # holding _ENSURE_MAIN_LOCK) is timeout-protected like every other git op.
+    result = _run_list(["git", "commit", "-m", full_msg], check=False)
     if result.returncode != 0:
         if "nothing to commit" in result.stdout + result.stderr:
             print("Nothing to commit")
@@ -821,11 +875,9 @@ def commit_code(role, branch, message):
     # Commit
     alias = _get_alias(role)
     full_msg = f"{role}: {message}\n\nCo-Authored-By: {alias} <noreply@squidsquad>"
-    result = subprocess.run(
-        ["git", "commit", "-m", full_msg],
-        capture_output=True, text=True, encoding="utf-8", errors="replace",
-        check=False, cwd=str(REPO_ROOT),
-    )
+    # #13262: route through _run_list so the commit (and a hung pre-commit hook
+    # holding _ENSURE_MAIN_LOCK) is timeout-protected like every other git op.
+    result = _run_list(["git", "commit", "-m", full_msg], check=False)
     if result.returncode != 0:
         if "nothing to commit" in result.stdout + result.stderr:
             print("Nothing to commit on branch")
@@ -1047,11 +1099,9 @@ def commit_state(role, message):
     # Commit
     alias = _get_alias(role)
     full_msg = f"{role}: {message}\n\nCo-Authored-By: {alias} <noreply@squidsquad>"
-    result = subprocess.run(
-        ["git", "commit", "-m", full_msg],
-        capture_output=True, text=True, encoding="utf-8", errors="replace",
-        check=False, cwd=str(REPO_ROOT),
-    )
+    # #13262: route through _run_list so the commit (and a hung pre-commit hook
+    # holding _ENSURE_MAIN_LOCK) is timeout-protected like every other git op.
+    result = _run_list(["git", "commit", "-m", full_msg], check=False)
     if result.returncode != 0:
         if "nothing to commit" in result.stdout + result.stderr:
             print("Nothing to commit")

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -27,6 +27,84 @@ def _mock_result(stdout="", stderr="", returncode=0):
 
 
 # ---------------------------------------------------------------------------
+# _run / _run_list subprocess timeout (#13262)
+# ---------------------------------------------------------------------------
+
+class TestRunTimeout:
+    def test_run_passes_default_timeout(self):
+        with patch("git_ops.subprocess.run") as sp:
+            sp.return_value = _mock_result()
+            git_ops._run("git status", check=False)
+        assert sp.call_args.kwargs["timeout"] == git_ops.DEFAULT_GIT_TIMEOUT
+
+    def test_run_list_passes_default_timeout(self):
+        with patch("git_ops.subprocess.run") as sp:
+            sp.return_value = _mock_result()
+            git_ops._run_list(["git", "status"], check=False)
+        assert sp.call_args.kwargs["timeout"] == git_ops.DEFAULT_GIT_TIMEOUT
+
+    def test_per_call_timeout_override(self):
+        with patch("git_ops.subprocess.run") as sp:
+            sp.return_value = _mock_result()
+            git_ops._run("git status", check=False, timeout=7)
+        assert sp.call_args.kwargs["timeout"] == 7
+
+    def test_env_override_respected(self, monkeypatch):
+        monkeypatch.setenv("SQUIDSQUAD_GIT_TIMEOUT", "42")
+        assert git_ops._git_timeout() == 42
+
+    def test_env_override_ignored_when_invalid(self, monkeypatch):
+        monkeypatch.setenv("SQUIDSQUAD_GIT_TIMEOUT", "not-an-int")
+        assert git_ops._git_timeout() == git_ops.DEFAULT_GIT_TIMEOUT
+        monkeypatch.setenv("SQUIDSQUAD_GIT_TIMEOUT", "0")  # non-positive → ignore
+        assert git_ops._git_timeout() == git_ops.DEFAULT_GIT_TIMEOUT
+
+    def test_timeout_check_false_returns_nonzero_result(self):
+        """A hung git with check=False must fail fast into the existing
+        non-zero recovery path, NOT raise (#13262)."""
+        with patch("git_ops.subprocess.run",
+                   side_effect=subprocess.TimeoutExpired("git pull", 300)):
+            res = git_ops._run("git pull", check=False)
+        assert res.returncode == 124
+        assert "timed out" in res.stderr
+
+    def test_timeout_check_true_raises_called_process_error(self):
+        """With check=True the timeout mirrors subprocess's check-failure
+        contract (raises CalledProcessError) so check=True callers' expectations
+        hold."""
+        with patch("git_ops.subprocess.run",
+                   side_effect=subprocess.TimeoutExpired("git pull", 300)):
+            with pytest.raises(subprocess.CalledProcessError) as ei:
+                git_ops._run("git pull", check=True)
+        assert ei.value.returncode == 124
+
+    def test_run_list_timeout_check_false_returns_nonzero(self):
+        with patch("git_ops.subprocess.run",
+                   side_effect=subprocess.TimeoutExpired(["git", "pull"], 300)):
+            res = git_ops._run_list(["git", "pull"], check=False)
+        assert res.returncode == 124
+        assert "timed out" in res.stderr
+
+    def test_run_list_timeout_check_true_raises(self):
+        """Symmetry with _run: _run_list + check=True + timeout raises."""
+        with patch("git_ops.subprocess.run",
+                   side_effect=subprocess.TimeoutExpired(["git", "fetch"], 300)):
+            with pytest.raises(subprocess.CalledProcessError) as ei:
+                git_ops._run_list(["git", "fetch"], check=True)
+        assert ei.value.returncode == 124
+
+    def test_commit_routes_through_run_list_with_timeout(self):
+        """#13262: commit() must go through the timeout-protected _run_list (not a
+        raw subprocess.run), so a hung commit / pre-commit hook fails fast."""
+        with patch("git_ops._run_list") as rl, patch("git_ops._get_alias",
+                                                      return_value="skill"):
+            rl.return_value = _mock_result(returncode=0)
+            git_ops.commit("skill", "msg")
+        assert rl.called
+        assert rl.call_args[0][0][:2] == ["git", "commit"]
+
+
+# ---------------------------------------------------------------------------
 # pull()
 # ---------------------------------------------------------------------------
 
@@ -1261,11 +1339,10 @@ class TestCommitCodePushFailure:
             _mock_result(stdout=" M src/app.py\n"),  # status --porcelain
             _mock_result(stdout="squidsquad/task/100\n"),  # branch --show-current
         ]
-        mock_subproc.return_value = _mock_result()  # git commit succeeds
-        mock_run_list.side_effect = [
-            _mock_result(),  # git add
-            _mock_result(),  # git checkout config.md revert (#7491)
-        ]
+        mock_subproc.return_value = _mock_result()  # (legacy: commit no longer here)
+        # #13262: the commit now routes through _run_list too — use return_value
+        # so the add / config-revert / commit calls all succeed regardless of count.
+        mock_run_list.return_value = _mock_result()
         # push now routed through _git_push (#9890) and FAILS here
         mock_git_push.return_value = _mock_result(returncode=1, stderr="push rejected")
         result = git_ops.commit_code("skill", "squidsquad/task/100", "test")
@@ -1286,11 +1363,9 @@ class TestCommitCodePushFailure:
             _mock_result(stdout=" M src/app.py\n"),  # status
             _mock_result(stdout="squidsquad/task/100\n"),  # branch
         ]
-        mock_subproc.return_value = _mock_result()  # commit
-        mock_run_list.side_effect = [
-            _mock_result(),  # git add
-            _mock_result(),  # git checkout config.md revert (#7491)
-        ]
+        mock_subproc.return_value = _mock_result()  # (legacy: commit no longer here)
+        # #13262: commit routes through _run_list now → any-count success.
+        mock_run_list.return_value = _mock_result()
         mock_git_push.return_value = _mock_result()  # push succeeds (#9890)
         result = git_ops.commit_code("skill", "squidsquad/task/100", "test")
         assert result is True
@@ -1316,12 +1391,9 @@ class TestCommitCodeUsesWorkingBranch:
             _mock_result(stdout=" M src/app.py\n"),  # git status --porcelain
             _mock_result(stdout="develop\n"),  # current branch
         ]
-        mock_run_list.side_effect = [
-            _mock_result(returncode=0),  # rev-parse (branch exists)
-            _mock_result(),  # git checkout
-            _mock_result(),  # git add
-            _mock_result(),  # git checkout config.md revert (#7491)
-        ]
+        # #13262: commit routes through _run_list now (one more call); use
+        # return_value so add / checkout / rev-parse / commit all succeed (rc0).
+        mock_run_list.return_value = _mock_result(returncode=0)
         mock_git_push.return_value = _mock_result()  # push (#9890)
         mock_subproc.return_value = _mock_result(stdout="1 file changed")
 


### PR DESCRIPTION
#13262: git_ops _run/_run_list — add fail-fast subprocess timeout --body ## #13262 — `_run`/`_run_list` had no subprocess timeout

A hung `git` (network stall, stuck `index.lock`, credential-helper wedge — cf. the documented `credential.helper=manager` silent hang) blocked the calling thread indefinitely. Since #13211 hoisted the freshen lock into `ensure_main_and_pull` (`_ENSURE_MAIN_LOCK`), a hang now starves the **whole in-process recompose surface** (watcher freshen + post-merge deploy), with no self-recovery.

### Fix
- `_run` / `_run_list` pass `timeout=` — default `DEFAULT_GIT_TIMEOUT = 300s`, overridable per-call and fleet-wide via the `SQUIDSQUAD_GIT_TIMEOUT` env var (no config-schema change → existing installs keep the default; high-latency/large-pack installs can raise it).
- `subprocess.TimeoutExpired` → each caller's existing failure shape: `CalledProcessError(124)` when `check=True` (mirrors subprocess's own check contract), else a synthetic non-zero `CompletedProcess(rc=124)` so `check=False` callers fall into their `returncode != 0` / `(False, ...)` recovery.
- Folded in the three raw `git commit` `subprocess.run` calls (`commit` / `commit_code` / `commit_state`) → routed through `_run_list`, so a hung commit / pre-commit hook holding `_ENSURE_MAIN_LOCK` is timeout-protected too (no git subprocess in the commit path left unprotected).

### Verification
- Full static gate: PASS — 5025 gated tests, 0 failures, 0 errors.
- DS-review (Sonnet): no HIGH / no blocker. All findings addressed — MED#2 (env-override doc for large-pack repos), MED#3 (the three commit calls), NIT (`output=None`), LOW (symmetric `_run_list` check=True test + commit-routing test).
- New tests: default + per-call timeout, env override (valid/invalid/zero), `TimeoutExpired` → rc=124 / `CalledProcessError` for both helpers, commit routes through `_run_list`.

Completes the git_ops deploy-path hardening cluster (#13211 / #13215 / #13261 / #13267 / #13262).

🤖 Generated with [Claude Code](https://claude.com/claude-code)