### PR TITLE
docs(#13551): document test-file placement to prevent recurring append-at-EOF PR conflicts

### DIFF
--- a/references/sub-skills/common/git-commit.md
+++ b/references/sub-skills/common/git-commit.md
@@ -86,3 +86,7 @@ Branch-per-feature workflow is the only mode (#9478). Split commits into code (f
      Log: `Merge of [WORKING_BRANCH] into [BRANCH_NAME] failed — manual conflict resolution needed.`
    - Only merge into branches for your own tasks — never touch other agents' PRs.
    - Skip this step when PR Flow is off or no open PRs exist.
+
+### Test-file placement (#13551)
+
+When a fix needs a regression test, **prefer a new dedicated file** — `tests/test_<issue-number>_<short-name>.py` — over appending a new test class to an existing shared file's tail (e.g. `test_git_ops.py`, `test_harness.py`). Two independent branches that each append a class after the same anchor point (commonly the last class in the file) cannot be auto-ordered by git: neither branch has seen the other's insertion, so the merge reports `mergeable=CONFLICTING/DIRTY` purely from insertion-position collision — not from any real code conflict. This has recurred across sibling branches worked in quick succession off the same file (e.g. the `git_ops.py` PR-lifecycle cluster). A dedicated per-issue file sidesteps the class of conflict entirely: two new files never collide at the git level. Only extend an existing shared test file (adding a class to it, not a new file) when the test is a direct, tightly-scoped addition to that file's own existing coverage of the same function — not merely "this fix happens to touch a function that file already tests."

--- a/tests/comprehension/.staleness-baseline.json
+++ b/tests/comprehension/.staleness-baseline.json
@@ -49,7 +49,7 @@
  },
  "12800_spec.json": {},
  "12818_spec.json": {
-  ".squidsquad/pm/CLAUDE.md": "4f2a02b250038297aec6dd6b304601cd38a44f70"
+  ".squidsquad/pm/CLAUDE.md": "aaf4d632617252c91c3c304bcd01042b5f00f73a"
  },
  "12825_spec.json": {
   "references/sub-skills/common/harness-restart.md": "a43cf57124e8cb35406ae1d0c243f14671e8c5ea"
@@ -173,9 +173,9 @@
   "tests/comprehension/8697_fixtures/skill_polling_CLAUDE.md": "b4c02ca4eaf7d3f370533052128c2eaea0d4e4af"
  },
  "9184_spec.json": {
-  ".squidsquad/pm/CLAUDE.md": "4f2a02b250038297aec6dd6b304601cd38a44f70",
-  ".squidsquad/qa/CLAUDE.md": "44dc673f25e8d7d7a39bba287707fb4f22eeb065",
-  ".squidsquad/skill/CLAUDE.md": "f482a37decf7d348258013e6f23c00bc534113b1",
+  ".squidsquad/pm/CLAUDE.md": "aaf4d632617252c91c3c304bcd01042b5f00f73a",
+  ".squidsquad/qa/CLAUDE.md": "5e280f67bf27c96071327d87702ad641e7870bc6",
+  ".squidsquad/skill/CLAUDE.md": "dae162488b92e6c6c7fe9fa9e57e741efca30ac1",
   "references/sub-skills/roles/pm/task-intake.md": "22dbd38d4796f7955075f30df3b5f5ff373d6fbd"
  },
  "9588_spec.json": {},

--- a/tests/test_13551_test_file_placement_guidance.py
+++ b/tests/test_13551_test_file_placement_guidance.py
@@ -1,0 +1,48 @@
+"""Regression test for #13551 — worker branches routinely appended new test
+classes to the same shared test file's tail (e.g. test_git_ops.py), and two
+independent branches forked in quick succession off the same file each
+appended after the same anchor point (commonly the last class in the
+file). Neither branch has seen the other's insertion, so the merge reports
+mergeable=CONFLICTING/DIRTY purely from insertion-position collision — not
+from any real code conflict. Verifier catches it and rejects back to
+in-progress, costing a full verify-reject-rebase-reverify round trip.
+
+The fix documents the preventive convention: prefer a new dedicated test
+file per issue over appending to a shared file's tail.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GIT_COMMIT_FILE = REPO_ROOT / "references" / "sub-skills" / "common" / "git-commit.md"
+
+
+@pytest.fixture
+def git_commit_text():
+    assert GIT_COMMIT_FILE.exists(), f"git-commit.md missing: {GIT_COMMIT_FILE}"
+    return GIT_COMMIT_FILE.read_text(encoding="utf-8")
+
+
+class TestTestFilePlacementGuidance13551:
+    def test_dedicated_file_preference_documented(self, git_commit_text):
+        assert "dedicated" in git_commit_text.lower()
+        assert "test_<issue-number>" in git_commit_text or "test_<issue" in git_commit_text
+
+    def test_explains_the_conflict_mechanism(self, git_commit_text):
+        idx = git_commit_text.index("#13551")
+        section = git_commit_text[idx:idx + 1200]
+        assert "conflicting" in section.lower() or "conflict" in section.lower()
+        assert "anchor" in section.lower()
+
+    def test_names_example_shared_files(self, git_commit_text):
+        idx = git_commit_text.index("#13551")
+        section = git_commit_text[idx:idx + 1200]
+        assert "test_git_ops.py" in section
+        assert "test_harness.py" in section
+
+    def test_carve_out_for_tightly_scoped_extension_present(self, git_commit_text):
+        idx = git_commit_text.index("#13551")
+        section = git_commit_text[idx:idx + 1200]
+        assert "tightly" in section.lower() or "existing coverage" in section.lower()


### PR DESCRIPTION
## Summary
- Worker branches routinely appended new test classes to a shared file's tail (e.g. `test_git_ops.py`) rather than creating a dedicated file. Two independent branches forked in quick succession off the same file, each appending after the same anchor point, cannot be auto-ordered by git — the merge reports `mergeable=CONFLICTING/DIRTY` purely from insertion-position collision, not a real code conflict. Recurred across sibling branches (e.g. the `git_ops.py` PR-lifecycle cluster: #13371/#13454), each costing a full verify-reject-rebase-reverify round trip.
- Adds explicit guidance to `git-commit.md`: prefer `tests/test_<issue-number>_<short-name>.py` (a new dedicated file per issue) over appending to a shared file's tail. Two new files never collide at the git level. Carves out an exception for tightly-scoped extensions of a file's own existing coverage of the same function.

## Test plan
- [x] tests/test_13551_test_file_placement_guidance.py (4 cases, confirmed fail-without-fix / pass-with-fix)
- [x] Full static gate: PASS (5677 gated tests, 0 failures)
- [x] comprehension_staleness.py check: clean

Closes #13551

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>