### PR TITLE
#13421: SKILL.md v1->v2 migration — PR Flow into ## PR Flow section (residual #13355 drift)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -390,7 +390,9 @@ Check for and add these sections if missing (with defaults):
 - `## Tools` — `(none)`
 - `## Iteration Interval` — `Minutes: [existing interval value, or 30]` (the polling-fallback cadence; config.py reads it here, not under the old `## Loop` heading)
 - `## Context Pressure` — `Threshold: [existing threshold value, or 70]`
-- `## Flags` — `Diagnostics: yes`, `Improvement Scan: [existing value]`, `PR Flow: [existing value]`, `Vault Remember: [existing value]`
+- `## Auto Merge` — `Enabled: [existing auto-merge value, or yes]` (the merge gate — the one surviving PR variable, #13355)
+- `## PR Flow` — `Enabled: yes` (branch+PR is an invariant since #9478/#13355; config.py reads pr-flow from this section, not from `## Flags`)
+- `## Flags` — `Diagnostics: yes`, `Improvement Scan: [existing value]`, `Vault Remember: [existing value]`
 - `## Git Branches` — `Working Branch: [existing value or main]`, `State Branch: [existing value or squid-squad]`
 - `## Forge Backend` — `Provider: github`, `Endpoint: https://api.github.com`
 - `## Model Routing` — carry over existing values or use defaults (`Default Model: claude`, etc.)

--- a/tests/test_feat_2495_upgrade_rewrite.py
+++ b/tests/test_feat_2495_upgrade_rewrite.py
@@ -87,6 +87,35 @@ def test_tc_01_skill_md_rewritten():
 
 
 # ---------------------------------------------------------------------------
+# #13421: v1->v2 migration checklist must match the shipped config sections
+# ---------------------------------------------------------------------------
+
+def test_13421_migration_checklist_matches_shipped_config_sections():
+    """The v1->v2 migration checklist must not list 'PR Flow' under ## Flags —
+    config.py reads pr-flow from the dedicated ## PR Flow section since #13355,
+    so a migrated config would carry a dead line under ## Flags (same dead-
+    section class #13328 fixed for ## Loop). The checklist must instead include
+    the ## PR Flow and ## Auto Merge sections config.py actually reads."""
+    upgrade_text = _read_skill_upgrade_section()
+
+    flags_line = next(
+        (ln for ln in upgrade_text.splitlines()
+         if ln.lstrip().startswith("- `## Flags`")), None
+    )
+    assert flags_line is not None, "migration checklist ## Flags line missing"
+    assert "PR Flow" not in flags_line, (
+        "SKILL.md v1->v2 migration still lists 'PR Flow' under ## Flags — "
+        "config.py reads pr-flow from the dedicated ## PR Flow section (#13355)"
+    )
+    assert "`## PR Flow`" in upgrade_text, (
+        "migration checklist must add the ## PR Flow section (invariant, #13355)"
+    )
+    assert "`## Auto Merge`" in upgrade_text, (
+        "migration checklist must add the ## Auto Merge section (merge gate, #13355)"
+    )
+
+
+# ---------------------------------------------------------------------------
 # TC-2: Upgrade skill file rewritten — no obsolete references
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## #13421 — SKILL.md v1->v2 migration lists PR Flow under `## Flags`

Residual #13355 drift, found by qa during #13328 verification. The v1->v2 migration checklist (SKILL.md Step 4) listed `PR Flow` under `## Flags`, but #13355 made PR Flow an INSTALLER-RUNTIME.md §3 invariant with its own `## PR Flow` section, and `build_config_md` excludes pr_flow from `## Flags` — config.py's FIELD_MAP reads pr-flow from `("PR Flow","Enabled")`, never from `## Flags`. A hand-migration following the checklist would write a dead `PR Flow` line under `## Flags` — the same dead-section class #13328 fixed for `## Loop`.

### Fix
- SKILL.md Step 4 checklist: dropped `PR Flow` from the `## Flags` line; added `## PR Flow` (Enabled: yes, invariant) and `## Auto Merge` (the merge gate) — the sections config.py actually reads, mirroring #13328's `## Loop` -> `## Iteration Interval`/`## Context Pressure` repoint.
- Regression (test_feat_2495): asserts the `## Flags` checklist line carries no `PR Flow`, and the checklist includes `## PR Flow` + `## Auto Merge`. Fails against the old checklist.

### Notes
- Severity low: a migrated config's dead `PR Flow` line is masked by config.py's pr-flow default `yes` (no runtime break) — but the checklist now matches the shipped invariant.
- No CQ: mechanical checklist correction, no new agent-comprehension surface.
- Full static gate: 5309 gated, 0 failures, 0 errors.

Reported by: qa. Cross-ref: #13355 (source of the invariant), #13328 (sibling `## Loop` dead-section fix, where this was observed + self-flagged).