### PR TITLE
#13494: harness _git_in_clone forces LC_ALL=C so deploy-pull message-substring checks are locale-robust

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -4970,11 +4970,21 @@ def _emit_boot_deploy_signals():
 
 def _git_in_clone(clone_path, args, timeout=120):
     """Run a git command inside a specific agent clone (the harness operating on
-    another clone is new machinery — design §0). Returns the CompletedProcess."""
+    another clone is new machinery — design §0). Returns the CompletedProcess.
+
+    #13494: force ``LC_ALL=C`` so git emits ENGLISH, stable messages. The
+    deploy-pull helpers branch on English message substrings ("untracked files
+    from stash" for the #13456 pulled-wins cleanup; "already up to date"; "would
+    be overwritten by merge") — under a non-English ``LANG``/``LC_MESSAGES`` on
+    the operator's machine those checks would silently fail. Forcing the locale
+    in this single choke point makes every message-substring check in the deploy
+    path locale-robust at once.
+    """
     return subprocess.run(
         ["git", *args],
         capture_output=True, text=True, encoding="utf-8", errors="replace",
         check=False, cwd=str(clone_path), timeout=timeout,
+        env={**os.environ, "LC_ALL": "C"},
     )
 
 

--- a/tests/test_13494_git_in_clone_c_locale.py
+++ b/tests/test_13494_git_in_clone_c_locale.py
@@ -1,0 +1,56 @@
+"""Regression for #13494 — _git_in_clone forces LC_ALL=C so git emits stable
+English messages that the deploy-pull helpers branch on ("untracked files from
+stash", "already up to date", "would be overwritten by merge"). Without a forced
+locale, a non-English LANG/LC_MESSAGES on the operator's machine would silently
+break those substring checks in deploy-critical code.
+"""
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "references", "scripts"))
+
+import harness  # noqa: E402
+
+
+def test_git_in_clone_forces_lc_all_c():
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        captured["env"] = kw.get("env")
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = ""
+        r.stderr = ""
+        return r
+
+    with patch("harness.subprocess.run", side_effect=fake_run):
+        harness._git_in_clone("/some/clone", ["status", "--porcelain"])
+
+    assert captured["cmd"] == ["git", "status", "--porcelain"]
+    assert captured["env"] is not None, "must pass an explicit env forcing the locale"
+    assert captured["env"].get("LC_ALL") == "C"
+
+
+def test_git_in_clone_preserves_existing_environment():
+    marker_key = "SQUIDSQUAD_13494_MARKER"
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured["env"] = kw.get("env")
+        r = MagicMock()
+        r.returncode = 0
+        r.stdout = ""
+        r.stderr = ""
+        return r
+
+    with patch.dict(os.environ, {marker_key: "keepme"}), \
+         patch("harness.subprocess.run", side_effect=fake_run):
+        harness._git_in_clone("/some/clone", ["rev-parse", "HEAD"])
+
+    # The forced-locale env is a SUPERSET of the process env, not a replacement —
+    # git still needs PATH, HOME, credential config, etc.
+    assert captured["env"].get(marker_key) == "keepme"
+    assert captured["env"].get("LC_ALL") == "C"


### PR DESCRIPTION
## Summary
Fixes #13494 (verifier-filed, low; surfaced while verifying #13456/#13472). The harness deploy-pull helpers branch on ENGLISH git message substrings, but _git_in_clone (harness.py:4971) ran git with no locale forced -- so under a non-English LANG/LC_MESSAGES those checks silently fail. Affected sites: _safe_stash_pop_in_clone ("untracked files from stash", the #13456 pulled-wins cleanup) and _safe_pull_in_clone ("already up to date").

## Fix
Central, one place: _git_in_clone now passes env={**os.environ, "LC_ALL": "C"} so git emits stable English messages and EVERY message-substring check in the deploy path becomes locale-robust at once. The env is a superset of the process env (preserves PATH/HOME/credentials), overriding only the locale. All deploy-path git calls (_safe_pull_in_clone, _safe_stash_pop_in_clone, stage/deploy sequence) route exclusively through _git_in_clone -- no bypasses.

## Tests
tests/test_13494_git_in_clone_c_locale.py: asserts LC_ALL=C is forced and the existing environment is preserved (superset, not replacement). The real-git deploy-pull sibling tests (#13215/#13456/#13472) still pass under the forced locale. Full static gate 5371 passed / 0 failures. DeepSeek review NO_FINDINGS.