### PR TITLE
skill: #13323 fix stale ./start.sh docstring refs in wizard.py

### DIFF
--- a/references/scripts/wizard.py
+++ b/references/scripts/wizard.py
@@ -1177,8 +1177,8 @@ def restart_agents(base_dir=None, timeout=HARNESS_PROBE_TIMEOUT):
       and boot the refreshed CLAUDE.md (AC2: no stale-instruction agents).
     - **Unreachable** — the wizard is ephemeral (Q-new21); it does NOT spawn a
       detached harness. Report the user-driven cold-start command and let the
-      runbook surface ``./start.sh`` to the user (AC1 "falls through to
-      start.sh").
+      runbook surface ``.squidsquad/start.sh`` to the user (AC1 "falls through
+      to start.sh").
 
     ``ok`` is False only when the harness was reachable AND a restart failed (or
     no aliases were found); an unreachable harness is a normal branch, not an
@@ -3244,7 +3244,7 @@ def cmd_restart_agents(args):
 
     Usage: wizard.py restart-agents [base_dir]
     Exit 0 on a clean restart OR an unreachable harness (a normal branch — the
-    runbook surfaces ./start.sh); exit 1 when the harness was reachable but a
+    runbook surfaces .squidsquad/start.sh); exit 1 when the harness was reachable but a
     restart failed, so the runbook can show the operator which aliases failed.
     """
     base_dir = args[0] if args else None


### PR DESCRIPTION
## Summary
After #13318 migrated the launcher to `.squidsquad/start.sh`, two docstrings in `references/scripts/wizard.py` still described the old repo-root `./start.sh` path:
- `restart_agents` docstring
- `cmd_restart_agents` docstring

The functional paths (`cold_start_cmd: ".squidsquad/start.sh"`, the detail message) were already correct — this is a doc-code mismatch only.

## Fix
Update both docstrings `./start.sh` → `.squidsquad/start.sh`.

Doc-only correction — no logic change, so no unit test is warranted (nothing behavioral to assert; the emitted command was already correct). Full static gate: 5381 gated tests, 0 failures.