### PR TITLE
#13275 + #13276: re-land TUI infra + agent_rows None-guard (lost in #13274 squash)

### DIFF
--- a/references/installer-files.txt
+++ b/references/installer-files.txt
@@ -1,7 +1,7 @@
 # SquidSquad installer file manifest
 # Every file the wizard needs, fetched by npx squidsquad before
 # launching Claude. One path per line, relative to repo root.
-# Total: 254 files
+# Total: 258 files
 #
 # Maintained alongside the wizard - when you add a new role,
 # capability, preset, or sub-skill, add its files here too.
@@ -229,6 +229,9 @@ references/sub-skills/roles/verifier/verification.md
 references/presets/design/manifest.yaml
 references/presets/software-dev/manifest.yaml
 references/templates/forgejo-compose.yaml
+references/tui/__init__.py
+references/tui/app.py
+references/tui/harness_client.py
 references/vault-templates/archives-template.md
 references/vault-templates/areas-template.md
 references/vault-templates/BRIEFING.md
@@ -266,4 +269,5 @@ references/sub-skills/roles/verifier/skill/finding-categories.md
 
 # Harness runtime dependency manifest (#11403) — seeded so the wizard's
 # Step 7.5b `pip install -r requirements.txt` provisioning step can run.
+requirements-tui.txt
 requirements.txt

--- a/references/tui/__init__.py
+++ b/references/tui/__init__.py
@@ -1,0 +1,4 @@
+"""SquidSquad harness TUI (#12801) — Textual operator console.
+
+Separate process consuming the harness HTTP endpoints (#8704 model).
+"""

--- a/references/tui/harness_client.py
+++ b/references/tui/harness_client.py
@@ -120,7 +120,14 @@ def agent_rows(status_json, now):
     Each row carries the already-derived display fields so panels render
     without re-deriving: role, work_state (+ color), lag, lag_bar, lag_alert,
     current task, and last-activity epoch.
+
+    #13276: tolerant of a missing/None status payload (harness unreachable →
+    fetch_status returns None) → []. Mirrors agent_table_rows' guard; without it
+    app.refresh_agents crashes building its meta rows exactly when the harness is
+    down — when an operator opens the TUI to reboot.
     """
+    if not status_json:
+        return []
     rows = []
     for a in status_json.get("agents", []):
         lag = a.get("lag", 0) or 0

--- a/requirements-tui.txt
+++ b/requirements-tui.txt
@@ -1,0 +1,13 @@
+# SquidSquad Harness TUI (references/tui/) dependencies (#12801).
+#
+# The TUI is a SEPARATE operator-console process that consumes the harness HTTP
+# surface (the #8704 model) — it is NOT imported by the harness runtime, so its
+# deps live here, distinct from requirements.txt (harness runtime) and
+# requirements-dev.txt (test tooling). Install to run the TUI:
+#     pip install -r requirements-tui.txt
+#     python references/tui/app.py
+#
+# Drift note: test_runtime_requirements.py intentionally scopes requirements.txt
+# to harness runtime imports only — textual must NOT be added there.
+
+textual>=8.2    # async-native TUI framework (operator-approved dep, #12801)

--- a/tests/test_feat_12801_reboot_action_bar.py
+++ b/tests/test_feat_12801_reboot_action_bar.py
@@ -242,6 +242,15 @@ class TestHarnessClientPost:
         assert ok is False
         assert "error" in payload
 
+    def test_agent_rows_tolerates_none_status(self):
+        """#13276: agent_rows must return [] for a None status (harness
+        unreachable → fetch_status returns None), mirroring agent_table_rows —
+        else app.refresh_agents crashes building meta rows exactly when the
+        harness is down (when the operator opens the TUI to reboot)."""
+        import harness_client as hc
+        assert hc.agent_rows(None, 0) == []
+        assert hc.agent_table_rows(None, 0) == []  # sibling already guarded
+
 
 # ---------------------------------------------------------------------------
 # C. App action dispatch — Textual headless Pilot

--- a/tests/test_tui_render_12801.py
+++ b/tests/test_tui_render_12801.py
@@ -1,0 +1,109 @@
+"""#12801 — headless RENDER verification for the Harness TUI (app.py).
+
+This is the automated replacement for the manual operator render-check that
+parked every TUI story. It uses **Textual's built-in headless test harness**
+(`App.run_test()` + Pilot) — no real terminal, no pyte/PTY, no new dependency —
+to drive the actual app and assert on what it renders. Operator-approved
+approach (2026-06-27); see vault `decision-tui-headless-render-verification`.
+
+`fetch_status` is mocked so the test needs no live harness. The TUI dep
+(`textual`, requirements-tui.txt) is optional at runtime, so the whole module
+skips when textual is absent — it runs in environments that have it (the dep is
+installed fleet-wide per #12801 S1.4).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("textual", reason="TUI dep (requirements-tui.txt); render test skips without it")
+
+# references/tui is importable; app.py self-bootstraps harness_client onto path.
+TUI_DIR = Path(__file__).resolve().parent.parent / "references" / "tui"
+sys.path.insert(0, str(TUI_DIR))
+
+import app as tui_app  # noqa: E402
+
+
+def _status_fixture(now):
+    """A minimal but realistic GET /status payload: two healthy agents."""
+    return {
+        "harness": {"status": "running", "port": 7373},
+        "agents": [
+            {
+                "role": "skill", "status": "running", "intent": "running",
+                "bootup_complete": True, "current_cycle": "12801",
+                "last_activity_at": now - 5, "lag": 0,
+            },
+            {
+                "role": "pm", "status": "running", "intent": "running",
+                "bootup_complete": True, "current_cycle": None,
+                "last_activity_at": now - 12, "lag": 0,
+            },
+        ],
+    }
+
+
+async def _drive(app):
+    """Run the app headless, let its threaded refresh worker finish + repaint."""
+    async with app.run_test() as pilot:
+        # on_mount kicks the @work(thread=True) refresh_agents; wait it out,
+        # then pump the message queue so call_from_thread repaint applies.
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        from textual.widgets import DataTable, Static
+        title = app.query_one("#titlebar", Static)
+        table = app.query_one("#agents", DataTable)
+        # Snapshot what we need BEFORE the context exits (app shuts down on exit).
+        title_str = str(title.render())
+        col_count = len(table.columns)
+        row_count = table.row_count
+        # Pull the role cell (col 0) of every row.
+        roles = [
+            str(table.get_row_at(i)[0]) for i in range(row_count)
+        ]
+        return title_str, col_count, row_count, roles
+
+
+@pytest.mark.asyncio
+async def test_titlebar_and_agents_panel_render(monkeypatch):
+    """The exact render-check a human used to do by eye, now automated:
+    the title bar shows the branded string and the Agents panel renders one
+    row per agent from a mocked /status."""
+    import time
+    now = time.time()
+    monkeypatch.setattr(tui_app.hc, "fetch_status",
+                        lambda *a, **k: _status_fixture(now))
+
+    app = tui_app.HarnessTUI(base_url="http://test", project="SquidSquad-2")
+    title_str, col_count, row_count, roles = await _drive(app)
+
+    # Title bar — branded contract string.
+    assert "SquidSquad" in title_str
+    assert "SquidSquad-2" in title_str
+    # Agents panel — 5 columns (Role/State/Task/Age/Lag), one row per agent.
+    assert col_count == 5
+    assert row_count == 2
+    assert "skill" in roles
+    assert "pm" in roles
+
+
+@pytest.mark.asyncio
+async def test_unreachable_harness_renders_sentinel(monkeypatch):
+    """When /status is unreachable (fetch_status -> None), the panel renders a
+    single 'harness unreachable' sentinel row rather than crashing or going
+    blank — the operator must see the down-state, not a frozen/empty table."""
+    monkeypatch.setattr(tui_app.hc, "fetch_status", lambda *a, **k: None)
+
+    app = tui_app.HarnessTUI(base_url="http://test", project="SquidSquad-2")
+    _title, col_count, row_count, _roles = await _drive(app)
+
+    assert col_count == 5
+    assert row_count == 1  # the single sentinel row
+
+
+def test_title_text_contract():
+    """Pure-function guard on the branded title string (contract:
+    `🦑 SquidSquad · <project>`)."""
+    assert tui_app.title_text("SquidSquad-2") == "🦑 SquidSquad · SquidSquad-2"

--- a/tests/test_tui_requirements.py
+++ b/tests/test_tui_requirements.py
@@ -1,0 +1,111 @@
+"""Drift guard: requirements-tui.txt must declare every third-party import the
+SquidSquad TUI (references/tui/) needs at runtime (#12801 S1.4).
+
+The TUI is a SEPARATE operator-launched process (the #8704 model) — it is NOT
+imported by the harness runtime, so its dependency (textual) deliberately does
+NOT live in requirements.txt (harness runtime, guarded by
+tests/test_runtime_requirements.py) nor requirements-dev.txt (pytest/dev-only).
+It lives in its own requirements-tui.txt, and this guard keeps that file honest.
+
+Static (``ast``-based) — does NOT import the TUI or ``textual``, so it runs in
+the static gate even where textual is not installed (the TUI dep is optional).
+It catches a NEW third-party import added under references/tui/ without a
+matching requirements-tui.txt entry.
+"""
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TUI_DIR = REPO_ROOT / "references" / "tui"
+REQUIREMENTS_TUI = REPO_ROOT / "requirements-tui.txt"
+
+# import-name -> distribution-name for the rare cases they differ. The TUI's
+# current deps match their import name; the hook keeps the guard correct if a
+# module whose import name differs from its PyPI distribution ever lands here.
+IMPORT_TO_DIST: dict[str, str] = {}
+
+
+def _tui_py_files() -> list[Path]:
+    return sorted(TUI_DIR.glob("*.py"))
+
+
+def _local_module_names() -> set[str]:
+    """Module names that resolve to local references/tui/ files (e.g. app.py
+    importing ``harness_client`` — a sibling, not a third-party dep)."""
+    return {p.stem for p in _tui_py_files()}
+
+
+def _imported_top_modules(path: Path) -> set[str]:
+    """Top-level module names imported anywhere in ``path`` — including guarded
+    (try/except) and lazy (in-function) imports, which ``ast.walk`` reaches."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    mods: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                mods.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            # Absolute imports only (level == 0); relative imports are local.
+            if node.level == 0 and node.module:
+                mods.add(node.module.split(".")[0])
+    return mods
+
+
+def _declared_dists() -> set[str]:
+    dists: set[str] = set()
+    for raw in REQUIREMENTS_TUI.read_text(encoding="utf-8").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        name = re.split(r"[<>=!~ \[]", line, 1)[0].strip().lower()
+        if name:
+            dists.add(name)
+    return dists
+
+
+def _third_party_imports() -> set[str]:
+    local = _local_module_names()
+    stdlib = set(sys.stdlib_module_names)  # py3.10+
+    third: set[str] = set()
+    for module_file in _tui_py_files():
+        for mod in _imported_top_modules(module_file):
+            if mod in stdlib or mod in local or mod.startswith("_"):
+                continue
+            third.add(mod)
+    return third
+
+
+def test_requirements_tui_exists():
+    assert REQUIREMENTS_TUI.exists(), (
+        "requirements-tui.txt (TUI process deps) is missing — #12801 S1.4 "
+        "declares the operator-TUI dependency there (NOT in requirements.txt)."
+    )
+
+
+def test_tui_third_party_imports_are_declared():
+    """Every third-party import under references/tui/ must be declared in
+    requirements-tui.txt. Fails loudly on drift."""
+    declared = _declared_dists()
+    missing = []
+    for mod in sorted(_third_party_imports()):
+        dist = IMPORT_TO_DIST.get(mod, mod).lower()
+        if dist not in declared:
+            missing.append(f"{mod} (distribution: {dist})")
+    assert not missing, (
+        "TUI third-party imports not declared in requirements-tui.txt: "
+        + ", ".join(missing)
+        + ". Add them to requirements-tui.txt (or extend IMPORT_TO_DIST if the "
+        "import name differs from the PyPI distribution name)."
+    )
+
+
+def test_textual_declared():
+    """Explicit pin: textual (the TUI framework) must stay declared — the TUI
+    cannot run without it."""
+    assert "textual" in _declared_dists(), (
+        "textual missing from requirements-tui.txt — it is the TUI process's "
+        "framework dependency (#12801)."
+    )


### PR DESCRIPTION
## Summary
Re-lands the two TUI fixes that PR #13274's squash dropped. The squash captured a **stale tree** (commit `b649dc5b9` only), silently omitting the two newest branch commits — same behind-clone squash partial-loss class as the #13271 SEV-1. The verifier correctly rejected #13275 and #13276 because the fixes never reached `main`.

## What was lost & restored (verbatim from branch tip `03ab86ef8`)
- **#13276** — `agent_rows()` now returns `[]` on a `None` status payload (harness unreachable → `fetch_status` returns `None`), mirroring `agent_table_rows`' guard. Without it `app.refresh_agents` crashes building meta rows exactly when the harness is down — i.e. when an operator opens the TUI to reboot. + regression test.
- **#13275** — `references/tui/__init__.py`, `requirements-tui.txt`, `tests/test_tui_render_12801.py`, `tests/test_tui_requirements.py`, and `references/installer-files.txt` (adds `references/tui/*` + `requirements-tui.txt`, Total 254→258).

## Verification
- Full static gate: **5076 passed, 0 failures**.
- TUI suite (feat + render + requirements + app): **30 passed**.

Closes #13275, closes #13276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)