### PR TITLE
#13328: retire loop-interval prompt; write interval to the section config reads

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -388,7 +388,8 @@ Check for and add these sections if missing (with defaults):
 
 - `## Preset` — `Id: software-dev`
 - `## Tools` — `(none)`
-- `## Loop` — `Interval Minutes: [existing interval value]`, `Context Threshold: [existing threshold value]`
+- `## Iteration Interval` — `Minutes: [existing interval value, or 30]` (the polling-fallback cadence; config.py reads it here, not under the old `## Loop` heading)
+- `## Context Pressure` — `Threshold: [existing threshold value, or 70]`
 - `## Flags` — `Diagnostics: yes`, `Improvement Scan: [existing value]`, `PR Flow: [existing value]`, `Vault Remember: [existing value]`
 - `## Git Branches` — `Working Branch: [existing value or main]`, `State Branch: [existing value or squid-squad]`
 - `## Forge Backend` — `Provider: github`, `Endpoint: https://api.github.com`

--- a/references/scripts/config.py
+++ b/references/scripts/config.py
@@ -218,6 +218,12 @@ _FIELD_DEFAULTS = {
     # SystemExit is a BaseException, so it would escape the harness health
     # poller's except-Exception and silently kill the whole poller on first tick.
     "context-threshold": "70",
+    # #13328 — polling-fallback cadence. Event mode is the always-on default and
+    # the loop is a boot-time fallback, so the interval is never prompted; a
+    # config.md missing the `## Iteration Interval` section reads 30 minutes
+    # rather than sys.exit(1)ing (the section used to be mis-written under a dead
+    # `## Loop` heading — same drift class as PR Flow, #13355).
+    "interval": "30",
     # #13355 — PR flow is an INSTALLER-RUNTIME.md §3 invariant (branch+PR is
     # the only mode, #9478 D2): a config.md missing the `## PR Flow` section
     # reads `yes`, never sys.exit(1)s and never silently flips the runtime

--- a/references/scripts/wizard.py
+++ b/references/scripts/wizard.py
@@ -1251,49 +1251,13 @@ def is_valid_project_name(name):
     return bool(_PROJECT_NAME_ALLOWED.match(name))
 
 
-def validate_interval(value, default=10):
-    """Parse and validate the Ralph Loop interval (Step 5, TC-49..TC-52).
-
-    Accepts any string-ish value the user might type. Returns a dict:
-
-        {"ok": bool, "minutes": int | None, "reason": str | None}
-
-    Rules:
-      - Empty string or None -> ok with minutes=default
-      - Whole integer >= 1 -> ok
-      - Zero, negative, float-ish, or non-numeric -> not ok, with a
-        user-facing reason the runbook can surface as a re-prompt
-    """
-    if value is None or (isinstance(value, str) and value.strip() == ""):
-        return {
-            "ok": True,
-            "minutes": int(default),
-            "reason": f"empty input — defaulting to {default} minutes",
-        }
-
-    raw = str(value).strip()
-    # Reject float-looking input explicitly so "10.5" doesn't silently truncate
-    if "." in raw or "," in raw:
-        return {
-            "ok": False,
-            "minutes": None,
-            "reason": f"{raw!r} must be a whole number of minutes",
-        }
-    try:
-        minutes = int(raw)
-    except ValueError:
-        return {
-            "ok": False,
-            "minutes": None,
-            "reason": f"{raw!r} is not a number — enter an integer minute count",
-        }
-    if minutes < 1:
-        return {
-            "ok": False,
-            "minutes": None,
-            "reason": f"interval must be at least 1 minute (got {minutes})",
-        }
-    return {"ok": True, "minutes": minutes, "reason": None}
+# validate_interval + the loop-interval prompt removed in #13328 — the polling
+# interval is NOT a setup question. Event mode is the always-on default and the
+# loop is an automatic boot-time fallback (INSTALLER-RUNTIME.md §5); prompting
+# the user to tune a fallback's cadence was stale and its "how often should each
+# agent run its cycle?" framing was misleading. build_config_md now writes the
+# ## Iteration Interval / Minutes field with a silent 30-minute default, and
+# config.py carries a matching graceful default.
 
 
 def project_name_default(base_dir=None):
@@ -1437,7 +1401,8 @@ _SECTION_ORDER = [
     "## Preset",
     "## Agents",
     "## Tools",
-    "## Loop",
+    "## Iteration Interval",  # #13328 — polling-fallback cadence (silent 30m default)
+    "## Context Pressure",    # #13328 — moved from the dead ## Loop section
     "## Auto Merge",  # #13355 — merge gate (the one surviving PR variable)
     "## PR Flow",     # #13355 — §3 invariant, always Enabled: yes
     "## Flags",
@@ -1530,7 +1495,7 @@ def build_config_md(spec):
                 "dm.tool": "local_delivery",
             },
             "loop": {
-                "interval_minutes": 10,
+                "interval_minutes": 30,
                 "context_threshold": 70,
             },
             "flags": {
@@ -1615,14 +1580,24 @@ def build_config_md(spec):
         lines.append("- (none)")
     lines.append("")
 
-    # --- ## Loop ---
-    lines.append("## Loop")
-    lines.append("")
+    # --- ## Iteration Interval + ## Context Pressure (#13328) ---
+    # These are the section/field names config.py's FIELD_MAP actually reads
+    # (("Iteration Interval","Minutes") / ("Context Pressure","Threshold")).
+    # The former ## Loop section wrote both fields under a heading nobody read,
+    # so config get interval / context-threshold saw them as absent and fell
+    # back to defaults (#13328 — same drift class as #13355's PR Flow mismatch).
+    # The interval is the polling-fallback cadence ONLY: event mode is the
+    # always-on default and the loop is an automatic boot-time fallback
+    # (INSTALLER-RUNTIME.md §5), so it is never a setup question — a silent
+    # 30-minute default, raised only if the user explicitly asks.
     loop = spec["loop"] or {}
-    lines.append(f"- **Interval Minutes**: {loop.get('interval_minutes', 10)}")
-    lines.append(
-        f"- **Context Threshold**: {loop.get('context_threshold', 70)}"
-    )
+    lines.append("## Iteration Interval")
+    lines.append("")
+    lines.append(f"- **Minutes**: {loop.get('interval_minutes', 30)}")
+    lines.append("")
+    lines.append("## Context Pressure")
+    lines.append("")
+    lines.append(f"- **Threshold**: {loop.get('context_threshold', 70)}")
     lines.append("")
 
     # --- ## Auto Merge + ## PR Flow (#13355) ---
@@ -3076,27 +3051,8 @@ def cmd_validate_name(args):
     return 0 if valid else 1
 
 
-def cmd_validate_interval(args):
-    """Usage: wizard.py validate-interval <value> [--default N]"""
-    if not args:
-        print(
-            "Usage: wizard.py validate-interval <value> [--default N]",
-            file=sys.stderr,
-        )
-        return 2
-    value = args[0]
-    default = 10
-    if "--default" in args:
-        idx = args.index("--default")
-        if idx + 1 < len(args):
-            try:
-                default = int(args[idx + 1])
-            except ValueError:
-                print(f"ERROR: --default must be an integer", file=sys.stderr)
-                return 2
-    result = validate_interval(value, default=default)
-    _print_json(result, ok=result["ok"])
-    return 0 if result["ok"] else 1
+# cmd_validate_interval removed in #13328 (see the validate_interval tombstone
+# above) — there is no loop-interval prompt for it to back.
 
 
 def cmd_build_config_md(args):
@@ -4012,7 +3968,6 @@ def main():
         "repo-info": cmd_repo_info,
         "project-name-default": cmd_project_name_default,
         "validate-name": cmd_validate_name,
-        "validate-interval": cmd_validate_interval,
         "validate-rerun-action": cmd_validate_rerun_action,
         "build-config-md": cmd_build_config_md,
         "scaffold": cmd_scaffold,

--- a/tests/comprehension/13328_spec.json
+++ b/tests/comprehension/13328_spec.json
@@ -1,0 +1,30 @@
+{
+  "issue": 13328,
+  "title": "Loop is a fallback, not a user-configured mode — INSTALLER-RUNTIME.md §5 runtime model + §8 do/don't + §9 silent-default interval comprehension",
+  "source_file": "docs/INSTALLER-RUNTIME.md",
+  "section": "§5 The runtime model — convey it correctly + §8 Do / don't + §9 Steps 3 & 5–6 (Config values with silent defaults)",
+  "method": "Fresh agent given ONLY the named sections (§5 The runtime model, §8 Do/Don't, §9 'Config values with silent defaults'), no other context. Answers must come from the text alone. Scenario framing: 'You are the installer agent walking a user through setup.' Pass = the event-mode-default / loop-fallback contract survives with zero drift: event mode is the always-on normal case; the loop/polling is an automatic boot-time fallback used only when an agent finds the harness unreachable; the interval is NEVER a headline question and the user is never asked to tune a cadence; a sensible 30-minute fallback interval is written to config silently, raised only if the user explicitly asks. Any answer that presents loops/cycles as the operating model, asks the user to choose or tune the cycle cadence, or frames the interval as a normal-operation setting is a reject.",
+  "model": "sonnet",
+  "questions": [
+    {
+      "id": "CQ1",
+      "q": "The user asks 'how often will my agents run — what cycle time should I set?' How do you answer, and do you offer them a cadence setting?",
+      "expected": "Don't offer a cadence setting. Agents are event-driven: they are woken by events on the harness event bus (changes on the forge) and react one event at a time, treating the forge as the source of truth — they do NOT run on a fixed timer in normal operation. Explain it in those terms; never present loops/cycles as the operating model or ask the user to tune a cadence. (§5 / §8 Don't: 'Present loops or cycles as the operating model, or ask the user to tune a cadence.')"
+    },
+    {
+      "id": "CQ2",
+      "q": "What actually is the polling loop, and when does it run? Is it a mode the user chooses?",
+      "expected": "The loop is a fallback, not a mode the user chooses. Polling is an automatic boot-time fallback used only when an agent finds the harness unreachable — event mode is the default and the normal case. The harness owns agent lifecycle (start, stop, restart, health, crash recovery). The user never selects loop mode."
+    },
+    {
+      "id": "CQ3",
+      "q": "A polling-fallback interval still has to exist in the config. What value goes there and how is it decided — do you ask the user?",
+      "expected": "A sensible default (30 minutes) is written to config silently — it is never a headline question. Config values with silent defaults (the polling-fallback interval and the context-pressure threshold, default 70) are written with their defaults unless the user explicitly raises them. You do not ask the user to set the interval; it is a fallback cadence, never a normal-operation setting."
+    },
+    {
+      "id": "CQ4",
+      "q": "Draft one sentence you'd say to the user about how their team runs day to day. What must it NOT imply?",
+      "expected": "The sentence must present the team as event-driven / always-on and responsive to changes on the forge — e.g. 'Your team runs continuously and reacts the moment there's something to do — you don't set a schedule or a cycle time.' It must NOT imply the team runs on a fixed loop/cycle by default, and must not surface a cadence/interval as a setting the user tunes."
+    }
+  ]
+}

--- a/tests/test_feat328_coverage.py
+++ b/tests/test_feat328_coverage.py
@@ -57,78 +57,11 @@ class TestTC47EmptySetupRequirements:
         assert ids == ["variant", "stack"]
 
 
-# ---------------------------------------------------------------------------
-# TC-49..TC-52 — Loop interval validation
-# ---------------------------------------------------------------------------
-
-
-class TestTC49To52IntervalValidation:
-    """Step 5 interval input must be an integer >= 1."""
-
-    def test_tc49_accepts_integer_10(self):
-        r = wizard.validate_interval("10")
-        assert r["ok"] is True
-        assert r["minutes"] == 10
-
-    def test_accepts_integer_1(self):
-        assert wizard.validate_interval("1")["minutes"] == 1
-
-    def test_accepts_integer_high(self):
-        assert wizard.validate_interval("60")["minutes"] == 60
-
-    def test_accepts_native_int(self):
-        r = wizard.validate_interval(5)
-        assert r["ok"] is True
-        assert r["minutes"] == 5
-
-    def test_tc50_rejects_zero(self):
-        r = wizard.validate_interval("0")
-        assert r["ok"] is False
-        assert "at least 1" in r["reason"]
-
-    def test_tc51_rejects_negative(self):
-        r = wizard.validate_interval("-5")
-        assert r["ok"] is False
-        assert r["minutes"] is None
-
-    def test_tc52_rejects_non_numeric(self):
-        r = wizard.validate_interval("abc")
-        assert r["ok"] is False
-        assert "not a number" in r["reason"]
-
-    def test_rejects_float(self):
-        r = wizard.validate_interval("10.5")
-        assert r["ok"] is False
-        assert "whole number" in r["reason"]
-
-    def test_rejects_comma_float(self):
-        """European-locale numeric should be rejected, not silently parsed."""
-        r = wizard.validate_interval("1,5")
-        assert r["ok"] is False
-
-    def test_empty_string_uses_default(self):
-        r = wizard.validate_interval("")
-        assert r["ok"] is True
-        assert r["minutes"] == 10
-
-    def test_none_uses_default(self):
-        r = wizard.validate_interval(None)
-        assert r["ok"] is True
-        assert r["minutes"] == 10
-
-    def test_whitespace_only_uses_default(self):
-        r = wizard.validate_interval("   ")
-        assert r["ok"] is True
-        assert r["minutes"] == 10
-
-    def test_custom_default_respected(self):
-        r = wizard.validate_interval("", default=30)
-        assert r["minutes"] == 30
-
-    def test_whitespace_around_integer_ok(self):
-        r = wizard.validate_interval("  15  ")
-        assert r["ok"] is True
-        assert r["minutes"] == 15
+# TC-49..TC-52 (loop interval validation) removed in #13328 — validate_interval
+# and the interactive loop-interval prompt were retired because the polling
+# interval is not a setup question (event mode is the default; the loop is a
+# boot-time fallback). The silent 30-minute default is covered by
+# tests/test_wizard_13328_interval_silent_default.py.
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -306,66 +306,12 @@ class TestValidateRerunAction:
         assert wizard.validate_rerun_action(raw) is None
 
 
-# ===========================================================================
-# validate_interval (#7947, TC-49..TC-52)
-# ===========================================================================
-
-
-class TestValidateInterval:
-    """Tests for validate_interval — Ralph Loop interval validation."""
-
-    @pytest.mark.parametrize("value,expected_minutes", [
-        ("10", 10),
-        ("1", 1),
-        ("30", 30),
-        ("120", 120),
-        (" 15 ", 15),  # whitespace trimmed
-    ])
-    def test_valid_integers(self, value, expected_minutes):
-        result = wizard.validate_interval(value)
-        assert result["ok"] is True
-        assert result["minutes"] == expected_minutes
-        assert result["reason"] is None
-
-    @pytest.mark.parametrize("value", [
-        "", "  ", None,
-    ])
-    def test_empty_input_returns_default(self, value):
-        result = wizard.validate_interval(value)
-        assert result["ok"] is True
-        assert result["minutes"] == 10  # default
-
-    def test_empty_input_custom_default(self):
-        result = wizard.validate_interval("", default=30)
-        assert result["ok"] is True
-        assert result["minutes"] == 30
-
-    @pytest.mark.parametrize("value", [
-        "10.5", "3.0", "1,5", "0.1",
-    ])
-    def test_float_rejected(self, value):
-        result = wizard.validate_interval(value)
-        assert result["ok"] is False
-        assert result["minutes"] is None
-        assert "whole number" in result["reason"]
-
-    @pytest.mark.parametrize("value", [
-        "0", "-1", "-100",
-    ])
-    def test_zero_and_negative_rejected(self, value):
-        result = wizard.validate_interval(value)
-        assert result["ok"] is False
-        assert result["minutes"] is None
-        assert "at least 1" in result["reason"]
-
-    @pytest.mark.parametrize("value", [
-        "abc", "ten", "!@#", "5m",
-    ])
-    def test_non_numeric_rejected(self, value):
-        result = wizard.validate_interval(value)
-        assert result["ok"] is False
-        assert result["minutes"] is None
-        assert "not a number" in result["reason"]
+# TestValidateInterval (TC-49..TC-52) removed in #13328 — validate_interval and
+# the loop-interval prompt were retired from wizard.py because the polling
+# interval is not a setup question (event mode is the default; the loop is a
+# boot-time fallback). The interval now lands as a silent 30-minute default via
+# build_config_md's ## Iteration Interval section; see
+# tests/test_wizard_13328_interval_silent_default.py.
 
 
 # ===========================================================================
@@ -598,7 +544,8 @@ class TestBuildConfigMdStructure:
             "## Preset",
             "## Agents",
             "## Tools",
-            "## Loop",
+            "## Iteration Interval",  # #13328
+            "## Context Pressure",  # #13328
             "## Auto Merge",  # #13355
             "## PR Flow",  # #13355
             "## Flags",
@@ -828,12 +775,15 @@ class TestBuildConfigMdToolsSection:
 
 
 class TestBuildConfigMdLoopAndFlags:
-    def test_loop_interval_and_threshold(self):
+    def test_iteration_interval_and_context_pressure(self):
+        # #13328 — interval + threshold render under the sections config.py's
+        # FIELD_MAP actually reads (## Iteration Interval / ## Context Pressure),
+        # not the dead ## Loop heading.
         spec = _minimal_spec()
         spec["loop"] = {"interval_minutes": 5, "context_threshold": 75}
         text = wizard.build_config_md(spec)
-        assert "- **Interval Minutes**: 5" in text
-        assert "- **Context Threshold**: 75" in text
+        assert "## Iteration Interval\n\n- **Minutes**: 5" in text
+        assert "## Context Pressure\n\n- **Threshold**: 75" in text
 
     def test_flags_sorted_alphabetically(self):
         spec = _minimal_spec()
@@ -863,11 +813,12 @@ class TestBuildConfigMdLoopAndFlags:
         assert "(none)" in flags_block
 
     def test_loop_defaults_when_fields_missing(self):
+        # #13328 — silent defaults: interval 30 (polling fallback), threshold 70.
         spec = _minimal_spec()
         spec["loop"] = {}
         text = wizard.build_config_md(spec)
-        assert "- **Interval Minutes**: 10" in text
-        assert "- **Context Threshold**: 70" in text
+        assert "- **Minutes**: 30" in text
+        assert "- **Threshold**: 70" in text
 
 
 class TestBuildConfigMdValidation:

--- a/tests/test_wizard_13328_interval_silent_default.py
+++ b/tests/test_wizard_13328_interval_silent_default.py
@@ -1,0 +1,102 @@
+"""#13328 — retire the loop-interval prompt; interval is a silent fallback default.
+
+Operator feedback (live greenfield install): the setup wizard shouldn't ask the
+user for a loop/iteration duration. Event mode is the always-on default and the
+loop is only an automatic boot-time fallback when the harness is unreachable
+(INSTALLER-RUNTIME.md §5), so prompting the user to tune a fallback's cadence is
+stale and the "how often should each agent run its cycle?" framing is misleading.
+
+This suite locks the retirement and the config wiring:
+- the prompt trio (validate_interval, cmd_validate_interval, the validate-interval
+  CLI command) is gone;
+- build_config_md writes the interval under the section config.py actually reads
+  (## Iteration Interval / Minutes), with a silent 30-minute default — NOT the
+  dead ## Loop heading the FIELD_MAP never read (the #13328 latent bug, same
+  drift class as #13355's PR Flow);
+- context-threshold likewise renders under its read section (## Context Pressure);
+- config.py carries a graceful interval default so a config.md missing the
+  section reads 30 rather than sys.exit(1)ing.
+"""
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "references" / "scripts"))
+
+import config  # noqa: E402
+import wizard  # noqa: E402
+
+WIZARD_PY = REPO_ROOT / "references" / "scripts" / "wizard.py"
+
+
+def _spec(loop):
+    return {
+        "project": {"name": "t", "repo": "o/r"},
+        "preset": "software-dev",
+        "agents": [{"id": "pm", "alias": "pm", "role": "pm"}],
+        "tools": {},
+        "loop": loop,
+        "flags": {"improvement_scan": True},
+    }
+
+
+class TestPromptRetired(unittest.TestCase):
+    def test_prompt_functions_gone(self):
+        self.assertFalse(hasattr(wizard, "validate_interval"))
+        self.assertFalse(hasattr(wizard, "cmd_validate_interval"))
+
+    def test_cli_command_gone(self):
+        proc = subprocess.run(
+            [sys.executable, str(WIZARD_PY), "validate-interval", "10"],
+            capture_output=True, text=True, encoding="utf-8",
+            errors="replace", timeout=60, check=False, cwd=str(REPO_ROOT),
+        )
+        self.assertNotEqual(
+            proc.returncode, 0,
+            "validate-interval must no longer be a wizard.py subcommand")
+
+
+class TestIntervalSection(unittest.TestCase):
+    def test_no_dead_loop_section(self):
+        text = wizard.build_config_md(_spec({}))
+        self.assertNotIn("## Loop", text)
+
+    def test_silent_default_30(self):
+        text = wizard.build_config_md(_spec({}))
+        self.assertIn("## Iteration Interval\n\n- **Minutes**: 30", text)
+
+    def test_spec_value_renders(self):
+        text = wizard.build_config_md(_spec({"interval_minutes": 15}))
+        self.assertIn("## Iteration Interval\n\n- **Minutes**: 15", text)
+
+    def test_context_pressure_section_default(self):
+        text = wizard.build_config_md(_spec({}))
+        self.assertIn("## Context Pressure\n\n- **Threshold**: 70", text)
+
+    def test_interval_reads_back_from_rendered_config(self):
+        """End-to-end: the section build_config_md emits is the one config.py's
+        FIELD_MAP actually reads (the #13328 fix)."""
+        text = wizard.build_config_md(_spec({}))
+        self.assertEqual(config._parse_field(text, "Iteration Interval", "Minutes"), "30")
+
+    def test_threshold_reads_back_from_rendered_config(self):
+        text = wizard.build_config_md(_spec({"context_threshold": 80}))
+        self.assertEqual(config._parse_field(text, "Context Pressure", "Threshold"), "80")
+
+
+class TestRuntimeGracefulDefault(unittest.TestCase):
+    def test_interval_defaults_to_30(self):
+        self.assertEqual(config._FIELD_DEFAULTS.get("interval"), "30")
+
+
+class TestGeneratedSpec(unittest.TestCase):
+    def test_generate_default_spec_interval_is_30(self):
+        spec = wizard.generate_default_spec()
+        self.assertEqual(spec["loop"]["interval_minutes"], 30)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## #13328 — Remove the loop-interval prompt; the interval is a silent fallback default

Operator feedback (live greenfield install): the setup wizard shouldn't ask for a loop/iteration duration. **Event mode is the always-on default; the loop is only an automatic boot-time fallback when the harness is unreachable** (INSTALLER-RUNTIME.md §5). Prompting the user to tune a fallback's cadence is stale, and the "how often should each agent run its cycle?" framing is misleading.

### Note on the issue body
It references `references/wizard/WIZARD.md` Step 5, but **WIZARD.md was deleted in #13336** — INSTALLER-RUNTIME.md is now the runbook and already frames the interval as a silent 30-min fallback (§5/§8/§9) with no `validate-interval` reference. So the runbook/messaging side was already done; this PR is the wizard.py/config side.

### Acceptance criteria
- [x] A fresh wizard run does not prompt for the interval — `validate_interval` + `cmd_validate_interval` + the `validate-interval` CLI command are retired (tombstoned).
- [x] config.md still receives a valid Iteration Interval default (polling fallback functional) — see the latent bug below.
- [x] The summary no longer implies a fixed loop — `post_setup_summary` already had no "Loop: N minutes" line (the stale one was in the deleted WIZARD.md).
- [x] Step 5 tests (TC-49..52) updated/removed — no orphans.
- [x] Comprehension: `13328_spec.json` locks event-mode-default / loop-fallback messaging.

### Latent bug fixed (same class as #13355's PR Flow mismatch)
`build_config_md` wrote the interval + threshold under a **dead `## Loop` heading** that `config.py`'s FIELD_MAP never read — it reads `interval` from `## Iteration Interval / Minutes` and `context-threshold` from `## Context Pressure / Threshold`. So `config._parse_field(scaffolded, "Iteration Interval", "Minutes")` returned `None`, and `interval` had no `_FIELD_DEFAULTS` entry (unlike context-threshold's "70") — `config get interval` could `sys.exit(1)`. Now:
- `build_config_md` writes `## Iteration Interval` (Minutes, silent 30 default) and `## Context Pressure` (Threshold, 70) — the sections actually read, wired end-to-end (round-trip test).
- `config.py` carries `interval: 30` graceful default (#13335-class fail-safe).
- **Same-block bonus fix:** context-threshold now lands in its read section too (`## Context Pressure`). **Zero behavior change** — both were default-backed at 30/70; #13335's harness context-pressure reader now resolves the value from a written section instead of the default (confirmed no regression).

### Also repointed
- **SKILL.md** v1→v2 migration step: `## Loop` → `## Iteration Interval` + `## Context Pressure`, so upgrading an old config stops writing the dead section (mechanical repoint, in-task).

### Verification
- Full static gate: **5281 gated, 0 failures, 0 errors.**
- CQ `13328_spec` self-checked clean via a fresh Sonnet section-scoped read (event-mode default / loop fallback / silent interval — zero drift). Yours to run live.
- Independent Sonnet code review: **SHIP** (FIELD_MAP alignment, `## Loop` fully removed, no remaining `validate_interval` callers, no #13335 regression all confirmed).

### Flags for the verifier (out of my scope)
- `.squidsquad/verifier/planning/FEAT-328-TEST-PLAN.md` TC-06 still lists `## Loop` in expected sections — a stale **verifier-owned** planning artifact (doc-only, low). Not edited (lane).
- `SKILL.md:392` still lists `PR Flow` under `## Flags` — that's residual **#13355** drift (PR Flow moved to its own section there), not #13328. Worth a follow-up cleanup for #13355.
- `tests/test_config_schema.py` `V2_FULL` fixture still uses `## Loop`, but it's never read for interval/threshold — harmless, left as-is.

Reported by: pm-lead. Part of the INSTALLER-RUNTIME.md implementation set. Reconciles with [[project_event_mode_default]].