### PR TITLE
#13465: tracker.py create-issue filters dual-aware role labels to the repo taxonomy (no more non-existent role:verifier create failure)

### DIFF
--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -340,6 +340,56 @@ def _build_dual_role_labels_6274(role: str) -> str:
     return f"{primary},role:{alias}"
 
 
+_REPO_LABELS_CACHE = None
+
+
+def _repo_labels():
+    """Return the set of label names the repo taxonomy defines (cached per
+    process). Empty set on any failure — callers fail CLOSED (drop unknown
+    labels) so a degraded ``gh`` never blocks a create (#13465)."""
+    global _REPO_LABELS_CACHE
+    if _REPO_LABELS_CACHE is not None:
+        return _REPO_LABELS_CACHE
+    result = _run_list(
+        ["gh", "label", "list", "--limit", "200", "--json", "name"],
+        check=False,
+    )
+    labels = set()
+    if result.returncode == 0 and result.stdout.strip():
+        try:
+            labels = {x["name"] for x in json.loads(result.stdout)}
+        except (ValueError, KeyError, TypeError):
+            labels = set()
+    _REPO_LABELS_CACHE = labels
+    return labels
+
+
+def _filter_role_labels_to_existing(role_label_str, primary_role):
+    """Drop dual-aware alias ``role:*`` labels the repo taxonomy does not define
+    (#13465).
+
+    During the pre-#6274.3 window ``_build_dual_role_labels_6274`` emits both the
+    OLD-form label (``role:qa``) and the NEW-form alias (``role:verifier``), but
+    only the OLD-form labels exist as repo labels — ``gh issue create`` rejects
+    the unknown alias, so the whole ``create-issue --role qa`` failed non-zero
+    and blocked qa-lane filing via the canonical tool.
+
+    Keep every role label the repo positively defines; ALWAYS keep the primary
+    ``role:{primary_role}`` even when the existence lookup is empty/unavailable,
+    so a create never loses its assignee. Fails CLOSED on a lookup miss (an alias
+    is dropped unless positively confirmed) so a degraded ``gh label list`` can
+    never re-introduce the unknown-label failure. When #6274.3 creates the
+    NEW-form labels this filter lets the dual-emit resume automatically.
+    """
+    labels = [l for l in role_label_str.split(",") if l]
+    existing = _repo_labels()
+    primary = f"role:{primary_role}"
+    kept = [lbl for lbl in labels if lbl == primary or lbl in existing]
+    if primary not in kept:
+        kept.insert(0, primary)
+    return ",".join(kept)
+
+
 def _get_issue_role_labels(number):
     """Return the set of role prefixes from an issue's `role:*` labels.
 
@@ -859,7 +909,8 @@ def create_issue(title, body, role, severity, reporter=None):
     deletes the role:dev/role:qa label classes altogether).
     """
     sev_label = SEVERITY_LABELS.get(severity, f"severity:{severity}")
-    role_label = _build_dual_role_labels_6274(role)
+    role_label = _filter_role_labels_to_existing(
+        _build_dual_role_labels_6274(role), role)  # #13465
     # Issues start at `open` (immediately actionable by the assigned dev agent).
     # Tasks start at `pending` (awaiting human approval via PM intake).
     # This distinction matters: dev-agent Step 2 picks up all non-shipped
@@ -912,7 +963,8 @@ def create_task(title, body, role, priority, reporter=None):
     migration window — see create_issue.
     """
     pri_label = PRIORITY_LABELS.get(priority, f"priority:{priority}")
-    role_label = _build_dual_role_labels_6274(role)
+    role_label = _filter_role_labels_to_existing(
+        _build_dual_role_labels_6274(role), role)  # #13465
     labels = f"type:task,{pri_label},{role_label},squidsquad,status:pending"
 
     full_body = body

--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -365,28 +365,34 @@ def _repo_labels():
 
 
 def _filter_role_labels_to_existing(role_label_str, primary_role):
-    """Drop dual-aware alias ``role:*`` labels the repo taxonomy does not define
+    """Drop dual-aware ``role:*`` labels the repo taxonomy does not define
     (#13465).
 
-    During the pre-#6274.3 window ``_build_dual_role_labels_6274`` emits both the
-    OLD-form label (``role:qa``) and the NEW-form alias (``role:verifier``), but
-    only the OLD-form labels exist as repo labels — ``gh issue create`` rejects
-    the unknown alias, so the whole ``create-issue --role qa`` failed non-zero
-    and blocked qa-lane filing via the canonical tool.
+    During the pre-#6274.3 window ``_build_dual_role_labels_6274`` emits both an
+    OLD-form label (``role:qa``) and a NEW-form one (``role:verifier``), but only
+    the OLD-form labels exist as repo labels — ``gh issue create`` rejects the
+    unknown one, so a create with the affected role failed non-zero and blocked
+    filing via the canonical tool.
 
-    Keep every role label the repo positively defines; ALWAYS keep the primary
-    ``role:{primary_role}`` even when the existence lookup is empty/unavailable,
-    so a create never loses its assignee. Fails CLOSED on a lookup miss (an alias
-    is dropped unless positively confirmed) so a degraded ``gh label list`` can
-    never re-introduce the unknown-label failure. When #6274.3 creates the
-    NEW-form labels this filter lets the dual-emit resume automatically.
+    Keep every role label the repo positively defines. This handles BOTH input
+    directions: ``--role qa`` (primary ``role:qa`` exists, alias ``role:verifier``
+    dropped) AND ``--role verifier`` (primary ``role:verifier`` does not exist and
+    is dropped, alias ``role:qa`` kept) — the primary is NOT force-kept, because a
+    new-form primary is exactly the non-existent label (the #13465 Finding-1 case).
+
+    If NONE of the emitted role labels are repo-defined — an unknown role, or the
+    existence lookup was empty/unavailable (degraded ``gh label list``) — fall back
+    to the primary ``role:{primary_role}`` so the issue is never left without a
+    role label. When #6274.3 creates the NEW-form labels this filter lets the
+    dual-emit resume automatically.
     """
     labels = [l for l in role_label_str.split(",") if l]
     existing = _repo_labels()
-    primary = f"role:{primary_role}"
-    kept = [lbl for lbl in labels if lbl == primary or lbl in existing]
-    if primary not in kept:
-        kept.insert(0, primary)
+    kept = [lbl for lbl in labels if lbl in existing]
+    if not kept:
+        # Nothing positively confirmed (unknown role or lookup unavailable) —
+        # keep the primary so the create still carries a role label.
+        kept = [f"role:{primary_role}"]
     return ",".join(kept)
 
 

--- a/tests/test_13465_create_issue_role_label_filter.py
+++ b/tests/test_13465_create_issue_role_label_filter.py
@@ -42,12 +42,22 @@ class TestFilterRoleLabelsToExisting:
             "role:qa,role:verifier", "qa") == "role:qa"
 
     @patch("tracker._repo_labels", return_value={"role:qa"})
-    def test_primary_always_kept_even_if_absent(self, _m):
-        # A create must never lose its assignee: the primary is never dropped,
-        # and unknown aliases are still filtered out.
+    def test_unknown_role_falls_back_to_primary(self, _m):
+        # When NONE of the emitted role labels exist (unknown role), fall back to
+        # the primary so the issue is never left without a role label.
         out = tracker._filter_role_labels_to_existing("role:foo,role:bar", "foo")
-        assert out.split(",")[0] == "role:foo"
+        assert out == "role:foo"
         assert "role:bar" not in out
+
+    @patch("tracker._repo_labels", return_value={"role:qa", "role:skill", "role:dm"})
+    def test_verifier_new_form_primary_dropped_keeps_existing_qa(self, _m):
+        # #13465 Finding 1: NEW-form input (--role verifier) makes role:verifier
+        # the PRIMARY, which does NOT exist pre-#6274.3. The filter must drop the
+        # non-existent primary and keep the existing alias role:qa — the same
+        # failure mode as --role qa but from the opposite direction.
+        out = tracker._filter_role_labels_to_existing("role:verifier,role:qa", "verifier")
+        assert out == "role:qa"
+        assert "role:verifier" not in out
 
 
 class TestRepoLabelsCaching:
@@ -100,6 +110,36 @@ class TestCreateIssueExcludesUnknownRoleLabel:
              patch("tracker._run_list", side_effect=fake_run_list):
             num = tracker.create_issue("x", "y", "qa", "low", reporter="dm-lead")
         assert num == 999
+        assert "role:qa" in captured["label"]
+        assert "role:verifier" not in captured["label"]
+        tracker._REPO_LABELS_CACHE = None
+
+    def test_create_issue_new_form_role_verifier_also_omits_unknown_label(self):
+        # #13465 Finding 1: create_issue with the NEW-form --role verifier must
+        # still emit only the existing role:qa label, never the non-existent
+        # role:verifier (which would fail the gh create the same way).
+        tracker._REPO_LABELS_CACHE = None
+        captured = {}
+
+        def fake_run_list(cmd, check=True, timeout=None):
+            r = MagicMock()
+            if "label" in cmd and "list" in cmd:
+                r.returncode = 0
+                r.stdout = '[{"name":"role:qa"}]'
+                return r
+            if "issue" in cmd and "create" in cmd:
+                captured["label"] = cmd[cmd.index("--label") + 1]
+                r.returncode = 0
+                r.stdout = "https://github.com/o/r/issues/1000"
+                return r
+            r.returncode = 0
+            r.stdout = ""
+            return r
+
+        with patch("tracker._get_forge_adapter", return_value=None), \
+             patch("tracker._run_list", side_effect=fake_run_list):
+            num = tracker.create_issue("x", "y", "verifier", "low", reporter="dm-lead")
+        assert num == 1000
         assert "role:qa" in captured["label"]
         assert "role:verifier" not in captured["label"]
         tracker._REPO_LABELS_CACHE = None

--- a/tests/test_13465_create_issue_role_label_filter.py
+++ b/tests/test_13465_create_issue_role_label_filter.py
@@ -1,0 +1,105 @@
+"""Regression tests for #13465 — tracker.py create-issue must not stamp a
+role:* label the repo taxonomy does not define.
+
+The #6274 dual-aware mapping emitted `role:qa,role:verifier` for `--role qa`, but
+the repo has no `role:verifier` label, so `gh issue create` rejected the unknown
+label and `create-issue --role qa` failed non-zero (blocking qa-lane filing via
+the canonical tool). `_filter_role_labels_to_existing` drops the unknown alias
+while always keeping the primary role label; `create_issue`/`create_task` apply
+it before the gh call.
+"""
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import tracker
+
+
+class TestFilterRoleLabelsToExisting:
+    @patch("tracker._repo_labels", return_value={"role:qa", "role:skill", "role:dm", "role:pm"})
+    def test_qa_drops_nonexistent_verifier_alias(self, _m):
+        # The bug: role:qa,role:verifier -> role:qa (verifier label absent).
+        assert tracker._filter_role_labels_to_existing(
+            "role:qa,role:verifier", "qa") == "role:qa"
+
+    @patch("tracker._repo_labels", return_value={"role:qa", "role:verifier"})
+    def test_qa_keeps_verifier_alias_when_it_exists(self, _m):
+        # Post-#6274.3: both labels exist -> dual emit resumes automatically.
+        assert tracker._filter_role_labels_to_existing(
+            "role:qa,role:verifier", "qa") == "role:qa,role:verifier"
+
+    @patch("tracker._repo_labels", return_value={"role:skill"})
+    def test_non_dual_role_unchanged(self, _m):
+        assert tracker._filter_role_labels_to_existing("role:skill", "skill") == "role:skill"
+
+    @patch("tracker._repo_labels", return_value=set())
+    def test_gh_failure_falls_closed_to_primary(self, _m):
+        # Empty existence set (gh label list failed/unavailable) -> primary only.
+        assert tracker._filter_role_labels_to_existing(
+            "role:qa,role:verifier", "qa") == "role:qa"
+
+    @patch("tracker._repo_labels", return_value={"role:qa"})
+    def test_primary_always_kept_even_if_absent(self, _m):
+        # A create must never lose its assignee: the primary is never dropped,
+        # and unknown aliases are still filtered out.
+        out = tracker._filter_role_labels_to_existing("role:foo,role:bar", "foo")
+        assert out.split(",")[0] == "role:foo"
+        assert "role:bar" not in out
+
+
+class TestRepoLabelsCaching:
+    def test_parses_and_caches_label_names(self):
+        tracker._REPO_LABELS_CACHE = None
+        fake = MagicMock()
+        fake.returncode = 0
+        fake.stdout = '[{"name":"role:qa"},{"name":"role:skill"}]'
+        with patch("tracker._run_list", return_value=fake) as m:
+            first = tracker._repo_labels()
+            second = tracker._repo_labels()  # cached: no 2nd gh call
+        assert first == {"role:qa", "role:skill"}
+        assert second == first
+        assert m.call_count == 1
+        tracker._REPO_LABELS_CACHE = None
+
+    def test_failure_returns_empty_set(self):
+        tracker._REPO_LABELS_CACHE = None
+        fake = MagicMock()
+        fake.returncode = 1
+        fake.stdout = ""
+        with patch("tracker._run_list", return_value=fake):
+            assert tracker._repo_labels() == set()
+        tracker._REPO_LABELS_CACHE = None
+
+
+class TestCreateIssueExcludesUnknownRoleLabel:
+    def test_create_issue_label_arg_omits_nonexistent_verifier(self):
+        tracker._REPO_LABELS_CACHE = None
+        captured = {}
+
+        def fake_run_list(cmd, check=True, timeout=None):
+            r = MagicMock()
+            if "label" in cmd and "list" in cmd:
+                r.returncode = 0
+                r.stdout = ('[{"name":"role:qa"},{"name":"type:issue"},'
+                            '{"name":"severity:low"},{"name":"squidsquad"},'
+                            '{"name":"status:open"}]')
+                return r
+            if "issue" in cmd and "create" in cmd:
+                captured["label"] = cmd[cmd.index("--label") + 1]
+                r.returncode = 0
+                r.stdout = "https://github.com/o/r/issues/999"
+                return r
+            r.returncode = 0
+            r.stdout = ""
+            return r
+
+        with patch("tracker._get_forge_adapter", return_value=None), \
+             patch("tracker._run_list", side_effect=fake_run_list):
+            num = tracker.create_issue("x", "y", "qa", "low", reporter="dm-lead")
+        assert num == 999
+        assert "role:qa" in captured["label"]
+        assert "role:verifier" not in captured["label"]
+        tracker._REPO_LABELS_CACHE = None

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -32,10 +32,12 @@ def _stub_repo_labels(monkeypatch):
     create tests never hit real `gh`, stay order-independent (no leaked module
     cache), and see no extra _run_list call — leaving calls[0] the create call."""
     tracker._REPO_LABELS_CACHE = None
+    # Pre-#6274.3 reality: the repo defines only the OLD-form role labels. The
+    # NEW-form labels (role:verifier/role:worker) do NOT exist yet — modelling
+    # them here would mask the #13465 drop path for any dual-role create test.
     monkeypatch.setattr(
         tracker, "_repo_labels",
-        lambda: {"role:skill", "role:dm", "role:pm", "role:qa", "role:designer",
-                 "role:verifier", "role:worker", "role:dev"},
+        lambda: {"role:skill", "role:dm", "role:pm", "role:qa", "role:designer"},
     )
     yield
     tracker._REPO_LABELS_CACHE = None

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -25,6 +25,22 @@ def _mock_result(stdout="", stderr="", returncode=0):
     return r
 
 
+@pytest.fixture(autouse=True)
+def _stub_repo_labels(monkeypatch):
+    """#13465: create_issue/create_task now consult the repo label taxonomy via
+    _repo_labels() (a cached `gh label list`). Stub it to a stable default so the
+    create tests never hit real `gh`, stay order-independent (no leaked module
+    cache), and see no extra _run_list call — leaving calls[0] the create call."""
+    tracker._REPO_LABELS_CACHE = None
+    monkeypatch.setattr(
+        tracker, "_repo_labels",
+        lambda: {"role:skill", "role:dm", "role:pm", "role:qa", "role:designer",
+                 "role:verifier", "role:worker", "role:dev"},
+    )
+    yield
+    tracker._REPO_LABELS_CACHE = None
+
+
 class TestCheckGh:
     def test_success(self, monkeypatch):
         monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)


### PR DESCRIPTION
## Summary
Fixes #13465 (dm-filed, low). `tracker.py create-issue --role qa` failed non-zero: the #6274 dual-aware mapping stamps `role:qa,role:verifier`, but the repo taxonomy has no `role:verifier` label, so `gh issue create` rejected the unknown label — blocking qa-lane filing via the canonical tool (dm had to fall back to raw gh for #13464).

## Fix
`_build_dual_role_labels_6274` stays pure (existing #6274 tests unchanged). A taxonomy-existence filter is applied at the create site:
- `_repo_labels()` — cached `gh label list`, empty set on failure.
- `_filter_role_labels_to_existing(role_label_str, primary_role)` — keeps only role labels the repo positively defines; falls back to the primary ONLY when none exist (unknown role / degraded gh) so the issue is never role-less.

Handles BOTH directions: `--role qa` keeps `role:qa`, drops `role:verifier`; `--role verifier` drops the non-existent `role:verifier`, keeps `role:qa`. Applied in `create_issue` and `create_task`. Auto-resumes the dual-emit once #6274.3 creates the new labels.

## Review (2 iterations)
DeepSeek deepseek-v4-pro. Iteration 1 findings (all FIXED):
- **F1 (error)**: new-form `--role verifier` made `role:verifier` the primary, which my initial always-keep-primary rule force-kept (same failure, opposite direction). Fixed by keep-only-what-exists + primary-fallback.
- **F2 (warning)**: added new-form-primary unit + integration tests.
- **F3 (warning)**: fixed the test_tracker.py autouse stub to pre-#6274.3 reality (old-form labels only).
Iteration 2: **NO_FINDINGS**.

## Tests
tests/test_13465_create_issue_role_label_filter.py (filter cases incl. new-form direction, `_repo_labels` caching/failure, create_issue integration for both `--role qa` and `--role verifier`). test_tracker.py autouse stub keeps create tests order-independent. Full static gate 5352 passed / 0 failures.