### PR TITLE
#13373: git_ops task-begin local-branch path syncs to origin (ff-when-behind, fail-loud on divergence)

### DIFF
--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -1456,6 +1456,77 @@ def get_branch_name(role, number):
     return pattern.format(role=role, number=number)
 
 
+def _sync_local_branch_to_origin(branch):
+    """Fast-forward an existing local task branch to origin/<branch> (#13373).
+
+    Called on task_begin's local-branch-exists path, which previously checked
+    out the local ref with NO fetch/compare — so a stale local ref (the normal
+    re-verification case: the worker pushed the fix commit after a round-1
+    bounce, and this clone's ref lags origin) got verified as-is, without the
+    fix commit. The remote path below already fetches for this reason (#5013);
+    the local path must too.
+
+    Cases:
+      - origin/<branch> absent (never pushed) -> keep local (no-op).
+      - local == origin -> already in sync (no-op).
+      - local strictly behind origin -> fast-forward (git merge --ff-only).
+      - local strictly ahead of origin -> keep local unpushed work (no-op).
+      - diverged (neither is an ancestor of the other) -> FAIL LOUDLY with both
+        SHAs (sys.exit 1); never silently check out an unsynced/diverged tip.
+        Manual resolution is merge-not-rebase per the project's standing rule.
+    """
+    _run_list(["git", "fetch", "origin", branch], check=False)
+    origin = _run_list(
+        ["git", "rev-parse", "--verify", f"refs/remotes/origin/{branch}"],
+        check=False,
+    )
+    if origin.returncode != 0:
+        # Never pushed to origin — nothing to sync against.
+        return
+    origin_sha = origin.stdout.strip()
+    local_sha = _run_list(
+        ["git", "rev-parse", f"refs/heads/{branch}"], check=False
+    ).stdout.strip()
+    if not local_sha or local_sha == origin_sha:
+        return
+    # local behind origin? (local is an ancestor of origin)
+    behind = _run_list(
+        ["git", "merge-base", "--is-ancestor", local_sha, origin_sha], check=False
+    ).returncode == 0
+    if behind:
+        ff = _run_list(["git", "merge", "--ff-only", f"origin/{branch}"], check=False)
+        if ff.returncode != 0:
+            print(
+                f"ERROR: task-begin could not fast-forward {branch} to origin/"
+                f"{branch} (local {local_sha[:9]}, origin {origin_sha[:9]}): "
+                f"{ff.stderr.strip()}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        print(
+            f"task-begin: fast-forwarded {branch} {local_sha[:9]} -> "
+            f"{origin_sha[:9]} (origin was ahead) (#13373)"
+        )
+        return
+    # origin behind local? (origin is an ancestor of local) -> unpushed local
+    # work; keep it.
+    ahead = _run_list(
+        ["git", "merge-base", "--is-ancestor", origin_sha, local_sha], check=False
+    ).returncode == 0
+    if ahead:
+        return
+    # Neither is an ancestor of the other -> diverged. Never verify an unsynced
+    # tip (#13373); surface both SHAs and stop.
+    print(
+        f"ERROR: task-begin: local {branch} ({local_sha[:9]}) and origin/"
+        f"{branch} ({origin_sha[:9]}) have DIVERGED. Resolve manually (merge "
+        f"origin, never rebase) before retrying — refusing to check out an "
+        f"unsynced tip (#13373).",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
 def task_begin(role, number):
     """Check out the task's feature branch (#3296, #9478).
 
@@ -1487,6 +1558,11 @@ def task_begin(role, number):
         if not _safe_checkout(branch):
             print(f"ERROR: task-begin failed to checkout {branch}", file=sys.stderr)
             sys.exit(1)
+        # Sync the existing local ref to origin before returning (#13373). A
+        # stale local ref (the normal re-verification case) would otherwise be
+        # checked out as-is, letting a verifier verify a tree without the fix
+        # commit. Fast-forward when behind; fail loudly on divergence.
+        _sync_local_branch_to_origin(branch)
         _emit("branch-checkout", {"branch": branch, "task_number": str(number)})
         print(branch)
         return

--- a/tests/test_13373_task_begin_local_sync.py
+++ b/tests/test_13373_task_begin_local_sync.py
@@ -1,0 +1,139 @@
+"""Regression tests for #13373 — task_begin local-branch path must sync to origin.
+
+The local-branch-exists path in git_ops.task_begin() previously checked out the
+local ref with NO fetch/compare, so a stale local ref (the normal re-verification
+case: the worker pushed the fix commit after a round-1 bounce and this clone's ref
+lags origin) got verified without the fix commit. _sync_local_branch_to_origin()
+fast-forwards when behind, keeps local when ahead/absent, and fails loudly on
+divergence — never checking out an unsynced tip.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import git_ops
+
+BRANCH = "squidsquad/task/13373"
+LOCAL = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+ORIGIN = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+
+def _mk(rc=0, stdout="", stderr=""):
+    m = MagicMock()
+    m.returncode = rc
+    m.stdout = stdout
+    m.stderr = stderr
+    return m
+
+
+def _dispatch(*, origin_exists=True, behind=False, ahead=False, ff_rc=0,
+              origin_sha=ORIGIN, local_sha=LOCAL):
+    """Build a _run_list side_effect + call log for _sync_local_branch_to_origin."""
+    calls = []
+
+    def side_effect(cmd, check=False):
+        calls.append(cmd)
+        s = str(cmd)
+        if cmd[:2] == ["git", "fetch"]:
+            return _mk(0)
+        if "rev-parse" in cmd and "refs/remotes/" in s:
+            return _mk(0 if origin_exists else 1, origin_sha + "\n")
+        if "rev-parse" in cmd and "refs/heads/" in s:
+            return _mk(0, local_sha + "\n")
+        if "merge-base" in cmd:
+            # cmd == [git, merge-base, --is-ancestor, A, B]
+            a = cmd[3]
+            if a == local_sha:   # is local an ancestor of origin? -> behind
+                return _mk(0 if behind else 1)
+            if a == origin_sha:  # is origin an ancestor of local? -> ahead
+                return _mk(0 if ahead else 1)
+            return _mk(1)
+        if "merge" in cmd and "--ff-only" in cmd:
+            return _mk(ff_rc, stderr="ff failed" if ff_rc else "")
+        return _mk(1)
+
+    return side_effect, calls
+
+
+class TestSyncLocalBranchToOrigin:
+    @patch("git_ops._run_list")
+    def test_behind_fast_forwards(self, mock_rl):
+        """Local behind origin -> a --ff-only merge onto origin/<branch> fires."""
+        side_effect, calls = _dispatch(origin_exists=True, behind=True)
+        mock_rl.side_effect = side_effect
+        git_ops._sync_local_branch_to_origin(BRANCH)
+        ff = [c for c in calls if "merge" in c and "--ff-only" in c]
+        assert len(ff) == 1
+        assert f"origin/{BRANCH}" in ff[0]
+
+    @patch("git_ops._run_list")
+    def test_diverged_exits_with_both_shas(self, mock_rl, capsys):
+        """Diverged -> non-zero exit, both SHAs in stderr, and NO merge attempted."""
+        side_effect, calls = _dispatch(origin_exists=True, behind=False, ahead=False)
+        mock_rl.side_effect = side_effect
+        with pytest.raises(SystemExit) as exc:
+            git_ops._sync_local_branch_to_origin(BRANCH)
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert LOCAL[:9] in err
+        assert ORIGIN[:9] in err
+        assert "DIVERGED" in err
+        assert not [c for c in calls if "merge" in c and "--ff-only" in c]
+
+    @patch("git_ops._run_list")
+    def test_ahead_keeps_local_no_merge(self, mock_rl):
+        """Local ahead of origin (unpushed work) -> no merge, no exit."""
+        side_effect, calls = _dispatch(origin_exists=True, behind=False, ahead=True)
+        mock_rl.side_effect = side_effect
+        git_ops._sync_local_branch_to_origin(BRANCH)  # returns normally
+        assert not [c for c in calls if "merge" in c and "--ff-only" in c]
+
+    @patch("git_ops._run_list")
+    def test_origin_absent_noop(self, mock_rl):
+        """origin/<branch> never pushed -> no compare, no merge."""
+        side_effect, calls = _dispatch(origin_exists=False)
+        mock_rl.side_effect = side_effect
+        git_ops._sync_local_branch_to_origin(BRANCH)
+        assert not [c for c in calls if "merge-base" in c]
+        assert not [c for c in calls if "merge" in c and "--ff-only" in c]
+
+    @patch("git_ops._run_list")
+    def test_in_sync_noop(self, mock_rl):
+        """local == origin -> no compare, no merge."""
+        side_effect, calls = _dispatch(origin_exists=True, origin_sha=LOCAL,
+                                       local_sha=LOCAL)
+        mock_rl.side_effect = side_effect
+        git_ops._sync_local_branch_to_origin(BRANCH)
+        assert not [c for c in calls if "merge-base" in c]
+        assert not [c for c in calls if "merge" in c and "--ff-only" in c]
+
+    @patch("git_ops._run_list")
+    def test_ff_failure_exits(self, mock_rl):
+        """A fast-forward that git refuses (e.g. dirty tree) -> non-zero exit."""
+        side_effect, calls = _dispatch(origin_exists=True, behind=True, ff_rc=1)
+        mock_rl.side_effect = side_effect
+        with pytest.raises(SystemExit) as exc:
+            git_ops._sync_local_branch_to_origin(BRANCH)
+        assert exc.value.code == 1
+
+
+class TestTaskBeginCallsSync:
+    @patch("git_ops._sync_local_branch_to_origin")
+    @patch("git_ops._safe_checkout", return_value=True)
+    @patch("git_ops._run_list")
+    def test_local_path_syncs_to_origin(self, mock_rl, mock_checkout, mock_sync):
+        """task_begin's local-branch-exists path invokes the origin sync (#13373)."""
+        def side_effect(cmd, check=False):
+            r = MagicMock()
+            r.returncode = 0 if ("rev-parse" in cmd and "refs/heads/" in str(cmd)) else 1
+            return r
+        mock_rl.side_effect = side_effect
+        with patch("config.get_field", return_value=None):
+            git_ops.task_begin("skill", "13373")
+        mock_sync.assert_called_once_with(BRANCH)


### PR DESCRIPTION
## Summary
Fixes #13373 (verifier-filed, medium). git_ops.task_begin() local-branch-exists path checked out the local ref with NO fetch/compare to origin, so on re-verification a stale local ref (round 1 created it; worker pushed the fix commit after a bounce; this clone lags) got verified WITHOUT the fix commit -> false verdict. The remote path already fetched for this reason (#5013); the local path did not.

## Fix
New helper _sync_local_branch_to_origin(branch), invoked on the local path after checkout:
- origin/<branch> absent (never pushed) -> keep local (no-op)
- local == origin -> in sync (no-op)
- local strictly behind origin -> fast-forward (git merge --ff-only)
- local strictly ahead (unpushed work) -> keep local (no-op)
- diverged (neither an ancestor) -> FAIL LOUDLY, both SHAs to stderr, sys.exit(1)

Merge-not-rebase and fail-loud-over-silent per project rules; remote/create paths unchanged.

## ACs
1. Behind -> lands on origin head (ff-only). 2. Diverged -> non-zero exit with both SHAs in stderr. Both covered by tests.

## Tests
tests/test_13373_task_begin_local_sync.py (7 cases: behind->ff, diverged->exit+both-SHAs, ahead->keep, origin-absent->noop, in-sync->noop, ff-failure->exit, + integration that the local path calls the sync). Existing task-boundary suite unchanged (its TC-1 mock returns origin-absent -> sync no-ops). Full static gate 5328 passed / 0 failures. DeepSeek review (deepseek-v4-pro): NO_FINDINGS.