### PR TITLE
#13352: stop test runs leaking into live surfaces (prod bus events, clone port files, clone scratch artifacts)

### DIFF
--- a/references/experiments/conpty_spike.py
+++ b/references/experiments/conpty_spike.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -180,9 +181,10 @@ def main() -> int:
         if proc.isalive():
             proc.terminate(force=True)
 
-    # Dump raw output to a file for inspection
-    dump_path = Path(".squidsquad/skill/planning/conpty-spike-raw-output.txt")
-    dump_path.parent.mkdir(parents=True, exist_ok=True)
+    # Dump raw output to a file for inspection. Scratch output MUST live
+    # outside any repo clone — a cwd-relative .squidsquad/ path wrote spike
+    # artifacts into whichever agent clone ran the script (#13352).
+    dump_path = Path(tempfile.mkdtemp(prefix="conpty-spike-")) / "conpty-spike-raw-output.txt"
     dump_path.write_text(output, encoding="utf-8")
     print(f"\nPTY output ({len(output)} chars) written to {dump_path}")
 

--- a/references/experiments/wt_direct_spawn_test.py
+++ b/references/experiments/wt_direct_spawn_test.py
@@ -94,15 +94,20 @@ def test_env_propagation() -> dict:
 
     sentinel_value = f"PROPAGATED-{int(time.time())}"
 
-    # Set env var in our subprocess's env
+    # Set env var in our subprocess's env. The probe path travels as an
+    # env var too (expanded by cmd.exe inside the tab) so temp paths with
+    # spaces/quotes never touch the wt/list2cmdline quoting layers —
+    # embedding the literal path in the command line breaks when the
+    # Windows username contains a space.
     env = os.environ.copy()
     env[SENTINEL_ENV_VAR] = sentinel_value
+    env["_WTE_OUT_FILE"] = str(out_file)
 
     wt_argv = [
         wt, "new-tab",
         "--title", "env-probe",
         "cmd.exe", "/c",
-        f'echo %{SENTINEL_ENV_VAR}% > "{out_file}"',
+        f'echo %{SENTINEL_ENV_VAR}% > "%_WTE_OUT_FILE%"',
     ]
     print(f"  spawning: wt new-tab cmd /c \"echo %{SENTINEL_ENV_VAR}% > <file>\"")
     print(f"  parent env {SENTINEL_ENV_VAR}={sentinel_value}")

--- a/references/experiments/wt_direct_spawn_test.py
+++ b/references/experiments/wt_direct_spawn_test.py
@@ -31,6 +31,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -86,10 +87,10 @@ def test_env_propagation() -> dict:
     if not wt:
         return {"name": "env_propagation", "ok": False, "reason": "wt not found on PATH"}
 
-    out_file = Path.cwd() / ".squidsquad" / "skill" / "planning" / "wt-env-probe.txt"
-    out_file.parent.mkdir(parents=True, exist_ok=True)
-    if out_file.exists():
-        out_file.unlink()
+    # Scratch probe file — MUST live outside any repo clone. A cwd-relative
+    # .squidsquad/ path here wrote probe artifacts into whichever agent
+    # clone the script happened to run from (#13352 live-surface leak).
+    out_file = Path(tempfile.mkdtemp(prefix="wt-env-probe-")) / "wt-env-probe.txt"
 
     sentinel_value = f"PROPAGATED-{int(time.time())}"
 

--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -2370,6 +2370,49 @@ def _cleanup_legacy_sentinels(clone_paths):
     return removed, errors
 
 
+def _distribute_port_to_clones(port) -> int | None:
+    """Write ``port`` into each agent clone's ``.squidsquad/.harness-port``.
+
+    Production-only (#13352): distribution runs ONLY when this harness's
+    ``SQUIDSQUAD_DIR`` is the repo's live ``.squidsquad`` — i.e. the real
+    production singleton. An isolated harness (a test's ``real_harness``
+    with ``SQUIDSQUAD_DIR`` pointing at a tmpdir) must never write its
+    ephemeral port into live clones: ``boot_remote._parse_local_config()``
+    reads the repo-scoped ``.local-config`` regardless of isolation, so
+    without this guard a test harness on an ephemeral port poisons every
+    live clone's port file and strands those agents in polling fallback
+    (the observed ``.harness-port=8251`` leak; same failure family as
+    #12820's second-instance refusal).
+
+    Returns the clone count on distribution, or ``None`` when skipped
+    because this harness is isolated. Exceptions propagate to the caller
+    (which logs a warning), matching the previous inline behavior.
+    """
+    live_squid = REPO_ROOT / ".squidsquad"
+    try:
+        is_production = SQUIDSQUAD_DIR.resolve() == live_squid.resolve()
+    except OSError:
+        is_production = False
+    if not is_production:
+        _log(
+            "Isolated SQUIDSQUAD_DIR — skipping clone port distribution "
+            "(#13352: test harnesses must not poison live clone port files)"
+        )
+        return None
+    clone_paths = boot_remote._parse_local_config()
+    for role, clone_root in clone_paths.items():
+        clone_squid = Path(clone_root) / ".squidsquad"
+        if clone_squid.is_dir() and Path(clone_root).resolve() != REPO_ROOT.resolve():
+            clone_port_file = clone_squid / ".harness-port"
+            try:
+                clone_tmp = clone_port_file.with_suffix(".tmp")
+                clone_tmp.write_text(str(port), encoding="utf-8")
+                clone_tmp.replace(clone_port_file)
+            except OSError:
+                pass
+    return len(clone_paths)
+
+
 # ---------------------------------------------------------------------------
 # FastAPI app
 # ---------------------------------------------------------------------------
@@ -2431,18 +2474,9 @@ async def lifespan(app: FastAPI):
     def _deferred_init():
         # Write port file to each agent clone's .squidsquad/ directory (#4709 TC-7)
         try:
-            clone_paths = boot_remote._parse_local_config()
-            for role, clone_root in clone_paths.items():
-                clone_squid = Path(clone_root) / ".squidsquad"
-                if clone_squid.is_dir() and Path(clone_root).resolve() != REPO_ROOT.resolve():
-                    clone_port_file = clone_squid / ".harness-port"
-                    try:
-                        clone_tmp = clone_port_file.with_suffix(".tmp")
-                        clone_tmp.write_text(str(state.port), encoding="utf-8")
-                        clone_tmp.replace(clone_port_file)
-                    except OSError:
-                        pass
-            _log(f"Port file distributed to {len(clone_paths)} clone(s)")
+            distributed = _distribute_port_to_clones(state.port)
+            if distributed is not None:
+                _log(f"Port file distributed to {distributed} clone(s)")
         except (SystemExit, Exception) as e:
             _log(f"WARNING: Could not distribute port to clones: {e}")
 

--- a/tests/integration/fixtures/event_mode_subprocess.py
+++ b/tests/integration/fixtures/event_mode_subprocess.py
@@ -268,13 +268,41 @@ def gh_shim_dir() -> Path:
     return Path(__file__).resolve().parent / "gh_shim"
 
 
+# Process-lifetime empty squid dir used to isolate shimmed subprocesses
+# from the live event bus (#13352). It deliberately stays EMPTY — no
+# ``.harness-port`` is ever written here, so ``event_bus._discover_port``
+# in the subprocess returns None and every emit is a silent no-op.
+# One dir per test process is enough; the OS temp cleaner reaps it.
+_ISOLATED_SQUID_DIR: Path | None = None
+
+
+def _isolated_squid_dir() -> Path:
+    global _ISOLATED_SQUID_DIR
+    if _ISOLATED_SQUID_DIR is None:
+        _ISOLATED_SQUID_DIR = Path(
+            tempfile.mkdtemp(prefix="squid-shim-isolated-")
+        )
+    return _ISOLATED_SQUID_DIR
+
+
 def env_with_gh_shim(
     base_env: dict[str, str] | None = None,
     fixtures_dir: Path | None = None,
+    squid_dir: Path | None = None,
 ) -> dict[str, str]:
     """Build a subprocess env dict with the gh-shim directory
     prepended to ``PATH`` and (optionally) ``GH_SHIM_FIXTURES_DIR``
     set so reads find their fixture files.
+
+    ``SQUIDSQUAD_DIR`` is ALWAYS set (#13352): to ``squid_dir`` when the
+    caller provides one (e.g. to pair the subprocess with a
+    ``real_harness`` squid dir), otherwise to a process-lifetime EMPTY
+    tmpdir. Without this, a shimmed ``tracker.py transition``
+    subprocess falls back to the live ``.squidsquad/.harness-port``
+    and posts its synthetic status-transition events (issue 87654)
+    onto the PRODUCTION event bus — every agent then pays a real
+    wake + forge-read for a fabricated event. Callers that assign
+    ``env["SQUIDSQUAD_DIR"]`` after this call still win.
 
     Returns a *new* dict — does not mutate ``base_env`` or
     ``os.environ``.
@@ -284,6 +312,9 @@ def env_with_gh_shim(
     env["PATH"] = shim + os.pathsep + env.get("PATH", "")
     if fixtures_dir is not None:
         env["GH_SHIM_FIXTURES_DIR"] = str(fixtures_dir)
+    env["SQUIDSQUAD_DIR"] = str(
+        squid_dir if squid_dir is not None else _isolated_squid_dir()
+    )
     return env
 
 

--- a/tests/test_13352_test_isolation_leaks.py
+++ b/tests/test_13352_test_isolation_leaks.py
@@ -80,16 +80,21 @@ class TestEnvWithGhShimIsolation(unittest.TestCase):
     def test_subprocess_port_discovery_returns_none(self):
         """End-to-end: an event_bus in a subprocess under the shim env
         discovers NO harness port — so every emit is a silent no-op
-        (the exact mechanism that kept fake 87654 events off the bus)."""
+        (the exact mechanism that kept fake 87654 events off the bus).
+
+        The scripts path travels via an env var, not interpolated into
+        the ``-c`` literal — a repo path containing a quote would
+        otherwise break the inline script."""
         env = ems.env_with_gh_shim()
+        env["_SQ_PROBE_SCRIPTS"] = str(REPO_ROOT / "references" / "scripts")
         proc = subprocess.run(
             [
                 sys.executable,
                 "-c",
                 (
-                    "import sys; sys.path.insert(0, r'"
-                    + str(REPO_ROOT / "references" / "scripts")
-                    + "'); import event_bus; "
+                    "import os, sys; "
+                    "sys.path.insert(0, os.environ['_SQ_PROBE_SCRIPTS']); "
+                    "import event_bus; "
                     "print(event_bus._discover_port())"
                 ),
             ],
@@ -142,19 +147,29 @@ class TestHarnessClonePortDistributionGuard(unittest.TestCase):
 
     def test_production_harness_never_writes_own_repo_root(self):
         """The pre-existing self-exclusion still holds after the refactor:
-        a clone entry pointing at REPO_ROOT itself is skipped."""
-        with patch.object(
-                 harness, "SQUIDSQUAD_DIR", REPO_ROOT / ".squidsquad"), \
-             patch.object(
-                 harness.boot_remote, "_parse_local_config",
-                 return_value={"skill": str(REPO_ROOT)},
-             ), \
-             patch.object(Path, "write_text",
-                          side_effect=AssertionError(
-                              "must not write into own REPO_ROOT"
-                          )):
-            result = harness._distribute_port_to_clones(7373)
-        self.assertEqual(result, 1)
+        a clone entry pointing at REPO_ROOT itself is skipped.
+
+        Uses a synthetic repo root (with a real ``.squidsquad`` dir) so
+        the test exercises the self-exclusion branch specifically —
+        pinning it to the checkout's live ``.squidsquad`` would pass
+        vacuously on a layout where that dir is absent (``is_dir()``
+        short-circuits before the exclusion check)."""
+        with tempfile.TemporaryDirectory(prefix="fake-repo-") as tmp:
+            fake_repo = Path(tmp) / "repo"
+            (fake_repo / ".squidsquad").mkdir(parents=True)
+            with patch.object(harness, "REPO_ROOT", fake_repo), \
+                 patch.object(
+                     harness, "SQUIDSQUAD_DIR", fake_repo / ".squidsquad"), \
+                 patch.object(
+                     harness.boot_remote, "_parse_local_config",
+                     return_value={"skill": str(fake_repo)},
+                 ), \
+                 patch.object(Path, "write_text",
+                              side_effect=AssertionError(
+                                  "must not write into own REPO_ROOT"
+                              )):
+                result = harness._distribute_port_to_clones(7373)
+            self.assertEqual(result, 1)
 
 
 class TestExperimentScratchPathsStayOutOfClones(unittest.TestCase):

--- a/tests/test_13352_test_isolation_leaks.py
+++ b/tests/test_13352_test_isolation_leaks.py
@@ -1,0 +1,190 @@
+"""#13352 — test runs must not leak into live surfaces.
+
+Three leak classes were observed in production (all artifacts from test /
+experiment runs landing on LIVE agent surfaces):
+
+1. Fabricated ``status-transition`` events (synthetic issue 87654) on the
+   PRODUCTION event bus: ``env_with_gh_shim()`` did not set
+   ``SQUIDSQUAD_DIR``, so a shimmed ``tracker.py transition`` subprocess
+   discovered the live ``.squidsquad/.harness-port`` and posted its
+   synthetic event for real. Fix: ``env_with_gh_shim`` always sets
+   ``SQUIDSQUAD_DIR`` to an isolated EMPTY tmpdir (no port file → emit is
+   a silent no-op) unless the caller supplies a ``squid_dir``.
+
+2. ``.harness-port`` poisoned in live clones (observed value 8251): the
+   harness's lifespan clone-port distribution ran unconditionally, so an
+   isolated test harness (``real_harness`` fixture, ephemeral port) wrote
+   its port into every live clone listed in ``.local-config`` — stranding
+   those agents in polling fallback at their next boot probe. Fix:
+   ``harness._distribute_port_to_clones`` distributes ONLY when
+   ``SQUIDSQUAD_DIR`` is the repo's live ``.squidsquad``.
+
+3. Scratch artifacts written into agent clones by experiment scripts
+   (``wt-env-probe.txt``, ``conpty-spike-raw-output.txt``) via
+   cwd-relative ``.squidsquad/`` paths. Fix: experiments write scratch
+   output under ``tempfile.mkdtemp`` only; this suite pins the absence of
+   the cwd-relative leak shapes at source level.
+"""
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "references" / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "tests" / "integration" / "fixtures"))
+
+import harness  # noqa: E402
+import event_mode_subprocess as ems  # noqa: E402
+
+LIVE_SQUID = (REPO_ROOT / ".squidsquad").resolve()
+
+
+class TestEnvWithGhShimIsolation(unittest.TestCase):
+    """Leak class 1 — the shim env must never route a subprocess's
+    event_bus at the live harness."""
+
+    def test_squidsquad_dir_always_set_and_isolated(self):
+        env = ems.env_with_gh_shim()
+        self.assertIn("SQUIDSQUAD_DIR", env)
+        iso = Path(env["SQUIDSQUAD_DIR"])
+        self.assertNotEqual(iso.resolve(), LIVE_SQUID)
+
+    def test_isolated_dir_has_no_harness_port_file(self):
+        env = ems.env_with_gh_shim()
+        port_file = Path(env["SQUIDSQUAD_DIR"]) / ".harness-port"
+        self.assertFalse(
+            port_file.exists(),
+            "the default isolation dir must stay EMPTY — a port file here "
+            "would re-route shimmed subprocess emits at a live harness",
+        )
+
+    def test_explicit_squid_dir_wins(self):
+        with tempfile.TemporaryDirectory(prefix="explicit-squid-") as tmp:
+            env = ems.env_with_gh_shim(squid_dir=Path(tmp))
+            self.assertEqual(env["SQUIDSQUAD_DIR"], str(Path(tmp)))
+
+    def test_outer_squidsquad_dir_is_overridden(self):
+        """A live SQUIDSQUAD_DIR inherited from the parent process env
+        must not survive into the shim env — isolation is the default,
+        not an accident of the parent environment."""
+        base = {"SQUIDSQUAD_DIR": str(LIVE_SQUID), "PATH": ""}
+        env = ems.env_with_gh_shim(base_env=base)
+        self.assertNotEqual(
+            Path(env["SQUIDSQUAD_DIR"]).resolve(), LIVE_SQUID
+        )
+
+    def test_subprocess_port_discovery_returns_none(self):
+        """End-to-end: an event_bus in a subprocess under the shim env
+        discovers NO harness port — so every emit is a silent no-op
+        (the exact mechanism that kept fake 87654 events off the bus)."""
+        env = ems.env_with_gh_shim()
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import sys; sys.path.insert(0, r'"
+                    + str(REPO_ROOT / "references" / "scripts")
+                    + "'); import event_bus; "
+                    "print(event_bus._discover_port())"
+                ),
+            ],
+            env=env,
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr[:500])
+        self.assertEqual(proc.stdout.strip(), "None")
+
+
+class TestHarnessClonePortDistributionGuard(unittest.TestCase):
+    """Leak class 2 — an isolated harness must not write its port into
+    live clones."""
+
+    def test_isolated_harness_skips_distribution(self):
+        with tempfile.TemporaryDirectory(prefix="iso-squid-") as tmp:
+            with patch.object(harness, "SQUIDSQUAD_DIR", Path(tmp)), \
+                 patch.object(
+                     harness.boot_remote, "_parse_local_config",
+                     side_effect=AssertionError(
+                         "isolated harness must not even READ .local-config"
+                     ),
+                 ):
+                result = harness._distribute_port_to_clones(8251)
+        self.assertIsNone(result)
+
+    def test_production_harness_distributes(self):
+        with tempfile.TemporaryDirectory(prefix="fake-clone-") as tmp:
+            clone_root = Path(tmp) / "clone-qa"
+            (clone_root / ".squidsquad").mkdir(parents=True)
+            with patch.object(
+                     harness, "SQUIDSQUAD_DIR", REPO_ROOT / ".squidsquad"), \
+                 patch.object(
+                     harness.boot_remote, "_parse_local_config",
+                     return_value={"qa": str(clone_root)},
+                 ):
+                result = harness._distribute_port_to_clones(7373)
+            self.assertEqual(result, 1)
+            port_file = clone_root / ".squidsquad" / ".harness-port"
+            self.assertTrue(port_file.exists())
+            self.assertEqual(
+                port_file.read_text(encoding="utf-8").strip(), "7373"
+            )
+
+    def test_production_harness_never_writes_own_repo_root(self):
+        """The pre-existing self-exclusion still holds after the refactor:
+        a clone entry pointing at REPO_ROOT itself is skipped."""
+        with patch.object(
+                 harness, "SQUIDSQUAD_DIR", REPO_ROOT / ".squidsquad"), \
+             patch.object(
+                 harness.boot_remote, "_parse_local_config",
+                 return_value={"skill": str(REPO_ROOT)},
+             ), \
+             patch.object(Path, "write_text",
+                          side_effect=AssertionError(
+                              "must not write into own REPO_ROOT"
+                          )):
+            result = harness._distribute_port_to_clones(7373)
+        self.assertEqual(result, 1)
+
+
+class TestExperimentScratchPathsStayOutOfClones(unittest.TestCase):
+    """Leak class 3 — experiment scripts must not write scratch files
+    into any repo clone's .squidsquad/ via cwd-relative paths."""
+
+    FORBIDDEN = (
+        'Path.cwd() / ".squidsquad"',
+        'Path(".squidsquad',
+    )
+
+    def test_no_cwd_relative_squidsquad_writes_in_experiments(self):
+        experiments = sorted(
+            (REPO_ROOT / "references" / "experiments").glob("*.py")
+        )
+        self.assertTrue(experiments, "experiments dir unexpectedly empty")
+        offenders = []
+        for py in experiments:
+            text = py.read_text(encoding="utf-8", errors="replace")
+            for pattern in self.FORBIDDEN:
+                if pattern in text:
+                    offenders.append(f"{py.name}: {pattern}")
+        self.assertEqual(
+            offenders, [],
+            "cwd-relative .squidsquad/ paths in experiments write scratch "
+            "artifacts into whichever LIVE clone the script runs from "
+            "(#13352). Use tempfile.mkdtemp for scratch output: "
+            + "; ".join(offenders),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes three observed leak classes where test/experiment runs wrote to LIVE SquidSquad surfaces (issue #13352, verifier-filed, severity:medium):

## 1. Fabricated events on the production bus
`env_with_gh_shim()` (integration fixture) did not set `SQUIDSQUAD_DIR`, so a shimmed `tracker.py transition` subprocess discovered the live `.squidsquad/.harness-port` and posted its synthetic issue-87654 `status-transition` events onto the real event bus (3 observed; each cost every agent a wake + forge-read). **Fix:** the fixture now always sets `SQUIDSQUAD_DIR` — isolated process-lifetime EMPTY tmpdir by default (no port file → `event_bus` emits are silent no-ops), new `squid_dir` param for pairing with a `real_harness`, and post-call assignment still wins.

## 2. `.harness-port` poisoned in live clones (observed 8251)
The harness lifespan's clone port distribution ran unconditionally via `boot_remote._parse_local_config()` (repo-scoped — ignores isolation), so an isolated test harness on an ephemeral port overwrote every live clone's port file, stranding those agents in polling fallback at their next boot probe. **Fix:** distribution extracted to `_distribute_port_to_clones()` with a production-only guard — distributes only when `SQUIDSQUAD_DIR` is the repo's live `.squidsquad`; isolated harnesses log a skip. Same failure family as #12820's second-instance refusal; this closes the test-harness flank.

## 3. Experiment scratch files inside agent clones
`wt_direct_spawn_test.py` and `conpty_spike.py` wrote scratch output to cwd-relative `.squidsquad/skill/planning/` paths (the `wt-env-probe.txt` / `PROPAGATED-*` artifact qa found in its clone). **Fix:** scratch goes under `tempfile.mkdtemp` only; the wt probe path now travels via env var so temp paths with spaces survive cmd.exe parsing.

## Issue ask #4 (harness-boot port clearing/liveness)
Assessed in-task: the production harness already rewrites every clone's port file at each boot (the distribution above), which self-heals stale values at the next harness boot; the fix here removes the source of NEW stale values. The residual agent-side gap (agent boots against a stale port before any harness reboot) is the already-tracked finding #13356 (boot-probe default-port fallback) — kept in its own lane.

## Tests
+9 regression tests (`tests/test_13352_test_isolation_leaks.py`): fixture isolation (incl. end-to-end subprocess no-port-discovery and outer-env override), harness guard (skip when isolated / distribute in production / self-exclusion non-vacuous), and a source-level ban on cwd-relative `.squidsquad` paths in experiments. Affected 9398 integration suites: 11/11 pass. Full static gate: PASS 5250/0/0 (re-run in flight on final tree). Sonnet review: SHIP-WITH-FIXES, all 3 findings applied (4fece99fc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)