### PR TITLE
#13513: ship docs/sub-skill-catalog.md in installer-files.txt (greenfield compose blocker)

### DIFF
--- a/references/installer-files.txt
+++ b/references/installer-files.txt
@@ -1,7 +1,7 @@
 # SquidSquad installer file manifest
 # Every file the wizard needs, fetched by npx squidsquad before
 # launching Claude. One path per line, relative to repo root.
-# Total: 254 files
+# Total: 255 files
 #
 # Maintained alongside the wizard - when you add a new role,
 # capability, preset, or sub-skill, add its files here too.
@@ -12,6 +12,7 @@ SKILL.md
 references/commands/squidsquad-compose.md
 references/commands/squidsquad-upgrade.md
 docs/INSTALLER-RUNTIME.md
+docs/sub-skill-catalog.md
 references/VERSION
 references/migrations/README.md
 references/scripts/activity_hook.py

--- a/tests/test_12821_installer_files_subskill_completeness.py
+++ b/tests/test_12821_installer_files_subskill_completeness.py
@@ -66,6 +66,26 @@ def test_all_wizard_seed_stubs_in_manifest():
     )
 
 
+def test_catalog_file_itself_in_manifest():
+    """#13513 — docs/sub-skill-catalog.md must be SHIPPED, not just its contents.
+
+    The catalog is a git-committed file that compose's v2 catalog gate reads at
+    ``<target>/docs/sub-skill-catalog.md`` on every role deploy. The sibling
+    tests above ship everything the catalog *references* but never assert the
+    catalog *itself* is in the manifest — that gap let a faithful foreign-target
+    greenfield install (the #12527 smoke) produce ZERO CLAUDE.md: every role
+    failed with "catalog file not found". Self-hosted installs masked it because
+    the repo already carries the catalog on disk.
+    """
+    manifest = _manifest_paths()
+    assert CATALOG.exists(), "catalog source file must exist on disk"
+    rel = _rel(CATALOG)
+    assert rel in manifest, (
+        f"{rel} (compose v2 catalog-gate dependency) absent from "
+        f"installer-files.txt — greenfield compose fails for every role (#13513)"
+    )
+
+
 def test_manifest_count_header_matches_payload():
     """The `# Total: N files` header must equal the payload line count (the
     same invariant #12525 checks — re-asserted here so a bulk add can't drift)."""


### PR DESCRIPTION
## Problem
A fresh `npx squidsquad` install composed **zero** CLAUDE.md. compose's v2 catalog gate reads `<target>/docs/sub-skill-catalog.md` on every role deploy, but that file — though git-committed — was **absent from `references/installer-files.txt`**, so npx never staged it. Every role failed with `catalog file not found`. Invisible self-hosted (the repo already carries the catalog on disk); surfaced by the #12527 foreign-target greenfield smoke.

## Fix
- Add `docs/sub-skill-catalog.md` to `installer-files.txt` (+ bump `# Total` header 254->255).
- Regression test in `test_12821`: assert the catalog **file itself** is shipped (the sibling tests only asserted everything the catalog *references*, which is exactly the gap that let this through).

## Verification
- Full static gate: 5376 passed, 0 failures.
- Faithful manifest-staged greenfield smoke now stages the catalog.

Fixes #13513. Refs #12527 (greenfield validation gate), #13514 (sibling: setup-yes masks compose failure).