### PR TITLE
pm: #13602 raise pipeline-sentinel.md gh issue list limits 50->500 + warn-at-cap

### DIFF
--- a/references/sub-skills/roles/pm/pipeline-sentinel.md
+++ b/references/sub-skills/roles/pm/pipeline-sentinel.md
@@ -33,8 +33,10 @@ The sentinel monitors the *flow* of the pipeline: detect a halt, **investigate t
 
 Query all open SquidSquad items:
 ```bash
-gh issue list --label squidsquad --state open --json number,title,labels,updatedAt --limit 50
+gh issue list --label squidsquad --state open --json number,title,labels,updatedAt --limit 500
 ```
+
+> **Note (#13602):** if this returns exactly 500 items, the query is at its cap and older open issues may be **invisible to halt detection** — the same silent-truncation class #13555 fixed for the harness's own issue poller. Raise `--limit` further and re-run before concluding the pipeline is healthy.
 
 **2.1 Detect a halt — by lack of PROGRESS, not by absence of comments.** A **halt** is *no forward progress on a non-terminal item past **90 minutes*** (3 cycles). Forward progress means a **status/label change or a PR push** — **NOT** a new comment. Treat any non-terminal item past threshold with no status/label/PR movement as a halt candidate, **regardless of comment activity**.
 
@@ -168,8 +170,10 @@ Parse the JSON output. If the assigned agent's health is `stalled`, `stopped`, o
 
 From the open items query, group by `role:*` label and count `status:in-progress` items per role:
 ```bash
-gh issue list --label squidsquad --label status:in-progress --state open --json number,title,labels --limit 50
+gh issue list --label squidsquad --label status:in-progress --state open --json number,title,labels --limit 500
 ```
+
+> **Note (#13602):** if this returns exactly 500 items, the query is at its cap and some in-progress items may be **invisible to the double-pickup check** — the anomaly detector this section exists to run would then silently miss exactly the thing it's for. Raise `--limit` further before trusting a clean read.
 For each role with >=2 `status:in-progress` items:
 - **Tier 1**: Comment on each of that role's in-progress items — `python references/scripts/tracker.py comment [NUMBER] --role pm-lead --message "PM pipeline-sentinel: [role] holds N status:in-progress items simultaneously (#[other numbers]). If one is a parked block-and-continue, transition it to status:blocked; otherwise this may be a double-pickup — investigate."` This is advisory (not a halt/unblock) — the flagged agent reconciles at its next pickup.
 - **Tier 2**: Only file a bug if the same role still shows >=2 `status:in-progress` on the NEXT sentinel run after the Tier-1 nudge (i.e. it did not self-resolve to one active + one `blocked`) — `"Role [role] held >=2 status:in-progress items across 2 consecutive pipeline-sentinel runs (#[numbers]). Possible true double-pickup, or the agent is not using status:blocked for parked work."`

--- a/tests/comprehension/.staleness-baseline.json
+++ b/tests/comprehension/.staleness-baseline.json
@@ -36,7 +36,7 @@
   "references/roles/SOUL.md": "123a7e0c083d236fdd1f20ebacd02420fe0642b8"
  },
  "12493_spec.json": {
-  "references/sub-skills/roles/pm/pipeline-sentinel.md": "655367dd88c6cd4e257f446e6c4a46123479c546"
+  "references/sub-skills/roles/pm/pipeline-sentinel.md": "c91c78946cc1a3db874f9d674a9c58677cd0586a"
  },
  "12506_spec.json": {},
  "12585_spec.json": {

--- a/tests/test_13602_pipeline_sentinel_limit.py
+++ b/tests/test_13602_pipeline_sentinel_limit.py
@@ -1,0 +1,97 @@
+"""Tests for #13602 — pipeline-sentinel.md's two `gh issue list --limit 50`
+calls share the #13555 silent-truncation class (harness.py's own issue
+poller hit the identical bug against the same growing open-issue set).
+
+These are comprehension tests verifying the sub-skill markdown content, not
+a Python script — pipeline-sentinel.md is PM's runtime-loaded instructions.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SENTINEL_FILE = (
+    REPO_ROOT / "references" / "sub-skills" / "roles" / "pm" / "pipeline-sentinel.md"
+)
+
+HALT_QUERY_OLD = (
+    "gh issue list --label squidsquad --state open "
+    "--json number,title,labels,updatedAt --limit 50"
+)
+HALT_QUERY_NEW = (
+    "gh issue list --label squidsquad --state open "
+    "--json number,title,labels,updatedAt --limit 500"
+)
+DOUBLE_PICKUP_QUERY_OLD = (
+    "gh issue list --label squidsquad --label status:in-progress --state open "
+    "--json number,title,labels --limit 50"
+)
+DOUBLE_PICKUP_QUERY_NEW = (
+    "gh issue list --label squidsquad --label status:in-progress --state open "
+    "--json number,title,labels --limit 500"
+)
+
+
+@pytest.fixture
+def sentinel_text():
+    assert SENTINEL_FILE.exists(), f"Pipeline sentinel file missing: {SENTINEL_FILE}"
+    return SENTINEL_FILE.read_text(encoding="utf-8")
+
+
+class TestHaltDetectionQueryLimit:
+    """2.1's halt-detection sweep queries ALL open squidsquad issues
+    (~165+ currently) — the more urgent of the two per #13602's report."""
+
+    def test_limit_raised_to_500(self, sentinel_text):
+        assert HALT_QUERY_NEW in sentinel_text, (
+            "halt-detection query must use --limit 500, matching #13555's "
+            "precedent for the identical truncation class"
+        )
+
+    def test_old_limit_50_query_gone(self, sentinel_text):
+        # "--limit 50" is a substring of "--limit 500" — anchor on the line
+        # ending right after the old value so the new (fixed) query doesn't
+        # false-fail this check.
+        assert (HALT_QUERY_OLD + "\n") not in sentinel_text
+
+    def test_warn_at_cap_note_present(self, sentinel_text):
+        idx = sentinel_text.index(HALT_QUERY_NEW)
+        tail = sentinel_text[idx:idx + 600]
+        assert "#13602" in tail
+        assert "500" in tail
+        assert "invisible" in tail.lower() or "truncat" in tail.lower()
+
+
+class TestDoublePickupQueryLimit:
+    """4g's double-pickup anomaly check (#13515) queries open +
+    status:in-progress items — the anomaly detector must not silently miss
+    the very anomaly it exists to find."""
+
+    def test_limit_raised_to_500(self, sentinel_text):
+        assert DOUBLE_PICKUP_QUERY_NEW in sentinel_text, (
+            "double-pickup query must use --limit 500, matching #13555's "
+            "precedent for the identical truncation class"
+        )
+
+    def test_old_limit_50_query_gone(self, sentinel_text):
+        assert (DOUBLE_PICKUP_QUERY_OLD + "\n") not in sentinel_text
+
+    def test_warn_at_cap_note_present(self, sentinel_text):
+        idx = sentinel_text.index(DOUBLE_PICKUP_QUERY_NEW)
+        tail = sentinel_text[idx:idx + 600]
+        assert "#13602" in tail
+        assert "500" in tail
+        assert "invisible" in tail.lower() or "truncat" in tail.lower()
+
+
+class TestUnrelatedLimitsUntouched:
+    """Only the two #13555-class queries change — the unrelated PR-conflict
+    `gh pr list ... --limit 20` (a different query, different bug class) must
+    be left alone."""
+
+    def test_pr_conflict_query_limit_unchanged(self, sentinel_text):
+        assert (
+            'gh pr list --search "squidsquad/" --state open '
+            "--json number,title,headRefName,mergeable --limit 20"
+        ) in sentinel_text


### PR DESCRIPTION
## Summary
- `pipeline-sentinel.md`'s two `gh issue list --limit 50` calls (line 36 halt-detection sweep over ALL open squidsquad issues, ~165+ currently; line 171 double-pickup anomaly check, #13515) share the identical silent-truncation class `#13555` fixed for `harness.py`'s own issue poller against the same growing open-issue set. Neither query warned on truncation.
- Raised both to `--limit 500`, matching `#13555`'s precedent.
- Since this is markdown instructions a PM agent reads and acts on at runtime (not code with a symbolic constant + a code-level warning branch), added a blockquote note after each query telling the agent to self-diagnose: exactly 500 results means the query is at its cap, raise `--limit` further and re-run before trusting the read.
- Left the unrelated `gh pr list --limit 20` (PR conflict detection, a much smaller PR set) and `gh issue list --state closed --limit 20` untouched — neither shares this truncation class.

## Test plan
- [x] New regression tests: `tests/test_13602_pipeline_sentinel_limit.py` (7 cases)
- [x] Verified fail-without-fix / pass-with-fix via `git stash`
- [x] DeepSeek code-review (`model_router.py`): NO_FINDINGS
- [x] Full `test_13602`/`test_feat_1228_pipeline_sentinel`/`test_13515_blocked_status` suite passes (45 tests)
- [x] Full static gate passes (5604 gated tests, 0 failures/0 errors)
- [x] Comprehension staleness gate: clean

Closes #13602

https://claude.ai/code/session_01LGXaogYiR2GxLSV6V8YEAU