### PR TITLE
verifier: #13354 repoint discussion-protocol.md off the deprecated qa role prefix

### DIFF
--- a/references/sub-skills/roles/verifier/discussion-protocol.md
+++ b/references/sub-skills/roles/verifier/discussion-protocol.md
@@ -9,7 +9,7 @@ roles: [verifier]
 - Discussion entries are Issue comments — append-only, never edit or delete.
 - Include your alias parenthetical in the signature:
   ```bash
-  python references/scripts/tracker.py comment [NUMBER] --role "qa ($(python references/scripts/config.py alias qa))" --message "[message]"
+  python references/scripts/tracker.py comment [NUMBER] --role "verifier-lead ($(python references/scripts/config.py alias qa))" --message "[message]"
   ```
 - You may comment on any GitHub Issue (bugs or features from any agent).
 - Use Discussion to communicate with other agents — they will read your entries on their next pull.

--- a/tests/test_13354_discussion_protocol_role.py
+++ b/tests/test_13354_discussion_protocol_role.py
@@ -1,0 +1,70 @@
+"""Regression test for #13354 — the composed verifier Discussion Protocol
+taught a deprecated `--role qa` form. `_canonicalize_role` in tracker.py
+(#6274 D11) treats bare `qa`/`qa-lead` as deprecated input and prints:
+"WARNING: --role 'qa' is deprecated and will be rejected after #6274.3
+cutover. Use 'verifier' instead." — hit live on the #13335 rejection
+transition. `roles/verifier/verification.md` already prescribes
+`verifier-lead`; `roles/verifier/discussion-protocol.md` disagreed, teaching
+every composed verifier instruction a command that will hard-fail once the
+#6274.3 cutover lands.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DISCUSSION_PROTOCOL_FILE = (
+    REPO_ROOT / "references" / "sub-skills" / "roles" / "verifier"
+    / "discussion-protocol.md"
+)
+
+
+@pytest.fixture
+def discussion_protocol_text():
+    assert DISCUSSION_PROTOCOL_FILE.exists(), (
+        f"verifier discussion-protocol.md missing: {DISCUSSION_PROTOCOL_FILE}"
+    )
+    return DISCUSSION_PROTOCOL_FILE.read_text(encoding="utf-8")
+
+
+class TestVerifierDiscussionProtocolRole:
+    def test_uses_verifier_lead(self, discussion_protocol_text):
+        assert (
+            '--role "verifier-lead ($(python references/scripts/config.py '
+            'alias qa))"'
+        ) in discussion_protocol_text, (
+            "must teach the class-based verifier-lead form, matching "
+            "verification.md's existing --role verifier-lead usage"
+        )
+
+    def test_deprecated_bare_qa_role_gone(self, discussion_protocol_text):
+        assert '--role "qa (' not in discussion_protocol_text, (
+            "the deprecated bare 'qa' --role prefix must not appear — it "
+            "warns today (#6274 D11 dual-aware) and will be a hard reject "
+            "after the #6274.3 cutover"
+        )
+
+    def test_config_alias_lookup_key_unchanged(self, discussion_protocol_text):
+        """config.py alias qa is a config.md lookup key (## Aliases ->
+        alias-qa), NOT a tracker --role value — no alias-verifier entry
+        exists in config.py's FIELD_MAP, so this part must stay 'qa'."""
+        assert "config.py alias qa" in discussion_protocol_text
+
+
+class TestDeprecatedRoleFormStillMatchesTrackerWarning:
+    """Confirms the fixed role string actually avoids tracker.py's live
+    #6274 D11 deprecation warning (the bug's original symptom)."""
+
+    def test_verifier_lead_is_not_flagged_deprecated(self):
+        import sys
+
+        sys.path.insert(
+            0, str(REPO_ROOT / "references" / "scripts")
+        )
+        import tracker
+
+        # bare "qa" IS the deprecated form tracker.py warns on.
+        assert tracker._DUAL_ROLE_PREFIXES_6274.get("qa") == ("qa", True)
+        # "verifier" is the new, non-deprecated form.
+        assert tracker._DUAL_ROLE_PREFIXES_6274.get("verifier") == ("qa", False)


### PR DESCRIPTION
## Summary
- The composed verifier Discussion Protocol taught `--role "qa ($(config.py alias qa))"` — `qa` is the deprecated tracker.py role prefix (`#6274` D11 dual-aware window): `_canonicalize_role` already emits a deprecation warning today and will hard-reject after the `#6274.3` cutover.
- `roles/verifier/verification.md` already prescribes `--role verifier-lead`; `discussion-protocol.md` disagreed, teaching every composed verifier instruction a command that fails after cutover.
- Fixed by repointing to `--role "verifier-lead ($(config.py alias qa))"`. Left `config.py alias qa` unchanged — that's a `config.md` lookup key (`## Aliases` → `FIELD_MAP['alias-qa']`), not a tracker `--role` value, and no `alias-verifier` entry exists.
- Scoped to `verifier/discussion-protocol.md` only — pm/dm's use their own non-deprecated prefixes (only `dev`/`qa` are in the `#6274` deprecated table).

## Test plan
- [x] New regression tests: `tests/test_13354_discussion_protocol_role.py` (4 cases)
- [x] Verified fail-without-fix / pass-with-fix via `git stash`
- [x] DeepSeek code-review (`model_router.py`): independently traced the full `_canonicalize_role` resolution chain, NO_FINDINGS
- [x] Full static gate passes (5613 gated tests, 0 failures/0 errors)
- [x] Comprehension staleness gate: clean

Closes #13354

https://claude.ai/code/session_01LGXaogYiR2GxLSV6V8YEAU