### PR TITLE
docs: #13317 repoint stale PID-sole-liveness claims to the #12492 dual model

### DIFF
--- a/references/sub-skills/common/agent-lifecycle.md
+++ b/references/sub-skills/common/agent-lifecycle.md
@@ -13,7 +13,7 @@ Agent lifecycle is managed by the harness (`harness.py`) via REST API (#4966). A
 2. **Graceful stop**: Harness sets intent=stopping via API. `cycle_post.py` queries `GET /agents/{role}` at cycle end, sees the intent, and exits with code 42. (Polling-mode wrapper. In event mode the per-event ack-cursor loop has no cycle boundary; the stop signal is observed at task boundaries per [[event-mode-contract]] Case E.)
 3. **Start correctly**: Harness spawns agents via thin launcher (`thin_launcher.py`) in visible terminal windows. `cycle_pre.py` handles git pull/branch per cycle. (Polling-mode wrapper. In event mode the harness owns git — pull, commit, and push are managed at boot and shutdown by the harness; agents do not run `cycle_pre.py` / `cycle_post.py` per event.)
 
-**Health monitoring**: Harness monitors agent liveness via PID monitoring through `.claude-pid` (sole liveness signal). The harness polls every 5 seconds.
+**Health monitoring**: Harness monitors agent liveness via a dual model (#12492 progress-liveness cutover), polled every 5 seconds. Progress-liveness (activity-heartbeat + dispatch reference + pause guard) is now AUTHORITATIVE for reboot decisions — it catches a PID-alive-but-inert "zombie" agent (a false-positive class PID monitoring alone cannot see) and kills it for respawn; the pause guard recognizes a legitimate long tool call, compaction, or wait so it is never misread as a zombie. `.claude-pid` remains the instant crash signal (a dead PID is still detected immediately), but PID-aliveness alone no longer VETOES a reboot — it is demoted to teardown-only, not proof the agent is truly alive.
 
 **Intent state machine** (per-agent, in harness memory + `.harness-state.json`):
 - `running` — agent should be alive; auto-reboot on death

--- a/references/sub-skills/roles/pm/health-check.md
+++ b/references/sub-skills/roles/pm/health-check.md
@@ -15,7 +15,7 @@ Run the deterministic health check script:
 python references/scripts/health_check.py
 ```
 
-The script reads each agent's `.claude-pid` (sole liveness signal) and `current-state` mtime for offline diagnostics. The harness monitors PIDs directly every 5 seconds (#4966); prefer `squidsquad_cli.py status` when the harness is reachable.
+The script reads each agent's `.claude-pid` and `current-state` mtime as an offline-diagnostic proxy when the harness itself isn't reachable. The harness's own liveness model (polled every 5s, #4966) is a dual model since #12492: progress-liveness (activity-heartbeat + dispatch reference + pause guard) is AUTHORITATIVE for reboot decisions — it catches a PID-alive-but-inert "zombie" agent that PID alone would miss, while the pause guard recognizes a legitimate long tool call/compaction/wait so it's never misread as one — while `.claude-pid` remains the instant crash signal but no longer vetoes a reboot on its own. Prefer `squidsquad_cli.py status` when the harness is reachable — it reflects this authoritative model, not just PID.
 
 Log the script's output in `pm/qa-log.md`. For any agent reporting stalled (👻) or unknown (❓):
 

--- a/tests/comprehension/.staleness-baseline.json
+++ b/tests/comprehension/.staleness-baseline.json
@@ -141,9 +141,9 @@
   "references/sub-skills/roles/dm/delivery-packaging.md": "5a5ea484685a605aeffdbe9c93ad2e523473a1bd"
  },
  "2183_spec.json": {
-  "references/sub-skills/common/agent-lifecycle.md": "cb8dcf9a5b8b5a630283da0c2f7b150c7c3d6b3d",
+  "references/sub-skills/common/agent-lifecycle.md": "149b51503eb3d33b52a25f0d89615e19bedec5b8",
   "references/sub-skills/common/self-restart.md": "c9a89c7c52e750bcda6b3db62699ce773af4cb33",
-  "references/sub-skills/roles/pm/health-check.md": "98bd0de263f47a060eb10dc4b91c3405af42e1f5"
+  "references/sub-skills/roles/pm/health-check.md": "e5b5b164a2db265cbaf8f23a2fe7d1e2cf19469d"
  },
  "2195_spec.json": {},
  "361_spec.json": {
@@ -151,9 +151,9 @@
   "references/sub-skills/roles/pm/soul-shepherd.md": "f9432644cc7661ef1801c2a58a93510c73f274f7"
  },
  "4792_spec.json": {
-  ".squidsquad/project/shared-instructions.md": "4609e83b47dba7fe4b751c15ff734bc4e76808df",
-  "references/sub-skills/common/agent-lifecycle.md": "cb8dcf9a5b8b5a630283da0c2f7b150c7c3d6b3d",
-  "references/sub-skills/roles/pm/health-check.md": "98bd0de263f47a060eb10dc4b91c3405af42e1f5"
+  ".squidsquad/project/shared-instructions.md": "d684d6ee8b2f1fc39cb7e9a9625fdc422bcb8e8f",
+  "references/sub-skills/common/agent-lifecycle.md": "149b51503eb3d33b52a25f0d89615e19bedec5b8",
+  "references/sub-skills/roles/pm/health-check.md": "e5b5b164a2db265cbaf8f23a2fe7d1e2cf19469d"
  },
  "8694_spec.json": {
   "references/sub-skills/common-events/comment-handling.md": "8d5a2a4ab4164fbdb3f5657f89ef08586bd5e254",

--- a/tests/comprehension/4792_spec.json
+++ b/tests/comprehension/4792_spec.json
@@ -1,6 +1,6 @@
 {
   "issue": 4792,
-  "title": "Sentinel-file cleanup — sole liveness signal & operator entry point",
+  "title": "Sentinel-file cleanup — agent liveness model & operator entry point",
   "files": [
     "references/sub-skills/common/agent-lifecycle.md",
     "references/sub-skills/roles/pm/health-check.md",
@@ -9,8 +9,9 @@
   "questions": [
     {
       "id": "1",
-      "question": "What does the harness use as the sole liveness signal for monitoring agents?",
-      "expected": "The `.claude-pid` file. The harness polls every 5 seconds and checks whether the PID written to `.claude-pid` is alive. There is no `.health` file fallback any more — `.claude-pid` is the only liveness signal."
+      "question": "What signal(s) does the harness use to determine agent liveness, and which is authoritative for reboot decisions?",
+      "expected": "A dual model (#12492 progress-liveness cutover), polled every 5 seconds. Progress-liveness (activity-heartbeat + dispatch reference + pause guard) is AUTHORITATIVE for reboot decisions — it catches a PID-alive-but-inert \"zombie\" agent that PID monitoring alone would miss, while the pause guard recognizes a legitimate long tool call/compaction/wait so it is never misread as one. `.claude-pid` remains the instant crash signal (a dead PID is still detected immediately), but PID-aliveness alone no longer vetoes a reboot — it is demoted to teardown-only. There is still no `.health` file fallback.",
+      "must_not": "Answering that `.claude-pid`/PID is the sole or only liveness signal — that was the pre-#12492 model and is no longer accurate."
     },
     {
       "id": "2",

--- a/tests/test_4792_fragment_hygiene.py
+++ b/tests/test_4792_fragment_hygiene.py
@@ -32,8 +32,12 @@ class TestLifecycleFragment:
         )
 
     def test_canonical_liveness_phrase_present(self):
+        # #13317: "sole liveness signal" was the pre-#12492 model — replaced
+        # by the dual model where progress-liveness is authoritative for
+        # reboot decisions and .claude-pid is demoted to teardown-only.
         text = LIFECYCLE_FRAGMENT.read_text(encoding="utf-8")
-        assert "sole liveness signal" in text
+        assert "progress-liveness" in text.lower()
+        assert "authoritative" in text.lower()
         assert ".claude-pid" in text
 
     @pytest.mark.parametrize("removed", REMOVED_SENTINELS)
@@ -78,8 +82,10 @@ class TestSharedInstructions:
         assert ".health" not in text
 
     def test_canonical_liveness_phrase_present(self):
+        # #13317: see TestLifecycleFragment.test_canonical_liveness_phrase_present
         text = SHARED_INSTRUCTIONS.read_text(encoding="utf-8")
-        assert "sole liveness signal" in text
+        assert "progress-liveness" in text.lower()
+        assert "authoritative" in text.lower()
         assert ".claude-pid" in text
 
     def test_canonical_operator_entry_point(self):
@@ -92,10 +98,11 @@ class TestComposedClaudeMd:
 
     Post-v0.44.0 cutover: agent-lifecycle is no longer inlined into CLAUDE.md
     at compose time — it is invoked at runtime via ``→ run sub-skill:``.
-    The lifecycle phrases ("sole liveness signal", "squidsquad_cli.py start")
-    live in the sub-skill source and in shared-instructions.md (tested
-    separately by TestSharedInstructions).  What the composed CLAUDE.md MUST
-    do is reference the sub-skill so the agent picks it up at runtime.
+    The lifecycle phrases ("progress-liveness", "authoritative",
+    "squidsquad_cli.py start") live in the sub-skill source and in
+    shared-instructions.md (tested separately by TestSharedInstructions).
+    What the composed CLAUDE.md MUST do is reference the sub-skill so the
+    agent picks it up at runtime.
     """
 
     @pytest.mark.parametrize("composed", COMPOSED_CLAUDE_MD,
@@ -107,17 +114,19 @@ class TestComposedClaudeMd:
             "recompose pass is incomplete"
         )
 
-    def test_sole_liveness_signal_present(self):
+    def test_liveness_model_present(self):
         # v2: lifecycle info lives in shared-instructions.md (always merged
         # into agent context) and in the agent-lifecycle sub-skill source.
         # Verify that shared-instructions carries the canonical phrase so the
         # agent definitely reads it — the sub-skill itself is tested by
         # TestLifecycleFragment.test_canonical_liveness_phrase_present.
+        # #13317: "sole liveness signal" was the pre-#12492 model.
         shared = SHARED_INSTRUCTIONS.read_text(encoding="utf-8")
-        assert "sole liveness signal" in shared, (
-            "sole liveness signal must be present in shared-instructions.md "
-            "— agents read this file every cycle."
+        assert "progress-liveness" in shared.lower(), (
+            "the #12492 dual liveness model must be present in "
+            "shared-instructions.md — agents read this file every cycle."
         )
+        assert "authoritative" in shared.lower()
 
     @pytest.mark.parametrize("composed", COMPOSED_CLAUDE_MD,
                              ids=lambda p: p.parent.name)
@@ -145,6 +154,10 @@ class TestComprehensionSpecExists:
         assert spec["issue"] == 4792
         for rel in spec["files"]:
             assert (REPO / rel).exists(), f"spec references missing: {rel}"
-        assert any("sole liveness signal" in q["question"].lower()
-                   or "sole liveness signal" in q["expected"].lower()
-                   for q in spec["questions"])
+        # #13317: the CQ1 question/expected pair now covers the #12492 dual
+        # liveness model, not the retired "sole liveness signal" claim.
+        assert any(
+            ("liveness" in q["question"].lower()
+             and "authoritative" in q["expected"].lower())
+            for q in spec["questions"]
+        )

--- a/tests/test_boot_remote.py
+++ b/tests/test_boot_remote.py
@@ -23,8 +23,10 @@ class TestRemovedLegacySentinelHelpers:
 
     def test_read_pid_file_removed(self):
         assert not hasattr(boot_remote, "_read_pid_file"), (
-            "boot_remote._read_pid_file must stay removed — .claude-pid "
-            "is the sole liveness signal per CONTEXT-4792.md §5.2"
+            "boot_remote._read_pid_file must stay removed — this helper's "
+            "removal predates #4966/#12492, unrelated to the current "
+            "liveness model (see CONTEXT-4792.md §5.2 for the original "
+            "removal rationale)"
         )
 
     def test_read_health_file_removed(self):

--- a/tests/test_comprehension_4792.py
+++ b/tests/test_comprehension_4792.py
@@ -1,4 +1,4 @@
-"""Comprehension tests for #4792 — sentinel cleanup, sole liveness signal, operator entry point."""
+"""Comprehension tests for #4792 — sentinel cleanup, agent liveness model, operator entry point."""
 
 import json
 from pathlib import Path
@@ -35,7 +35,7 @@ class TestComprehension4792:
             str(r["id"]) for r in comprehension_results
         }
 
-    def test_q1_sole_liveness_signal(self, comprehension_results):
+    def test_q1_agent_liveness_model(self, comprehension_results):
         r = _get(comprehension_results, "1")
         assert r and r["pass"], f"Q-1: {r.get('reason')}"
 


### PR DESCRIPTION
## Summary
- Two compose-consumed sub-skills (`agent-lifecycle.md`, `health-check.md`) still described `.claude-pid`/PID as the "sole liveness signal", directly contradicting the shipped `#12492` progress-liveness cutover (`harness.py` `_PROGRESS_LIVENESS_AUTHORITATIVE=True`): progress-liveness (activity-heartbeat + dispatch reference + pause guard) is now AUTHORITATIVE for reboot decisions — it catches a PID-alive-but-inert "zombie" agent PID monitoring alone cannot see, while the pause guard recognizes a legitimate long tool call/compaction/wait so it's never misread as one. PID remains the instant crash signal but no longer VETOES a reboot — demoted to teardown-only.
- Checked for sibling occurrences per the issue's suggested direction: found a THIRD copy of the same stale claim in `.squidsquad/project/shared-instructions.md` — fixed via a separate `commit-state` (main-direct, per the `#11511` state-file guard), already merged to main.
- Corrected `tests/comprehension/4792_spec.json`'s CQ1 (question/expected/must_not/title) — a real semantic conflict, not a staleness-gate false-positive, since it directly quizzed "what is the sole liveness signal" with a now-wrong answer. Updated `tests/test_4792_fragment_hygiene.py`'s hygiene assertions to check for the new canonical phrases.
- Two rounds of DeepSeek code-review: round 1 found 4 real gaps (stale spec title, stale test docstring, stale test_boot_remote.py assertion message, missing pause-guard detail) — all fixed. Round 2: NO_FINDINGS.

## Test plan
- [x] Full `test_4792_fragment_hygiene.py` (23 cases) + `test_comprehension_4792.py` (live CQ run against a real model — confirmed a fresh agent correctly answers the corrected question) + `test_boot_remote.py` pass
- [x] Verified fail-without-fix / pass-with-fix via `git stash` (4/23 hygiene assertions failed against the pre-fix content)
- [x] Full static gate passes (5628 gated tests, 0 failures/0 errors)
- [x] Comprehension staleness gate: clean

Closes #13317

https://claude.ai/code/session_01LGXaogYiR2GxLSV6V8YEAU