### PR TITLE
#13595: foreign compose reads target_root's own config.md, not the installing clone's

### DIFF
--- a/references/scripts/compose.py
+++ b/references/scripts/compose.py
@@ -12,6 +12,8 @@ Usage:
     python scripts/compose.py --help
 """
 
+import contextlib
+import io
 import json
 import re
 import subprocess
@@ -527,10 +529,18 @@ def _read_config_value(field: str) -> str:
     hard-exit the whole process just because the field is missing. Empty
     string is the correct fallback — downstream callers substitute a
     friendly default.
+
+    #13595: a missing field is EXPECTED and already handled here — swallow
+    the "Field not found" stderr `get_field` prints on its way to
+    `sys.exit(1)` so a normal fresh-scaffold compose (which reads
+    target_root's own, often-sparse, just-scaffolded config.md — see
+    `config.config_path_override`) doesn't spray scary-looking ERROR lines
+    for every optional placeholder the target hasn't set yet.
     """
     try:
         from config import get_field
-        return get_field(field)
+        with contextlib.redirect_stderr(io.StringIO()):
+            return get_field(field)
     except SystemExit:
         return ""
     except BaseException:  # noqa: BLE001 — genuinely want a last-resort fallback
@@ -1274,7 +1284,12 @@ def deploy_alias_v2(alias, registry=None, target_root=None):
     # these deterministic passes all three classes leak through every
     # operator ``deploy <alias>`` and every harness ``deploy-all``.
     body = _resolve_includes_v2(body)
-    body = _substitute_placeholders(body, alias, role)
+    # #13595: read config-value placeholders (workers/aliases/test-commands/
+    # project-name/...) from target_root's OWN config.md, never the installing
+    # clone's — a foreign target_root's just-scaffolded config.md is what a
+    # foreign compose must substitute from.
+    with _config_module.config_path_override(target_root / ".squidsquad" / "config.md"):
+        body = _substitute_placeholders(body, alias, role)
     body = _inject_role_roster(body, alias)
 
     output_dir = target_root / ".squidsquad" / alias
@@ -1488,7 +1503,11 @@ def deploy_role_v2(role_name: str, target_root: Path = None,
     # squidsquad install holding ``references/``), not from
     # ``target_root`` (the foreign project being installed into).
     body = _resolve_includes_v2(body, source_root=source_root)
-    body = _substitute_placeholders(body, output_name, role_class)
+    # #13595: same target_root config-value redirect as deploy_alias_v2 —
+    # read config-value placeholders from target_root's own config.md, not
+    # the installing/wizard clone's.
+    with _config_module.config_path_override(target_root / ".squidsquad" / "config.md"):
+        body = _substitute_placeholders(body, output_name, role_class)
     body = _inject_role_roster(body, output_name)
 
     output_dir = target_root / ".squidsquad" / output_name

--- a/references/scripts/config.py
+++ b/references/scripts/config.py
@@ -28,6 +28,8 @@ field. v1 files have `1`, v2 files have `2`. Readers that don't care
 about agents (e.g. `get interval`) work unchanged against either schema.
 """
 
+import contextlib
+import contextvars
 import json
 import re
 import sys
@@ -38,6 +40,29 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent
 CONFIG_PATH = REPO_ROOT / ".squidsquad" / "config.md"
+
+# #13595: CONFIG_PATH is fixed at import time to the INSTALLING clone's own
+# repo root — it has no awareness of a foreign `target_root` a compose call
+# is writing into. During a foreign compose (`deploy_role_v2`/`deploy_alias_v2`
+# with `target_root != REPO_ROOT`), every `get_field()` call must read the
+# TARGET's just-scaffolded config.md, not the installing clone's own. A
+# contextvar override — rather than threading a path parameter through every
+# `get_field()` call site across the whole codebase — keeps every existing
+# caller's default behavior (read the ambient CONFIG_PATH) unchanged; only
+# the compose call sites that know about `target_root` opt in.
+_config_path_override = contextvars.ContextVar("_config_path_override", default=None)
+
+
+@contextlib.contextmanager
+def config_path_override(path):
+    """Temporarily redirect every `get_field()` read to `path` instead of
+    `CONFIG_PATH`. Used by compose.py to read a foreign `target_root`'s
+    scaffolded config.md instead of the installing clone's own (#13595)."""
+    token = _config_path_override.set(Path(path))
+    try:
+        yield
+    finally:
+        _config_path_override.reset(token)
 
 # #12823: the ship counter lives in its OWN file with `merge=ours`, separate from
 # config.md. config.md previously carried `merge=ours` solely to protect this one
@@ -144,11 +169,17 @@ FIELD_MAP = {
 
 
 def _read_config():
-    """Read config.md and return raw text."""
-    if not CONFIG_PATH.exists():
-        print(f"ERROR: config.md not found at {CONFIG_PATH}", file=sys.stderr)
+    """Read config.md and return raw text.
+
+    Honors `_config_path_override` (#13595) when set, so a foreign-target
+    compose reads the target's own scaffolded config.md instead of the
+    installing clone's.
+    """
+    path = _config_path_override.get() or CONFIG_PATH
+    if not path.exists():
+        print(f"ERROR: config.md not found at {path}", file=sys.stderr)
         sys.exit(1)
-    return CONFIG_PATH.read_text(encoding="utf-8")
+    return path.read_text(encoding="utf-8")
 
 
 def _parse_sections(text):

--- a/tests/test_13595_config_target_root_leak.py
+++ b/tests/test_13595_config_target_root_leak.py
@@ -1,0 +1,185 @@
+"""Regression test for #13595: compose's config-value placeholder substitution
+must read the TARGET install's own config.md, not the installing clone's.
+
+Root cause: config.py's CONFIG_PATH is fixed at import time to the installing
+clone's own repo root. compose.py's _substitute_placeholders -> _read_config_value
+-> config.get_field always read that fixed path, so every foreign
+deploy_role_v2/deploy_alias_v2(target_root=foreign) call silently substituted
+the INSTALLING clone's own config values (workers/aliases/test-commands/
+project-name/interval) into the foreign target's composed CLAUDE.md.
+
+Fix: config.config_path_override (a contextvar) lets compose.py redirect
+get_field() reads to target_root's own config.md for the duration of
+_substitute_placeholders, without touching any other get_field() call site.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO_ROOT / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import compose  # noqa: E402
+import config  # noqa: E402
+import atomic_emit  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _stub_assemble_pipeline(monkeypatch):
+    """Bypass the LLM assemble pipeline — write the linked composite verbatim
+    (same stub pattern as test_compose_a2f_10492.py)."""
+
+    def fake_assemble_and_emit(
+        linked_composite, output_dir, *, role_class, model_id=None,
+        commit_sha=None, generated_at=None, filename_suffix=".v2.md",
+        **kwargs,
+    ):
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        if filename_suffix == "":
+            base, linked, conflicts = "CLAUDE.md", "CLAUDE.linked.md", "CLAUDE.conflicts.md"
+        else:
+            base = f"CLAUDE{filename_suffix}"
+            linked = f"CLAUDE.linked{filename_suffix}"
+            conflicts = f"CLAUDE.conflicts{filename_suffix}"
+        (output_dir / base).write_text(linked_composite, encoding="utf-8")
+        (output_dir / linked).write_text(linked_composite, encoding="utf-8")
+        (output_dir / conflicts).write_text("# stub\n", encoding="utf-8")
+        return output_dir / base, output_dir / linked, output_dir / conflicts
+
+    monkeypatch.setattr(atomic_emit, "assemble_and_emit", fake_assemble_and_emit)
+
+
+def _frontmatter(slot, ordinal, roles=None):
+    lines = ["---", f"slot: {slot}", f"ordinal: {ordinal}"]
+    if roles is not None:
+        lines.append(f"roles: [{', '.join(roles)}]")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def _write_source(path, slot, ordinal, body, roles=None):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = _frontmatter(slot, ordinal, roles=roles) + "\n\n" + body
+    path.write_text(text, encoding="utf-8")
+
+
+def _stage_minimal_install(root, alias="pm", role="pm", pm_alias_value="pm"):
+    """Stage a tiny fixture install under `root`, whose own config.md sets
+    `alias-pm` to `pm_alias_value` — the value a foreign compose must read."""
+    refs = root / "references"
+    _write_source(refs / "roles" / "identity.md", "identity", 10, "Identity base.")
+    _write_source(refs / "roles" / "responsibility.md", "responsibility", 10, "Responsibility base.")
+    _write_source(refs / "roles" / "SOUL.md", "soul", 10, "Soul base.")
+    _write_source(refs / "roles" / "instructions.md", "instructions", 10,
+                  "### step:cycle/boot\nBoot body. [PM_ALIAS]\n")
+    _write_source(refs / "roles" / "vault.md", "vault", 10, "Vault base.")
+    _write_source(refs / "roles" / role / "instructions.md", "instructions", 20,
+                  "### step:cycle/work\nWork body.\n", roles=[role])
+
+    catalog = root / "docs" / "sub-skill-catalog.md"
+    catalog.parent.mkdir(parents=True, exist_ok=True)
+    catalog.write_text(
+        "## `common/` — Cross-cutting\n\n"
+        "| Sub-skill | One-liner | Used by |\n"
+        "|---|---|---|\n"
+        "| `boot-bootstrap` | Mode detection | all |\n",
+        encoding="utf-8",
+    )
+
+    config_md = root / ".squidsquad" / "config.md"
+    config_md.parent.mkdir(parents=True, exist_ok=True)
+    config_md.write_text(
+        "## Aliases\n\n"
+        "| alias | role-class | L3 domain |\n"
+        "|---|---|---|\n"
+        f"| {alias} | {role} | |\n\n"
+        f"- **pm**: {pm_alias_value}\n\n"
+        "## Iteration Interval\n\n"
+        "- **Minutes**: 30\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+def _mk_registry(alias_to_role):
+    return {alias: (role, None) for alias, role in alias_to_role.items()}
+
+
+class TestConfigValuePlaceholderReadsTargetRoot:
+    """#13595: a foreign target_root's own config.md must win, never the
+    installing clone's ambient config.CONFIG_PATH."""
+
+    def test_deploy_alias_v2_reads_target_config_not_installing_clone(self, tmp_path, monkeypatch):
+        # The "installing clone" — a completely separate config.md the
+        # compose call must NEVER read from during a foreign install.
+        installing_clone_config = tmp_path / "installing-clone" / ".squidsquad" / "config.md"
+        installing_clone_config.parent.mkdir(parents=True, exist_ok=True)
+        installing_clone_config.write_text(
+            "## Aliases\n\n- **pm**: INSTALLING-CLONE-LEAK\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(config, "CONFIG_PATH", installing_clone_config)
+
+        # The foreign target — its own config.md has a DIFFERENT value.
+        target_root = tmp_path / "foreign-target"
+        _stage_minimal_install(target_root, pm_alias_value="foreign-pm")
+
+        registry = _mk_registry({"pm": "pm"})
+        out = compose.deploy_alias_v2("pm", registry=registry, target_root=target_root)
+        text = out.read_text(encoding="utf-8")
+
+        assert "foreign-pm" in text, (
+            "compose must substitute [PM_ALIAS] from the TARGET's own "
+            "config.md — the foreign target's value never appeared"
+        )
+        assert "INSTALLING-CLONE-LEAK" not in text, (
+            "#13595 regression: the installing clone's own config value "
+            "leaked into the foreign target's composed output"
+        )
+
+    def test_config_get_field_unaffected_outside_override(self, monkeypatch, tmp_path):
+        """The contextvar must not leak state across calls — a plain
+        get_field() outside any override still reads the ambient CONFIG_PATH,
+        unaffected by a prior compose call's override."""
+        real_config = tmp_path / "config.md"
+        real_config.write_text("## Aliases\n\n- **pm**: real-value\n", encoding="utf-8")
+        monkeypatch.setattr(config, "CONFIG_PATH", real_config)
+
+        other = tmp_path / "other-config.md"
+        other.write_text("## Aliases\n\n- **pm**: other-value\n", encoding="utf-8")
+
+        with config.config_path_override(other):
+            assert config.get_field("alias-pm") == "other-value"
+
+        # Override released — back to the ambient CONFIG_PATH.
+        assert config.get_field("alias-pm") == "real-value"
+
+    def test_deploy_role_v2_reads_target_config_not_installing_clone(self, tmp_path, monkeypatch):
+        """Same regression, via the wizard's deploy_role_v2 path (hermetic
+        install; source_root/target_root split)."""
+        installing_clone_config = tmp_path / "installing-clone" / ".squidsquad" / "config.md"
+        installing_clone_config.parent.mkdir(parents=True, exist_ok=True)
+        installing_clone_config.write_text(
+            "## Aliases\n\n- **pm**: INSTALLING-CLONE-LEAK\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(config, "CONFIG_PATH", installing_clone_config)
+
+        source_root = tmp_path / "source"
+        _stage_minimal_install(source_root, pm_alias_value="source-unused")
+
+        target_root = tmp_path / "foreign-target"
+        _stage_minimal_install(target_root, pm_alias_value="foreign-pm-v2")
+
+        out = compose.deploy_role_v2(
+            "pm", target_root=target_root, source_root=source_root,
+            output_name="pm",
+        )
+        text = Path(out).read_text(encoding="utf-8")
+
+        assert "foreign-pm-v2" in text
+        assert "INSTALLING-CLONE-LEAK" not in text


### PR DESCRIPTION
## Summary

High-severity leak found during #12527's greenfield installer verification: `compose.py`'s `_substitute_placeholders` -> `_read_config_value` -> `config.get_field` always read `config.CONFIG_PATH`, which is fixed at import time to the **installing clone's own repo root** -- never `target_root`. Every foreign `deploy_role_v2`/`deploy_alias_v2(target_root=foreign)` call therefore silently substituted the installing clone's own config values (workers/aliases/test-commands/project-name/interval -- at least 9 placeholder reads) into a foreign target's composed CLAUDE.md, instead of the target's own just-scaffolded config.md.

**Fix**: `config.config_path_override` -- a contextvar-based override, not a threaded parameter -- so every *other* `get_field()` call site across the codebase keeps its existing default behavior unchanged. Only the two `_substitute_placeholders` call sites in `compose.py` (inside `deploy_alias_v2` and `deploy_role_v2`) opt in, wrapping the call with `target_root / ".squidsquad" / "config.md"`.

**Side-effect fix**: `_read_config_value` already degrades gracefully when a field is missing (documented as expected for a fresh scaffold's sparse config.md), but `get_field`'s own `sys.exit(1)` path prints a "Field not found" ERROR to stderr on its way there. Previously masked because the leak meant fields were (almost) always found on the installing clone's own, fully-populated config.md. Now that we correctly read the target's sparser config, this printed noise became visible -- fixed by swallowing stderr for this already-handled fallback path.

## Test plan
- [x] `tests/test_13595_config_target_root_leak.py` -- reproduces the leak with a divergent installing-clone/target-root config.md pair (both `deploy_alias_v2` and `deploy_role_v2` paths), confirms the fix reads the target's value and never the installing clone's; contextvar-isolation test confirms no cross-call leakage
- [x] Verified each new test FAILS without the fix (reverted `config.py`/`compose.py`, confirmed 3/3 failures) and PASSES with it
- [x] Full compose/config/wizard suites: 808 passed, 1 pre-existing known-failure (#10360, gate-excluded, unrelated)
- [x] Full static gate: 5580 gated tests, 0 failures, 0 errors