### PR TITLE
skill: #13517 ASCII-safe gh --title for tracker.py create-issue/create-task

### DIFF
--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -580,6 +580,42 @@ def _run_gh_with_body(cmd_list, body, check=True):
     )
 
 
+# #13517: issue/PR TITLES are passed as a ``--title`` ARGV argument (gh has no
+# ``--title-file``), so #13370's stdin technique — which fixed non-ASCII BODIES —
+# cannot cover them. A non-ASCII title (em-dash U+2014, arrow, smart quote) still
+# crashes gh on a cp1252 Windows console, the exact class #13370 closed for
+# bodies. Titles are short and ASCII-by-convention, so we transliterate the common
+# offenders to readable ASCII rather than hard-blocking the create; the
+# ``encode("ascii", "replace")`` backstop then guarantees the result is pure ASCII
+# (any residual codepoint becomes ``?``) so ``gh`` can never crash on the argv.
+_TITLE_TRANSLIT = {
+    "—": "--",   # em dash
+    "–": "-",    # en dash
+    "‘": "'", "’": "'",       # smart single quotes / apostrophe
+    "“": '"', "”": '"',       # smart double quotes
+    "…": "...",  # ellipsis
+    "→": "->", "←": "<-", "↔": "<->",  # arrows
+    " ": " ",    # non-breaking space
+    "•": "*",    # bullet
+}
+
+
+def _asciiize_title(title):
+    """Return an ASCII-safe form of ``title`` for a gh ``--title`` argv (#13517).
+
+    Common Unicode punctuation is transliterated to a readable ASCII equivalent
+    (see ``_TITLE_TRANSLIT``); any remaining non-ASCII codepoint is replaced with
+    ``?`` via ``encode("ascii", "replace")`` so the result is guaranteed pure
+    ASCII and cannot crash gh on a cp1252 console. Returns the input unchanged
+    when it is already ASCII.
+    """
+    if title is None:
+        return title
+    for uni, asc in _TITLE_TRANSLIT.items():
+        title = title.replace(uni, asc)
+    return title.encode("ascii", "replace").decode("ascii")
+
+
 def _resolve_status(name):
     """Resolve a status name to its full label."""
     if name.startswith("status:"):
@@ -971,9 +1007,13 @@ def create_issue(title, body, role, severity, reporter=None):
         print(json.dumps(result))
         return result.get("number", -1)
 
+    gh_title = _asciiize_title(full_title)  # #13517: gh --title argv is cp1252-fragile
+    if gh_title != full_title:
+        print(f"NOTE: title transliterated to ASCII for gh --title (#13517): "
+              f"{gh_title!r}", file=sys.stderr)
     result = _run_gh_with_body([  # #13370: body via stdin, not argv --body
         "gh", "issue", "create",
-        "--title", full_title,
+        "--title", gh_title,
         "--label", labels,
     ], full_body)
     url = result.stdout.strip()
@@ -1019,9 +1059,13 @@ def create_task(title, body, role, priority, reporter=None):
         print(json.dumps(result))
         return result.get("number", -1)
 
+    gh_title = _asciiize_title(full_title)  # #13517: gh --title argv is cp1252-fragile
+    if gh_title != full_title:
+        print(f"NOTE: title transliterated to ASCII for gh --title (#13517): "
+              f"{gh_title!r}", file=sys.stderr)
     result = _run_gh_with_body([  # #13370: body via stdin, not argv --body
         "gh", "issue", "create",
-        "--title", full_title,
+        "--title", gh_title,
         "--label", labels,
     ], full_body)
     url = result.stdout.strip()

--- a/tests/test_13517_title_ascii.py
+++ b/tests/test_13517_title_ascii.py
@@ -1,0 +1,99 @@
+"""Regression tests for #13517 — issue/PR TITLES are passed as a gh ``--title``
+ARGV argument (gh has no ``--title-file``), so #13370's stdin fix for non-ASCII
+BODIES cannot cover them. A non-ASCII title (em-dash U+2014, arrow, smart quote)
+still crashed gh on a cp1252 Windows console. create_issue/create_task now
+transliterate the title to ASCII (with an encode('ascii','replace') backstop)
+before ``--title`` so gh can never crash on the argv.
+
+Sibling of #13370 (bodies via stdin) and #13185 (crash-proof print surface).
+"""
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import tracker
+
+
+def _ok(stdout="https://github.com/o/r/issues/7"):
+    r = MagicMock()
+    r.returncode = 0
+    r.stdout = stdout
+    r.stderr = ""
+    return r
+
+
+class TestAsciiizeTitle:
+    def test_ascii_unchanged(self):
+        assert tracker._asciiize_title("Plain ASCII title-123") == "Plain ASCII title-123"
+
+    def test_em_dash(self):
+        assert tracker._asciiize_title("fix — thing") == "fix -- thing"
+
+    def test_en_dash(self):
+        assert tracker._asciiize_title("a – b") == "a - b"
+
+    def test_arrows(self):
+        assert tracker._asciiize_title("x → y ← z ↔ w") == "x -> y <- z <-> w"
+
+    def test_smart_quotes(self):
+        assert tracker._asciiize_title("“it’s”") == '"it\'s"'
+
+    def test_ellipsis_and_bullet_and_nbsp(self):
+        assert tracker._asciiize_title("a…b") == "a...b"
+        assert tracker._asciiize_title("x•y") == "x*y"
+        assert tracker._asciiize_title("x y") == "x y"
+
+    def test_residual_non_ascii_replaced_not_crashed(self):
+        out = tracker._asciiize_title("cjk 中文 end")
+        assert out.isascii()
+        assert out == "cjk ?? end"
+
+    def test_output_is_always_ascii(self):
+        for t in ("plain", "em—dash", "中", "arrow→", "’quote"):
+            assert tracker._asciiize_title(t).isascii()
+
+    def test_none_passthrough(self):
+        assert tracker._asciiize_title(None) is None
+
+
+class TestCreateRoutesAsciiTitle:
+    def _run_create(self, create_fn, *args):
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            if "create" in cmd:
+                captured["cmd"] = cmd
+                return _ok("https://github.com/o/r/issues/8")
+            return _ok("[]")  # gh label list -> empty
+
+        tracker._REPO_LABELS_CACHE = None
+        with patch("tracker._resolve_gh_bin", return_value="gh"), \
+             patch("tracker._get_forge_adapter", return_value=None), \
+             patch("tracker.subprocess.run", side_effect=fake_run):
+            create_fn(*args)
+        tracker._REPO_LABELS_CACHE = None
+        return captured["cmd"]
+
+    def test_create_issue_title_is_ascii(self):
+        cmd = self._run_create(
+            tracker.create_issue, "crash on em-dash — here → now", "body", "skill", "low")
+        title = cmd[cmd.index("--title") + 1]
+        assert title.isascii(), f"title not ASCII-safe: {title!r}"
+        assert "—" not in title and "→" not in title
+        assert "ISSUE: crash on em-dash -- here -> now" == title
+
+    def test_create_task_title_is_ascii(self):
+        cmd = self._run_create(
+            tracker.create_task, "task with smart ’quote’", "body", "skill", "medium")
+        title = cmd[cmd.index("--title") + 1]
+        assert title.isascii(), f"title not ASCII-safe: {title!r}"
+        assert title == "TASK: task with smart 'quote'"
+
+    def test_ascii_title_passes_through_unchanged(self):
+        cmd = self._run_create(
+            tracker.create_issue, "plain ascii title", "body", "skill", "low")
+        title = cmd[cmd.index("--title") + 1]
+        assert title == "ISSUE: plain ascii title"


### PR DESCRIPTION
## #13517 — tracker.py ASCII-safe issue/task titles for the gh `--title` argv

**Residual of #13370**: #13370 routed comment/create **bodies** through `gh --body-file -` (UTF-8 stdin), fixing the cp1252 crash for bodies. But issue/PR **titles** are still passed as a `--title` **argv** argument (`create_issue`, `create_task`), and `gh` has no `--title-file` — so a non-ASCII title (em-dash U+2014, arrow, smart quote) still crashed gh with `CalledProcessError` on a cp1252 Windows console, the exact class #13370 closed for bodies. #13370's own PR flagged this as a residual exposure.

**Fix**: `create_issue`/`create_task` pass the title through a new `_asciiize_title()` before `--title`:
- Transliterate common Unicode punctuation to readable ASCII (`_TITLE_TRANSLIT`): em/en-dash → `--`/`-`, smart quotes → straight, arrows → `->`/`<-`/`<->`, ellipsis → `...`, non-breaking space → space, bullet → `*`.
- Backstop: `encode("ascii", "replace")` turns any residual codepoint into `?`, so the result is **guaranteed pure ASCII** and gh can never crash on the argv regardless of input.
- A `NOTE:` line is printed to stderr when a title is altered, so the change is visible.
- Titles are short and ASCII-by-convention, so this transliterates (keeps the create flowing) rather than hard-blocking.

Applied only on the gh path; the non-GitHub forge-adapter path (API, not argv) keeps the full Unicode title.

**Tests**: `tests/test_13517_title_ascii.py` — `TestAsciiizeTitle` (9: ascii-unchanged, em/en-dash, arrows, smart quotes, ellipsis/bullet/nbsp, residual-CJK backstop, always-ASCII, None) + `TestCreateRoutesAsciiTitle` (3: create_issue/create_task route an ASCII-safe `--title`, ASCII title unchanged). 12 green. Full static gate 0-fail.

Code-only (no LLM-consumed instructions → no CQ); deterministic normalization + regression test (no DS review). Sibling of #13370 (bodies) and #13185 (print surface).