### PR TITLE
#13303: gate L4 watcher restart-required on actual composed-output change

### DIFF
--- a/references/scripts/l4_file_watcher.py
+++ b/references/scripts/l4_file_watcher.py
@@ -8,9 +8,17 @@ file (e.g. ``.squidsquad/project/pm.md``):
    ``.squidsquad/config.md`` ``## Aliases`` registry.
 2. For each affected alias, run ``compose.py deploy <alias>``.
 3. Per-alias outcome:
-   - **Success** -> emit ``assigned-to(target_alias=<alias>,
+   - **Success (output changed)** -> emit ``assigned-to(target_alias=<alias>,
      event_context="restart-required", payload={reason:"l4-recompose"})``
      per AGENT-RUNTIME §8.5 catalog-trim translators.
+   - **Success (output unchanged, #13303)** -> no event. A recompose whose
+     composed ``CLAUDE.md`` is byte-identical to what is already deployed is
+     a no-op; emitting ``restart-required`` would force a wasteful agent
+     restart. A spurious filesystem touch on an L4 file (the freshen-pull's
+     own mtime rewrite, or a teammate-merge propagation into the harness
+     clone) drives exactly this no-op recompose. The content-change gate
+     reads the deployed file before/after compose and suppresses the event
+     when nothing changed.
    - **Failure** -> emit ``assigned-to(target_alias=<alias>,
      event_context="compose-failed", payload={reason:"l4-recompose",
      stderr:<truncated>})``. Agents stay on their existing CLAUDE.md
@@ -70,6 +78,12 @@ class RecomposeResult:
     event_type: str = "assigned-to"
     event_context: str = ""
     payload: dict = field(default_factory=dict)
+    # #13303: a successful recompose whose composed CLAUDE.md is byte-
+    # identical to what was already deployed is a no-op — the agent has
+    # nothing new to pick up, so emitting ``restart-required`` would force
+    # a wasteful restart. ``noop`` results are produced (so callers can log
+    # them) but ``emit_results`` skips emitting any event for them.
+    noop: bool = False
 
 
 def role_class_from_path(path, *, repo_root):
@@ -127,6 +141,7 @@ def recompose_for_role_class(
     registry,
     *,
     run_compose,
+    read_deployed=None,
 ):
     """Run compose for every affected alias and return one result per alias.
 
@@ -138,22 +153,71 @@ def recompose_for_role_class(
     NOT emit ``restart-required`` for that alias and does NOT halt
     iteration over the remaining aliases. Each alias's outcome is
     independent.
+
+    #13303 content-change gate: ``read_deployed(alias)`` (optional,
+    injected) returns the alias's currently-deployed ``CLAUDE.md`` text
+    (or ``None`` if absent). When supplied, the deployed content is
+    captured BEFORE and AFTER a successful ``run_compose`` and the
+    ``restart-required`` event is emitted ONLY if the composed output
+    actually changed; a byte-identical recompose yields a ``noop`` result
+    that ``emit_results`` does not emit. When ``read_deployed`` is ``None``
+    the gate is disabled and every success emits ``restart-required`` (the
+    pre-#13303 behavior — kept so direct callers/tests need no reader).
+    A spurious filesystem touch on an L4 file (the watcher's own
+    freshen-pull mtime rewrite, or a teammate-merge propagation) drives a
+    no-op recompose; without this gate that produced a needless agent
+    restart.
     """
     results = []
     for alias in compute_affected_aliases(role_class, registry):
+        before = None
+        before_ok = True
+        if read_deployed is not None:
+            try:
+                before = read_deployed(alias)
+            except Exception:  # noqa: BLE001 — reader must never crash the watch
+                before_ok = False
         try:
             outcome = run_compose(alias)
         except Exception as exc:  # noqa: BLE001 — any unexpected raise is a failure
             outcome = (False, "", f"compose runner raised: {exc!r}")
         ok, _stdout, stderr = outcome
         if ok:
-            results.append(RecomposeResult(
-                alias=alias,
-                role_class=role_class,
-                succeeded=True,
-                event_context="restart-required",
-                payload={"reason": "l4-recompose"},
-            ))
+            # Gate off (no reader) -> always emit (pre-#13303 behavior).
+            # Gate on -> emit only on a real content change; but if EITHER
+            # read failed we cannot prove no-change, so fail safe and emit
+            # (a needless restart beats silently dropping a real update).
+            changed = True
+            if read_deployed is not None:
+                after_ok = True
+                try:
+                    after = read_deployed(alias)
+                except Exception:  # noqa: BLE001 — reader must never crash the watch
+                    after_ok = False
+                if before_ok and after_ok:
+                    changed = before != after
+                else:
+                    changed = True
+            if changed:
+                results.append(RecomposeResult(
+                    alias=alias,
+                    role_class=role_class,
+                    succeeded=True,
+                    event_context="restart-required",
+                    payload={"reason": "l4-recompose"},
+                ))
+            else:
+                # No-op recompose: composed output byte-identical to the
+                # deployed CLAUDE.md. Record the outcome (for logging) but
+                # emit no restart-required — nothing changed for the agent.
+                results.append(RecomposeResult(
+                    alias=alias,
+                    role_class=role_class,
+                    succeeded=True,
+                    event_context="",
+                    payload={"reason": "l4-recompose-noop"},
+                    noop=True,
+                ))
         else:
             truncated = (stderr or "")[:_COMPOSE_FAILED_STDERR_MAX]
             results.append(RecomposeResult(
@@ -181,6 +245,10 @@ def emit_results(results, *, emit_event):
     that the harness uses for the alias-care filter).
     """
     for r in results:
+        if getattr(r, "noop", False):
+            # #13303: no-op recompose (output unchanged) — nothing for the
+            # agent to pick up, so emit no restart-required event.
+            continue
         emit_event(
             r.event_type,
             "harness",
@@ -308,6 +376,24 @@ def _default_run_compose(alias, *, repo_root):
     return proc.returncode == 0, proc.stdout, proc.stderr
 
 
+def _default_read_deployed(alias, *, repo_root):
+    """Return the alias's currently-deployed ``CLAUDE.md`` text, or ``None``.
+
+    Backs the #13303 content-change gate: the deployed file at
+    ``<repo_root>/.squidsquad/<alias>/CLAUDE.md`` is read before and after
+    a recompose so a byte-identical (no-op) recompose suppresses the
+    spurious ``restart-required``. A missing file returns ``None`` (treated
+    as "changed" once compose writes it — a genuine first deploy). Lives
+    behind ``read_deployed=`` injection (same pattern as ``run_compose=``)
+    so unit tests can stub it without touching disk.
+    """
+    p = Path(repo_root) / ".squidsquad" / alias / "CLAUDE.md"
+    try:
+        return p.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError):
+        return None
+
+
 def recompose_path(
     path,
     *,
@@ -316,6 +402,7 @@ def recompose_path(
     emit_event,
     run_compose=None,
     ensure_fresh_source=None,
+    read_deployed=None,
 ):
     """Handle a single L4 file change end-to-end.
 
@@ -341,8 +428,15 @@ def recompose_path(
     if run_compose is None:
         def run_compose(alias):
             return _default_run_compose(alias, repo_root=repo_root)
+    # #13303: default to the real deployed-file reader so the content-change
+    # gate is active for this end-to-end entry (file-watch + post-commit
+    # hook). Tests inject a stub (or rely on the in-tree CLAUDE.md files).
+    if read_deployed is None:
+        def read_deployed(alias):
+            return _default_read_deployed(alias, repo_root=repo_root)
     results = recompose_for_role_class(
         role_class, registry, run_compose=run_compose,
+        read_deployed=read_deployed,
     )
     emit_results(results, emit_event=emit_event)
     return results
@@ -431,6 +525,7 @@ def make_change_callback(
     emit_event,
     run_compose=None,
     ensure_fresh_source=None,
+    read_deployed=None,
 ):
     """Build the callback the watcher/debouncer hands a role-class to.
 
@@ -476,8 +571,13 @@ def make_change_callback(
         if resolved_compose is None:
             def resolved_compose(alias):
                 return _default_run_compose(alias, repo_root=repo_root)
+        # #13303: ``read_deployed`` passes straight through to the
+        # content-change gate. It defaults to ``None`` here (gate off) so
+        # direct unit-test callers keep the pre-#13303 always-emit behavior;
+        # production wires the real reader via ``start_watcher`` below.
         results = recompose_for_role_class(
             role_class, registry, run_compose=resolved_compose,
+            read_deployed=read_deployed,
         )
         emit_results(results, emit_event=emit_event)
     return _on_change
@@ -490,6 +590,7 @@ def start_watcher(
     emit_event,
     run_compose=None,
     ensure_fresh_source=None,
+    read_deployed=None,
     debounce_seconds=DEFAULT_DEBOUNCE_SECONDS,
 ):
     """Start a ``watchdog.Observer`` watching ``.squidsquad/project/``.
@@ -516,12 +617,21 @@ def start_watcher(
     watch_path = repo_root / WATCH_SUBDIR
     watch_path.mkdir(parents=True, exist_ok=True)
 
+    # #13303: default to the real deployed-file reader so the production
+    # file-watch path gates restart-required on actual composed-output
+    # change. A benign FS touch (freshen-pull mtime rewrite, teammate-merge
+    # propagation) drives a no-op recompose that must NOT restart agents.
+    if read_deployed is None:
+        def read_deployed(alias):
+            return _default_read_deployed(alias, repo_root=repo_root)
+
     on_change = make_change_callback(
         repo_root=repo_root,
         registry_provider=registry_provider,
         emit_event=emit_event,
         run_compose=run_compose,
         ensure_fresh_source=ensure_fresh_source,
+        read_deployed=read_deployed,
     )
     debouncer = _Debouncer(debounce_seconds, on_change)
 

--- a/references/scripts/l4_file_watcher.py
+++ b/references/scripts/l4_file_watcher.py
@@ -245,7 +245,7 @@ def emit_results(results, *, emit_event):
     that the harness uses for the alias-care filter).
     """
     for r in results:
-        if getattr(r, "noop", False):
+        if r.noop:
             # #13303: no-op recompose (output unchanged) — nothing for the
             # agent to pick up, so emit no restart-required event.
             continue

--- a/tests/test_l4_file_watcher_e3.py
+++ b/tests/test_l4_file_watcher_e3.py
@@ -239,12 +239,24 @@ class TestRecomposePath:
         target = tmp_path / ".squidsquad" / "project" / "pm.md"
         target.parent.mkdir(parents=True)
         target.write_text("# pm\n")
+
+        # #13303: the default read_deployed gate is now active in
+        # recompose_path, so the compose stub must actually CHANGE the
+        # deployed CLAUDE.md for restart-required to fire (AC6a intent:
+        # a real L4 write -> recompose -> event). A first deploy
+        # (no prior file) counts as a change.
+        def writing_compose(alias):
+            out = tmp_path / ".squidsquad" / alias / "CLAUDE.md"
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(f"composed {alias} v2\n")
+            return True, f"deployed {alias}\n", ""
+
         results = lfw.recompose_path(
             target,
             repo_root=tmp_path,
             registry=_REGISTRY,
             emit_event=sink,
-            run_compose=_ok_compose,
+            run_compose=writing_compose,
             ensure_fresh_source=_fresh_ok,
         )
         assert [r.alias for r in results] == ["pm", "pm-mobile"]
@@ -945,3 +957,179 @@ class TestHarnessLifespanWiring:
         assert "state.stop_l4_watcher()" in block, (
             "lifespan must call state.stop_l4_watcher() on shutdown"
         )
+
+
+# ---------------------------------------------------------------------------
+# #13303 — content-change gate: a no-op recompose (composed CLAUDE.md
+# byte-identical to what is already deployed) must NOT emit restart-required.
+# A benign FS touch on an L4 file (the watcher's own freshen-pull mtime
+# rewrite, or a teammate-merge propagation) drives such a no-op recompose;
+# without this gate it produced a spurious agent restart.
+# ---------------------------------------------------------------------------
+
+
+class TestContentChangeGate13303:
+
+    def _stateful(self, initial):
+        """Return (deployed_dict, read_deployed, make_compose) helpers.
+
+        ``read_deployed(alias)`` reads the simulated deployed CLAUDE.md;
+        ``make_compose(new_content)`` returns a run_compose stub that writes
+        ``new_content`` for the alias.
+        """
+        deployed = dict(initial)
+
+        def read_deployed(alias):
+            return deployed.get(alias)
+
+        def make_compose(new_content):
+            def compose(alias):
+                deployed[alias] = new_content
+                return True, f"deployed {alias}\n", ""
+            return compose
+
+        return deployed, read_deployed, make_compose
+
+    def test_noop_recompose_yields_noop_result_no_event(self):
+        _dep, read_deployed, make_compose = self._stateful(
+            {"dm-skill": "SAME\n"})
+        results = lfw.recompose_for_role_class(
+            "dm", _REGISTRY,
+            run_compose=make_compose("SAME\n"),  # idempotent: identical output
+            read_deployed=read_deployed,
+        )
+        assert len(results) == 1
+        r = results[0]
+        assert r.succeeded is True
+        assert r.noop is True
+        assert r.event_context == ""
+        assert r.payload["reason"] == "l4-recompose-noop"
+        sink = _EventSink()
+        lfw.emit_results(results, emit_event=sink)
+        assert sink.events == []
+
+    def test_changed_recompose_emits_restart_required(self):
+        _dep, read_deployed, make_compose = self._stateful(
+            {"dm-skill": "OLD\n"})
+        results = lfw.recompose_for_role_class(
+            "dm", _REGISTRY,
+            run_compose=make_compose("NEW\n"),
+            read_deployed=read_deployed,
+        )
+        assert results[0].noop is False
+        assert results[0].event_context == "restart-required"
+        sink = _EventSink()
+        lfw.emit_results(results, emit_event=sink)
+        assert len(sink.events) == 1
+        assert sink.events[0]["payload"]["event_context"] == "restart-required"
+        assert sink.events[0]["payload"]["reason"] == "l4-recompose"
+
+    def test_first_deploy_no_prior_file_counts_as_change(self):
+        _dep, read_deployed, make_compose = self._stateful({})
+        results = lfw.recompose_for_role_class(
+            "dm", _REGISTRY,
+            run_compose=make_compose("fresh\n"),
+            read_deployed=read_deployed,
+        )
+        assert results[0].noop is False
+        assert results[0].event_context == "restart-required"
+
+    def test_gate_off_when_no_reader_preserves_legacy_emit(self):
+        results = lfw.recompose_for_role_class(
+            "dm", _REGISTRY, run_compose=_ok_compose,
+        )
+        assert results[0].noop is False
+        assert results[0].event_context == "restart-required"
+
+    def test_reader_raises_fails_safe_to_emit(self):
+        def boom_reader(alias):
+            raise RuntimeError("deployed file unreadable")
+        results = lfw.recompose_for_role_class(
+            "dm", _REGISTRY, run_compose=_ok_compose,
+            read_deployed=boom_reader,
+        )
+        assert results[0].noop is False
+        assert results[0].event_context == "restart-required"
+
+    def test_compose_failure_unaffected_by_gate(self):
+        _dep, read_deployed, _mc = self._stateful({"dm-skill": "X\n"})
+        results = lfw.recompose_for_role_class(
+            "dm", _REGISTRY, run_compose=_fail_compose,
+            read_deployed=read_deployed,
+        )
+        assert results[0].succeeded is False
+        assert results[0].noop is False
+        assert results[0].event_context == "compose-failed"
+
+    def test_recompose_path_noop_emits_nothing_end_to_end(self, tmp_path):
+        sink = _EventSink()
+        target = tmp_path / ".squidsquad" / "project" / "pm.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("# pm\n")
+        for alias in ("pm", "pm-mobile"):
+            out = tmp_path / ".squidsquad" / alias / "CLAUDE.md"
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(f"composed {alias} stable\n")
+
+        def identity_compose(alias):
+            out = tmp_path / ".squidsquad" / alias / "CLAUDE.md"
+            out.write_text(f"composed {alias} stable\n")  # identical bytes
+            return True, f"deployed {alias}\n", ""
+
+        results = lfw.recompose_path(
+            target, repo_root=tmp_path, registry=_REGISTRY,
+            emit_event=sink, run_compose=identity_compose,
+            ensure_fresh_source=_fresh_ok,
+        )
+        assert all(r.noop for r in results)
+        assert sink.events == []
+
+    def test_recompose_path_change_emits_end_to_end(self, tmp_path):
+        sink = _EventSink()
+        target = tmp_path / ".squidsquad" / "project" / "pm.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("# pm\n")
+        for alias in ("pm", "pm-mobile"):
+            out = tmp_path / ".squidsquad" / alias / "CLAUDE.md"
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(f"composed {alias} v1\n")
+
+        def changing_compose(alias):
+            out = tmp_path / ".squidsquad" / alias / "CLAUDE.md"
+            out.write_text(f"composed {alias} v2\n")  # real change
+            return True, f"deployed {alias}\n", ""
+
+        results = lfw.recompose_path(
+            target, repo_root=tmp_path, registry=_REGISTRY,
+            emit_event=sink, run_compose=changing_compose,
+            ensure_fresh_source=_fresh_ok,
+        )
+        assert not any(r.noop for r in results)
+        assert {e["payload"]["target_alias"] for e in sink.events} == {
+            "pm", "pm-mobile",
+        }
+        assert {e["payload"]["event_context"] for e in sink.events} == {
+            "restart-required",
+        }
+
+    def test_make_change_callback_gate_suppresses_noop(self, tmp_path):
+        sink = _EventSink()
+        deployed = {"dm-skill": "SAME\n"}
+
+        def read_deployed(alias):
+            return deployed.get(alias)
+
+        def compose(alias):
+            deployed[alias] = "SAME\n"  # idempotent
+            return True, "", ""
+
+        cb = lfw.make_change_callback(
+            repo_root=tmp_path,
+            registry_provider=lambda: _REGISTRY,
+            emit_event=sink,
+            run_compose=compose,
+            ensure_fresh_source=_fresh_ok,
+            read_deployed=read_deployed,
+        )
+        cb("dm")
+        assert sink.events == []  # no-op suppressed through the callback

--- a/tests/test_l4_file_watcher_e3.py
+++ b/tests/test_l4_file_watcher_e3.py
@@ -1051,6 +1051,26 @@ class TestContentChangeGate13303:
         assert results[0].noop is False
         assert results[0].event_context == "restart-required"
 
+    def test_after_read_raises_fails_safe_to_emit(self):
+        # Asymmetric failure: the BEFORE read succeeds but the AFTER read
+        # raises (e.g. file locked mid-write). The gate cannot prove
+        # no-change -> must emit, never silently suppress. Locks the
+        # fail-safe direction against a future "smarter" refactor.
+        calls = [0]
+
+        def partial_reader(alias):
+            calls[0] += 1
+            if calls[0] == 1:
+                return "existing content\n"   # before: succeeds
+            raise RuntimeError("deployed file locked")  # after: raises
+
+        results = lfw.recompose_for_role_class(
+            "dm", _REGISTRY, run_compose=_ok_compose,
+            read_deployed=partial_reader,
+        )
+        assert results[0].noop is False
+        assert results[0].event_context == "restart-required"
+
     def test_compose_failure_unaffected_by_gate(self):
         _dep, read_deployed, _mc = self._stateful({"dm-skill": "X\n"})
         results = lfw.recompose_for_role_class(


### PR DESCRIPTION
## #13303 — gate L4 file-watcher `restart-required` on actual composed-output change

### Problem
The L4 file-watcher (`l4_file_watcher.py`, PRD-E E3) emitted `restart-required` on **every** successful `compose.py deploy <alias>`, with no comparison of composed output before/after. Any benign filesystem touch on a watched `.squidsquad/project/<role-class>.md` file — the watcher's own freshen-pull mtime rewrite, or a teammate ship-merge propagating into the harness clone — drove a no-op recompose (byte-identical output) that still demanded an agent restart.

**Discovered live**: while idle I received `assigned-to(restart-required, reason=l4-recompose)` at 04:10; `git diff HEAD -- .squidsquad/skill/CLAUDE.md` was empty (composed output unchanged) and no L4 commit had occurred. I declined the no-op restart and filed this.

### Fix
Content-change gate in `recompose_for_role_class`, via an injected `read_deployed(alias)` reader that returns the deployed `CLAUDE.md` text (or `None` if absent):
- Capture deployed content **before** and **after** a successful compose; emit `restart-required` only when it actually changed.
- A byte-identical recompose yields a `noop=True` result that `emit_results` skips (no event).
- **Fail-safe**: if either read raises, the gate cannot prove no-change → emit anyway (a needless restart beats silently dropping a real instruction update).
- Gate is **off** when no reader is passed (`read_deployed=None`) → preserves pre-#13303 behavior for direct callers/tests.

Wiring:
- `start_watcher` (production file-watch) and `recompose_path` (post-commit hook) default `read_deployed` to the real deployed-file reader → gate **ON** in both end-to-end entries. Harness needs no change (it calls `start_watcher` with defaults).
- `make_change_callback` is pass-through (default `None`); production reaches it via `start_watcher`, which supplies the reader.
- `compose-failed` path unchanged (AC5 preserved).

### Tests
+9 regression tests (`TestContentChangeGate13303`): no-op → no event; real change → `restart-required`; first deploy (no prior file) → change; gate-off legacy emit; reader-raises fail-safe; compose-failure unaffected; end-to-end no-op/change via `recompose_path`; `make_change_callback` gate suppresses no-op. Updated `test_pm_md_write_triggers_emit` so its compose stub writes a changed file (AC6a intent under the new gate).

Static gate: **5192 passed, 0 failures, 0 errors**.

Refs: #13303, l4_file_watcher.py (PRD-E E3 / #10682), AGENT-RUNTIME §8.2/§8.5, COMPOSE-ARCHITECTURE §8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)