### PR TITLE
skill: #13554 pr_merge refuses a PR carrying main-only state/vault paths (merge=ours modify-vs-delete gap)

### DIFF
--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -749,6 +749,37 @@ def _pr_declared_files(pr_number):
         return None
 
 
+def _pr_state_scope_violations(pr_number):
+    """#13554 -- main-only state/vault paths the PR DECLARES that must never ride
+    a feature PR. Returns the sorted violating paths, or ``None`` if the PR's file
+    set can't be determined (fail-OPEN, matching ``_pr_behind_by`` -- a gh hiccup
+    must not wedge shipping; the #13285 post-merge audit backstops).
+
+    Reuses the exact ``_is_state_file`` predicate the #11511 commit-time guard uses
+    to strip these on feature-branch commits (``.squidsquad/`` + ``.claude/`` minus
+    the launcher-script allow-list), plus the ``_is_plan_body`` (#12750) exemption.
+
+    Why a MERGE-gate check is needed even with the #11511 commit-time guard: that
+    guard only unstages NEWLY-staged state on a branch commit -- it does not
+    restore a path already ABSENT/emptied in the branch tree (from the branch's own
+    prior merge-conflict resolution, or a fork point that predates a teammate's new
+    file), and it has a fork-point gap on paths created after the branch forked.
+    Such a path rides the PR as a DELETE/REVERT, and ``.gitattributes``
+    merge=ours/union does NOT protect a modify-vs-DELETE (it only fires
+    modify-vs-modify -- see the #13554 incident: a squash silently reverted 1328
+    lines of teammate state+vault on main with zero conflict signal). The #13271
+    behind-count guard misses it (the incident branch was only a few commits
+    behind, not >50) and the #13285 post-merge deletion-audit misses it (the
+    reversions ARE in the PR's declared set, so ``deleted - declared`` is empty).
+    This gate catches the whole class at the last safe point before main is
+    touched."""
+    declared = _pr_declared_files(pr_number)
+    if declared is None:
+        return None
+    return sorted(f for f in declared
+                  if _is_state_file(f) and not _is_plan_body(f))
+
+
 def _merge_commit_sha(pr_number):
     """The squash/merge commit SHA GitHub recorded for the PR, or ``None``."""
     res = _run_list(
@@ -993,6 +1024,34 @@ def pr_merge(pr_number, strategy="squash", _max_base_retries=3, _base_retry_dela
                    f"(run `gh pr ready {pr_number}` and retry)")
             print(f"ERROR: {msg}", file=sys.stderr)
             return False, "PR is a draft"
+
+    # #13554 (SEV prevention): refuse to merge a PR that DECLARES changes to
+    # main-only state/vault paths. These must never ride a feature PR -- the
+    # #11511 commit-time guard strips them, but has gaps (a path already
+    # ABSENT/emptied in the branch tree, or created after the branch's fork
+    # point), and merge=ours/union does NOT protect a modify-vs-DELETE, so the
+    # squash silently reverts teammate state+vault on main (#13554: 1328
+    # out-of-scope lines, dm working-state emptied, 10 vault notes deleted). The
+    # #13271 behind-count guard misses it (fires at LOW behind-counts too) and
+    # the #13285 post-merge deletion-audit misses it (the reversions ARE in the
+    # PR's declared set). Fail-SAFE: refuse BEFORE any damage; fail-OPEN when the
+    # file set is undeterminable (a gh hiccup must not wedge shipping -- the
+    # post-merge audit backstops). Applies to ALL strategies (state files belong
+    # in no PR, squash or merge-commit).
+    state_violations = _pr_state_scope_violations(pr_number)
+    if state_violations:
+        preview = ", ".join(state_violations[:8])
+        more = (f" (+{len(state_violations) - 8} more)"
+                if len(state_violations) > 8 else "")
+        msg = (f"PR #{pr_number} declares {len(state_violations)} main-only "
+               f"state/vault path(s) that must not ride a feature PR: {preview}"
+               f"{more}. Merging would silently revert teammate state on main "
+               f"(#13554). Restore these paths to origin/main on the branch "
+               f"(`git checkout origin/main -- <path>`; use `git commit "
+               f"--no-verify` to bypass the #11511 branch state-guard) and "
+               f"re-push, then retry.")
+        print(f"ERROR: {msg}", file=sys.stderr)
+        return False, "PR carries out-of-scope state/vault changes"
 
     # #13271 (SEV-1 prevention): refuse to squash-merge a branch that is FAR
     # behind base — a stale-tree squash from a deeply-behind clone mass-reverts

--- a/tests/test_feat_1074_auto_merge.py
+++ b/tests/test_feat_1074_auto_merge.py
@@ -22,8 +22,13 @@ def _safe_behind_guard():
     """#13271: the pre-merge behind-count guard adds two gh calls before the
     squash. These pre-existing pr_merge tests mock _run_list sequences that
     predate the guard, so default the behind-count to 0 (current) — the guard's
-    own behavior is covered in test_git_ops.py::TestPrMerge/TestPrBehindBy."""
-    with patch("git_ops._pr_behind_by", return_value=0):
+    own behavior is covered in test_git_ops.py::TestPrMerge/TestPrBehindBy.
+    #13554: same rationale for the pre-merge state-scope guard — stub it to
+    "no violations" so its _pr_declared_files -> _run_list call stays out of
+    these predating mock sequences (guard behavior covered in test_git_ops.py::
+    TestPrMerge/TestPrStateScopeViolations13554)."""
+    with patch("git_ops._pr_behind_by", return_value=0), \
+            patch("git_ops._pr_state_scope_violations", return_value=[]):
         yield
 
 

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -542,7 +542,13 @@ class TestPrMerge:
         # #13285: stub the post-merge scope-audit to a no-op so it does not consume
         # the per-test _run_list mock sequence (the audit has its own tests in
         # TestScopeAudit13285).
+        # #13554: stub the pre-merge state-scope guard to "no violations" so the
+        # existing merge-flow tests exercise the merge path unchanged; the
+        # dedicated guard tests (TestPrMergeStateScopeGuard13554) re-patch it to
+        # assert the refusal. Stubbing it also keeps its _pr_declared_files ->
+        # _run_list call out of the per-test mock sequence.
         with patch("git_ops._pr_behind_by", return_value=0), \
+                patch("git_ops._pr_state_scope_violations", return_value=[]), \
                 patch("git_ops._post_merge_scope_audit"):
             yield
 
@@ -786,6 +792,104 @@ class TestPrMerge:
         assert git_ops._merge_max_behind() == 7
         monkeypatch.setenv("SQUIDSQUAD_MERGE_MAX_BEHIND", "bad")
         assert git_ops._merge_max_behind() == git_ops.MERGE_MAX_BEHIND_DEFAULT
+
+    # --- #13554: pre-merge state/vault scope guard (SEV prevention) ---
+
+    @patch("git_ops._run_list")
+    def test_state_violation_refuses_before_merge(self, mock_run):
+        """A PR declaring main-only state/vault paths is refused (fail-safe)
+        BEFORE any merge call — preventing the #13554 merge=ours-defeated revert."""
+        with patch("git_ops._pr_state_scope_violations",
+                   return_value=[".squidsquad/dm/working-state.md",
+                                 ".squidsquad/vault/galaxy/learning-x.md"]):
+            mock_run.side_effect = [_mock_result(stdout='{"state": "OPEN"}')]
+            success, msg = git_ops.pr_merge(42)
+        assert success is False
+        assert msg == "PR carries out-of-scope state/vault changes"
+        # state check only — NO merge attempt (call_count==1 proves no `gh pr merge`).
+        assert mock_run.call_count == 1
+
+    @patch("git_ops._run_list")
+    def test_state_violation_refuses_non_squash_too(self, mock_run):
+        """Unlike the behind-count guard, the state guard is NOT squash-specific —
+        state files belong in no PR, so a merge-commit strategy is refused too."""
+        with patch("git_ops._pr_state_scope_violations",
+                   return_value=[".claude/worktrees/agent-x"]):
+            mock_run.side_effect = [_mock_result(stdout='{"state": "OPEN"}')]
+            success, msg = git_ops.pr_merge(42, strategy="merge")
+        assert success is False
+        assert msg == "PR carries out-of-scope state/vault changes"
+        assert mock_run.call_count == 1
+
+    @patch("git_ops._run_list")
+    def test_no_state_violation_proceeds(self, mock_run):
+        """A code-only PR (no state/vault paths declared) merges normally."""
+        with patch("git_ops._pr_state_scope_violations", return_value=[]):
+            mock_run.side_effect = [
+                _mock_result(stdout='{"state": "OPEN"}'),
+                _mock_result(stdout=""),  # merge
+                _mock_result(stdout='{"headRefName": "squidsquad/skill/42"}'),
+            ]
+            success, msg = git_ops.pr_merge(42)
+        assert success is True
+
+    @patch("git_ops._run_list")
+    def test_undeterminable_scope_fails_open(self, mock_run):
+        """If the PR file set can't be determined (gh hiccup → None), the guard
+        fails OPEN (merge proceeds) — it must not wedge all shipping."""
+        with patch("git_ops._pr_state_scope_violations", return_value=None):
+            mock_run.side_effect = [
+                _mock_result(stdout='{"state": "OPEN"}'),
+                _mock_result(stdout=""),  # merge
+                _mock_result(stdout='{"headRefName": "squidsquad/skill/42"}'),
+            ]
+            success, msg = git_ops.pr_merge(42)
+        assert success is True
+
+
+class TestPrStateScopeViolations13554:
+    """#13554: _pr_state_scope_violations — reuses _is_state_file (the #11511
+    predicate) + the _is_plan_body/launcher exemptions to flag main-only paths a
+    PR must never carry. Kept OUT of TestPrMerge (whose fixture patches it)."""
+
+    def _violations(self, declared):
+        with patch("git_ops._pr_declared_files", return_value=declared):
+            return git_ops._pr_state_scope_violations(1)
+
+    def test_state_and_vault_paths_flagged(self):
+        v = self._violations({
+            ".squidsquad/dm/working-state.md",
+            ".squidsquad/vault/galaxy/learning-x.md",
+            ".squidsquad/.ship-counter",
+            "references/scripts/git_ops.py",  # code — not flagged
+        })
+        assert v == [
+            ".squidsquad/.ship-counter",
+            ".squidsquad/dm/working-state.md",
+            ".squidsquad/vault/galaxy/learning-x.md",
+        ]
+
+    def test_claude_paths_flagged(self):
+        assert self._violations({".claude/worktrees/agent-x"}) == \
+            [".claude/worktrees/agent-x"]
+
+    def test_plan_body_exempt(self):
+        # A PM plan body legitimately rides the branch (#12750) — not a violation.
+        assert self._violations({".squidsquad/pm/planning/13554-body.md"}) == []
+
+    def test_launcher_scripts_exempt(self):
+        # start.sh/start.ps1 are versioned code deliverables (#13318), not state.
+        assert self._violations({".squidsquad/start.sh",
+                                 ".squidsquad/start.ps1"}) == []
+
+    def test_code_only_pr_clean(self):
+        assert self._violations({"references/scripts/harness.py",
+                                 "tests/test_harness.py",
+                                 "docs/HARNESS-ARCH.md"}) == []
+
+    def test_undeterminable_declared_returns_none(self):
+        # _pr_declared_files None (gh/parse failure) → fail-open sentinel.
+        assert self._violations(None) is None
 
 
 class TestPrBehindBy:
@@ -2859,7 +2963,13 @@ class TestScopeAudit13285:
 class TestPrMergeDraftSelfHeal:
     @pytest.fixture(autouse=True)
     def _safe_behind(self):
+        # #13554: stub the pre-merge state-scope guard to "no violations" so the
+        # existing merge-flow tests exercise the merge path unchanged; the
+        # dedicated guard tests (TestPrMergeStateScopeGuard13554) re-patch it to
+        # assert the refusal. Stubbing it also keeps its _pr_declared_files ->
+        # _run_list call out of the per-test mock sequence.
         with patch("git_ops._pr_behind_by", return_value=0), \
+                patch("git_ops._pr_state_scope_violations", return_value=[]), \
                 patch("git_ops._post_merge_scope_audit"):
             yield
 


### PR DESCRIPTION
Addresses #13554 (SEV). Durable guard fix; Part 1 recovery already completed by dm (#13556).

## Root cause
PR #13546's squash silently reverted 1328 lines of teammate state+vault on main (dm working-state emptied 798->0, 10 vault notes deleted). `.gitattributes` `merge=ours`/`merge=union` only protects **modify-vs-modify** -- a **modify-vs-DELETE** defeats it with zero conflict signal (see [[learning-merge-driver-defeated-by-delete-not-modify]]). The #11511 commit-time state-guard has gaps (a path already absent/emptied in the branch tree, or created after the branch's fork point -- e.g. a teammate's mid-session vault note), so such a path rides the PR as a DELETE.

## Why the existing guards missed it
- **#13271 behind-count**: fires only >50 behind; this branch was a few commits behind.
- **#13285 post-merge deletion-audit**: computes `deleted - declared`; here the reversions ARE in the PR's declared set, so the difference is empty. It also only sees full-file deletions (`--diff-filter=D`), missing emptied/truncated files.

## Fix
New `_pr_state_scope_violations(pr_number)`: the PR's declared files matching `_is_state_file` (the exact #11511 predicate: `.squidsquad/` + `.claude/` minus the launcher allow-list) and not `_is_plan_body` (#12750); `None` (fail-open) if the file set is undeterminable. `pr_merge`, after the draft self-heal and before the behind-count check, **refuses the merge (fail-safe, before any damage)** if violations exist -- all strategies. This applies the #11511 main-only invariant at the merge gate as the backstop the commit-time guard's gaps let through.

Fail-open on an undeterminable file set (a gh hiccup must not wedge shipping; the #13285 audit backstops). #13271/#13285 guards unchanged. Refusal message tells the worker how to clean the branch (`git checkout origin/main -- <path>` + `git commit --no-verify`).

## Tests
6 unit (state/vault/.claude flagged; plan-body/launcher/code clean; None fail-open) + 4 pr_merge integration (refuse+no-merge for squash and merge-commit; proceed clean; None fail-open). Existing pr_merge suites stubbed via fixture (backward-compat). Full static gate 5472/0. DeepSeek review NO_FINDINGS (high-blast-radius merge gate; verified via installer-files.txt that no legit `.squidsquad/` PR content exists beyond the exempted launchers).

## Follow-up (not this PR)
The #11511 source-side gap (guard unstages but does not restore; fork-point gap) dm flagged is the complementary cure -- tracked separately.