### PR TITLE
skill: #13433 git_ops.py pr-merge validates PR number before side effects

### DIFF
--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -1958,7 +1958,7 @@ def _ensure_hooks_installed():
 
 def _parse_args():
     args = sys.argv[1:]
-    if not args or args[0] == "--help":
+    if not args or args[0] in ("--help", "-h"):
         print(__doc__)
         sys.exit(0)
     return args[0], args[1:]
@@ -2017,9 +2017,23 @@ def main():
         success = pr_ready(rest[0])
         sys.exit(0 if success else 1)
     elif cmd == "pr-merge":
-        if not rest:
-            print("Usage: git_ops.py pr-merge <pr-number> [--strategy squash|merge]", file=sys.stderr)
-            sys.exit(1)
+        _pr_merge_usage = "Usage: git_ops.py pr-merge <pr-number> [--strategy squash|merge]"
+        # Validate the PR number BEFORE any side effect. pr_merge() runs a real
+        # squash-merge + post-merge scope-audit/compose, so calling it with a bogus
+        # "PR number" (e.g. the literal "--help" from `pr-merge --help`, which
+        # `_parse_args` only catches in the SUBCOMMAND position) dirtied the tree
+        # and printed a false "PR #--help merged (squash)" (#13433). Treat a
+        # subcommand-position -h/--help as a help request (exit 0), a missing arg
+        # as a usage error (exit 1), and a non-numeric arg as invalid usage
+        # (exit 2 — distinct from a genuine merge failure, which returns exit 1).
+        if not rest or rest[0] in ("-h", "--help"):
+            print(_pr_merge_usage, file=sys.stderr)
+            sys.exit(0 if rest else 1)
+        if not rest[0].isdigit():
+            print(f"ERROR: invalid PR number {rest[0]!r} (expected a positive "
+                  f"integer); no merge attempted.", file=sys.stderr)
+            print(_pr_merge_usage, file=sys.stderr)
+            sys.exit(2)
         strategy = "squash"
         if "--strategy" in rest:
             idx = rest.index("--strategy")

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -874,6 +874,13 @@ class TestParseArgs:
             with pytest.raises(SystemExit):
                 git_ops._parse_args()
 
+    def test_dash_h_exits(self):
+        # -h at the subcommand position prints usage and exits (#13433).
+        with patch.object(sys, "argv", ["git_ops.py", "-h"]):
+            with pytest.raises(SystemExit) as exc:
+                git_ops._parse_args()
+        assert exc.value.code == 0
+
     def test_no_args_exits(self):
         with patch.object(sys, "argv", ["git_ops.py"]):
             with pytest.raises(SystemExit):
@@ -890,6 +897,64 @@ class TestParseArgs:
             cmd, rest = git_ops._parse_args()
             assert cmd == "commit"
             assert rest == ["skill", "msg"]
+
+
+# ---------------------------------------------------------------------------
+# pr-merge dispatch arg guard (#13433)
+# ---------------------------------------------------------------------------
+
+class TestPrMergeArgGuard:
+    """`pr-merge` must validate the PR number BEFORE any side effect. Previously
+    `pr-merge --help` (and other non-numeric first args) reached pr_merge(), which
+    runs a real squash-merge + post-merge compose — dirtying the tree and printing
+    a false 'PR #--help merged (squash)'. These tests assert pr_merge is never
+    invoked with a bogus PR number."""
+
+    def _run_main(self, argv, monkeypatch):
+        spy = MagicMock(return_value=(True, "ok"))
+        monkeypatch.setattr(git_ops, "pr_merge", spy)
+        # Keep the dispatch hermetic — main() self-heals git hooks otherwise.
+        monkeypatch.setattr(git_ops, "_ensure_hooks_installed", lambda: None)
+        monkeypatch.setattr(sys, "argv", ["git_ops.py"] + argv)
+        with pytest.raises(SystemExit) as exc:
+            git_ops.main()
+        return spy, exc.value.code
+
+    def test_help_does_not_merge(self, monkeypatch):
+        spy, code = self._run_main(["pr-merge", "--help"], monkeypatch)
+        spy.assert_not_called()
+        assert code == 0  # help is a successful request
+
+    def test_dash_h_does_not_merge(self, monkeypatch):
+        spy, code = self._run_main(["pr-merge", "-h"], monkeypatch)
+        spy.assert_not_called()
+        assert code == 0
+
+    def test_missing_number_is_usage_error(self, monkeypatch):
+        spy, code = self._run_main(["pr-merge"], monkeypatch)
+        spy.assert_not_called()
+        assert code == 1  # missing required arg
+
+    def test_non_numeric_is_rejected(self, monkeypatch):
+        spy, code = self._run_main(["pr-merge", "notanumber"], monkeypatch)
+        spy.assert_not_called()
+        assert code == 2  # invalid usage, distinct from a merge failure (1)
+
+    def test_flag_in_number_position_is_rejected(self, monkeypatch):
+        # `pr-merge --strategy squash` (forgot the number) must NOT merge.
+        spy, code = self._run_main(["pr-merge", "--strategy", "squash"], monkeypatch)
+        spy.assert_not_called()
+        assert code == 2
+
+    def test_valid_number_merges(self, monkeypatch):
+        spy, code = self._run_main(["pr-merge", "13523"], monkeypatch)
+        spy.assert_called_once_with("13523", "squash")
+        assert code == 0
+
+    def test_valid_number_honors_strategy(self, monkeypatch):
+        spy, code = self._run_main(["pr-merge", "13523", "--strategy", "merge"], monkeypatch)
+        spy.assert_called_once_with("13523", "merge")
+        assert code == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`git_ops.py pr-merge --help` (and any non-numeric first arg) reached `pr_merge()`, which runs a real squash-merge + post-merge scope-audit/compose — dirtying the working tree with 8 composed `CLAUDE.md` files and printing a false `PR #--help merged (squash)`. Observed live ~repeatedly during verification (ref #13433). `_parse_args` only caught `--help` in the subcommand position.

## Fix
- Accept `-h` at the top-level `_parse_args` (alongside `--help`).
- Validate the `pr-merge` PR number **before any side effect**: `-h`/`--help` → usage, exit 0; missing → exit 1; non-numeric (incl. a stray flag in the number position) → exit 2 with a clear `no merge attempted` error. `pr_merge()` is never called with a bogus number.
- Scoped to `pr-merge`'s number position only — free-text args elsewhere (commit messages, PR bodies) that legitimately contain `--help` are unaffected.

## Tests
`tests/test_git_ops.py`:
- `TestPrMergeArgGuard` (7 cases) — spy asserts `pr_merge` is never called on `--help`/`-h`/missing/non-numeric/flag-in-number-position; valid numbers still merge and honor `--strategy`.
- `TestParseArgs::test_dash_h_exits`.

Live smoke: `pr-merge --help` → usage/exit 0; `pr-merge notanumber` → error/exit 2; **zero composed-file churn** in the tree. Full static gate: 5389 gated tests, 0 failures. DeepSeek review: NO_FINDINGS.