### PR TITLE
#13456: deploy-pull stashes --include-untracked so an untracked-file collision no longer aborts the merge

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -4992,9 +4992,18 @@ def _safe_stash_pop_in_clone(clone_path):
         clone_path, ["diff", "--name-only", "--diff-filter=U"])
     unmerged = [p.strip() for p in conflicted.stdout.splitlines() if p.strip()]
     if not unmerged:
-        # Pop failed for a NON-conflict reason (no stash entry / unrelated git
-        # error) — the stash was NOT applied. Do NOT drop it (that would discard
-        # un-applied work). Leave it intact and report the pop did not succeed.
+        # No tracked-file (diff-filter=U) merge conflict. Distinguish the #13456
+        # untracked-restore case — a ``--include-untracked`` stash whose path the
+        # pull now tracks, so ``git stash pop`` refuses to overwrite it ("Could
+        # not restore untracked files from stash") — from a genuine non-conflict
+        # pop error. In the untracked case the pulled/tracked version is
+        # authoritative and already on disk (the failed restore left it
+        # untouched), so DROP the now-redundant stash (same pulled-wins rule as
+        # the tracked-conflict path below). Otherwise the stash was NOT applied
+        # (no stash entry / unrelated git error) — leave it intact, since
+        # dropping would discard un-applied work.
+        if "untracked files from stash" in (pop.stdout + pop.stderr).lower():
+            _git_in_clone(clone_path, ["stash", "drop"])
         return False
     for path in unmerged:
         _git_in_clone(clone_path, ["checkout", "HEAD", "--", path])
@@ -5017,6 +5026,13 @@ def _safe_pull_in_clone(clone_path):
     pulled ``HEAD`` and dropped (same authoritative-pulled-state rule as
     ``_safe_stash_pop_in_clone``).
 
+    #13456: the sibling UNTRACKED case — an untracked local file at a path the
+    incoming commit now tracks makes the pull ABORT with ``untracked working
+    tree files would be overwritten by merge``. A plain ``git stash`` does NOT
+    stash untracked files, so the retry still aborted (recurring dm boot
+    deploy-error). The stash below uses ``--include-untracked`` so those files
+    are moved aside too; on pop, the pulled/tracked version wins.
+
     A genuine MERGE conflict (committed divergence that truly conflicts) still
     fails the retry pull → returns ``(False, …)`` so the caller routes to §11
     recovery; only a DIRTY-TREE abort is newly survived.
@@ -5031,16 +5047,21 @@ def _safe_pull_in_clone(clone_path):
     if "already up to date" in combined or "up to date" in combined:
         return True, "already-up-to-date"
 
-    # First pull failed. Stash any dirty change and retry: a dirty-tree abort
+    # First pull failed. Stash any local change and retry: a dirty-tree abort
     # then merges cleanly; a genuine merge conflict fails the retry the same way
-    # and routes to recovery.
+    # and routes to recovery. #13456: use --include-untracked so an UNTRACKED
+    # local file colliding with an incoming tracked path ("untracked working tree
+    # files would be overwritten by merge") is also moved aside — a plain
+    # `git stash` leaves untracked files in place, so the retry pull still
+    # aborted (recurring dm boot deploy-error). On pop, the untracked-restore
+    # conflict is resolved pulled-wins by _safe_stash_pop_in_clone.
     def _stash_ref():
         r = _git_in_clone(
             clone_path, ["rev-parse", "--quiet", "--verify", "refs/stash"])
         return r.stdout.strip() if r.returncode == 0 else ""
 
     pre_ref = _stash_ref()
-    stash = _git_in_clone(clone_path, ["stash"])
+    stash = _git_in_clone(clone_path, ["stash", "--include-untracked"])
     if stash.returncode != 0:
         return False, f"stash-failed: {(stash.stderr or first.stderr).strip()[:200]}"
     # #13167: `git stash` on a CLEAN tree is a no-op that still exits 0 — only

--- a/tests/test_feat_13456_deploy_pull_untracked_collision.py
+++ b/tests/test_feat_13456_deploy_pull_untracked_collision.py
@@ -1,0 +1,112 @@
+"""Regression for #13456 — deploy-pull survives an UNTRACKED-file collision.
+
+REAL git (not mocked): builds an origin + a clone where the clone has an
+UNTRACKED file at a path the incoming commit now tracks — the exact trigger where
+`git pull` ABORTS ("untracked working tree files would be overwritten by merge").
+A plain `git stash` (the #13215 fix for dirty TRACKED files) does NOT stash
+untracked files, so the retry pull still aborted (recurring dm boot deploy-error).
+Asserts harness._safe_pull_in_clone now survives via --include-untracked + the
+pulled-wins untracked-restore resolution in _safe_stash_pop_in_clone.
+
+Sibling of tests/test_feat_13215_deploy_pull_dirty_clone.py (dirty TRACKED case).
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "references", "scripts"))
+
+import harness  # noqa: E402
+
+
+def _git(cwd, *args):
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+
+
+@unittest.skipIf(shutil.which("git") is None, "git not available")
+class TestDeployPullUntrackedCollision13456(unittest.TestCase):
+    # A nested path mirrors the observed .squidsquad/vault/galaxy/<file> case.
+    REL = os.path.join("vault", "galaxy", "note.txt")
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.origin = os.path.join(self.tmp, "origin")
+        self.clone = os.path.join(self.tmp, "clone")
+        os.makedirs(self.origin)
+        _git(self.origin, "init", "-q", "-b", "main")
+        _git(self.origin, "config", "user.email", "t@t.t")
+        _git(self.origin, "config", "user.name", "t")
+        with open(os.path.join(self.origin, "base.txt"), "w") as f:
+            f.write("base\n")
+        _git(self.origin, "add", ".")
+        _git(self.origin, "commit", "-q", "-m", "c1")
+        _git(self.tmp, "clone", "-q", self.origin, self.clone)
+        _git(self.clone, "config", "user.email", "t@t.t")
+        _git(self.clone, "config", "user.name", "t")
+        # origin adds a NEW tracked file at REL (the incoming commit)
+        opath = os.path.join(self.origin, self.REL)
+        os.makedirs(os.path.dirname(opath), exist_ok=True)
+        with open(opath, "w") as f:
+            f.write("origin-tracked\n")
+        _git(self.origin, "add", ".")
+        _git(self.origin, "commit", "-q", "-m", "c2 adds tracked note")
+        # clone creates the SAME path as an UNTRACKED file (the #13456 trigger)
+        cpath = os.path.join(self.clone, self.REL)
+        os.makedirs(os.path.dirname(cpath), exist_ok=True)
+        with open(cpath, "w") as f:
+            f.write("untracked-local\n")
+        _git(self.clone, "fetch", "-q", "origin")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_bare_pull_aborts_then_safe_pull_survives(self):
+        # The bug: a bare merge-pull aborts on the untracked collision.
+        bare = _git(self.clone, "pull", "--no-rebase", "--no-edit", "origin", "main")
+        self.assertNotEqual(bare.returncode, 0)
+        self.assertIn("untracked working tree files would be overwritten",
+                      (bare.stdout + bare.stderr).lower(),
+                      "bare pull should abort on the untracked collision (bug reproduced)")
+
+        # The fix: _safe_pull_in_clone survives.
+        ok, detail = harness._safe_pull_in_clone(self.clone)
+        self.assertTrue(ok, f"_safe_pull_in_clone must succeed; detail={detail}")
+
+        clone_head = _git(self.clone, "rev-parse", "HEAD").stdout.strip()
+        origin_head = _git(self.origin, "rev-parse", "HEAD").stdout.strip()
+        self.assertEqual(clone_head, origin_head, "deploy-sync must land (HEADs equal)")
+        self.assertFalse(os.path.exists(os.path.join(self.clone, ".git", "MERGE_HEAD")),
+                         "clone must not be left in MERGING state")
+        with open(os.path.join(self.clone, self.REL)) as f:
+            self.assertEqual(f.read().strip(), "origin-tracked",
+                             "pulled (authoritative) content must win over the untracked local file")
+        # The moved-aside untracked stash must be DROPPED (pulled wins), not linger —
+        # a lingering stash would silently accumulate on every deploy.
+        stash_list = _git(self.clone, "stash", "list").stdout.strip()
+        self.assertEqual(stash_list, "", "untracked-restore stash must be dropped, not left behind")
+
+    def test_dirty_tracked_still_works_with_include_untracked(self):
+        """The #13215 dirty-TRACKED path must still survive after the -u change."""
+        # Make base.txt dirty (tracked) and also diverge origin's base.txt.
+        with open(os.path.join(self.origin, "base.txt"), "w") as f:
+            f.write("base-v2-origin\n")
+        _git(self.origin, "add", "base.txt")
+        _git(self.origin, "commit", "-q", "-m", "c3 base changes")
+        with open(os.path.join(self.clone, "base.txt"), "w") as f:
+            f.write("base-dirty-local\n")
+        _git(self.clone, "fetch", "-q", "origin")
+
+        ok, detail = harness._safe_pull_in_clone(self.clone)
+        self.assertTrue(ok, f"_safe_pull_in_clone must survive dirty tracked; detail={detail}")
+        clone_head = _git(self.clone, "rev-parse", "HEAD").stdout.strip()
+        origin_head = _git(self.origin, "rev-parse", "HEAD").stdout.strip()
+        self.assertEqual(clone_head, origin_head, "deploy-sync must land (HEADs equal)")
+        self.assertFalse(os.path.exists(os.path.join(self.clone, ".git", "MERGE_HEAD")),
+                         "clone must not be left in MERGING state")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes #13456 (pm-filed, low). Sibling of shipped #13215. harness._safe_pull_in_clone stashed dirty TRACKED files via plain git stash to survive a merge-abort, but plain git stash does NOT stash untracked files — so an UNTRACKED local file at a path the incoming commit now tracks made the retry pull still ABORT ("untracked working tree files would be overwritten by merge"). Observed as a recurring dm boot deploy-error (stage=pull) on a .squidsquad/vault/galaxy/ file.

## Fix
1. Stash with --include-untracked (strict superset of plain stash) so untracked collisions are moved aside and the merge can land.
2. Extend _safe_stash_pop_in_clone: when git stash pop fails with NO tracked (diff-filter=U) conflict but the output contains "untracked files from stash" (git could not restore an untracked file whose path the pull now tracks), DROP the stash — the pulled/tracked version is authoritative and already on disk (same pulled-wins rule already used for tracked conflicts). On any other non-conflict failure the stash is left intact (no data loss); on a translated/changed git message it degrades gracefully (lingering stash is harmless, pull still succeeded).

## ACs
1. Untracked collision: bare pull aborts; _safe_pull_in_clone succeeds, HEADs equal, pulled content wins, no MERGE_HEAD, stash dropped. 2. #13215 dirty-tracked path still survives with --include-untracked.

## Tests
tests/test_feat_13456_deploy_pull_untracked_collision.py (real git, mirrors the #13215 sibling): 2 cases (untracked-collision + dirty-tracked-regression). Existing #13215 test unchanged/green. Full static gate 5336 passed / 0 failures. DeepSeek review (deepseek-v4-pro): NO_FINDINGS (confirmed superset-safe, detection string stable since git 2.10, coexisting-conflict case handled).