### PR TITLE
#13370: tracker.py passes gh bodies via --body-file - (UTF-8 stdin) so non-ASCII prose no longer crashes gh on cp1252 Windows

### DIFF
--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -551,6 +551,35 @@ def _run_list(cmd_list, check=True):
     )
 
 
+def _run_gh_with_body(cmd_list, body, check=True):
+    """Run a ``gh`` command whose body/message is agent-authored prose, passing
+    the body via ``--body-file -`` (UTF-8 stdin) instead of as a command-line
+    argument (#13370).
+
+    On Windows with a cp1252 default locale, a non-ASCII body (em-dash U+2014,
+    arrows, smart quotes) passed as a ``--body``/``--message`` ARGV argument is
+    mangled in the command line and ``gh`` exits non-zero (observed live; a
+    verifier comment and an in-session pickup comment both crashed on em-dashes).
+    Reading the body from stdin bypasses the argv-encoding path entirely, so any
+    Unicode body round-trips. Sibling of #13185, which crash-proofed the
+    stdout/stderr PRINT surface — a different call surface that did not cover this
+    argv path.
+
+    ``cmd_list`` is the gh command WITHOUT the body flag (e.g.
+    ``["gh", "issue", "comment", "123"]``); this helper appends
+    ``["--body-file", "-"]`` and feeds ``body`` on stdin as UTF-8.
+    """
+    if cmd_list and cmd_list[0] == "gh":
+        cmd_list = [_resolve_gh_bin()] + list(cmd_list[1:])
+    return subprocess.run(
+        cmd_list + ["--body-file", "-"],
+        input=body,
+        capture_output=True, text=True,
+        encoding="utf-8", errors="replace",
+        check=check, cwd=str(REPO_ROOT),
+    )
+
+
 def _resolve_status(name):
     """Resolve a status name to its full label."""
     if name.startswith("status:"):
@@ -942,12 +971,11 @@ def create_issue(title, body, role, severity, reporter=None):
         print(json.dumps(result))
         return result.get("number", -1)
 
-    result = _run_list([
+    result = _run_gh_with_body([  # #13370: body via stdin, not argv --body
         "gh", "issue", "create",
         "--title", full_title,
-        "--body", full_body,
         "--label", labels,
-    ])
+    ], full_body)
     url = result.stdout.strip()
     try:
         number = int(url.rstrip("/").split("/")[-1])
@@ -991,12 +1019,11 @@ def create_task(title, body, role, priority, reporter=None):
         print(json.dumps(result))
         return result.get("number", -1)
 
-    result = _run_list([
+    result = _run_gh_with_body([  # #13370: body via stdin, not argv --body
         "gh", "issue", "create",
         "--title", full_title,
-        "--body", full_body,
         "--label", labels,
-    ])
+    ], full_body)
     url = result.stdout.strip()
     try:
         number = int(url.rstrip("/").split("/")[-1])
@@ -1627,7 +1654,9 @@ def comment(number, role, message, _suppress_event=False):
     if adapter:
         adapter.add_comment(number, body)
     else:
-        _run_list(["gh", "issue", "comment", str(number), "--body", body])
+        # #13370: body via stdin (--body-file -), not an argv --body, so a
+        # non-ASCII body (em-dash etc.) does not crash gh on a cp1252 console.
+        _run_gh_with_body(["gh", "issue", "comment", str(number)], body)
     print(f"Commented on #{number}")
 
     # Emit tracker-comment event (#4709) — suppressed for auto-comments from transition()

--- a/tests/test_13370_gh_body_via_stdin.py
+++ b/tests/test_13370_gh_body_via_stdin.py
@@ -1,0 +1,93 @@
+"""Regression tests for #13370 — tracker.py must pass agent-authored gh bodies
+via `--body-file -` (UTF-8 stdin), not as an argv `--body`/`--message`, so a
+non-ASCII body (em-dash U+2014, arrow U+2192) does not crash gh on a cp1252
+Windows console.
+
+Sibling of shipped #13185 (which crash-proofed the stdout/stderr PRINT surface —
+a different call surface that did not cover this argv path).
+"""
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import tracker
+
+# Non-ASCII body: em-dash + arrow (the exact class that crashed gh live).
+EM_DASH_BODY = "Body with an em-dash — and an arrow → end."
+
+
+def _ok(stdout="https://github.com/o/r/issues/7"):
+    r = MagicMock()
+    r.returncode = 0
+    r.stdout = stdout
+    r.stderr = ""
+    return r
+
+
+class TestRunGhWithBody:
+    def test_body_goes_via_stdin_not_argv(self):
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            captured["input"] = kw.get("input")
+            captured["encoding"] = kw.get("encoding")
+            return _ok()
+
+        with patch("tracker._resolve_gh_bin", return_value="gh"), \
+             patch("tracker.subprocess.run", side_effect=fake_run):
+            tracker._run_gh_with_body(["gh", "issue", "comment", "123"], EM_DASH_BODY)
+
+        assert "--body-file" in captured["cmd"]
+        assert captured["cmd"][captured["cmd"].index("--body-file") + 1] == "-"
+        assert captured["input"] == EM_DASH_BODY          # body fed on stdin
+        assert captured["encoding"] == "utf-8"
+        assert EM_DASH_BODY not in captured["cmd"]         # never a bare argv arg
+        assert "--body" not in captured["cmd"]
+
+
+class TestCommentUsesStdin:
+    def test_comment_routes_body_via_stdin(self):
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            captured["input"] = kw.get("input")
+            return _ok()
+
+        with patch("tracker._resolve_gh_bin", return_value="gh"), \
+             patch("tracker._get_forge_adapter", return_value=None), \
+             patch("tracker.subprocess.run", side_effect=fake_run):
+            tracker.comment(123, "skill-lead (skill)", EM_DASH_BODY, _suppress_event=True)
+
+        assert "--body-file" in captured["cmd"]
+        assert EM_DASH_BODY in captured["input"]           # role-prefixed body on stdin
+        assert "--body" not in captured["cmd"]
+        assert EM_DASH_BODY not in captured["cmd"]
+
+
+class TestCreateIssueUsesStdin:
+    def test_create_issue_routes_body_via_stdin(self):
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            # _repo_labels() issues a `gh label list` first; only capture create.
+            if "create" in cmd:
+                captured["cmd"] = cmd
+                captured["input"] = kw.get("input")
+                return _ok("https://github.com/o/r/issues/8")
+            return _ok("[]")  # label list -> empty -> filter falls back to primary
+
+        tracker._REPO_LABELS_CACHE = None
+        with patch("tracker._resolve_gh_bin", return_value="gh"), \
+             patch("tracker._get_forge_adapter", return_value=None), \
+             patch("tracker.subprocess.run", side_effect=fake_run):
+            tracker.create_issue("title", EM_DASH_BODY, "skill", "low")
+
+        assert "--body-file" in captured["cmd"]
+        assert EM_DASH_BODY in captured["input"]
+        assert "--body" not in captured["cmd"]
+        tracker._REPO_LABELS_CACHE = None

--- a/tests/test_13465_create_issue_role_label_filter.py
+++ b/tests/test_13465_create_issue_role_label_filter.py
@@ -85,61 +85,50 @@ class TestRepoLabelsCaching:
 
 
 class TestCreateIssueExcludesUnknownRoleLabel:
-    def test_create_issue_label_arg_omits_nonexistent_verifier(self):
-        tracker._REPO_LABELS_CACHE = None
+    def _run_create_capturing_label(self, role, label_list_json, issue_url):
+        """Drive create_issue with _repo_labels' `gh label list` mocked on
+        _run_list and the create routed through _run_gh_with_body (#13370, stdin
+        body). Returns (issue_number, captured_label_arg)."""
         captured = {}
 
         def fake_run_list(cmd, check=True, timeout=None):
             r = MagicMock()
-            if "label" in cmd and "list" in cmd:
-                r.returncode = 0
-                r.stdout = ('[{"name":"role:qa"},{"name":"type:issue"},'
-                            '{"name":"severity:low"},{"name":"squidsquad"},'
-                            '{"name":"status:open"}]')
-                return r
-            if "issue" in cmd and "create" in cmd:
-                captured["label"] = cmd[cmd.index("--label") + 1]
-                r.returncode = 0
-                r.stdout = "https://github.com/o/r/issues/999"
-                return r
             r.returncode = 0
-            r.stdout = ""
+            r.stdout = label_list_json if ("label" in cmd and "list" in cmd) else ""
             return r
 
-        with patch("tracker._get_forge_adapter", return_value=None), \
-             patch("tracker._run_list", side_effect=fake_run_list):
-            num = tracker.create_issue("x", "y", "qa", "low", reporter="dm-lead")
-        assert num == 999
-        assert "role:qa" in captured["label"]
-        assert "role:verifier" not in captured["label"]
+        def fake_gwb(cmd, body, check=True):
+            captured["label"] = cmd[cmd.index("--label") + 1]
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = issue_url
+            return r
+
         tracker._REPO_LABELS_CACHE = None
+        with patch("tracker._get_forge_adapter", return_value=None), \
+             patch("tracker._run_list", side_effect=fake_run_list), \
+             patch("tracker._run_gh_with_body", side_effect=fake_gwb):
+            num = tracker.create_issue("x", "y", role, "low", reporter="dm-lead")
+        tracker._REPO_LABELS_CACHE = None
+        return num, captured["label"]
+
+    def test_create_issue_label_arg_omits_nonexistent_verifier(self):
+        num, label = self._run_create_capturing_label(
+            "qa",
+            '[{"name":"role:qa"},{"name":"type:issue"},{"name":"severity:low"},'
+            '{"name":"squidsquad"},{"name":"status:open"}]',
+            "https://github.com/o/r/issues/999")
+        assert num == 999
+        assert "role:qa" in label
+        assert "role:verifier" not in label
 
     def test_create_issue_new_form_role_verifier_also_omits_unknown_label(self):
         # #13465 Finding 1: create_issue with the NEW-form --role verifier must
         # still emit only the existing role:qa label, never the non-existent
         # role:verifier (which would fail the gh create the same way).
-        tracker._REPO_LABELS_CACHE = None
-        captured = {}
-
-        def fake_run_list(cmd, check=True, timeout=None):
-            r = MagicMock()
-            if "label" in cmd and "list" in cmd:
-                r.returncode = 0
-                r.stdout = '[{"name":"role:qa"}]'
-                return r
-            if "issue" in cmd and "create" in cmd:
-                captured["label"] = cmd[cmd.index("--label") + 1]
-                r.returncode = 0
-                r.stdout = "https://github.com/o/r/issues/1000"
-                return r
-            r.returncode = 0
-            r.stdout = ""
-            return r
-
-        with patch("tracker._get_forge_adapter", return_value=None), \
-             patch("tracker._run_list", side_effect=fake_run_list):
-            num = tracker.create_issue("x", "y", "verifier", "low", reporter="dm-lead")
+        num, label = self._run_create_capturing_label(
+            "verifier", '[{"name":"role:qa"}]',
+            "https://github.com/o/r/issues/1000")
         assert num == 1000
-        assert "role:qa" in captured["label"]
-        assert "role:verifier" not in captured["label"]
-        tracker._REPO_LABELS_CACHE = None
+        assert "role:qa" in label
+        assert "role:verifier" not in label

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -167,18 +167,20 @@ class TestListAllOpen:
 
 class TestCreateIssue:
     def test_creates_with_correct_labels(self, monkeypatch):
+        # #13370: create_issue routes the body via _run_gh_with_body (stdin); the
+        # title/label stay in the cmd argv.
         calls = []
 
-        def fake_run(cmd, **kw):
-            calls.append(cmd)
+        def fake_gwb(cmd, body, **kw):
+            calls.append((cmd, body))
             return _mock_result(stdout="https://github.com/org/repo/issues/99\n")
 
         monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
-        monkeypatch.setattr(tracker, "_run_list", fake_run)
+        monkeypatch.setattr(tracker, "_run_gh_with_body", fake_gwb)
         number = tracker.create_issue("test bug", "body", "skill", "high", "pm-lead")
         assert number == 99
-        # Verify labels include type:issue, severity:high, role:skill
-        label_arg = calls[0][calls[0].index("--label") + 1]
+        cmd = calls[0][0]
+        label_arg = cmd[cmd.index("--label") + 1]
         assert "type:issue" in label_arg
         assert "severity:high" in label_arg
         assert "role:skill" in label_arg
@@ -187,14 +189,15 @@ class TestCreateIssue:
     def test_strips_duplicate_prefix(self, monkeypatch):
         calls = []
 
-        def fake_run(cmd, **kw):
-            calls.append(cmd)
+        def fake_gwb(cmd, body, **kw):
+            calls.append((cmd, body))
             return _mock_result(stdout="https://github.com/org/repo/issues/1\n")
 
         monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
-        monkeypatch.setattr(tracker, "_run_list", fake_run)
+        monkeypatch.setattr(tracker, "_run_gh_with_body", fake_gwb)
         tracker.create_issue("ISSUE: already prefixed", "body", "skill", "low")
-        title_arg = calls[0][calls[0].index("--title") + 1]
+        cmd = calls[0][0]
+        title_arg = cmd[cmd.index("--title") + 1]
         assert title_arg == "ISSUE: already prefixed"
         assert not title_arg.startswith("ISSUE: ISSUE:")
 
@@ -203,15 +206,16 @@ class TestCreateTask:
     def test_creates_with_pending_status(self, monkeypatch):
         calls = []
 
-        def fake_run(cmd, **kw):
-            calls.append(cmd)
+        def fake_gwb(cmd, body, **kw):
+            calls.append((cmd, body))
             return _mock_result(stdout="https://github.com/org/repo/issues/50\n")
 
         monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
-        monkeypatch.setattr(tracker, "_run_list", fake_run)
+        monkeypatch.setattr(tracker, "_run_gh_with_body", fake_gwb)
         number = tracker.create_task("new feature", "body", "skill", "medium")
         assert number == 50
-        label_arg = calls[0][calls[0].index("--label") + 1]
+        cmd = calls[0][0]
+        label_arg = cmd[cmd.index("--label") + 1]
         assert "type:task" in label_arg
         assert "status:pending" in label_arg
 
@@ -236,15 +240,15 @@ class TestCreateTask:
         """#6848: create_task should include reporter in body when provided."""
         calls = []
 
-        def fake_run(cmd, **kw):
-            calls.append(cmd)
+        def fake_gwb(cmd, body, **kw):
+            calls.append((cmd, body))
             return _mock_result(stdout="https://github.com/org/repo/issues/51\n")
 
         monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
-        monkeypatch.setattr(tracker, "_run_list", fake_run)
+        monkeypatch.setattr(tracker, "_run_gh_with_body", fake_gwb)
         tracker.create_task("feat", "body", "skill", "medium", reporter="skill-lead")
-        body_idx = calls[0].index("--body") + 1
-        assert "**Reported By**: skill-lead" in calls[0][body_idx]
+        # #13370: the reporter-annotated body is now passed as the stdin body arg.
+        assert "**Reported By**: skill-lead" in calls[0][1]
 
 
 class TestCommentNoRedundantImport:
@@ -260,19 +264,20 @@ class TestCommentNoRedundantImport:
 
 class TestComment:
     def test_adds_comment(self, monkeypatch):
+        # #13370: comment() routes the body via _run_gh_with_body (stdin).
         calls = []
 
-        def fake_run(cmd, **kw):
-            calls.append(cmd)
+        def fake_gwb(cmd, body, **kw):
+            calls.append((cmd, body))
             return _mock_result()
 
         monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
-        monkeypatch.setattr(tracker, "_run_list", fake_run)
+        monkeypatch.setattr(tracker, "_run_gh_with_body", fake_gwb)
         tracker.comment(42, "skill-lead", "test message")
-        assert any("comment" in c for c in calls)
-        body_idx = calls[0].index("--body") + 1
-        assert "**skill-lead**:" in calls[0][body_idx]
-        assert "test message" in calls[0][body_idx]
+        assert any("comment" in c for c, _ in calls)
+        body = calls[0][1]
+        assert "**skill-lead**:" in body
+        assert "test message" in body
 
 
 class TestGetLabels:


### PR DESCRIPTION
## Summary
Fixes #13370 (verifier-filed, low; reproduced firsthand this session -- an em-dash in a pickup comment crashed tracker.py comment(), ASCII rewrite succeeded). tracker.py comment()/create_issue()/create_task() passed agent-authored prose as a gh --body/--message ARGV argument; on Windows with a cp1252 default locale a non-ASCII body (em-dash U+2014, arrows, smart quotes) is mangled in the command line and gh exits non-zero. Sibling of shipped #13185, which crash-proofed the stdout/stderr PRINT surface -- a different call surface that did not cover this argv path.

## Fix
New _run_gh_with_body(cmd_list, body, check) appends --body-file - and feeds the body on UTF-8 stdin (input=body, encoding=utf-8), bypassing the argv-encoding path entirely so any Unicode body round-trips. Routed comment(), create_issue(), create_task() through it. Titles/labels remain argv (short, effectively ASCII; gh has no --title-file). Fix is at the subprocess boundary, not per-call-site prose munging, per the issue.

## Tests
tests/test_13370_gh_body_via_stdin.py: asserts the body (incl. an em-dash + arrow) is fed via stdin (input=) with --body-file - and never appears as a bare --body argv element, for _run_gh_with_body, comment(), and create_issue(). test_tracker.py + test_13465 create/comment tests updated to the new stdin path. Full static gate 5365 passed / 0 failures. DeepSeek review NO_FINDINGS.