### PR TITLE
#13355: retire pr_flow on/off prompt — PR flow is a §3 invariant, always-on

### DIFF
--- a/references/scripts/config.py
+++ b/references/scripts/config.py
@@ -218,6 +218,16 @@ _FIELD_DEFAULTS = {
     # SystemExit is a BaseException, so it would escape the harness health
     # poller's except-Exception and silently kill the whole poller on first tick.
     "context-threshold": "70",
+    # #13355 — PR flow is an INSTALLER-RUNTIME.md §3 invariant (branch+PR is
+    # the only mode, #9478 D2): a config.md missing the `## PR Flow` section
+    # reads `yes`, never sys.exit(1)s and never silently flips the runtime
+    # into a direct-commit mode that no longer exists.
+    "pr-flow": "yes",
+    # #13355 — the merge gate is the one surviving PR variable. Fresh installs
+    # always carry an explicit `## Auto Merge` section (build_config_md); for
+    # a legacy/hand-rolled config.md missing it, default to the conservative
+    # direction — a human approves each merge — rather than self-merging.
+    "auto-merge": "no",
 }
 
 

--- a/references/scripts/wizard.py
+++ b/references/scripts/wizard.py
@@ -1438,6 +1438,8 @@ _SECTION_ORDER = [
     "## Agents",
     "## Tools",
     "## Loop",
+    "## Auto Merge",  # #13355 — merge gate (the one surviving PR variable)
+    "## PR Flow",     # #13355 — §3 invariant, always Enabled: yes
     "## Flags",
 ]
 
@@ -1532,12 +1534,20 @@ def build_config_md(spec):
                 "context_threshold": 70,
             },
             "flags": {
-                "pr_flow": False,
+                "auto_merge": True,
                 "improvement_scan": True,
                 "vault_remember": True,
                 "diagnostics": True,
             },
         }
+
+    PR Flow is NOT a flag (#13355): every change lands through a reviewable
+    pull request (INSTALLER-RUNTIME.md §3 invariant; #9478 D2 — branch+PR is
+    the only mode), so the output always carries `## PR Flow / Enabled: yes`.
+    A legacy spec passing `flags.pr_flow` is ignored, never rendered. The one
+    surviving choice is the merge gate — `flags.auto_merge` (default yes)
+    renders as `## Auto Merge / Enabled` so `config.py get auto-merge` (the
+    verifier/DM merge-gate read) works on fresh installs.
 
     Returns the config.md text. Does NOT write to disk — callers persist
     the output themselves. Deterministic: same spec -> same bytes.
@@ -1615,14 +1625,37 @@ def build_config_md(spec):
     )
     lines.append("")
 
+    # --- ## Auto Merge + ## PR Flow (#13355) ---
+    # PR Flow is an INSTALLER-RUNTIME.md §3 invariant (every change lands
+    # through a reviewable PR; #9478 D2 — branch+PR is the only mode): always
+    # Enabled: yes, never spec-driven. The merge gate is the one surviving
+    # variable: flags.auto_merge (default yes — squad self-merges once
+    # verification passes; the installer asks per manual §9 and records the
+    # answer here). Both render as the dedicated sections config.py's
+    # FIELD_MAP reads (("Auto Merge","Enabled") / ("PR Flow","Enabled")) —
+    # a generic ## Flags line is invisible to those runtime reads.
+    flags = spec["flags"] or {}
+    lines.append("## Auto Merge")
+    lines.append("")
+    lines.append(f"- **Enabled**: {_render_bool(flags.get('auto_merge', True))}")
+    lines.append("")
+    lines.append("## PR Flow")
+    lines.append("")
+    lines.append("- **Enabled**: yes")
+    lines.append("")
+
     # --- ## Flags ---
     lines.append("## Flags")
     lines.append("")
-    flags = spec["flags"] or {}
-    # Emit in deterministic order regardless of dict insertion
-    for key in sorted(flags):
-        lines.append(f"- **{_flag_label(key)}**: {_render_bool(flags[key])}")
-    if not flags:
+    # Emit in deterministic order regardless of dict insertion. pr_flow and
+    # auto_merge never render here: pr_flow is retired (legacy specs may still
+    # carry it — ignored), auto_merge has its dedicated section above.
+    render_flags = {k: v for k, v in flags.items()
+                    if k not in ("pr_flow", "auto_merge")}
+    for key in sorted(render_flags):
+        lines.append(
+            f"- **{_flag_label(key)}**: {_render_bool(render_flags[key])}")
+    if not render_flags:
         lines.append("- (none)")
     lines.append("")
 
@@ -3428,20 +3461,11 @@ def cmd_merge_deny_list(args):
     return 0 if result.get("ok") else 1
 
 
-def pr_flow_prompt():
-    """Return the PR Flow question text and options for the setup agent."""
-    return {
-        "question": (
-            "Do you want Pull Request review flow enabled?\n\n"
-            "**PR Flow OFF** (default): Agents commit directly to the working branch. "
-            "Code lands immediately. Faster iteration, less overhead per change.\n\n"
-            "**PR Flow ON**: Agents create feature branches and open Pull Requests. "
-            "Code only lands after you review and merge each PR. "
-            "Gives you a review gate on every change."
-        ),
-        "options": ["Off (default — direct commits)", "On (PRs for every change)"],
-        "default": False,
-    }
+# pr_flow_prompt removed in #13355 — PR flow is an INSTALLER-RUNTIME.md §3
+# invariant (every change lands through a reviewable PR; #9478 D2: branch+PR
+# is the only mode), so the installer never offers an on/off choice. The one
+# surviving question is the merge gate — see build_config_md's Auto Merge
+# section and the manual's §9 merge-gate framing.
 
 
 def post_setup_summary(spec):
@@ -3673,7 +3697,10 @@ def generate_default_spec(scan_data=None, repo_info=None):
             "context_threshold": 70,
         },
         "flags": {
-            "pr_flow": False,
+            # #13355: pr_flow retired — PR flow is a §3 invariant, not a
+            # spec choice. auto_merge is the surviving merge-gate variable
+            # (default yes: squad self-merges once verification passes).
+            "auto_merge": True,
             "improvement_scan": True,
             "vault_remember": True,
             "diagnostics": True,
@@ -3907,10 +3934,7 @@ def cmd_setup_yes(args):
     return 0
 
 
-def cmd_pr_flow_prompt(_args):
-    """Print the PR Flow question and options as JSON."""
-    _print_json(pr_flow_prompt())
-    return 0
+# cmd_pr_flow_prompt removed in #13355 (see pr_flow_prompt tombstone above).
 
 
 def cmd_post_setup_summary(args):
@@ -3996,7 +4020,6 @@ def main():
         "list-issues-by-label": cmd_list_issues_by_label,
         "migrate-label": cmd_migrate_label,
         "migrate-labels-staged": cmd_migrate_labels_staged,
-        "pr-flow-prompt": cmd_pr_flow_prompt,
         "post-setup-summary": cmd_post_setup_summary,
         "load-spec": cmd_load_spec,
         "save-spec": cmd_save_spec,

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -599,6 +599,8 @@ class TestBuildConfigMdStructure:
             "## Agents",
             "## Tools",
             "## Loop",
+            "## Auto Merge",  # #13355
+            "## PR Flow",  # #13355
             "## Flags",
             "## Improvement Scanning",  # #11091
             "## Verbose Mode",  # #13162
@@ -848,9 +850,9 @@ class TestBuildConfigMdLoopAndFlags:
 
     def test_bool_flags_rendered_as_yes_no(self):
         spec = _minimal_spec()
-        spec["flags"] = {"pr_flow": True, "diagnostics": False}
+        spec["flags"] = {"vault_remember": True, "diagnostics": False}
         text = wizard.build_config_md(spec)
-        assert "**Pr Flow**: yes" in text
+        assert "**Vault Remember**: yes" in text
         assert "**Diagnostics**: no" in text
 
     def test_no_flags_emits_none_marker(self):
@@ -2237,28 +2239,10 @@ class TestSoulMdSeeding:
 # ---------------------------------------------------------------------------
 
 
-class TestPrFlowPrompt:
-    """PR Flow question returns structured data for agent to present."""
-
-    def test_returns_question_and_options(self):
-        result = wizard.pr_flow_prompt()
-        assert "question" in result
-        assert "options" in result
-        assert "default" in result
-        assert result["default"] is False
-
-    def test_question_uses_plain_language(self):
-        result = wizard.pr_flow_prompt()
-        q = result["question"]
-        assert "PR Flow OFF" in q
-        assert "PR Flow ON" in q
-        # No internal jargon
-        assert "Ralph Loop" not in q
-        assert "tracker.py" not in q
-
-    def test_has_two_options(self):
-        result = wizard.pr_flow_prompt()
-        assert len(result["options"]) == 2
+# TestPrFlowPrompt removed in #13355 — pr_flow_prompt was deleted from
+# wizard.py because PR flow is an INSTALLER-RUNTIME.md §3 invariant (never
+# an on/off question); the merge gate (Auto Merge) is the surviving
+# variable. See tests/test_wizard_13355_pr_flow_invariant.py.
 
 
 # TestBranchWorkflowPrompt removed in #9478 — branch_workflow_prompt

--- a/tests/test_wizard_13355_pr_flow_invariant.py
+++ b/tests/test_wizard_13355_pr_flow_invariant.py
@@ -1,0 +1,124 @@
+"""#13355 — retire the PR-flow on/off prompt; PR flow is always-on.
+
+INSTALLER-RUNTIME.md §3 makes PR flow an invariant (every change lands
+through a reviewable pull request; direct commits are never offered) and
+the harness has treated branch+PR as the only mode since #9478 D2 — yet
+wizard.py still shipped `pr_flow_prompt()` defaulting to OFF (direct
+commits), and `build_config_md` rendered the flag as a generic
+`- **Pr Flow**:` line under `## Flags` that `config.py`'s FIELD_MAP
+(`("PR Flow", "Enabled")`) never reads — so fresh installs had NO
+`## PR Flow` section at all and the runtime read pr-flow as absent.
+Same gap for the merge gate: the manual's §9 says to record the Auto
+Merge answer in config, but nothing emitted an `## Auto Merge` section,
+and `config.py get auto-merge` (the verifier/DM merge-gate read)
+sys.exit(1)s on a missing field with no registered default.
+
+This suite locks the retirement and the wiring:
+- the prompt trio (function, cmd wrapper, CLI dispatch) is gone;
+- config.md always ships `## PR Flow / Enabled: yes` (invariant — a
+  legacy spec's `pr_flow: False` is ignored, never rendered);
+- the merge gate renders as `## Auto Merge / Enabled` from
+  `flags.auto_merge` (default yes);
+- runtime graceful defaults: pr-flow → yes (the only mode), auto-merge →
+  no (conservative human gate) for configs missing the sections.
+"""
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "references" / "scripts"))
+
+import config  # noqa: E402
+import wizard  # noqa: E402
+
+WIZARD_PY = REPO_ROOT / "references" / "scripts" / "wizard.py"
+
+
+def _spec(flags):
+    return {
+        "project": {"name": "t", "repo": "o/r"},
+        "preset": "software-dev",
+        "agents": [
+            {"id": "pm", "alias": "pm", "role": "pm"},
+        ],
+        "tools": {},
+        "loop": {"interval_minutes": 30, "context_threshold": 70},
+        "flags": flags,
+    }
+
+
+class TestPromptRetired(unittest.TestCase):
+    def test_prompt_functions_gone(self):
+        self.assertFalse(hasattr(wizard, "pr_flow_prompt"))
+        self.assertFalse(hasattr(wizard, "cmd_pr_flow_prompt"))
+
+    def test_cli_command_gone(self):
+        proc = subprocess.run(
+            [sys.executable, str(WIZARD_PY), "pr-flow-prompt"],
+            capture_output=True, text=True, encoding="utf-8",
+            errors="replace", timeout=60, check=False,
+            cwd=str(REPO_ROOT),
+        )
+        self.assertNotEqual(
+            proc.returncode, 0,
+            "pr-flow-prompt must no longer be a wizard.py subcommand",
+        )
+
+
+class TestPrFlowSectionInvariant(unittest.TestCase):
+    def test_always_enabled_yes(self):
+        text = wizard.build_config_md(_spec({"improvement_scan": True}))
+        self.assertIn("## PR Flow\n\n- **Enabled**: yes", text)
+
+    def test_legacy_pr_flow_false_is_ignored(self):
+        """A pre-#13355 spec still carrying pr_flow: False cannot turn the
+        invariant off — and the retired flag never renders anywhere."""
+        text = wizard.build_config_md(_spec({"pr_flow": False}))
+        self.assertIn("## PR Flow\n\n- **Enabled**: yes", text)
+        self.assertNotIn("**Pr Flow**", text)
+
+    def test_runtime_reads_yes_from_rendered_config(self):
+        """End-to-end: the section build_config_md emits is the one the
+        runtime FIELD_MAP actually reads."""
+        text = wizard.build_config_md(_spec({}))
+        val = config._parse_field(text, "PR Flow", "Enabled")
+        self.assertEqual(val, "yes")
+
+
+class TestAutoMergeSection(unittest.TestCase):
+    def test_defaults_to_yes(self):
+        text = wizard.build_config_md(_spec({"improvement_scan": True}))
+        self.assertIn("## Auto Merge\n\n- **Enabled**: yes", text)
+
+    def test_spec_no_renders_no(self):
+        """The merge gate is the surviving variable — a 'human approves
+        each merge' answer flows through to the section."""
+        text = wizard.build_config_md(_spec({"auto_merge": False}))
+        self.assertIn("## Auto Merge\n\n- **Enabled**: no", text)
+        val = config._parse_field(text, "Auto Merge", "Enabled")
+        self.assertEqual(val, "no")
+
+    def test_auto_merge_not_duplicated_under_flags(self):
+        text = wizard.build_config_md(_spec({"auto_merge": True}))
+        flags_block = text.split("## Flags")[1].split("## ")[0]
+        self.assertNotIn("Auto Merge", flags_block)
+
+    def test_generate_default_spec_carries_auto_merge_not_pr_flow(self):
+        spec = wizard.generate_default_spec()
+        self.assertNotIn("pr_flow", spec["flags"])
+        self.assertIs(spec["flags"]["auto_merge"], True)
+
+
+class TestRuntimeGracefulDefaults(unittest.TestCase):
+    def test_pr_flow_defaults_yes(self):
+        self.assertEqual(config._FIELD_DEFAULTS.get("pr-flow"), "yes")
+
+    def test_auto_merge_defaults_no(self):
+        self.assertEqual(config._FIELD_DEFAULTS.get("auto-merge"), "no")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wizard_runbook.py
+++ b/tests/test_wizard_runbook.py
@@ -38,7 +38,9 @@ _WIZARD_COMMANDS = {
     "check-gh", "check-existing", "repo-info", "project-name-default",
     "validate-name", "validate-rerun-action", "build-config-md",
     "scaffold", "ensure-labels", "list-issues-by-label", "migrate-label",
-    "pr-flow-prompt",
+    # pr-flow-prompt retired in #13355 (PR flow is a §3 invariant, never a
+    # choice) — the command no longer exists, so a manual mention of it now
+    # fails this suite's exists-check instead of passing an allowlist.
     # #11613 §4.1 Phase 0 gather-all dependency provisioning.
     "gather-deps", "provision-deps",
     # #12419 §10 existing-install migration walk.
@@ -193,8 +195,8 @@ class TestManualStructure:
     def test_pr_flow_is_invariant_not_a_choice(self, manual):
         """PR flow is a §3 invariant (change lands through review); the manual
         must never offer a PR-flow on/off choice — only the merge gate is a
-        variable. `pr-flow-prompt` is drifted wizard.py surface (#9478 D2);
-        its retirement is a sibling task — the manual must not carry it."""
+        variable. `pr-flow-prompt` was drifted wizard.py surface (#9478 D2),
+        retired in #13355 — the manual must not carry it."""
         assert "pr-flow-prompt" not in manual, (
             "Manual offers the retired 'PR flow on/off' choice — PR flow is "
             "an invariant; only the merge gate (Auto Merge) is a variable"


### PR DESCRIPTION
## #13355 — Retire the PR-flow on/off prompt; PR flow is a §3 invariant (always-on)

INSTALLER-RUNTIME.md §3 makes PR flow an invariant (every change lands through a reviewable PR; direct commit never offered) and the harness has treated branch+PR as the only mode since #9478 D2 — but wizard.py still shipped an on/off question defaulting to OFF (direct commits), and rendered the flag as a generic "- **Pr Flow**:" line under ## Flags that config.py's FIELD_MAP (("PR Flow","Enabled")) never reads. Fresh installs had NO ## PR Flow section, so the runtime read pr-flow as absent.

### Acceptance criteria
- [x] Retire pr_flow_prompt() + cmd_pr_flow_prompt() + the `pr-flow-prompt` CLI dispatch entry (tombstoned with #13355/#9478 rationale).
- [x] Default PR flow always-on: build_config_md emits a dedicated `## PR Flow` section with Enabled: yes, never spec-driven. A legacy spec's flags.pr_flow is ignored and never rendered.
- [x] Surviving variable = the merge gate: flags.auto_merge (default yes) renders as `## Auto Merge / Enabled` — the section config.py get auto-merge reads.
- [x] Tests updated: TestPrFlowPrompt removed, new test_wizard_13355_pr_flow_invariant.py, section-order/bool-render retargeted, pr-flow-prompt out of the runbook allowlist.
- [x] Reconciles with #9478 (branch+PR is the only mode).

### Additional latent bug fixed
The old flag rendered under ## Flags as "- **Pr Flow**:" was invisible to config.py's FIELD_MAP (expects a ## PR Flow section). Both PR Flow and Auto Merge now emit as the dedicated sections the runtime actually reads, wired end-to-end (test_runtime_reads_yes_from_rendered_config / Auto Merge parse test).

### config.py graceful defaults (#13335-class fail-safe)
- pr-flow → yes (the only mode; a config.md missing the section never sys.exit(1)s into a nonexistent direct-commit runtime).
- auto-merge → no (conservative human gate for a legacy config lacking the section).

### Notes for the verifier
- Full static gate green: 5294 gated, 0 failures, 0 errors.
- Independent Sonnet review: SHIP, no blockers (config round-trip, section order, no dangling callers, None-safe rendering, legacy-spec-ignored all confirmed).
- No CQ spec: this task changes only deterministic wizard.py/config.py + tests and REMOVES an LLM-consumed prompt; the agent-facing runbook (INSTALLER-RUNTIME.md §3/§9) was updated under #13336 with its own CQ and is unchanged here. Nothing new to comprehension-test.
- Doc surfaces already consistent: INSTALLER-RUNTIME.md:211 (no PR-flow choice, capture merge gate) landed in #13336; docs/CONFIGURATION.md documents PR Flow → Enabled: yes default. No repoints needed.

Reported by: operator. Part of the INSTALLER-RUNTIME.md implementation set (sibling to #13336–#13339, #13327/#13328/#13329).