### PR TITLE
#13472: harness _safe_pull_in_clone aborts the in-progress merge on the stash-failed path so a committed-conflict deploy-pull never leaves the clone MERGING

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -5063,6 +5063,16 @@ def _safe_pull_in_clone(clone_path):
     pre_ref = _stash_ref()
     stash = _git_in_clone(clone_path, ["stash", "--include-untracked"])
     if stash.returncode != 0:
+        # #13472: a GENUINE committed conflict makes the FIRST pull start a merge
+        # that conflicts, leaving an unmerged index — on which `git stash` then
+        # fails ("could not write index"). Returning here without aborting would
+        # leave the clone MERGING (.git/MERGE_HEAD), wedging the NEXT deploy's
+        # `checkout main` ("you have not concluded your merge") — the exact state
+        # this function's docstring says it prevents. Abort the in-progress merge
+        # first; it is a harmless no-op when no merge is underway (the ordinary
+        # dirty-tree stash-failure). The pull still FAILED (origin not synced) →
+        # report failure so the caller routes to §11 recovery.
+        _git_in_clone(clone_path, ["merge", "--abort"])
         return False, f"stash-failed: {(stash.stderr or first.stderr).strip()[:200]}"
     # #13167: `git stash` on a CLEAN tree is a no-op that still exits 0 — only
     # pop a stash we actually created (ref changed), else a pop would splatter a

--- a/tests/test_13472_safe_pull_committed_conflict_no_merging.py
+++ b/tests/test_13472_safe_pull_committed_conflict_no_merging.py
@@ -1,0 +1,88 @@
+"""Regression for #13472 — _safe_pull_in_clone must not leave a clone MERGING on
+a genuine committed conflict.
+
+When the FIRST `git pull --no-rebase` hits a genuine committed conflict it starts
+a merge and leaves an unmerged index; the subsequent `git stash --include-untracked`
+then fails ("could not write index"), and the pre-fix code returned at the
+stash-failed early branch BEFORE the retry-branch's `git merge --abort` — leaving
+the clone MERGING (.git/MERGE_HEAD), which wedges the NEXT deploy's `checkout main`
+(the exact state the function's docstring says it prevents). The fix runs
+`git merge --abort` on the stash-failed path.
+
+Pre-existing gap (NOT introduced by #13456); surfaced during #13456 verification.
+Sibling of tests/test_feat_13215_deploy_pull_dirty_clone.py.
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "references", "scripts"))
+
+import harness  # noqa: E402
+
+
+def _git(cwd, *args):
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+
+
+@unittest.skipIf(shutil.which("git") is None, "git not available")
+class TestSafePullCommittedConflict13472(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.origin = os.path.join(self.tmp, "origin")
+        self.clone = os.path.join(self.tmp, "clone")
+        os.makedirs(self.origin)
+        _git(self.origin, "init", "-q", "-b", "main")
+        _git(self.origin, "config", "user.email", "t@t.t")
+        _git(self.origin, "config", "user.name", "t")
+        with open(os.path.join(self.origin, "shared.txt"), "w") as f:
+            f.write("base\n")
+        _git(self.origin, "add", ".")
+        _git(self.origin, "commit", "-q", "-m", "c1")
+        _git(self.tmp, "clone", "-q", self.origin, self.clone)
+        _git(self.clone, "config", "user.email", "t@t.t")
+        _git(self.clone, "config", "user.name", "t")
+        # origin COMMITS a change to the shared line
+        with open(os.path.join(self.origin, "shared.txt"), "w") as f:
+            f.write("origin-line\n")
+        _git(self.origin, "add", ".")
+        _git(self.origin, "commit", "-q", "-m", "c2 origin")
+        # clone COMMITS a DIVERGENT change to the same line (committed, not dirty)
+        with open(os.path.join(self.clone, "shared.txt"), "w") as f:
+            f.write("clone-line\n")
+        _git(self.clone, "add", ".")
+        _git(self.clone, "commit", "-q", "-m", "c2 clone divergent")
+        _git(self.clone, "fetch", "-q", "origin")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _merging(self):
+        return os.path.exists(os.path.join(self.clone, ".git", "MERGE_HEAD"))
+
+    def test_committed_conflict_does_not_leave_merging(self):
+        # Reproduce: a bare merge-pull on the divergent-committed tree conflicts
+        # and leaves the clone MERGING.
+        bare = _git(self.clone, "pull", "--no-rebase", "--no-edit", "origin", "main")
+        self.assertNotEqual(bare.returncode, 0)
+        self.assertTrue(self._merging(), "bare pull should leave MERGING (bug precondition)")
+        # Clean up that bare-merge state so we test _safe_pull_in_clone from a
+        # non-merging start (its own first pull re-creates the conflict).
+        _git(self.clone, "merge", "--abort")
+        self.assertFalse(self._merging())
+
+        # The fix: _safe_pull_in_clone must report failure AND not leave MERGING.
+        ok, detail = harness._safe_pull_in_clone(self.clone)
+        self.assertFalse(ok, f"a genuine committed conflict must fail; detail={detail}")
+        self.assertFalse(
+            self._merging(),
+            "clone must NOT be left MERGING after a committed-conflict deploy-pull "
+            "(#13472) — a lingering MERGE_HEAD wedges the next deploy's checkout main",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes #13472 (verifier-filed, low; PRE-EXISTING gap, surfaced during #13456 verification, NOT introduced by it). harness._safe_pull_in_clone left an agent clone MERGING on a genuine committed conflict: the first git pull --no-rebase starts a merge that conflicts (unmerged index); the subsequent git stash --include-untracked then fails (could not write index), so the function returned at the stash-failed early branch BEFORE the retry-branch git merge --abort. A lingering .git/MERGE_HEAD wedges the NEXT deploy checkout main (you have not concluded your merge) -> recurring deploy-error until manually cleared (the exact state the docstring says it prevents).

## Fix
Run git merge --abort on the stash-failed early-return path before returning. Mirrors the existing retry-branch abort; harmless no-op when no merge is in progress (the ordinary dirty-tree stash-failure). Does not disturb the #13215/#13456 paths (their stash succeeds because the tree is dirty/untracked, not unmerged, so this branch is never reached).

## Tests
tests/test_13472_safe_pull_committed_conflict_no_merging.py (real git): committed divergent line in clone vs conflicting line in origin -> _safe_pull_in_clone returns (False, ...) and the clone is NOT left MERGING. The verifier promoted xfail (test_feat_13456_..._qa.py::test_tc_03b, strict=False) now XPASSes (verifier flips it in their lane). Full static gate 5359 passed / 0 failures. DeepSeek review NO_FINDINGS.

Note: my first review pass raced with a commit-code branch switch (read the reverted main tree) and false-flagged the fix as missing; re-reviewed on the branch state -> NO_FINDINGS.