### PR TITLE
skill: #13514 setup-yes surfaces per-role compose failure

### DIFF
--- a/references/scripts/wizard.py
+++ b/references/scripts/wizard.py
@@ -4274,10 +4274,23 @@ def cmd_setup_yes(args):
     print("\nScaffolding...")
     try:
         result = scaffold_install(spec, target_path, overwrite_existing=True)
-        print(f"  Created {len(result.get('agents', []))} agent(s)")
     except (ValueError, FileExistsError) as e:
         print(f"ERROR: scaffold failed: {e}", file=sys.stderr)
         return 1
+
+    # scaffold_install records a per-role compose failure as claude_md == "FAILED"
+    # (see the deploy loop). Surface it here: a role that failed to compose has NO
+    # valid CLAUDE.md, so the install is not bootable for that agent. "Created N"
+    # must count only agents that actually produced a CLAUDE.md, not every
+    # scaffolded directory — otherwise a broken install reads as a successful one
+    # and the operator gets no signal (#13514).
+    agents = result.get("agents", [])
+    failed = [a for a in agents if a.get("claude_md") == "FAILED"]
+    succeeded = [a for a in agents if a.get("claude_md") != "FAILED"]
+    msg = f"  Created {len(succeeded)} agent(s)"
+    if failed:
+        msg += f" ({len(failed)} FAILED to compose)"
+    print(msg)
 
     # 6. Ensure labels
     print("Creating GitHub labels...")
@@ -4291,9 +4304,24 @@ def cmd_setup_yes(args):
     except Exception as e:
         print(f"WARNING: label creation failed: {e}", file=sys.stderr)
 
-    # 7. Post-setup summary
-    print()
-    print(post_setup_summary(spec))
+    # 7. Post-setup summary — only on a bootable install. post_setup_summary()
+    # hardcodes "SquidSquad is installed for ..."; printing it when a role failed
+    # to compose contradicts the ERROR below and gives CI/operator a false success
+    # signal (#13514). Suppress it whenever any role failed.
+    if not failed:
+        print()
+        print(post_setup_summary(spec))
+
+    # A role that failed to compose leaves the install non-bootable. Fail loudly
+    # with a non-zero exit so the operator (or CI) is not misled by exit 0 (#13514).
+    if failed:
+        print(
+            f"\nERROR: {len(failed)} role(s) failed to compose a CLAUDE.md: "
+            f"{', '.join(a.get('id', '?') for a in failed)}. The install is NOT "
+            f"bootable for those agents — see the WARNING(s) above for the cause.",
+            file=sys.stderr,
+        )
+        return 1
 
     return 0
 

--- a/tests/test_13514_setup_yes_surfaces_compose_failure.py
+++ b/tests/test_13514_setup_yes_surfaces_compose_failure.py
@@ -1,0 +1,108 @@
+"""#13514 — `wizard.py setup-yes` must NOT report success when a role fails to
+compose its CLAUDE.md.
+
+Regression for the greenfield failure surfaced by the #12527 smoke: with a role's
+compose failing (e.g. the #13513 missing-catalog condition), `setup-yes` printed
+"Created N agent(s)" and returned 0 — a broken, non-bootable install masquerading
+as a successful one. `scaffold_install` already records a per-role failure as
+``claude_md == "FAILED"``; `cmd_setup_yes` must surface it: count only composed
+agents and return non-zero when any role failed.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "references", "scripts"))
+
+import wizard  # noqa: E402
+
+
+class _GhMiss:
+    """Fake `gh repo view` result — returns non-zero so repo_info falls back to
+    the target dir name (keeps the test off the network)."""
+    returncode = 1
+    stdout = ""
+    stderr = ""
+
+
+def _common_stubs(monkeypatch):
+    monkeypatch.setattr(wizard, "ensure_labels", lambda dry_run=False: {"created": 0})
+    monkeypatch.setattr(wizard, "_run", lambda *a, **k: _GhMiss())
+
+
+def test_setup_yes_returns_nonzero_when_a_role_fails_to_compose(tmp_path, monkeypatch, capsys):
+    def fake_scaffold(spec, target_root, overwrite_existing=False):
+        return {
+            "target": str(target_root),
+            "agents": [
+                {"id": "pm", "role": "pm", "claude_md": "FAILED",
+                 "soul_md": "FAILED", "working_state": "FAILED"},
+                {"id": "skill", "role": "worker", "claude_md": str(target_root),
+                 "soul_md": "s", "working_state": "w"},
+            ],
+        }
+    monkeypatch.setattr(wizard, "scaffold_install", fake_scaffold)
+    _common_stubs(monkeypatch)
+
+    rc = wizard.cmd_setup_yes([str(tmp_path)])
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+
+    assert rc != 0, "setup-yes must return non-zero when any role fails to compose"
+    assert "FAILED" in combined or "failed to compose" in combined.lower(), (
+        "the failure must be visible in output, not silently swallowed"
+    )
+    # "Created N" must reflect only the composed agent, not the failed one.
+    assert "Created 1 agent" in combined
+
+
+def test_setup_yes_returns_nonzero_when_every_role_fails(tmp_path, monkeypatch, capsys):
+    # The exact scenario in the bug title: EVERY role's compose fails, so zero
+    # agents produce a CLAUDE.md. The install is fully non-bootable; setup-yes must
+    # still fail loudly (rc!=0), report "Created 0 agent(s)", and print the ERROR.
+    def fake_scaffold(spec, target_root, overwrite_existing=False):
+        return {
+            "target": str(target_root),
+            "agents": [
+                {"id": "pm", "role": "pm", "claude_md": "FAILED",
+                 "soul_md": "FAILED", "working_state": "FAILED"},
+                {"id": "skill", "role": "worker", "claude_md": "FAILED",
+                 "soul_md": "FAILED", "working_state": "FAILED"},
+            ],
+        }
+    monkeypatch.setattr(wizard, "scaffold_install", fake_scaffold)
+    _common_stubs(monkeypatch)
+
+    rc = wizard.cmd_setup_yes([str(tmp_path)])
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+
+    assert rc != 0, "setup-yes must return non-zero when every role fails to compose"
+    assert "Created 0 agent" in combined, "'Created' must reflect zero composed agents"
+    assert "failed to compose" in combined.lower()
+    # The 'installed' success banner must NOT appear on a fully non-bootable install.
+    assert "is installed" not in combined, (
+        "the success summary must be suppressed when no role composed"
+    )
+
+
+def test_setup_yes_returns_zero_when_all_roles_compose(tmp_path, monkeypatch, capsys):
+    def fake_scaffold(spec, target_root, overwrite_existing=False):
+        return {
+            "target": str(target_root),
+            "agents": [
+                {"id": "pm", "role": "pm", "claude_md": str(target_root),
+                 "soul_md": "s", "working_state": "w"},
+                {"id": "skill", "role": "worker", "claude_md": str(target_root),
+                 "soul_md": "s", "working_state": "w"},
+            ],
+        }
+    monkeypatch.setattr(wizard, "scaffold_install", fake_scaffold)
+    _common_stubs(monkeypatch)
+
+    rc = wizard.cmd_setup_yes([str(tmp_path)])
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+
+    assert rc == 0, "a fully-composed install must still return 0"
+    assert "Created 2 agent(s)" in combined
+    assert "FAILED" not in combined


### PR DESCRIPTION
## Summary
`wizard.py setup-yes` reported success (`Created N agent(s)`) and exited 0 even when every role's compose failed and no CLAUDE.md was produced — a broken, non-bootable install masquerading as a successful one (ref #13514).

## Root cause
`scaffold_install` records a per-role compose failure as `claude_md == "FAILED"` (wizard.py:2094), but `cmd_setup_yes` counted every scaffolded agent as "Created" and returned 0.

## Fix
- Count only agents whose `claude_md != "FAILED"`; print `(K FAILED to compose)` when any failed.
- Suppress the `SquidSquad is installed for ...` success banner whenever any role failed (it otherwise contradicts the error and gives CI/operator a false success signal).
- Return non-zero with a distinct `ERROR:` summary naming the failed role ids (defensive `.get('id','?')`).

## Tests
`tests/test_13514_setup_yes_surfaces_compose_failure.py` — three cases:
- partial failure → `rc != 0`, `Created 1 agent`, failure visible
- every role fails → `rc != 0`, `Created 0 agent`, no `is installed` banner
- all compose → `rc == 0`, `Created 2 agent(s)`, no `FAILED`

Full static gate: 5384 gated tests, 0 failures. DeepSeek review clean (3 warnings, all addressed in this diff).