### PR TITLE
skill: #13532 fix stale restart-harness.sh prose in test docstring

### DIFF
--- a/tests/test_12825_harness_restart.py
+++ b/tests/test_12825_harness_restart.py
@@ -141,8 +141,8 @@ _BASH = shutil.which("bash")
 
 @unittest.skipUnless(_BASH, "bash not available")
 class TestSupervisedLauncherSh(unittest.TestCase):
-    """AC1 behavioral test: run restart-harness.sh against a stub harness whose
-    exit codes are scripted, and verify relaunch / stop / crash-guard."""
+    """AC1 behavioral test: run .squidsquad/start.sh --bare against a stub harness
+    whose exit codes are scripted, and verify relaunch / stop / crash-guard."""
 
     def _run_launcher(self, tmp, stub_body, extra_env=None):
         # Lay out tmp/.squidsquad/start.sh + tmp/references/scripts/harness.py stub.


### PR DESCRIPTION
## #13532 — fix stale `restart-harness.sh` prose in test docstring (post-#13318)

Residual of the #13318 launcher migration (`.squidsquad/start.sh`). The class docstring at `tests/test_12825_harness_restart.py:144` still said *"run restart-harness.sh against a stub harness"*, but the test **body** already runs `.squidsquad/start.sh --bare` (L148/156/163). Cosmetic/maintainability only — no functional impact; the body + functional code already target the migrated path.

**Change**: one line — `restart-harness.sh` → `.squidsquad/start.sh --bare` in the L144 docstring. Confirmed via grep it was the sole stale reference (L8/148/156/163/275/288 already correct).

**Out of scope (deliberately)**: the optional `tests/comprehension/12420_spec.json` CQ-foil half named in the issue — its discriminator is per-alias-restart vs cold-start-command, not the exact path string, so it is not functionally wrong; left untouched to avoid churning an LLM-consumed CQ spec for a purely-cosmetic gain.

Doc-only in a non-LLM-consumed test docstring → no CQ, no new test, no DS. Full static gate 0-fail is the gate.