### PR TITLE
harness: #13558 read current_phase from the agent's own clone (mirrors #13345)

### DIFF
--- a/references/scripts/harness.py
+++ b/references/scripts/harness.py
@@ -1509,12 +1509,17 @@ class HarnessState:
         except (SystemExit, Exception):
             return CONTEXT_THRESHOLD_DEFAULT
 
-    def _read_agent_pressure(self, role, agent):
-        """#13335 — read an agent's current context-pressure (int %) from its
-        own clone's ``.squidsquad/<role>/context-pressure`` (the file the
-        statusline writes each cycle). Returns ``None`` when the file is
-        absent, unreadable, or non-integer — treated as 'no signal', never
-        enforced against."""
+    def _read_agent_clone_file(self, role, agent, filename):
+        """#13558 — read ``<agent's own clone>/.squidsquad/<role>/<filename>``
+        as text. Shared clone-resolution helper for the per-agent state
+        files the statusline/cycle machinery writes each cycle
+        (``context-pressure``, ``current-state``). Sibling-clone agents
+        (skill/qa/dm running in their own clones) write these to THEIR OWN
+        clone's ``.squidsquad/<role>/``, not the harness-root
+        ``SQUIDSQUAD_DIR`` — reading the harness-root path for them returns a
+        stale/absent value (the bug #13345 fixed for context-pressure).
+        Returns ``None`` (never raises) when the clone can't be resolved or
+        the file is absent/unreadable."""
         clone_path = getattr(agent, "clone_path", None)
         if not clone_path:
             try:
@@ -1522,11 +1527,23 @@ class HarnessState:
             except Exception:
                 return None
         try:
-            ctx_file = (
-                Path(clone_path) / ".squidsquad" / role / "context-pressure"
-            )
-            return int(ctx_file.read_text(encoding="utf-8").strip())
-        except (FileNotFoundError, OSError, ValueError):
+            f = Path(clone_path) / ".squidsquad" / role / filename
+            return f.read_text(encoding="utf-8").strip()
+        except (FileNotFoundError, OSError):
+            return None
+
+    def _read_agent_pressure(self, role, agent):
+        """#13335 — read an agent's current context-pressure (int %) from its
+        own clone's ``.squidsquad/<role>/context-pressure`` (the file the
+        statusline writes each cycle). Returns ``None`` when the file is
+        absent, unreadable, or non-integer — treated as 'no signal', never
+        enforced against."""
+        text = self._read_agent_clone_file(role, agent, "context-pressure")
+        if text is None:
+            return None
+        try:
+            return int(text)
+        except ValueError:
             return None
 
     def _enforce_context_pressure(self):
@@ -3135,20 +3152,16 @@ async def get_agent_health(role: str):
         result["alive"] = agent.status == "running"
         result["status"] = agent.status
 
-    # Read current-state file for phase
-    state_file = SQUIDSQUAD_DIR / role / "current-state"
-    try:
-        result["current_phase"] = state_file.read_text(encoding="utf-8").strip()
-    except (OSError, FileNotFoundError):
-        pass
-
-    # Read context-pressure from the agent's OWN clone (#13345). Sibling-clone
-    # agents (skill/qa/dm) write context-pressure to
-    # <clone>/.squidsquad/<role>/context-pressure, NOT the harness-root
-    # .squidsquad/, so reading SQUIDSQUAD_DIR/role here returned a stale/absent
-    # value for them. Reuse _read_agent_pressure — the same clone-relative read
-    # the #13335 enforcement path uses — so the reported number matches what is
-    # actually enforced (and it fails-safe to None on absent/unreadable/non-int).
+    # Read current-state (phase) and context-pressure from the agent's OWN
+    # clone (#13345 fixed context_pressure; #13558 mirrors the identical fix
+    # for current_phase — same root cause). Sibling-clone agents (skill/qa/dm)
+    # write BOTH files to <clone>/.squidsquad/<role>/, NOT the harness-root
+    # .squidsquad/, so reading SQUIDSQUAD_DIR/role here returned a
+    # stale/absent value for them. _read_agent_clone_file is the shared
+    # clone-relative read both this and the #13335 enforcement path use, so
+    # the reported values match what the agent's own clone actually holds
+    # (and both fail-safe to None on an unresolvable clone or missing file).
+    result["current_phase"] = state._read_agent_clone_file(role, agent, "current-state")
     result["context_pressure"] = state._read_agent_pressure(role, agent)
 
     return result

--- a/tests/comprehension/.staleness-baseline.json
+++ b/tests/comprehension/.staleness-baseline.json
@@ -190,7 +190,7 @@
  },
  "9873_spec.json": {
   "references/scripts/event_catalog.py": "8577ca61909d3d93c1221ac1b984800581f228c5",
-  "references/scripts/harness.py": "35b1b6cf8b501013f953a7717945df7ffe9dcdbb"
+  "references/scripts/harness.py": "32c0e62c4596543b28691e66f4781b21fd343e0f"
  },
  "_note": "Initialized 2026-07-18 (#13575), re-baselined same day after merging main (the gate's first live catch: the merge moved several fragments' shas). Pairs at initialization were grandfathered WITHOUT retroactive re-review \u2014 only 13175_spec.json had a known overrule (superseded_by:13569, annotation authored by verifier). From here on, any fragment change must refresh its dependent specs' entries in the same PR (comprehension_staleness.py refresh) or mark them superseded_by."
 }

--- a/tests/test_13558_health_clone_phase.py
+++ b/tests/test_13558_health_clone_phase.py
@@ -1,0 +1,130 @@
+"""Regression test for #13558 — GET /agents/{role}/health must read
+current_phase from the agent's OWN clone
+(<clone>/.squidsquad/<role>/current-state), not the harness-root
+SQUIDSQUAD_DIR/<role>/. Sibling-clone agents (skill/qa/dm) write the file to
+their own clone, so the harness-root read returned a stale/absent value —
+the exact sibling half of #13345, which fixed context_pressure but
+explicitly left current_phase out of scope.
+
+The fix routes the endpoint through the new shared
+HarnessState._read_agent_clone_file(role, agent, filename) helper, which
+_read_agent_pressure (#13335/#13345) is also refactored onto so both fields
+share one clone-resolution implementation.
+"""
+import asyncio
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import harness  # noqa: E402
+from harness import AgentState  # noqa: E402
+
+
+def _running_agent(role, clone):
+    a = AgentState(role, clone)
+    a.status = "running"
+    a.bootup_complete = True
+    return a
+
+
+def _write_phase(clone, role, value):
+    d = Path(clone) / ".squidsquad" / role
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "current-state").write_text(value, encoding="utf-8")
+
+
+class TestHealthReadsClonePhase13558(unittest.TestCase):
+    def test_reads_from_clone_not_harness_root(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_phase(td, "skill", "verifying")
+            agent = _running_agent("skill", str(td))
+            with patch.object(harness.state, "get_agent", return_value=agent):
+                result = asyncio.run(harness.get_agent_health("skill"))
+            self.assertEqual(result["current_phase"], "verifying")
+
+    def test_absent_clone_file_is_none(self):
+        with tempfile.TemporaryDirectory() as td:
+            agent = _running_agent("skill", str(td))  # no current-state file
+            with patch.object(harness.state, "get_agent", return_value=agent):
+                result = asyncio.run(harness.get_agent_health("skill"))
+            self.assertIsNone(result["current_phase"])
+
+    def test_no_agent_is_safe(self):
+        with patch.object(harness.state, "get_agent", return_value=None), \
+             patch("harness.boot_remote._get_clone_path",
+                   side_effect=RuntimeError("no clone")):
+            result = asyncio.run(harness.get_agent_health("skill"))
+        self.assertIsNone(result["current_phase"])
+        self.assertFalse(result["alive"])
+
+    def test_harness_root_file_ignored_for_sibling_clone(self):
+        """The #13345/#13558 root cause: a STALE harness-root current-state
+        must NOT leak into the response for a sibling-clone agent — the
+        agent's own clone is authoritative. Patches SQUIDSQUAD_DIR to an
+        isolated temp dir (never touches this session's real
+        .squidsquad/skill/current-state)."""
+        with tempfile.TemporaryDirectory() as clone_dir, \
+             tempfile.TemporaryDirectory() as harness_root:
+            harness_root_state = Path(harness_root) / "skill"
+            harness_root_state.mkdir(parents=True, exist_ok=True)
+            (harness_root_state / "current-state").write_text(
+                "STALE_HARNESS_ROOT_VALUE", encoding="utf-8")
+
+            agent = _running_agent("skill", clone_dir)  # own clone: no file
+            with patch.object(harness.state, "get_agent", return_value=agent), \
+                 patch.object(harness, "SQUIDSQUAD_DIR", Path(harness_root)):
+                result = asyncio.run(harness.get_agent_health("skill"))
+            self.assertIsNone(
+                result["current_phase"],
+                "must read the agent's own clone, not the harness-root file "
+                "(which held a stale value)",
+            )
+
+
+class TestReadAgentCloneFileHelper13558(unittest.TestCase):
+    """The shared clone-resolution helper both context_pressure and
+    current_phase now go through."""
+
+    def test_reads_arbitrary_filename(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_phase(td, "skill", "shipping")
+            agent = _running_agent("skill", str(td))
+            text = harness.state._read_agent_clone_file(
+                "skill", agent, "current-state")
+            self.assertEqual(text, "shipping")
+
+    def test_falls_back_to_get_clone_path_when_agent_has_no_clone_path(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_phase(td, "skill", "planning")
+            agent = AgentState("skill", None)  # no clone_path on the agent
+            with patch("harness.boot_remote._get_clone_path", return_value=td):
+                text = harness.state._read_agent_clone_file(
+                    "skill", agent, "current-state")
+            self.assertEqual(text, "planning")
+
+    def test_unresolvable_clone_is_none(self):
+        agent = AgentState("skill", None)
+        with patch("harness.boot_remote._get_clone_path",
+                   side_effect=RuntimeError("no clone")):
+            text = harness.state._read_agent_clone_file(
+                "skill", agent, "current-state")
+        self.assertIsNone(text)
+
+    def test_context_pressure_still_int_parses_via_shared_helper(self):
+        """Non-regression: _read_agent_pressure's int-parsing contract must
+        survive being refactored onto the shared text helper."""
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td) / ".squidsquad" / "skill"
+            d.mkdir(parents=True, exist_ok=True)
+            (d / "context-pressure").write_text("55", encoding="utf-8")
+            agent = _running_agent("skill", str(td))
+            self.assertEqual(harness.state._read_agent_pressure("skill", agent), 55)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `#13345` fixed `GET /agents/{role}/health`'s `context_pressure` to read from the agent's OWN clone instead of the harness-root `SQUIDSQUAD_DIR/role` path (stale/absent for sibling-clone agents: skill/qa/dm running in their own clones) — but explicitly left `current_phase` out of scope as the sibling half of the same bug.
- `current_phase` still read `SQUIDSQUAD_DIR / role / "current-state"` — the harness-root path, identical root cause: `cycle.py`'s `status-bar-self` (every agent calls it every cycle) writes `current-state` to the agent's OWN clone's `.squidsquad/<role>/current-state`.
- Factored the suggested shared helper: `HarnessState._read_agent_clone_file(role, agent, filename)` resolves the target agent's clone path and reads `<clone>/.squidsquad/<role>/<filename>` as text. `_read_agent_pressure` (`#13335`/`#13345`) is refactored onto this helper (int-parsing the result), so both fields now share one clone-resolution implementation instead of duplicating it.

## Test plan
- [x] New regression tests: `tests/test_13558_health_clone_phase.py` (8 cases)
- [x] Verified fail-without-fix / pass-with-fix via `git stash` — one failure directly reproduced the reported bug by catching this actual session's real `current-state` content (`'idle|'`) leaking through
- [x] Full `test_13558`/`test_13345`/`test_13335`/`test_feat_13335` suite passes (48 tests)
- [x] Full `test_harness.py` passes (326 tests)
- [x] Full static gate passes (5613 gated tests, 0 failures/0 errors)
- [x] Comprehension staleness gate: clean

Closes #13558

https://claude.ai/code/session_01LGXaogYiR2GxLSV6V8YEAU