### PR TITLE
wizard: #13593 scope setup-yes gh ops to target_dir

### DIFF
--- a/references/scripts/wizard.py
+++ b/references/scripts/wizard.py
@@ -2601,15 +2601,19 @@ def build_label_inventory():
     return inventory
 
 
-def list_gh_labels():
+def list_gh_labels(cwd=None):
     """Return the set of label names currently on the repo via `gh label list`.
+
+    Args:
+        cwd: directory whose git remote `gh` should resolve against. None
+            (default) uses the ambient process CWD — the historical behavior.
 
     Empty set on any error — caller decides whether to treat that as an
     API failure or an uninitialised repo.
     """
     result = _run([
         "gh", "label", "list", "--limit", "200", "--json", "name",
-    ])
+    ], cwd=cwd)
     if result.returncode != 0 or not result.stdout.strip():
         return set()
     try:
@@ -2619,11 +2623,15 @@ def list_gh_labels():
     return {item["name"] for item in data if isinstance(item, dict) and "name" in item}
 
 
-def ensure_labels(dry_run=False):
+def ensure_labels(dry_run=False, cwd=None):
     """Seed every required label. Idempotent — only creates what is missing.
 
     Args:
         dry_run: if True, reports what WOULD be created without calling gh.
+        cwd: directory whose git remote `gh` should resolve against (#13593
+            — setup-yes must create labels on the target repo, not whatever
+            repo the ambient process CWD happens to point at). None (default)
+            uses the ambient process CWD — the historical behavior.
 
     Returns a summary dict:
         {
@@ -2638,7 +2646,7 @@ def ensure_labels(dry_run=False):
     repo-side step. Safe to re-run at any time.
     """
     inventory = build_label_inventory()
-    existing = list_gh_labels()
+    existing = list_gh_labels(cwd=cwd)
 
     summary = {
         "total": len(inventory),
@@ -2660,7 +2668,7 @@ def ensure_labels(dry_run=False):
             "gh", "label", "create", name,
             "--description", spec["description"],
             "--color", spec["color"],
-        ])
+        ], cwd=cwd)
         if result.returncode == 0:
             summary["created"].append(name)
         else:
@@ -4248,9 +4256,12 @@ def cmd_setup_yes(args):
         except ImportError:
             pass
 
-    # 2. Load repo info
+    # 2. Load repo info — scoped to target_path's own remote (#13593), not
+    # the ambient process CWD. Without this, `setup-yes /path/to/foreign`
+    # invoked from a different CWD stamps the CWD repo's identity into the
+    # foreign install's config.md.
     repo_info = {}
-    result = _run(["gh", "repo", "view", "--json", "name,url"])
+    result = _run(["gh", "repo", "view", "--json", "name,url"], cwd=str(target_path))
     if result.returncode == 0:
         try:
             data = json.loads(result.stdout)
@@ -4294,10 +4305,12 @@ def cmd_setup_yes(args):
         msg += f" ({len(failed)} FAILED to compose)"
     print(msg)
 
-    # 6. Ensure labels
+    # 6. Ensure labels — scoped to target_path's own remote (#13593), not
+    # the ambient process CWD (which could be a different repo entirely,
+    # e.g. the SquidSquad self-hosted clone this command was launched from).
     print("Creating GitHub labels...")
     try:
-        label_result = ensure_labels(dry_run=False)
+        label_result = ensure_labels(dry_run=False, cwd=str(target_path))
         created = label_result.get("created", 0)
         if created:
             print(f"  Created {created} label(s)")

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -2660,3 +2660,81 @@ class TestCmdSetupYes:
             assert "check" not in kw, (
                 f"_run called with check={kw['check']} — this causes TypeError"
             )
+
+
+# ---------------------------------------------------------------------------
+# cmd_setup_yes gh-scoping — #13593
+# ---------------------------------------------------------------------------
+
+
+class TestSetupYesGhScoping:
+    """#13593: setup-yes's gh operations must target target_dir's own
+    remote, not whatever repo the ambient process CWD happens to point at."""
+
+    def _tracking_run(self, calls):
+        from unittest.mock import MagicMock
+
+        def tracking_run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return MagicMock(returncode=1, stdout="", stderr="")
+        return tracking_run
+
+    def test_gh_repo_view_scoped_to_target_dir(self, tmp_path):
+        from unittest.mock import patch
+        calls = []
+        with patch.object(wizard, "_run", side_effect=self._tracking_run(calls)):
+            try:
+                wizard.cmd_setup_yes([str(tmp_path)])
+            except Exception:
+                pass
+        repo_view_calls = [
+            (cmd, kw) for cmd, kw in calls
+            if cmd[:3] == ["gh", "repo", "view"]
+        ]
+        assert repo_view_calls, "expected a 'gh repo view' call"
+        for cmd, kw in repo_view_calls:
+            assert kw.get("cwd") == str(tmp_path), (
+                f"'gh repo view' must be scoped to target_dir via cwd=, "
+                f"got cwd={kw.get('cwd')!r}"
+            )
+
+    def test_ensure_labels_scoped_to_target_dir(self, tmp_path):
+        from unittest.mock import patch
+        calls = []
+        with patch.object(wizard, "_run", side_effect=self._tracking_run(calls)):
+            try:
+                wizard.cmd_setup_yes([str(tmp_path)])
+            except Exception:
+                pass
+        label_calls = [
+            (cmd, kw) for cmd, kw in calls
+            if cmd[:2] == ["gh", "label"]
+        ]
+        assert label_calls, "expected at least one 'gh label ...' call"
+        for cmd, kw in label_calls:
+            assert kw.get("cwd") == str(tmp_path), (
+                f"'gh label ...' must be scoped to target_dir via cwd=, "
+                f"got cwd={kw.get('cwd')!r} for {cmd}"
+            )
+
+    def test_list_gh_labels_passes_cwd_through(self):
+        from unittest.mock import patch, MagicMock
+        with patch.object(wizard, "_run",
+                           return_value=MagicMock(returncode=0, stdout="[]")) as m:
+            wizard.list_gh_labels(cwd="/some/target")
+        assert m.call_args.kwargs.get("cwd") == "/some/target"
+
+    def test_list_gh_labels_default_cwd_is_none(self):
+        """Historical behavior (ambient CWD) is preserved when cwd is omitted."""
+        from unittest.mock import patch, MagicMock
+        with patch.object(wizard, "_run",
+                           return_value=MagicMock(returncode=0, stdout="[]")) as m:
+            wizard.list_gh_labels()
+        assert m.call_args.kwargs.get("cwd") is None
+
+    def test_ensure_labels_dry_run_passes_cwd_through(self):
+        from unittest.mock import patch, MagicMock
+        with patch.object(wizard, "_run",
+                           return_value=MagicMock(returncode=0, stdout="[]")) as m:
+            wizard.ensure_labels(dry_run=True, cwd="/some/target")
+        assert m.call_args.kwargs.get("cwd") == "/some/target"


### PR DESCRIPTION
## Summary
- `non_interactive_setup` (`setup-yes [target_dir]`) ran `gh repo view` and `ensure_labels()` against the ambient process CWD instead of `target_dir`.
- Invoked from a CWD other than the target repo (the documented normal usage — "as a normal user would, NOT from this repo's context" — but from any *other* CWD too), this stamps the wrong repo's identity into the generated `config.md` and creates SquidSquad labels on the wrong repo's GitHub remote.
- Threads `cwd=` through `list_gh_labels()`/`ensure_labels()` (both default `cwd=None`, preserving historical ambient-CWD behavior for `cmd_ensure_labels` and other unscoped callers) and scopes both the `gh repo view` call and the `ensure_labels` call in `cmd_setup_yes` to `str(target_path)`.

## Test plan
- [x] New regression tests: `TestSetupYesGhScoping` (5 cases) in `tests/test_wizard.py`
- [x] Verified fail-without-fix / pass-with-fix via `git stash`
- [x] Full `tests/test_wizard.py` suite passes (257 tests, base predates #13592's still-pending-test additions)
- [x] Full static gate passes (5585 gated tests, 0 failures/0 errors)
- [x] Comprehension staleness gate: clean

Closes #13593

https://claude.ai/code/session_01LGXaogYiR2GxLSV6V8YEAU