### PR TITLE
skill: #13345 health endpoint reads context-pressure from agent clone

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -3090,12 +3090,14 @@ async def get_agent_health(role: str):
     except (OSError, FileNotFoundError):
         pass
 
-    # Read context-pressure file
-    ctx_file = SQUIDSQUAD_DIR / role / "context-pressure"
-    try:
-        result["context_pressure"] = int(ctx_file.read_text(encoding="utf-8").strip())
-    except (OSError, FileNotFoundError, ValueError):
-        pass
+    # Read context-pressure from the agent's OWN clone (#13345). Sibling-clone
+    # agents (skill/qa/dm) write context-pressure to
+    # <clone>/.squidsquad/<role>/context-pressure, NOT the harness-root
+    # .squidsquad/, so reading SQUIDSQUAD_DIR/role here returned a stale/absent
+    # value for them. Reuse _read_agent_pressure — the same clone-relative read
+    # the #13335 enforcement path uses — so the reported number matches what is
+    # actually enforced (and it fails-safe to None on absent/unreadable/non-int).
+    result["context_pressure"] = state._read_agent_pressure(role, agent)
 
     return result
 

--- a/tests/test_13345_health_clone_pressure.py
+++ b/tests/test_13345_health_clone_pressure.py
@@ -1,0 +1,72 @@
+"""Regression test for #13345 — GET /agents/{role}/health must read
+context-pressure from the agent's OWN clone
+(<clone>/.squidsquad/<role>/context-pressure), not the harness-root
+SQUIDSQUAD_DIR/<role>/. Sibling-clone agents (skill/qa/dm) write the file to
+their own clone, so the harness-root read returned a stale/absent value.
+
+The fix routes the endpoint through HarnessState._read_agent_pressure — the same
+clone-relative read #13335's enforcement path uses — so the reported number
+matches what is actually enforced.
+"""
+import asyncio
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import harness  # noqa: E402
+from harness import AgentState  # noqa: E402
+
+
+def _running_agent(role, clone):
+    a = AgentState(role, clone)
+    a.status = "running"
+    a.bootup_complete = True
+    return a
+
+
+def _write_pressure(clone, role, value):
+    d = Path(clone) / ".squidsquad" / role
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "context-pressure").write_text(str(value), encoding="utf-8")
+
+
+class TestHealthReadsClonePressure13345(unittest.TestCase):
+    def test_reads_from_clone_not_harness_root(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pressure(td, "skill", "72")
+            agent = _running_agent("skill", str(td))
+            with patch.object(harness.state, "get_agent", return_value=agent):
+                result = asyncio.run(harness.get_agent_health("skill"))
+            self.assertEqual(result["context_pressure"], 72)
+
+    def test_absent_clone_file_is_none(self):
+        with tempfile.TemporaryDirectory() as td:
+            agent = _running_agent("skill", str(td))  # no context-pressure file
+            with patch.object(harness.state, "get_agent", return_value=agent):
+                result = asyncio.run(harness.get_agent_health("skill"))
+            self.assertIsNone(result["context_pressure"])
+
+    def test_malformed_clone_file_is_none(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pressure(td, "skill", "high")
+            agent = _running_agent("skill", str(td))
+            with patch.object(harness.state, "get_agent", return_value=agent):
+                result = asyncio.run(harness.get_agent_health("skill"))
+            self.assertIsNone(result["context_pressure"])
+
+    def test_no_agent_is_safe(self):
+        with patch.object(harness.state, "get_agent", return_value=None), \
+             patch("harness.boot_remote._get_clone_path",
+                   side_effect=RuntimeError("no clone")):
+            result = asyncio.run(harness.get_agent_health("skill"))
+        self.assertIsNone(result["context_pressure"])
+        self.assertFalse(result["alive"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## #13345 — /agents/{role}/health reads context-pressure from the agent's own clone

**Bug**: `GET /agents/{role}/health` read context-pressure from `SQUIDSQUAD_DIR / role / "context-pressure"` (the **harness-root** `.squidsquad/`). Sibling-clone agents (skill/qa/dm) run in their own clones and the statusline writes context-pressure to `<clone>/.squidsquad/<role>/context-pressure`, so the health endpoint reported a **stale/absent** value for those agents (the `/status` + TUI `context_pressure` field showed 0/absent/stale).

**Display-only** — enforcement was already correct: #13335's `_enforce_context_pressure` reads the clone-relative path via `_read_agent_pressure`, so the threshold trip is accurate; only the *reported* number was wrong.

**Fix**: route the endpoint through the existing `HarnessState._read_agent_pressure(role, agent)` — the exact same clone-relative read the enforcement path uses — so the reported number matches what is enforced. It fails safe to `None` on absent/unreadable/non-int (same as the prior default) and handles `agent is None` (falls back to `boot_remote._get_clone_path`). One-line behavioral change; the stale inline `SQUIDSQUAD_DIR/role` read is removed.

**Scope**: context-pressure only, per the issue. (`current_phase` reads `current-state` from the same harness-root path and has the sibling defect, but that is outside this issue's scope — not touched.)

**Tests**: `tests/test_13345_health_clone_pressure.py` — 4 cases calling the async endpoint end-to-end against a temp clone: reads clone value (72), absent → None, malformed → None, no-agent → None + not-alive. Green. Full static gate 0-fail.

Code-only (no LLM-consumed instructions → no CQ); display-only reuse of a tested helper (no DS). Found by skill during the #13335 review (finding Mi1).