### PR TITLE
#13327: generic customize-trigger + L4-affordance discoverability

### DIFF
--- a/docs/INSTALLER-RUNTIME.md
+++ b/docs/INSTALLER-RUNTIME.md
@@ -138,6 +138,10 @@ Describe the delivered system accurately, always in user-benefit terms:
 
 The user must leave knowing they can reshape the team any time, not just by re-running setup: they simply tell the PM how they want the team to behave — e.g. "from now on, always write tests first" or "I want to customize the workflow" — and it's saved as a durable project customization behind the scenes. This capability is built into the PM's composed instructions — nothing extra for you to set up; it's live the moment the team is composed. Surface it to the user in plain language.
 
+**Two moments make it discoverable — hit both:**
+- **When the user asks any "can I change this later?" question** during setup (about the roster, the workflow, a convention, anything) — including the open-ended "can I customize the workflow later?" — lead with the everyday affordance: *"Yes — anytime, just tell your PM how you'd like things to work (like 'from now on, always write tests first') and it sticks."* Do **not** answer only with re-running setup or the upgrade path; those are heavier fallbacks, not the everyday answer.
+- **In the hand-off summary (§4 step 9 / §9 Step 9)** — state it plainly as part of what they now have: they steer the team by talking to their PM, and changes persist as project customizations. Never expose the internal mechanism (no "L4", "compose", etc.) — describe only the benefit.
+
 ## 8. Do / don't
 
 **Do:**

--- a/references/roles/pm/instructions.md
+++ b/references/roles/pm/instructions.md
@@ -126,6 +126,8 @@ These sub-skills are invoked reactively when their trigger condition appears in 
 
 When the human gives a project-specific durable customization directive (e.g. "from now on, before X do Y"; "in this project, never Z"), invoke `l4-curation` BEFORE doing any implementation work. The sub-skill handles the elicitation dialog, the decision tree (replace / insert-before / insert-after / append), the safety-gate pipeline, and the project-customization commit. One-off requests and feature requests are explicitly NOT routed through `l4-curation` — see the sub-skill itself for the durable vs one-off vs feature-request triage.
 
+A **generic customization invitation** also routes here — you are the human's interface for reshaping the team, so recognize the open-ended ask, not just the fully-formed directive. If the human says something like "I want to customize the workflow", "I'd like to change how the team works", or "can I tweak how you all operate?" — a request to customize *without yet naming the specific rule* — do **not** answer by pointing at re-running setup or the upgrade path. Ask one short, plain-language question — e.g. "Sure — what would you like the team to do differently?" — to draw out the concrete durable directive, then invoke `l4-curation` with it exactly as above. Reshaping the team is conversational: the human simply tells you and it is saved as a durable project customization automatically — no command or re-install needed. (This is only the entry point; `l4-curation`'s elicitation dialog and safety gates are unchanged.)
+
 ### Harness recovery (when the harness itself is degraded)
 
 → run sub-skill: harness-restart

--- a/references/roles/worker/instructions.md
+++ b/references/roles/worker/instructions.md
@@ -105,6 +105,8 @@ These sub-skills are invoked reactively when their trigger condition appears in 
 
 When the human gives a project-specific durable customization directive (e.g. "from now on, before X do Y"; "in this project, never Z"), invoke `l4-curation` BEFORE doing any implementation work. The sub-skill handles the elicitation dialog, the decision tree (replace / insert-before / insert-after / append), the safety-gate pipeline, and the project-customization commit. One-off requests and feature requests are explicitly NOT routed through `l4-curation` — see the sub-skill itself for the durable vs one-off vs feature-request triage.
 
+A **generic customization invitation** also routes here — recognize the open-ended ask, not just the fully-formed directive. If the human says something like "I want to customize the workflow", "I'd like to change how the team works", or "can I tweak how you operate?" — a request to customize *without yet naming the specific rule* — do **not** answer by pointing at re-running setup or the upgrade path. Ask one short, plain-language question — e.g. "Sure — what would you like changed?" — to draw out the concrete durable directive, then invoke `l4-curation` with it exactly as above. Reshaping the team is conversational: the human simply tells you and it is saved as a durable project customization automatically — no command or re-install needed. (This is only the entry point; `l4-curation`'s elicitation dialog and safety gates are unchanged.)
+
 ### Harness recovery (when the harness itself is degraded)
 
 → run sub-skill: harness-restart

--- a/tests/comprehension/13327_spec.json
+++ b/tests/comprehension/13327_spec.json
@@ -1,0 +1,30 @@
+{
+  "issue": 13327,
+  "title": "Generic customize-invitation trigger + L4 affordance discoverability — PM 'Project customization' comprehension",
+  "source_file": "references/roles/pm/instructions.md",
+  "section": "### Project customization (project-specific durable directives)",
+  "method": "Fresh agent given ONLY the named section (references/roles/pm/instructions.md '### Project customization'), no other context. Answers must come from the text alone. Scenario framing: 'You are the PM agent talking to the human.' Pass = both triggers are recognized with zero drift: a fully-formed durable directive routes straight into l4-curation; a GENERIC open-ended invitation ('I want to customize the workflow') is ALSO recognized — the PM does NOT answer with re-running setup / the upgrade path, but asks one short plain-language question to draw out the concrete directive and then invokes l4-curation; the trigger is conversational (no slash command) and is an entry-point change only (l4-curation's dialog + safety gates are unchanged); one-off/feature requests still do not route through l4-curation. Any answer that points a generic customize ask at re-running setup, treats the generic invitation as out of scope, or claims the gates change is a reject.",
+  "model": "sonnet",
+  "questions": [
+    {
+      "id": "CQ1",
+      "q": "The human says 'from now on, always write tests before implementation on this project.' What do you do?",
+      "expected": "Recognize a project-specific durable customization directive and invoke the l4-curation sub-skill BEFORE any implementation work. l4-curation runs the elicitation dialog, the decision tree (replace / insert-before / insert-after / append), the safety-gate pipeline, and the project-customization commit. (Do not just start writing tests-first as a one-off — this is a durable rule.)"
+    },
+    {
+      "id": "CQ2",
+      "q": "Mid-conversation the human says 'I want to customize the workflow' — nothing more specific. How do you respond, and what must you NOT do?",
+      "expected": "Recognize this generic customization invitation as a trigger too — not just fully-formed directives. Do NOT answer by pointing at re-running setup or the upgrade path. Ask one short, plain-language question — e.g. 'Sure — what would you like the team to do differently?' — to draw out the concrete durable directive, then invoke l4-curation with it exactly as for a specific directive. Reshaping the team is conversational: the human tells you and it's saved as a durable project customization automatically, no command or re-install needed."
+    },
+    {
+      "id": "CQ3",
+      "q": "Does the generic customize invitation require the human to type a special command? And does handling it change how l4-curation validates the customization?",
+      "expected": "No special command — the trigger is conversational; the human simply tells the PM in plain language. And no, handling the generic invitation is only the entry point: l4-curation's elicitation dialog and safety gates are unchanged. The generic-recognition + one short clarifying question happens before l4-curation is invoked; once invoked, l4-curation runs exactly as always."
+    },
+    {
+      "id": "CQ4",
+      "q": "The human says 'for this next task, skip the changelog.' Is that a customization you route into l4-curation? How is it different from the generic invitation?",
+      "expected": "No — that is a one-off task request ('for this next task'), not a durable customization, so it does NOT route through l4-curation (one-off requests and feature requests are explicitly excluded). The difference: a customization — whether a specific 'from now on…' directive or a generic 'I want to customize the workflow' invitation — is about a durable, across-cycles rule; a one-off is scoped to the current task. When unsure whether an ask is durable, ask a short clarifying question rather than assuming."
+    }
+  ]
+}


### PR DESCRIPTION
## #13327 — Surface the "customize the workflow anytime" affordance (L4 discoverability + generic trigger)

Operator feedback (live greenfield install): when the user asked "I should be able to customize these workers later?", the wizard answered about **re-running setup** — not the real, lightweight everyday affordance: **they reshape how the team behaves anytime just by telling the PM**, which runs L4 customization behind the scenes. And the `l4-curation` entry point only fired on fully-formed durable directives, so a generic "I want to customize the workflow" was never recognized.

### Acceptance criteria
- [x] **Wizard discoverability** — INSTALLER-RUNTIME.md §7 now makes the affordance explicit at **both** moments: the "can I change this later?" answer (lead with the talk-to-PM affordance, not re-running setup/upgrade) and the hand-off summary. Plain benefit language, no internal jargon (no "L4", "compose", etc.).
- [x] **Generic invitation trigger** — `references/roles/{pm,worker}/instructions.md` broadened the `l4-curation` trigger to recognize a generic customize request ("I want to customize the workflow", "change how the team works"), not just a specific "from now on…" directive. On a generic ask the PM asks one short plain-language question ("what would you like the team to do differently?") to draw out the concrete directive, then invokes `l4-curation`.
- [x] **Pipeline unchanged** — this is an entry-point + discoverability change only; `l4-curation`'s elicitation dialog and safety gates are untouched (stated explicitly in the instruction text).
- [x] **Comprehension** — `13327_spec` (4 Qs) confirms PM recognizes BOTH the specific-directive and generic-invitation triggers, treats the generic ask conversationally (no slash command), and still excludes one-off/feature requests.

### Open question (resolved)
Per the PM recommendation in the issue: the generic trigger is **conversational-to-PM only** (PM is the human interface), not a slash command. Implemented that way.

### Verification
- Full static gate: **5332 gated, 0 failures, 0 errors.**
- CQ `13327_spec` self-checked clean via a fresh Sonnet section-scoped read (all four answers, zero drift). Yours to run live.
- Source-only change; composed `.squidsquad/*/CLAUDE.md` regenerate via deploy post-merge (pm + worker/skill recompose; not hand-edited).

Reported by: pm-lead (PM-specced UX; skill owns the instruction edits). Part of the INSTALLER-RUNTIME.md implementation set.