### PR TITLE
skill: #13357 run_tests.py argument validation (argparse)

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -12,6 +12,7 @@ Teardown runs automatically after integration tests, even on failure.
 Static analysis tests do not require cleanup (no side effects).
 """
 
+import argparse
 import os
 import subprocess
 import sys
@@ -289,12 +290,50 @@ def run_integration_tests(targets):
     return result.wasSuccessful()
 
 
-def main():
-    if "--cleanup" in sys.argv:
+def _build_arg_parser():
+    """#13357: explicit argparse so ``--help`` prints usage (instead of silently
+    launching the full ~5400-test static suite) and an unknown arg / typo'd mode
+    (e.g. ``staitc``) is REJECTED with exit 2 instead of running the wrong thing.
+
+    Backward-compatible with every prior invocation:
+      run_tests.py               -> static gate + all integration (the default)
+      run_tests.py static        -> static gate only
+      run_tests.py <target>...   -> those integration target(s) only
+      run_tests.py --cleanup     -> cleanup only
+    Targets are restricted to the known set (``static`` + the integration
+    registry), so a mistyped mode is caught rather than silently no-op'd.
+    """
+    valid_targets = ["static", *INTEGRATION_TARGET_NAMES]
+    parser = argparse.ArgumentParser(
+        prog="run_tests.py",
+        description="SquidSquad test runner (static gate + integration suites).",
+        epilog=(
+            "modes: no args = static gate + all integration; "
+            "'static' = static gate only (~5400 gated tests, several minutes); "
+            "a target name runs that integration suite only "
+            f"(targets: {', '.join(INTEGRATION_TARGET_NAMES)}). "
+            "The config.md 'Tests' command uses the bare integration mode "
+            "(~53 tests, ~70s)."
+        ),
+    )
+    parser.add_argument(
+        "targets", nargs="*", choices=valid_targets, metavar="TARGET",
+        help="test target(s) to run; omit to run static + all integration",
+    )
+    parser.add_argument(
+        "--cleanup", action="store_true",
+        help="run test-artifact cleanup only, then exit",
+    )
+    return parser
+
+
+def main(argv=None):
+    args = _build_arg_parser().parse_args(sys.argv[1:] if argv is None else argv)
+    if args.cleanup:
         run_cleanup_only()
         return 0
 
-    targets = [a for a in sys.argv[1:] if not a.startswith("-")]
+    targets = args.targets
     static_only = targets == ["static"]
     # #12903: derive from the shared registry so the guard always matches the
     # set of targets run_integration_tests() actually dispatches.

--- a/tests/test_13357_run_tests_argparse.py
+++ b/tests/test_13357_run_tests_argparse.py
@@ -1,0 +1,69 @@
+"""Regression tests for #13357 — tests/run_tests.py must validate its CLI:
+`--help` prints usage and exits 0 (instead of silently launching the full
+~5400-test static suite), and an unknown arg / typo'd mode is rejected with a
+non-zero exit instead of running the wrong thing.
+
+Backward-compat is the hard constraint: every prior invocation
+(no-args / `static` / a target name / `--cleanup`) must still parse the same.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+# run_tests.py lives in tests/ alongside this file.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import run_tests  # noqa: E402
+
+
+class TestRunTestsArgParsing13357(unittest.TestCase):
+    def setUp(self):
+        self.parser = run_tests._build_arg_parser()
+
+    # --- backward-compatible valid invocations ---
+    def test_no_args_runs_everything(self):
+        args = self.parser.parse_args([])
+        self.assertEqual(args.targets, [])
+        self.assertFalse(args.cleanup)
+
+    def test_static_only(self):
+        self.assertEqual(self.parser.parse_args(["static"]).targets, ["static"])
+
+    def test_integration_target(self):
+        args = self.parser.parse_args(["event_mode_e2e"])
+        self.assertEqual(args.targets, ["event_mode_e2e"])
+
+    def test_every_registered_target_is_valid(self):
+        for name in run_tests.INTEGRATION_TARGET_NAMES:
+            self.assertEqual(self.parser.parse_args([name]).targets, [name])
+
+    def test_multiple_targets(self):
+        args = self.parser.parse_args(["static", "harness"])
+        self.assertEqual(args.targets, ["static", "harness"])
+
+    def test_cleanup_flag(self):
+        self.assertTrue(self.parser.parse_args(["--cleanup"]).cleanup)
+
+    # --- the #13357 fixes ---
+    def test_help_exits_zero(self):
+        with self.assertRaises(SystemExit) as cm:
+            self.parser.parse_args(["--help"])
+        self.assertEqual(cm.exception.code, 0)
+
+    def test_unknown_target_rejected(self):
+        with self.assertRaises(SystemExit) as cm:
+            self.parser.parse_args(["staitc"])  # typo of "static"
+        self.assertEqual(cm.exception.code, 2)
+
+    def test_unknown_flag_rejected(self):
+        with self.assertRaises(SystemExit) as cm:
+            self.parser.parse_args(["--bogus"])
+        self.assertEqual(cm.exception.code, 2)
+
+    def test_valid_target_mixed_with_typo_rejected(self):
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(["static", "nope"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## #13357 — run_tests.py argument validation (argparse)

**Bug**: `python tests/run_tests.py --help` did not print usage — it silently started the full ~5400-test static suite (`--help` was filtered out by `not a.startswith("-")` and fell through to the default run). Unknown args / typo'd modes (`staitc`) were likewise ignored, so they ran the wrong thing silently instead of erroring.

**Fix**: `_build_arg_parser()` (argparse) replaces the ad-hoc `sys.argv` parsing in `main()`:
- Positional `TARGET`s restricted to `choices = ["static", *INTEGRATION_TARGET_NAMES]` — a typo or unknown mode is rejected with `exit 2` and an "invalid choice" message listing the valid targets.
- `--help` / `-h` prints usage and exits 0 (no suite launched). Unknown flags → `exit 2`.
- Epilog documents per-mode runtimes (bare integration ~53 tests ~70s; static ~5400 gated, several minutes) since config.md's `Tests` command points at the bare mode.

**Backward-compatible with every prior invocation** (verified):
- `run_tests.py` → static gate + all integration (default)
- `run_tests.py static` → static-only
- `run_tests.py <target>…` → those integration target(s)
- `run_tests.py --cleanup` → cleanup-only

`main()` now takes `argv=None` (defaults to `sys.argv[1:]`) for testability; downstream `static_only` / `integration_only` / dispatch logic is unchanged.

**Self-verifying**: the preserved `run_tests.py static` path is the very gate re-run to validate this change — the full static gate passing proves the runner still works end-to-end.

**Tests**: `tests/test_13357_run_tests_argparse.py` — 10 cases: all valid invocations (no-args, static, each registered target, multi-target, --cleanup) + the fixes (--help exit 0, unknown target exit 2, unknown flag exit 2, valid+typo rejected). Green. Full static gate 0-fail.

Code-only (no LLM-consumed instructions → no CQ); deterministic CLI-arg change + regression test (no DS).