### PR TITLE
skill

### DIFF
--- a/.squidsquad/inject-permissions.ps1
+++ b/.squidsquad/inject-permissions.ps1
@@ -1,4 +1,4 @@
-# inject-permissions.ps1 — Merge .squidsquad/permissions.template.json into .claude/settings.json
+# inject-permissions.ps1 -- Merge .squidsquad/permissions.template.json into .claude/settings.json
 # Called by startup scripts before launching Claude.
 #
 # Strategy: read the template (stripping comment lines), then replace
@@ -42,7 +42,7 @@ Move-Item -Path $tmp -Destination $settings -Force
 $count = $permsArray.Count
 Write-Host "[inject-permissions] Injected $count permission rules from template."
 
-# Ensure statusLine is set as an object (not a string) — #2008
+# Ensure statusLine is set as an object (not a string) -- #2008
 $settingsRaw2 = [System.IO.File]::ReadAllText($settings, [System.Text.Encoding]::UTF8)
 $settingsObj2 = $settingsRaw2 | ConvertFrom-Json
 if ($null -eq $settingsObj2.statusLine -or $settingsObj2.statusLine -is [string]) {

--- a/.squidsquad/inject-permissions.ps1
+++ b/.squidsquad/inject-permissions.ps1
@@ -1,4 +1,4 @@
-# inject-permissions.ps1 -- Merge .squidsquad/permissions.template.json into .claude/settings.json
+# inject-permissions.ps1 - Merge .squidsquad/permissions.template.json into .claude/settings.json
 # Called by startup scripts before launching Claude.
 #
 # Strategy: read the template (stripping comment lines), then replace
@@ -42,7 +42,7 @@ Move-Item -Path $tmp -Destination $settings -Force
 $count = $permsArray.Count
 Write-Host "[inject-permissions] Injected $count permission rules from template."
 
-# Ensure statusLine is set as an object (not a string) -- #2008
+# Ensure statusLine is set as an object (not a string) - #2008
 $settingsRaw2 = [System.IO.File]::ReadAllText($settings, [System.Text.Encoding]::UTF8)
 $settingsObj2 = $settingsRaw2 | ConvertFrom-Json
 if ($null -eq $settingsObj2.statusLine -or $settingsObj2.statusLine -is [string]) {

--- a/.squidsquad/inject-permissions.ps1
+++ b/.squidsquad/inject-permissions.ps1
@@ -1,4 +1,4 @@
-# inject-permissions.ps1 - Merge .squidsquad/permissions.template.json into .claude/settings.json
+# inject-permissions.ps1 — Merge .squidsquad/permissions.template.json into .claude/settings.json
 # Called by startup scripts before launching Claude.
 #
 # Strategy: read the template (stripping comment lines), then replace
@@ -42,7 +42,7 @@ Move-Item -Path $tmp -Destination $settings -Force
 $count = $permsArray.Count
 Write-Host "[inject-permissions] Injected $count permission rules from template."
 
-# Ensure statusLine is set as an object (not a string) - #2008
+# Ensure statusLine is set as an object (not a string) — #2008
 $settingsRaw2 = [System.IO.File]::ReadAllText($settings, [System.Text.Encoding]::UTF8)
 $settingsObj2 = $settingsRaw2 | ConvertFrom-Json
 if ($null -eq $settingsObj2.statusLine -or $settingsObj2.statusLine -is [string]) {

--- a/.squidsquad/start.ps1
+++ b/.squidsquad/start.ps1
@@ -1,4 +1,4 @@
-# SquidSquad — THE single Windows launcher (#13318).
+# SquidSquad -- THE single Windows launcher (#13318).
 #
 # Consolidates the former start.ps1 + start.bat + start-harness.bat +
 # restart-harness.bat into one script. Running it brings up ALL of SquidSquad:
@@ -15,7 +15,7 @@
 #
 # Behaviors folded in:
 #   - deps + clone-sync           (former start.ps1)
-#   - supervised auto-relaunch    (former restart-harness.bat, #12825 — exit-42
+#   - supervised auto-relaunch    (former restart-harness.bat, #12825 -- exit-42
 #                                  relaunch / exit-0 stop / crash-loop guard)
 #   - bare/no-setup path          (former start-harness.bat, #12525)
 #   - TUI bundling                (references/tui/app.py, #12801/#13277)
@@ -82,7 +82,7 @@ function Invoke-Supervised {
         }
         if ($code -eq $RestartCode) {
             Write-Host "[start] restart requested (exit $code) - relaunching..."
-            $crashCount = 0   # intentional restart — reset crash accounting
+            $crashCount = 0   # intentional restart -- reset crash accounting
             continue
         }
         # Abnormal exit -> crash-loop guard. A run that lasted at least
@@ -109,7 +109,7 @@ function Initialize-Deps {
     python -c "import fastapi, uvicorn, starlette, watchdog, yaml" 2>$null
     if ($LASTEXITCODE -ne 0) { pip install -r requirements.txt }
     # TUI dep (#12801/#13318): full mode launches references/tui/app.py, which
-    # imports `textual` — kept in requirements-tui.txt, separate from the harness
+    # imports `textual` -- kept in requirements-tui.txt, separate from the harness
     # runtime set. Without this, full mode would pass the harness-dep probe then
     # crash at TUI launch on a fresh machine.
     python -c "import textual" 2>$null
@@ -163,7 +163,7 @@ Initialize-Deps
 Sync-Clones
 
 if (Test-HarnessUp) {
-    Write-Host "[start] harness already running on port $(Get-HarnessPort) — attaching TUI (singleton-safe)."
+    Write-Host "[start] harness already running on port $(Get-HarnessPort) -- attaching TUI (singleton-safe)."
 } else {
     Write-Host "[start] launching harness (supervised, detached background)..."
     # Re-invoke self in --bare mode, detached, so the supervised loop (#12825)

--- a/.squidsquad/start.ps1
+++ b/.squidsquad/start.ps1
@@ -1,4 +1,4 @@
-# SquidSquad -- THE single Windows launcher (#13318).
+# SquidSquad - THE single Windows launcher (#13318).
 #
 # Consolidates the former start.ps1 + start.bat + start-harness.bat +
 # restart-harness.bat into one script. Running it brings up ALL of SquidSquad:
@@ -15,7 +15,7 @@
 #
 # Behaviors folded in:
 #   - deps + clone-sync           (former start.ps1)
-#   - supervised auto-relaunch    (former restart-harness.bat, #12825 -- exit-42
+#   - supervised auto-relaunch    (former restart-harness.bat, #12825 - exit-42
 #                                  relaunch / exit-0 stop / crash-loop guard)
 #   - bare/no-setup path          (former start-harness.bat, #12525)
 #   - TUI bundling                (references/tui/app.py, #12801/#13277)
@@ -82,7 +82,7 @@ function Invoke-Supervised {
         }
         if ($code -eq $RestartCode) {
             Write-Host "[start] restart requested (exit $code) - relaunching..."
-            $crashCount = 0   # intentional restart -- reset crash accounting
+            $crashCount = 0   # intentional restart - reset crash accounting
             continue
         }
         # Abnormal exit -> crash-loop guard. A run that lasted at least
@@ -109,7 +109,7 @@ function Initialize-Deps {
     python -c "import fastapi, uvicorn, starlette, watchdog, yaml" 2>$null
     if ($LASTEXITCODE -ne 0) { pip install -r requirements.txt }
     # TUI dep (#12801/#13318): full mode launches references/tui/app.py, which
-    # imports `textual` -- kept in requirements-tui.txt, separate from the harness
+    # imports `textual` - kept in requirements-tui.txt, separate from the harness
     # runtime set. Without this, full mode would pass the harness-dep probe then
     # crash at TUI launch on a fresh machine.
     python -c "import textual" 2>$null
@@ -163,7 +163,7 @@ Initialize-Deps
 Sync-Clones
 
 if (Test-HarnessUp) {
-    Write-Host "[start] harness already running on port $(Get-HarnessPort) -- attaching TUI (singleton-safe)."
+    Write-Host "[start] harness already running on port $(Get-HarnessPort) - attaching TUI (singleton-safe)."
 } else {
     Write-Host "[start] launching harness (supervised, detached background)..."
     # Re-invoke self in --bare mode, detached, so the supervised loop (#12825)

--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -1144,7 +1144,12 @@ def _is_launcher_script(path):
     stages them as code, the ``guard_staged_state`` hook does not strip them, and
     ``_auto_resolve_state_conflicts`` leaves a launcher conflict unresolved (a code
     conflict the worker must resolve, never silently --theirs'd like state)."""
-    return path in (".squidsquad/start.sh", ".squidsquad/start.ps1")
+    # #13577: inject-permissions.ps1 is start.ps1's helper (invoked by the
+    # launcher, listed in installer-files.txt, gated by
+    # test_launcher_ascii_safe) — versioned CODE, same as the launchers. Its
+    # omission here silently stripped its bug-fix commit from a feature branch.
+    return path in (".squidsquad/start.sh", ".squidsquad/start.ps1",
+                    ".squidsquad/inject-permissions.ps1")
 
 
 def _is_state_file(path):

--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -759,6 +759,14 @@ def _pr_state_scope_violations(pr_number):
     to strip these on feature-branch commits (``.squidsquad/`` + ``.claude/`` minus
     the launcher-script allow-list), plus the ``_is_plan_body`` (#12750) exemption.
 
+    BOOTSTRAP PROPERTY (#13577, discovered live): this check evaluates against
+    the merging clone's CURRENT predicate -- deliberately, since trusting the
+    PR's own tree would let any PR exempt itself. Consequence: a PR that EXTENDS
+    the launcher allow-list can never also carry content changes to the newly
+    exempted path -- the guard refuses it against the not-yet-updated predicate.
+    Sequencing rule: land the allow-list extension (code-only PR) first; the
+    content fix for the newly exempted path rides a follow-up PR.
+
     Why a MERGE-gate check is needed even with the #11511 commit-time guard: that
     guard only unstages NEWLY-staged state on a branch commit -- it does not
     restore a path already ABSENT/emptied in the branch tree (from the branch's own

--- a/tests/test_13318_consolidated_launcher.py
+++ b/tests/test_13318_consolidated_launcher.py
@@ -108,5 +108,11 @@ class TestGitOpsLauncherCarveOut:
         import git_ops
         assert git_ops._is_launcher_script(".squidsquad/start.sh") is True
         assert git_ops._is_launcher_script(".squidsquad/start.ps1") is True
+        # #13577: the launcher's permissions helper is versioned CODE too — its
+        # omission silently stripped a bug-fix commit from a feature branch.
+        assert git_ops._is_launcher_script(
+            ".squidsquad/inject-permissions.ps1") is True
         assert git_ops._is_launcher_script(".squidsquad/sub/start.sh") is False
         assert git_ops._is_launcher_script("start.sh") is False
+        assert git_ops._is_launcher_script(
+            ".squidsquad/inject-permissions.ps1.bak") is False


### PR DESCRIPTION
Fixes #13577 (high, verifier-found) — **PR 1 of 2** after the #13554 scope-guard bounce (see issue Discussion for the full diagnosis).

## Why the split

DM's merge of the original version was refused by the #13554 scope guard: it declared `.squidsquad/inject-permissions.ps1`, which is not in main's `_is_launcher_script` allow-list — and extending that list is exactly what this PR does. The guard deliberately evaluates against main's current predicate (a PR must not be able to exempt itself), so an allow-list extension can never ride with content changes to the newly exempted path. That bootstrap property is now documented in `_pr_state_scope_violations`' docstring.

## This PR (guard-clean)

- `.squidsquad/start.ps1`: 5 em-dashes → ASCII `-` (already exempt; byte-parity with the primary clone's local fix). Parse-clean, 0 non-ASCII.
- `_is_launcher_script`: `+.squidsquad/inject-permissions.ps1` (the launcher's versioned, manifest-listed, ASCII-gated helper), with test coverage incl. `.bak` non-match.
- Guard docstring: the two-PR sequencing rule for future allow-list extensions.

Merging turns 2 of main's 3 red launcher tests green.

## Follow-up PR (2 of 2, same issue)

The 2-hunk `inject-permissions.ps1` em-dash fix — passes the guard once this PR's predicate is live (the merging clone must pull main first, which the DM flow already does). Its 1 ASCII test stays red on main until then: **pre-existing** red, not introduced here; main goes fully green at the follow-up merge, minutes later.
