### PR TITLE
skill: #13371 pr_create neutralizes PR-body closing keywords

### DIFF
--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -32,6 +32,7 @@ Usage:
 
 import io
 import json
+import re
 import subprocess
 import sys
 import threading
@@ -550,9 +551,53 @@ def current_branch():
     return name
 
 
+# #13371: A PR body carrying a GitHub closing keyword (Close/Fix/Resolve[sd] #N)
+# auto-closes the issue at squash-merge — BEFORE the verifier verdict is on the
+# record and bypassing pending-ship -> shipped (DM's gate + ship counter +
+# changelog). Issue closure must stay EXCLUSIVELY tracker.py's shipped-transition
+# auto-close. pr_create neutralizes closing keywords to a non-closing "Addresses"
+# form so the reference still cross-links but does not close. Deterministic guard
+# at the sanctioned PR-creation path, so correctness no longer rests on every
+# agent remembering to omit "Fixes #N" by hand.
+#
+# Reference forms GitHub honors for auto-close (all covered): "#123", "GH-123",
+# "owner/repo#123", and a full ".../issues/123" URL — each optionally preceded by
+# a colon. \b anchors keep sub-words safe ("prefix", "hotfixes", "affixes" never
+# match); the separator requires a colon or whitespace, so "fix#1" (which GitHub
+# also ignores) is left alone.
+_CLOSING_KEYWORD_RE = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b"          # closing keyword
+    r"(\s*:\s*|\s+)"                                          # separator (colon or space)
+    r"(#\d+|GH-\d+|https?://\S+?/issues/\d+|"                 # #N / GH-N / issue URL
+    r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#\d+)",                  # owner/repo#N
+    re.IGNORECASE,
+)
+
+
+def _neutralize_closing_keywords(body):
+    """Rewrite GitHub closing keywords in a PR body to a non-closing form (#13371).
+
+    "Fixes #12" -> "Addresses #12"; "Closes: #12" -> "Addresses: #12". The issue
+    reference (and any colon separator) is preserved verbatim so the cross-link
+    survives; only the closing verb is swapped. Non-keyword references
+    ("Cross-ref #12", "Addresses #12") pass through untouched. Returns the body
+    unchanged when it is empty/None.
+    """
+    if not body:
+        return body
+    return _CLOSING_KEYWORD_RE.sub(
+        lambda m: "Addresses" + m.group(1) + m.group(2), body
+    )
+
+
 def pr_create(title, body):
     """Create a draft PR. Uses forge adapter for non-GitHub backends,
-    gh CLI for GitHub. PRs start as drafts — QA converts to ready."""
+    gh CLI for GitHub. PRs start as drafts — QA converts to ready.
+
+    The body is passed through _neutralize_closing_keywords (#13371) so a stray
+    "Fixes #N" cannot auto-close the issue at merge and bypass the DM ship gate.
+    """
+    body = _neutralize_closing_keywords(body)
     try:
         from forge_adapter import get_adapter, _read_forge_config
         config = _read_forge_config()

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -2847,3 +2847,83 @@ class TestScopeAudit13285:
         called = [c.args[0] for c in rl_mock.call_args_list]
         assert ["git", "revert", "--abort"] in called
         assert not any(c[:2] == ["git", "push"] for c in called)
+
+
+# ---------------------------------------------------------------------------
+# #13371 — pr_create neutralizes GitHub closing keywords in the PR body so a
+# stray "Fixes #N" cannot auto-close the issue at squash-merge and bypass the
+# pending-ship -> shipped DM gate (ship counter + changelog + recorded verdict).
+# ---------------------------------------------------------------------------
+
+class TestNeutralizeClosingKeywords:
+    def test_fixes_hash_rewritten(self):
+        assert git_ops._neutralize_closing_keywords("Fixes #123") == "Addresses #123"
+
+    def test_all_keyword_variants_rewritten(self):
+        for kw in ("close", "closes", "closed", "fix", "fixes", "fixed",
+                   "resolve", "resolves", "resolved"):
+            out = git_ops._neutralize_closing_keywords(f"{kw} #7")
+            assert out == "Addresses #7", f"{kw!r} not neutralized: {out!r}"
+
+    def test_case_insensitive(self):
+        assert git_ops._neutralize_closing_keywords("FIXES #1") == "Addresses #1"
+        assert git_ops._neutralize_closing_keywords("Resolves #2") == "Addresses #2"
+
+    def test_colon_separator_preserved(self):
+        assert git_ops._neutralize_closing_keywords("Closes: #45") == "Addresses: #45"
+
+    def test_cross_repo_reference(self):
+        assert (git_ops._neutralize_closing_keywords("Fixes owner/repo#12")
+                == "Addresses owner/repo#12")
+
+    def test_issue_url_reference(self):
+        body = "Fixes https://github.com/WallyDoodlez/SquidSquad/issues/34"
+        assert (git_ops._neutralize_closing_keywords(body)
+                == "Addresses https://github.com/WallyDoodlez/SquidSquad/issues/34")
+
+    def test_multiple_occurrences_all_rewritten(self):
+        assert (git_ops._neutralize_closing_keywords("Fixes #1, closes #2")
+                == "Addresses #1, Addresses #2")
+
+    def test_non_closing_reference_untouched(self):
+        for body in ("Cross-ref #12", "Addresses #12", "See #12", "Part of #12"):
+            assert git_ops._neutralize_closing_keywords(body) == body
+
+    def test_subword_keywords_not_matched(self):
+        # \b anchors: these contain a keyword as a substring but are not one.
+        for body in ("prefix #1", "hotfixes #2", "affixes #3", "postfixed #4"):
+            assert git_ops._neutralize_closing_keywords(body) == body, body
+
+    def test_keyword_without_immediate_reference_untouched(self):
+        # GitHub only closes when the ref directly follows the keyword.
+        body = "This fixes the bug described in #5 nicely."
+        assert git_ops._neutralize_closing_keywords(body) == body
+
+    def test_empty_and_none_passthrough(self):
+        assert git_ops._neutralize_closing_keywords("") == ""
+        assert git_ops._neutralize_closing_keywords(None) is None
+
+    def test_bare_reference_no_space_untouched(self):
+        # No separator -> GitHub does not close -> leave alone.
+        assert git_ops._neutralize_closing_keywords("fix#1") == "fix#1"
+
+
+class TestPrCreateNeutralizesBody:
+    def test_body_neutralized_before_gh(self):
+        captured = {}
+
+        def fake_run_list(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return _mock_result(stdout="https://github.com/o/r/pull/99")
+
+        with patch.object(git_ops, "_get_working_branch", return_value="main"), \
+             patch.object(git_ops, "_run_list", side_effect=fake_run_list), \
+             patch.object(git_ops, "_run",
+                          return_value=_mock_result(stdout="squidsquad/task/13371")), \
+             patch.object(git_ops, "_emit"):
+            git_ops.pr_create("skill: #13371 title", "Body text.\nFixes #13335")
+
+        cmd = captured["cmd"]
+        body_arg = cmd[cmd.index("--body") + 1]
+        assert "Fixes #13335" not in body_arg
+        assert "Addresses #13335" in body_arg


### PR DESCRIPTION
## #13371 — pr_create neutralizes GitHub closing keywords in PR bodies

**Incident**: PR #13346's body carried a `Fixes`-style closing keyword targeting #13335. The verifier auto-merge auto-Addresses #13335 **at merge time** — before the verdict was on the record and bypassing `pending-ship → shipped` (DM's gate + ship counter + changelog). Compounded by a verifier session kill (#13369), the forge showed a CLOSED `severity:high` issue still wearing `status:pending-test` with no recorded verdict — indistinguishable from an unverified ship until manually reconciled. Hit live again this session (forced the `Fixes #N`-omission workaround on PR #13523).

**Root fix (code-only)**: `git_ops.pr_create` now passes the body through `_neutralize_closing_keywords` before **both** the forge-adapter and gh paths. GitHub closing keywords (`Close/Closes/Closed`, `Fix/Fixes/Fixed`, `Resolve/Resolves/Resolved`) directly preceding an issue reference are rewritten to a non-closing `Addresses` form; the reference and any colon separator are preserved verbatim so the cross-link survives but no longer auto-closes. Issue closure stays exclusively `tracker.py`'s shipped-transition auto-close.

Reference forms covered: `#N`, `GH-N`, `owner/repo#N`, full `.../issues/N` URL, each optionally colon-separated. `\b` anchors keep sub-words safe (`prefix`, `hotfixes`, `affixes` never match); a keyword without an immediately-following reference (`This fixes the bug in #5`) is left alone, matching GitHub's own behavior.

**Why code, not prose**: a deterministic guard at the sanctioned PR-creation path removes reliance on every agent remembering to hand-omit `Fixes #N`. No `pr-protocol.md` edit (would be redundant with the code guard and pull in a CQ gate for zero behavioral lift).

**Tests**: `tests/test_git_ops.py::TestNeutralizeClosingKeywords` (12 cases: all keyword variants, case-insensitivity, colon separator, cross-repo, issue-URL, multiple occurrences, non-keyword pass-through, sub-word safety, no-immediate-ref, empty/None, no-separator) + `TestPrCreateNeutralizesBody` (asserts the neutralized body reaches gh). 13 new cases green. Full static gate 0-fail.

No behavioral change to the merge/close machinery itself (no DS review); pure body-text sanitization with a regression test.