### PR TITLE
harness: #13596 bound _MERGE_LOCK acquire + the actually-unbounded compose.py call

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -99,6 +99,21 @@ _teardown_in_progress = False
 # reset git_ops._ENSURE_MAIN_LOCK out from under a concurrent same-clone pull).
 _MERGE_LOCK = threading.Lock()
 
+# #13596: _do_merge() holds _MERGE_LOCK across the whole merge+compose sequence.
+# git_ops.pr_merge()'s own subprocess calls already bound themselves via
+# _run_list's _git_timeout() default (300s/call) -- but the compose.py
+# deploy-all subprocess.run() below this lock does NOT (a plain subprocess.run
+# with no timeout=, genuinely unbounded). Before this fix, one hung compose.py
+# call while holding the lock wedged every subsequent /merge request forever
+# (.acquire() with no args blocks indefinitely) -- the harness's entire merge
+# subsystem, not just the hung thread. MERGE_LOCK_TIMEOUT bounds the QUEUE
+# side (a queued /merge fails loud instead of hanging forever); COMPOSE_TIMEOUT
+# bounds the actual unbounded call so the lock gets released in the first place.
+# Both generous (a full merge can legitimately involve several 300s-capped git
+# ops back to back) so neither false-trips a slow-but-healthy merge.
+MERGE_LOCK_TIMEOUT = 900
+COMPOSE_TIMEOUT = 300
+
 
 def _begin_teardown() -> bool:
     """Atomically claim the single teardown slot. Returns True for the first
@@ -4650,7 +4665,25 @@ async def merge_pr(request: Request):
         # #13588: hold _MERGE_LOCK across the WHOLE merge so the reload below can
         # never mutate git_ops out from under a concurrent merge thread, and
         # merges never race ensure_main_and_pull on the shared clone.
-        _MERGE_LOCK.acquire()
+        # #13596: bounded acquire — a hung merge ahead in the queue must fail
+        # loud, not wedge every subsequent /merge request forever.
+        acquired = _MERGE_LOCK.acquire(timeout=MERGE_LOCK_TIMEOUT)
+        if not acquired:
+            msg = (
+                f"could not acquire merge lock within {MERGE_LOCK_TIMEOUT}s -- "
+                f"another merge is hung holding it (#13596)"
+            )
+            _log(f"ERROR: merge lock timeout for PR #{pr_number}: {msg}")
+            _emit_event("pr-merged", "harness", payload={
+                "pr_number": str(pr_number),
+                "branch": branch,
+                "issue_number": "",
+                "files_changed": [],
+                "success": False,
+                "error": msg,
+                "requesting_role": role,
+            })
+            return
         try:
             # #13588: reload git_ops from on-disk source each merge — the cached
             # module would otherwise pin merge-time scope logic at process start.
@@ -4712,13 +4745,21 @@ async def merge_pr(request: Request):
                         "trigger_pr": str(pr_number),
                     })
                     return
-                compose_result = subprocess.run(
-                    [sys.executable, str(SCRIPT_DIR / "compose.py"), "deploy-all"],
-                    capture_output=True, text=True, encoding="utf-8", errors="replace",
-                    check=False, cwd=str(REPO_ROOT),
-                )
-                compose_success = compose_result.returncode == 0
-                compose_error = "" if compose_success else compose_result.stderr.strip()[:500]
+                # #13596: bounded — this ran with no timeout= before, the one
+                # genuinely-unbounded call inside the _MERGE_LOCK critical
+                # section (git_ops's own subprocess calls already self-bound
+                # via _run_list's _git_timeout() default).
+                try:
+                    compose_result = subprocess.run(
+                        [sys.executable, str(SCRIPT_DIR / "compose.py"), "deploy-all"],
+                        capture_output=True, text=True, encoding="utf-8", errors="replace",
+                        check=False, cwd=str(REPO_ROOT), timeout=COMPOSE_TIMEOUT,
+                    )
+                    compose_success = compose_result.returncode == 0
+                    compose_error = "" if compose_success else compose_result.stderr.strip()[:500]
+                except subprocess.TimeoutExpired:
+                    compose_success = False
+                    compose_error = f"compose.py deploy-all timed out after {COMPOSE_TIMEOUT}s (#13596)"
 
                 _emit_event("compose-completed", "harness", payload={
                     "success": compose_success,

--- a/tests/comprehension/.staleness-baseline.json
+++ b/tests/comprehension/.staleness-baseline.json
@@ -190,7 +190,7 @@
  },
  "9873_spec.json": {
   "references/scripts/event_catalog.py": "8577ca61909d3d93c1221ac1b984800581f228c5",
-  "references/scripts/harness.py": "15e80e037454c81cdb96cc89690b58ac2920edd9"
+  "references/scripts/harness.py": "35b1b6cf8b501013f953a7717945df7ffe9dcdbb"
  },
  "_note": "Initialized 2026-07-18 (#13575), re-baselined same day after merging main (the gate's first live catch: the merge moved several fragments' shas). Pairs at initialization were grandfathered WITHOUT retroactive re-review \u2014 only 13175_spec.json had a known overrule (superseded_by:13569, annotation authored by verifier). From here on, any fragment change must refresh its dependent specs' entries in the same PR (comprehension_staleness.py refresh) or mark them superseded_by."
 }

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -5484,6 +5484,123 @@ class TestMergeGitOpsReload13588(unittest.TestCase):
         self.assertFalse(harness._MERGE_LOCK.locked())
 
 
+class _SyncThread:
+    """Runs the merge body inline so assertions are deterministic — no daemon
+    -thread join race (the flake class filed as #13589)."""
+
+    def __init__(self, target=None, daemon=None, name=None, args=(), kwargs=None):
+        self._t, self._a, self._k = target, args, kwargs or {}
+
+    def start(self):
+        self._t(*self._a, **self._k)
+
+
+class TestMergeLockTimeout13596(unittest.TestCase):
+    """#13596: #13588's _MERGE_LOCK.acquire() had no timeout — one hung
+    subprocess call while holding the lock wedged every subsequent /merge
+    request forever (the harness's entire merge subsystem, not just the
+    hung thread). Two independent fixes: (1) a bounded acquire so a queued
+    /merge fails loud instead of hanging forever, (2) the compose.py
+    deploy-all subprocess.run() — the actual unbounded call inside the
+    locked section — now carries a timeout= of its own."""
+
+    def test_do_merge_lock_timeout_fails_loud_without_deadlock(self):
+        """A queued /merge must fail loud (not hang forever, not attempt the
+        merge) when _MERGE_LOCK is already held by a hung merge ahead of it."""
+        import harness
+        from fastapi.testclient import TestClient
+
+        fake_go = MagicMock(name="git_ops_module")
+        client = TestClient(harness.app, raise_server_exceptions=False)
+
+        harness._MERGE_LOCK.acquire()  # simulate a hung merge holding the lock
+        try:
+            with patch("harness.MERGE_LOCK_TIMEOUT", 0.05), \
+                 patch("harness._reload_git_ops", return_value=fake_go), \
+                 patch("harness._get_pr_files", return_value=[]), \
+                 patch("harness.threading.Thread", _SyncThread), \
+                 patch("harness._emit_event") as mock_emit:
+                resp = client.post(
+                    "/merge",
+                    json={"pr_number": 4343, "branch": "squidsquad/task/4343",
+                          "role": "dm"})
+            self.assertEqual(resp.status_code, 202)
+            fake_go.pr_merge.assert_not_called()
+            pr_merged_calls = [
+                c for c in mock_emit.call_args_list if c.args[0] == "pr-merged"
+            ]
+            self.assertEqual(len(pr_merged_calls), 1)
+            payload = pr_merged_calls[0].kwargs.get("payload")
+            self.assertFalse(payload["success"])
+            self.assertIn("lock", payload["error"].lower())
+        finally:
+            harness._MERGE_LOCK.release()
+
+    def test_compose_subprocess_run_uses_bounded_timeout(self):
+        """compose.py deploy-all previously ran via subprocess.run() with NO
+        timeout= at all — the one genuinely-unbounded call inside the
+        _MERGE_LOCK critical section. Must now pass timeout=COMPOSE_TIMEOUT."""
+        import harness
+        from fastapi.testclient import TestClient
+
+        fake_go = MagicMock(name="git_ops_module")
+        fake_go.pr_merge.return_value = (True, "merged")
+        fake_go.ensure_main_and_pull.return_value = (True, "ok")
+
+        client = TestClient(harness.app, raise_server_exceptions=False)
+        with patch("harness._reload_git_ops", return_value=fake_go), \
+             patch("harness._get_pr_files",
+                   return_value=["references/scripts/foo.py"]), \
+             patch("harness.threading.Thread", _SyncThread), \
+             patch("harness._emit_event"), \
+             patch("harness.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            resp = client.post(
+                "/merge",
+                json={"pr_number": 4344, "branch": "squidsquad/task/4344",
+                      "role": "dm"})
+        self.assertEqual(resp.status_code, 202)
+        mock_run.assert_called_once()
+        self.assertEqual(mock_run.call_args.kwargs.get("timeout"),
+                         harness.COMPOSE_TIMEOUT)
+
+    def test_compose_subprocess_timeout_handled_gracefully(self):
+        """A hung compose.py must not crash the merge thread or leave the
+        lock stuck — TimeoutExpired is caught and surfaced as a compose
+        failure, and _MERGE_LOCK is still released via the finally clause."""
+        import harness
+        import subprocess as _subprocess
+        from fastapi.testclient import TestClient
+
+        fake_go = MagicMock(name="git_ops_module")
+        fake_go.pr_merge.return_value = (True, "merged")
+        fake_go.ensure_main_and_pull.return_value = (True, "ok")
+
+        client = TestClient(harness.app, raise_server_exceptions=False)
+        with patch("harness._reload_git_ops", return_value=fake_go), \
+             patch("harness._get_pr_files",
+                   return_value=["references/scripts/foo.py"]), \
+             patch("harness.threading.Thread", _SyncThread), \
+             patch("harness._emit_event") as mock_emit, \
+             patch("harness.subprocess.run",
+                   side_effect=_subprocess.TimeoutExpired(
+                       cmd="compose.py", timeout=harness.COMPOSE_TIMEOUT)):
+            resp = client.post(
+                "/merge",
+                json={"pr_number": 4345, "branch": "squidsquad/task/4345",
+                      "role": "dm"})
+        self.assertEqual(resp.status_code, 202)
+        self.assertFalse(harness._MERGE_LOCK.locked(),
+                         "lock must be released even after a compose timeout")
+        compose_calls = [
+            c for c in mock_emit.call_args_list if c.args[0] == "compose-completed"
+        ]
+        self.assertEqual(len(compose_calls), 1)
+        payload = compose_calls[0].kwargs.get("payload")
+        self.assertFalse(payload["success"])
+        self.assertIn("timed out", payload["error"])
+
+
 # ---------------------------------------------------------------------------
 # EAD issue-poll --limit must not silently truncate the open set — #13555
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `#13588`'s `_do_merge()` holds `_MERGE_LOCK` across the whole merge+compose sequence via `.acquire()` with no arguments (blocks forever).
- Verified empirically that `git_ops.pr_merge()`'s own subprocess calls (`state_result`/`result`/`branch_result`) already self-bound via `_run_list`'s `_git_timeout()` default (300s/call — **not** unbounded, contrary to the original report's claim about this specific call site).
- The actual genuinely-unbounded call is the `compose.py deploy-all` `subprocess.run()` inside the same locked section — a plain call with no `timeout=` at all. One hung `compose.py` while holding the lock wedges every subsequent `/merge` request forever, since a queued thread's `.acquire()` also has no timeout.

## Fix (both, generous enough not to false-trip a slow-but-healthy merge)
1. `_MERGE_LOCK.acquire(timeout=MERGE_LOCK_TIMEOUT=900)` — a queued `/merge` now fails loud (emits a `pr-merged` failure event, never attempts the merge) instead of hanging forever. The `finally`-release is guarded to only fire when the acquire actually succeeded, so a failed/timed-out acquire never erroneously releases a lock held by someone else.
2. The `compose.py` `subprocess.run()` now passes `timeout=COMPOSE_TIMEOUT=300` and catches `TimeoutExpired`, surfacing it as a `compose-completed` failure event like any other compose failure — this is what actually lets the lock get released when compose hangs.

## Test plan
- [x] New regression tests: `TestMergeLockTimeout13596` (3 cases) in `tests/test_harness.py`
- [x] Verified fail-without-fix / pass-with-fix via `git stash`
- [x] Full `test_harness.py` suite passes (326 tests)
- [x] `test_git_ops.py` / `test_feat_6126_harness_merge.py` / `test_feat_13170_merge_body_guard.py` / `test_harness_route_contract.py` pass (322 tests)
- [x] Full static gate passes (5583 gated tests, 0 failures/0 errors)
- [x] Comprehension staleness gate: clean

Closes #13596

https://claude.ai/code/session_01LGXaogYiR2GxLSV6V8YEAU