### PR TITLE
fix(#13447): pr_merge() reverts dirty composed outputs and syncs local main after merge

### DIFF
--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -837,6 +837,76 @@ def _scope_audit_violations(pr_number, sha):
     return sorted(deleted - declared)
 
 
+def _revert_composed_state_contamination(working):
+    """Revert locally-dirtied composed outputs after a merge (#13447).
+
+    compose.py's file-watcher regenerates ``.squidsquad/<role>/CLAUDE.md`` and
+    ``CLAUDE.linked.md`` from templates + config independently of the agent's
+    own commit flow. In a verifier/DM clone, that regeneration can leave these
+    TRACKED files locally MODIFIED right around merge time — the next
+    ``git checkout`` then aborts with "local changes would be overwritten".
+    Same pattern as the existing ``.squidsquad/config.md`` revert (#7491) used
+    by ``commit_code``/``task_end``: these are compose-owned outputs, never
+    hand-edited, so reverting to the committed ``working`` version is always
+    safe. Best-effort — a revert failure here must never block the merge
+    result the caller already has in hand.
+    """
+    status = _run("git status --porcelain", check=False)
+    if not status.stdout.strip():
+        return
+    for line in status.stdout.splitlines():
+        if not line.strip():
+            continue
+        path = line[3:].strip().strip('"')
+        if " -> " in path:
+            path = path.split(" -> ")[1]
+        if path.endswith("/CLAUDE.md") or path.endswith("/CLAUDE.linked.md"):
+            _run_list(["git", "checkout", working, "--", path], check=False)
+
+
+def _checkout_and_ff_working_after_merge(working):
+    """Return to `working` and fast-forward it to origin after a merge (#13447).
+
+    ``pr_merge()`` never left the caller on any particular local branch, and
+    never synced `working` (main) to origin after the server-side merge — so
+    a verifier/DM clone's local main silently drifted behind origin/main with
+    every merge. Fail-open throughout: never force-overwrite local main
+    (fast-forward only), never exit the process on divergence or a network
+    hiccup (a merge that already succeeded on GitHub must not be reported as
+    a failure over a best-effort local sync step).
+    """
+    if not _safe_checkout(working):
+        return
+    _run_list(["git", "fetch", "origin", working], check=False)
+    origin = _run_list(
+        ["git", "rev-parse", "--verify", f"refs/remotes/origin/{working}"],
+        check=False,
+    )
+    if origin.returncode != 0:
+        return
+    origin_sha = origin.stdout.strip()
+    local_sha = _run_list(
+        ["git", "rev-parse", f"refs/heads/{working}"], check=False
+    ).stdout.strip()
+    if not local_sha or local_sha == origin_sha:
+        return
+    behind = _run_list(
+        ["git", "merge-base", "--is-ancestor", local_sha, origin_sha], check=False
+    ).returncode == 0
+    if not behind:
+        # Ahead (unpushed local commits) or diverged — only a fast-forward is
+        # safe here; leave it for a human/task-begin to reconcile.
+        return
+    ff = _run_list(["git", "merge", "--ff-only", f"origin/{working}"], check=False)
+    if ff.returncode != 0:
+        print(
+            f"WARNING: could not fast-forward local {working} to origin/"
+            f"{working} ({local_sha[:9]} -> {origin_sha[:9]}): "
+            f"{ff.stderr.strip()} (#13447)",
+            file=sys.stderr,
+        )
+
+
 def _post_merge_scope_audit(pr_number, issue_num):
     """#13285 -- after a successful merge, audit the squash for an out-of-scope
     mass file-deletion (the behind-clone stale-tree revert, #13271 SEV-1) and
@@ -1131,6 +1201,19 @@ def pr_merge(pr_number, strategy="squash", _max_base_retries=3, _base_retry_dela
             # incident comment always run; auto-revert is opt-in (default OFF).
             # Fully fail-safe — never raises, never blocks the merge result.
             _post_merge_scope_audit(pr_number, audit_issue)
+            # #13447 -- a successful merge left two things dirty for the caller's
+            # clone: (1) compose.py's file-watcher can leave composed outputs
+            # (.squidsquad/<role>/CLAUDE.md, CLAUDE.linked.md) locally MODIFIED,
+            # which aborts the caller's next `git checkout` with "local changes
+            # would be overwritten"; (2) local `working` (main) was never
+            # fast-forwarded to origin after the server-side merge, so it drifts
+            # behind. Revert the composed-output contamination (same pattern as
+            # the existing config.md revert, #7491) before checking out +
+            # fast-forwarding `working` — reverting first avoids _safe_checkout's
+            # stash/pop carrying the dirty files onto `working`.
+            working = _get_working_branch()
+            _revert_composed_state_contamination(working)
+            _checkout_and_ff_working_after_merge(working)
             return True, "merged"
 
         error = result.stderr.strip()

--- a/tests/test_13447_pr_merge_post_merge_sync.py
+++ b/tests/test_13447_pr_merge_post_merge_sync.py
@@ -1,0 +1,234 @@
+"""Regression tests for #13447 — on a successful squash-merge, a
+verifier/DM clone was left with two problems:
+
+1. compose.py's file-watcher can leave composed outputs
+   (.squidsquad/<role>/CLAUDE.md, CLAUDE.linked.md) locally MODIFIED,
+   which aborts the clone's next `git checkout` with "local changes
+   would be overwritten".
+2. pr_merge() never fast-forwarded local `working` (main) to origin after
+   the server-side merge, so it silently drifted behind — same failure
+   class as #13613, but a different call site (pr_merge, not commit_code).
+
+_revert_composed_state_contamination() reverts any dirty CLAUDE.md /
+CLAUDE.linked.md to the working-branch version (mirrors the existing
+config.md revert, #7491). _checkout_and_ff_working_after_merge() returns
+to `working` and fast-forwards it, fail-open throughout (a merge that
+already succeeded on GitHub must never be reported as a failure over a
+best-effort local sync step).
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import git_ops
+
+WORKING = "main"
+LOCAL = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+ORIGIN = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+
+def _mk(rc=0, stdout="", stderr=""):
+    m = MagicMock()
+    m.returncode = rc
+    m.stdout = stdout
+    m.stderr = stderr
+    return m
+
+
+class TestRevertComposedStateContamination:
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_reverts_dirty_claude_md(self, mock_run, mock_rl):
+        mock_run.return_value = _mk(0, " M .squidsquad/pm/CLAUDE.md\n")
+        git_ops._revert_composed_state_contamination(WORKING)
+        calls = [c.args[0] for c in mock_rl.call_args_list]
+        assert ["git", "checkout", WORKING, "--", ".squidsquad/pm/CLAUDE.md"] in calls
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_reverts_dirty_claude_linked_md(self, mock_run, mock_rl):
+        mock_run.return_value = _mk(0, " M .squidsquad/skill/CLAUDE.linked.md\n")
+        git_ops._revert_composed_state_contamination(WORKING)
+        calls = [c.args[0] for c in mock_rl.call_args_list]
+        assert ["git", "checkout", WORKING, "--",
+                ".squidsquad/skill/CLAUDE.linked.md"] in calls
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_reverts_multiple_roles(self, mock_run, mock_rl):
+        mock_run.return_value = _mk(
+            0,
+            " M .squidsquad/pm/CLAUDE.md\n"
+            " M .squidsquad/qa/CLAUDE.linked.md\n"
+            " M .squidsquad/dm/CLAUDE.md\n",
+        )
+        git_ops._revert_composed_state_contamination(WORKING)
+        calls = [c.args[0] for c in mock_rl.call_args_list]
+        assert len(calls) == 3
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_leaves_unrelated_dirty_files_alone(self, mock_run, mock_rl):
+        """Only composed CLAUDE.md/CLAUDE.linked.md are reverted -- never
+        working-state.md or other legitimately-dirty state."""
+        mock_run.return_value = _mk(
+            0,
+            " M .squidsquad/pm/CLAUDE.md\n"
+            " M .squidsquad/pm/working-state.md\n"
+            " M references/scripts/harness.py\n",
+        )
+        git_ops._revert_composed_state_contamination(WORKING)
+        calls = [c.args[0] for c in mock_rl.call_args_list]
+        assert len(calls) == 1
+        assert calls[0][-1] == ".squidsquad/pm/CLAUDE.md"
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_clean_tree_noop(self, mock_run, mock_rl):
+        mock_run.return_value = _mk(0, "")
+        git_ops._revert_composed_state_contamination(WORKING)
+        mock_rl.assert_not_called()
+
+
+class TestCheckoutAndFfWorkingAfterMerge:
+    @patch("git_ops._run_list")
+    @patch("git_ops._safe_checkout", return_value=True)
+    def test_behind_fast_forwards(self, mock_checkout, mock_rl):
+        def side_effect(cmd, check=False):
+            s = str(cmd)
+            if cmd[:2] == ["git", "fetch"]:
+                return _mk(0)
+            if "rev-parse" in cmd and "refs/remotes/" in s:
+                return _mk(0, ORIGIN + "\n")
+            if "rev-parse" in cmd and "refs/heads/" in s:
+                return _mk(0, LOCAL + "\n")
+            if "merge-base" in cmd:
+                return _mk(0 if cmd[3] == LOCAL else 1)
+            if "merge" in cmd and "--ff-only" in cmd:
+                return _mk(0)
+            return _mk(1)
+        mock_rl.side_effect = side_effect
+        git_ops._checkout_and_ff_working_after_merge(WORKING)
+        mock_checkout.assert_called_once_with(WORKING)
+        ff_calls = [c.args[0] for c in mock_rl.call_args_list
+                    if "merge" in c.args[0] and "--ff-only" in c.args[0]]
+        assert len(ff_calls) == 1
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._safe_checkout", return_value=False)
+    def test_checkout_failure_never_raises(self, mock_checkout, mock_rl):
+        git_ops._checkout_and_ff_working_after_merge(WORKING)  # must not raise
+        mock_rl.assert_not_called()
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._safe_checkout", return_value=True)
+    def test_diverged_never_raises_never_merges(self, mock_checkout, mock_rl):
+        def side_effect(cmd, check=False):
+            s = str(cmd)
+            if cmd[:2] == ["git", "fetch"]:
+                return _mk(0)
+            if "rev-parse" in cmd and "refs/remotes/" in s:
+                return _mk(0, ORIGIN + "\n")
+            if "rev-parse" in cmd and "refs/heads/" in s:
+                return _mk(0, LOCAL + "\n")
+            if "merge-base" in cmd:
+                return _mk(1)  # neither is an ancestor -> diverged
+            return _mk(1)
+        mock_rl.side_effect = side_effect
+        git_ops._checkout_and_ff_working_after_merge(WORKING)  # must not raise
+        ff_calls = [c.args[0] for c in mock_rl.call_args_list
+                    if "merge" in c.args[0] and "--ff-only" in c.args[0]]
+        assert not ff_calls
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._safe_checkout", return_value=True)
+    def test_ff_failure_warns_never_raises(self, mock_checkout, mock_rl, capsys):
+        def side_effect(cmd, check=False):
+            s = str(cmd)
+            if cmd[:2] == ["git", "fetch"]:
+                return _mk(0)
+            if "rev-parse" in cmd and "refs/remotes/" in s:
+                return _mk(0, ORIGIN + "\n")
+            if "rev-parse" in cmd and "refs/heads/" in s:
+                return _mk(0, LOCAL + "\n")
+            if "merge-base" in cmd:
+                return _mk(0 if cmd[3] == LOCAL else 1)
+            if "merge" in cmd and "--ff-only" in cmd:
+                return _mk(1, stderr="ff failed")
+            return _mk(1)
+        mock_rl.side_effect = side_effect
+        git_ops._checkout_and_ff_working_after_merge(WORKING)  # must not raise
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+        assert "#13447" in err
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._safe_checkout", return_value=True)
+    def test_origin_unreachable_noop(self, mock_checkout, mock_rl):
+        mock_rl.return_value = _mk(1)  # rev-parse --verify remotes fails
+        git_ops._checkout_and_ff_working_after_merge(WORKING)  # must not raise
+
+
+class TestPrMergePostMergeSync13447:
+    """pr_merge()'s success path invokes both the contamination revert and
+    the working-branch checkout+sync, in that order."""
+
+    @pytest.fixture(autouse=True)
+    def _safe_behind(self):
+        with patch("git_ops._pr_behind_by", return_value=0), \
+                patch("git_ops._pr_state_scope_violations", return_value=[]), \
+                patch("git_ops._post_merge_scope_audit"):
+            yield
+
+    @patch("git_ops._get_working_branch", return_value=WORKING)
+    @patch("git_ops._checkout_and_ff_working_after_merge")
+    @patch("git_ops._revert_composed_state_contamination")
+    @patch("git_ops._run_list")
+    def test_success_path_reverts_then_syncs(
+        self, mock_rl, mock_revert, mock_sync, mock_gwb
+    ):
+        mock_rl.side_effect = [
+            _mk(0, '{"state": "OPEN"}'),
+            _mk(0, ""),
+            _mk(0, '{"headRefName": "squidsquad/skill/13447"}'),
+        ]
+        success, msg = git_ops.pr_merge(13447)
+        assert success is True
+        mock_revert.assert_called_once_with(WORKING)
+        mock_sync.assert_called_once_with(WORKING)
+
+    @patch("git_ops._get_working_branch", return_value=WORKING)
+    @patch("git_ops._checkout_and_ff_working_after_merge")
+    @patch("git_ops._revert_composed_state_contamination")
+    @patch("git_ops._run_list")
+    def test_failed_merge_never_syncs(
+        self, mock_rl, mock_revert, mock_sync, mock_gwb
+    ):
+        mock_rl.side_effect = [
+            _mk(0, '{"state": "OPEN"}'),
+            _mk(1, stderr="permission denied"),
+        ]
+        success, msg = git_ops.pr_merge(13447)
+        assert success is False
+        mock_revert.assert_not_called()
+        mock_sync.assert_not_called()
+
+    @patch("git_ops._get_working_branch", return_value=WORKING)
+    @patch("git_ops._checkout_and_ff_working_after_merge")
+    @patch("git_ops._revert_composed_state_contamination")
+    @patch("git_ops._run_list")
+    def test_already_merged_never_syncs(
+        self, mock_rl, mock_revert, mock_sync, mock_gwb
+    ):
+        mock_rl.return_value = _mk(0, '{"state": "MERGED"}')
+        success, msg = git_ops.pr_merge(13447)
+        assert success is True
+        assert msg == "already merged"
+        mock_revert.assert_not_called()
+        mock_sync.assert_not_called()

--- a/tests/test_feat_1074_auto_merge.py
+++ b/tests/test_feat_1074_auto_merge.py
@@ -4,6 +4,7 @@ Verifies that pr_merge() in git_ops.py calls the correct merge strategy,
 handles already-merged PRs, closed PRs, merge conflicts, and successful merges.
 """
 
+import itertools
 import json
 import sys
 from pathlib import Path
@@ -51,12 +52,14 @@ class TestPrMergeSquashStrategy:
         # Second call: gh pr merge (success)
         # Third call: gh pr view (branch name extraction)
         branch_json = json.dumps({"headRefName": "squidsquad/skill/42"})
-        mock_run_list.side_effect = [
+        mock_run_list.side_effect = itertools.chain([
             _mock_result(stdout=state_json),   # state check
             _mock_result(),                     # merge
             _mock_result(stdout=branch_json),   # branch name
             _mock_result(),                     # ship transition (#3747)
-        ]
+        ], itertools.repeat(_mock_result()))
+        # #13447: tail repeat() covers pr_merge's post-merge dirty-tree-revert
+        # + working-branch-sync probe calls beyond the fixed list above.
         success, msg = git_ops.pr_merge(42)
         assert success is True
         assert msg == "merged"
@@ -72,12 +75,13 @@ class TestPrMergeSquashStrategy:
         """#1074: pr_merge respects explicit rebase strategy."""
         state_json = json.dumps({"state": "OPEN"})
         branch_json = json.dumps({"headRefName": "squidsquad/skill/99"})
-        mock_run_list.side_effect = [
+        mock_run_list.side_effect = itertools.chain([
             _mock_result(stdout=state_json),
             _mock_result(),
             _mock_result(stdout=branch_json),
             _mock_result(),                     # ship transition (#3747)
-        ]
+        ], itertools.repeat(_mock_result()))
+        # #13447: tail repeat() covers the post-merge sync probe calls
         success, msg = git_ops.pr_merge(99, strategy="rebase")
         assert success is True
         merge_call = mock_run_list.call_args_list[1]
@@ -137,12 +141,13 @@ class TestPrMergeIssueExtraction:
         """#1074: After merge, parses squidsquad/role/NUMBER branch to find issue."""
         state_json = json.dumps({"state": "OPEN"})
         branch_json = json.dumps({"headRefName": "squidsquad/skill/475"})
-        mock_run_list.side_effect = [
+        mock_run_list.side_effect = itertools.chain([
             _mock_result(stdout=state_json),
             _mock_result(),
             _mock_result(stdout=branch_json),
             _mock_result(),                     # ship transition (#3747)
-        ]
+        ], itertools.repeat(_mock_result()))
+        # #13447: tail repeat() covers the post-merge sync probe calls
         success, _ = git_ops.pr_merge(30)
         assert success is True
         captured = capsys.readouterr()

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -566,9 +566,14 @@ class TestPrMerge:
         # dedicated guard tests (TestPrMergeStateScopeGuard13554) re-patch it to
         # assert the refusal. Stubbing it also keeps its _pr_declared_files ->
         # _run_list call out of the per-test mock sequence.
+        # #13447: stub the post-merge dirty-tree revert + working-branch sync so
+        # they don't consume the per-test _run_list mock sequence (they have
+        # their own tests in TestPrMergePostMergeSync13447).
         with patch("git_ops._pr_behind_by", return_value=0), \
                 patch("git_ops._pr_state_scope_violations", return_value=[]), \
-                patch("git_ops._post_merge_scope_audit"):
+                patch("git_ops._post_merge_scope_audit"), \
+                patch("git_ops._revert_composed_state_contamination"), \
+                patch("git_ops._checkout_and_ff_working_after_merge"):
             yield
 
     @patch("git_ops._run_list")
@@ -3351,9 +3356,14 @@ class TestPrMergeDraftSelfHeal:
         # dedicated guard tests (TestPrMergeStateScopeGuard13554) re-patch it to
         # assert the refusal. Stubbing it also keeps its _pr_declared_files ->
         # _run_list call out of the per-test mock sequence.
+        # #13447: stub the post-merge dirty-tree revert + working-branch sync so
+        # they don't consume the per-test _run_list mock sequence (they have
+        # their own tests in TestPrMergePostMergeSync13447).
         with patch("git_ops._pr_behind_by", return_value=0), \
                 patch("git_ops._pr_state_scope_violations", return_value=[]), \
-                patch("git_ops._post_merge_scope_audit"):
+                patch("git_ops._post_merge_scope_audit"), \
+                patch("git_ops._revert_composed_state_contamination"), \
+                patch("git_ops._checkout_and_ff_working_after_merge"):
             yield
 
     @patch("git_ops.pr_ready", return_value=True)


### PR DESCRIPTION
## Summary
- On a successful squash-merge, a verifier/DM clone was left with two problems: (1) compose.py's file-watcher can leave composed outputs (`.squidsquad/<role>/CLAUDE.md`, `CLAUDE.linked.md`) locally MODIFIED, aborting the clone's next `git checkout`; (2) `pr_merge()` never fast-forwarded local `working` (main) to origin after the server-side merge, so it silently drifted behind (same failure class as #13613, different call site).
- Adds `_revert_composed_state_contamination()` (mirrors the existing `config.md` revert, #7491) and `_checkout_and_ff_working_after_merge()` — self-contained, does not depend on #13613's unshipped helper (that branch hasn't merged yet; depending on it would recreate the stacked-PR problem).
- Both are fail-open: never force-overwrite local main, never block/fail the merge result over a best-effort local sync step.

## Test plan
- [x] tests/test_13447_pr_merge_post_merge_sync.py (13 cases, confirmed fail-without-fix / pass-with-fix)
- [x] Fixed 3 pre-existing tests in test_feat_1074_auto_merge.py whose fixed-length mock sequences didn't anticipate the new post-merge probe calls
- [x] Full static gate: PASS (5649 gated tests, 0 failures)
- [x] comprehension_staleness.py check: clean

Closes #13447

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>