### PR TITLE
fix(#13654): pr_merge() neutralizes closing keywords in the PR body right before merge

### DIFF
--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -1026,6 +1026,40 @@ def _auto_revert_merge(sha, pr_number):
           f"non-destructive revert commit pushed to main (#13285).")
 
 
+def _neutralize_pr_body_before_merge(pr_number):
+    """#13654 -- patch any live closing keyword out of the PR body right
+    before merge, regardless of how the PR was created (pr_create()'s own
+    #13371 guard, a bare `gh pr create`, or a manual edit). This is the last
+    sanctioned checkpoint before GitHub's own merge-time auto-close fires, so
+    unlike pr_create()'s guard it cannot be bypassed by skipping the
+    "canonical" creation path. Fail-open throughout: a `gh pr view`/`gh pr
+    edit` hiccup must never wedge a merge that already passed every other
+    gate -- it only warns.
+    """
+    view_result = _run_list(
+        ["gh", "pr", "view", str(pr_number), "--json", "body"], check=False)
+    if view_result.returncode != 0:
+        return
+    try:
+        current_body = json.loads(view_result.stdout).get("body", "") or ""
+    except (json.JSONDecodeError, AttributeError):
+        return
+    neutralized_body = _neutralize_closing_keywords(current_body)
+    if neutralized_body == current_body:
+        return
+    edit_result = _run_list(
+        ["gh", "pr", "edit", str(pr_number), "--body", neutralized_body],
+        check=False)
+    if edit_result.returncode == 0:
+        print(f"PR #{pr_number}: neutralized closing keyword(s) in body "
+              f"before merge (#13654)")
+    else:
+        print(f"WARNING: PR #{pr_number} body carries an unneutralized "
+              f"closing keyword and the pre-merge edit failed: "
+              f"{edit_result.stderr.strip()} -- merge proceeding anyway "
+              f"(#13654)", file=sys.stderr)
+
+
 def pr_merge(pr_number, strategy="squash", _max_base_retries=3, _base_retry_delay=2.0):
     """Merge a PR. Uses forge adapter for non-GitHub backends,
     gh CLI for GitHub. Returns (success, message).
@@ -1105,6 +1139,18 @@ def pr_merge(pr_number, strategy="squash", _max_base_retries=3, _base_retry_dela
                    f"(run `gh pr ready {pr_number}` and retry)")
             print(f"ERROR: {msg}", file=sys.stderr)
             return False, "PR is a draft"
+
+    # #13654: neutralize any closing keyword still live in the PR body,
+    # regardless of how the PR was created. #13371 neutralizes at pr_create()
+    # time, but that guard is bypassed by a bare `gh pr create` (the
+    # documented-but-unenforced anti-pattern pr-protocol.md already warns
+    # against) -- proven live: 12 issues closed out from under DM's
+    # pending-ship gate this session alone, each via a hand-rolled `gh pr
+    # create` call that never routed through pr_create(). A prose rule a
+    # human/agent must remember to follow is not a guard; this is the last
+    # sanctioned checkpoint before GitHub's own merge-time auto-close fires,
+    # so it is where the guard must be unconditional and unbypassable.
+    _neutralize_pr_body_before_merge(pr_number)
 
     # #13554 (SEV prevention): refuse to merge a PR that DECLARES changes to
     # main-only state/vault paths. These must never ride a feature PR -- the

--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -1032,9 +1032,16 @@ def _neutralize_pr_body_before_merge(pr_number):
     #13371 guard, a bare `gh pr create`, or a manual edit). This is the last
     sanctioned checkpoint before GitHub's own merge-time auto-close fires, so
     unlike pr_create()'s guard it cannot be bypassed by skipping the
-    "canonical" creation path. Fail-open throughout: a `gh pr view`/`gh pr
-    edit` hiccup must never wedge a merge that already passed every other
-    gate -- it only warns.
+    "canonical" creation path. Fail-open throughout: a `gh` hiccup must never
+    wedge a merge that already passed every other gate -- it only warns.
+
+    #13654 verifier round 2: `gh pr edit` (ANY field, not just --body)
+    unconditionally fails in this environment -- an old `gh` CLI (2.34.0)
+    still queries a GraphQL field GitHub removed with Projects (classic)'s
+    deprecation. Live-reproduced against a real scratch PR: `gh pr edit`
+    fails, `gh api -X PATCH repos/:owner/:repo/pulls/<N> -f body=<...>`
+    (the REST endpoint, not GraphQL) succeeds against the identical PR.
+    Route the patch through `gh api` instead.
     """
     view_result = _run_list(
         ["gh", "pr", "view", str(pr_number), "--json", "body"], check=False)
@@ -1048,7 +1055,8 @@ def _neutralize_pr_body_before_merge(pr_number):
     if neutralized_body == current_body:
         return
     edit_result = _run_list(
-        ["gh", "pr", "edit", str(pr_number), "--body", neutralized_body],
+        ["gh", "api", "-X", "PATCH", f"repos/:owner/:repo/pulls/{pr_number}",
+         "-f", f"body={neutralized_body}"],
         check=False)
     if edit_result.returncode == 0:
         print(f"PR #{pr_number}: neutralized closing keyword(s) in body "

--- a/tests/test_13447_pr_merge_post_merge_sync.py
+++ b/tests/test_13447_pr_merge_post_merge_sync.py
@@ -183,7 +183,8 @@ class TestPrMergePostMergeSync13447:
     def _safe_behind(self):
         with patch("git_ops._pr_behind_by", return_value=0), \
                 patch("git_ops._pr_state_scope_violations", return_value=[]), \
-                patch("git_ops._post_merge_scope_audit"):
+                patch("git_ops._post_merge_scope_audit"), \
+                patch("git_ops._neutralize_pr_body_before_merge"):
             yield
 
     @patch("git_ops._get_working_branch", return_value=WORKING)

--- a/tests/test_13654_pre_merge_body_neutralize.py
+++ b/tests/test_13654_pre_merge_body_neutralize.py
@@ -1,0 +1,158 @@
+"""Regression test for #13654 — PR closing-keyword auto-close bypassing DM's
+ship gate recurred at scale post-#13371. #13371's guard neutralizes closing
+keywords inside pr_create(), but that guard is bypassed entirely by a bare
+`gh pr create` call — the documented-but-unenforced anti-pattern
+pr-protocol.md already warns against ("git_ops.py pr-create lock vs bare gh
+pr create"). Proven live: 12 issues auto-closed by GitHub at merge time,
+stranding them outside DM's pending-ship gate (no CHANGELOG entry, no
+ship-comment, no ship-counter increment).
+
+The fix adds a second, unconditional checkpoint: pr_merge() now neutralizes
+any closing keyword still live in the PR body immediately before merging,
+regardless of how the PR was created. Unlike pr_create()'s guard, this one
+cannot be bypassed by skipping the "canonical" creation path — it is the
+last sanctioned checkpoint before GitHub's own merge-time auto-close fires.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import git_ops
+
+
+def _mk(rc=0, stdout="", stderr=""):
+    m = MagicMock()
+    m.returncode = rc
+    m.stdout = stdout
+    m.stderr = stderr
+    return m
+
+
+class TestNeutralizePrBodyBeforeMerge:
+    @patch("git_ops._run_list")
+    def test_unneutralized_keyword_gets_edited(self, mock_rl):
+        def side_effect(cmd, check=False):
+            if cmd[:3] == ["gh", "pr", "view"]:
+                return _mk(0, json.dumps({"body": "Summary.\nFixes #13531"}))
+            if cmd[:3] == ["gh", "pr", "edit"]:
+                return _mk(0)
+            return _mk(1)
+        mock_rl.side_effect = side_effect
+
+        git_ops._neutralize_pr_body_before_merge(13624)
+
+        edit_calls = [c.args[0] for c in mock_rl.call_args_list
+                      if c.args[0][:3] == ["gh", "pr", "edit"]]
+        assert len(edit_calls) == 1
+        body_arg = edit_calls[0][edit_calls[0].index("--body") + 1]
+        assert "Fixes #13531" not in body_arg
+        assert "Addresses #13531" in body_arg
+
+    @patch("git_ops._run_list")
+    def test_already_clean_body_no_edit_call(self, mock_rl):
+        def side_effect(cmd, check=False):
+            if cmd[:3] == ["gh", "pr", "view"]:
+                return _mk(0, json.dumps({"body": "Summary.\nAddresses #13531"}))
+            return _mk(1)
+        mock_rl.side_effect = side_effect
+
+        git_ops._neutralize_pr_body_before_merge(13624)
+
+        edit_calls = [c.args[0] for c in mock_rl.call_args_list
+                      if c.args[0][:3] == ["gh", "pr", "edit"]]
+        assert not edit_calls
+
+    @patch("git_ops._run_list")
+    def test_view_failure_never_raises_no_edit_call(self, mock_rl):
+        mock_rl.return_value = _mk(1, stderr="not found")
+        git_ops._neutralize_pr_body_before_merge(13624)  # must not raise
+        edit_calls = [c.args[0] for c in mock_rl.call_args_list
+                      if c.args[0][:3] == ["gh", "pr", "edit"]]
+        assert not edit_calls
+
+    @patch("git_ops._run_list")
+    def test_malformed_json_never_raises_no_edit_call(self, mock_rl):
+        def side_effect(cmd, check=False):
+            if cmd[:3] == ["gh", "pr", "view"]:
+                return _mk(0, "not json")
+            return _mk(1)
+        mock_rl.side_effect = side_effect
+
+        git_ops._neutralize_pr_body_before_merge(13624)  # must not raise
+        edit_calls = [c.args[0] for c in mock_rl.call_args_list
+                      if c.args[0][:3] == ["gh", "pr", "edit"]]
+        assert not edit_calls
+
+    @patch("git_ops._run_list")
+    def test_edit_failure_warns_never_raises(self, mock_rl, capsys):
+        def side_effect(cmd, check=False):
+            if cmd[:3] == ["gh", "pr", "view"]:
+                return _mk(0, json.dumps({"body": "Fixes #1"}))
+            if cmd[:3] == ["gh", "pr", "edit"]:
+                return _mk(1, stderr="edit failed")
+            return _mk(1)
+        mock_rl.side_effect = side_effect
+
+        git_ops._neutralize_pr_body_before_merge(13624)  # must not raise
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+        assert "#13654" in err
+
+
+class TestPrMergeCallsNeutralizeBeforeMerging:
+    @pytest.fixture(autouse=True)
+    def _safe_behind(self):
+        with patch("git_ops._pr_behind_by", return_value=0), \
+                patch("git_ops._pr_state_scope_violations", return_value=[]), \
+                patch("git_ops._post_merge_scope_audit"), \
+                patch("git_ops._revert_composed_state_contamination"), \
+                patch("git_ops._checkout_and_ff_working_after_merge"):
+            yield
+
+    @patch("git_ops._neutralize_pr_body_before_merge")
+    @patch("git_ops._run_list")
+    def test_success_path_neutralizes_before_merge_call(self, mock_rl, mock_neutralize):
+        calls = []
+
+        def side_effect(cmd, check=False):
+            calls.append(("neutralize" if mock_neutralize.called else "other", cmd))
+            if cmd[:3] == ["gh", "pr", "view"] and "state,isDraft" in cmd:
+                return _mk(0, json.dumps({"state": "OPEN", "isDraft": False}))
+            if cmd[:3] == ["gh", "pr", "merge"]:
+                return _mk(0)
+            return _mk(0, json.dumps({"headRefName": "squidsquad/skill/13654"}))
+
+        mock_rl.side_effect = side_effect
+        success, msg = git_ops.pr_merge(13654)
+        assert success is True
+        mock_neutralize.assert_called_once_with(13654)
+
+    @patch("git_ops._neutralize_pr_body_before_merge")
+    @patch("git_ops._run_list")
+    def test_already_merged_skips_neutralize(self, mock_rl, mock_neutralize):
+        mock_rl.return_value = _mk(0, json.dumps({"state": "MERGED"}))
+        success, msg = git_ops.pr_merge(13654)
+        assert success is True
+        mock_neutralize.assert_not_called()
+
+    @patch("git_ops._neutralize_pr_body_before_merge")
+    @patch("git_ops._run_list")
+    def test_neutralize_runs_before_state_scope_and_behind_guards(
+        self, mock_rl, mock_neutralize
+    ):
+        """Neutralize the body even on a PR that gets refused by a later
+        guard -- the keyword must never survive to a human's manual retry."""
+        with patch("git_ops._pr_state_scope_violations",
+                    return_value=["config.md"]):
+            mock_rl.return_value = _mk(0, json.dumps(
+                {"state": "OPEN", "isDraft": False}))
+            success, msg = git_ops.pr_merge(13654)
+        assert success is False
+        mock_neutralize.assert_called_once_with(13654)

--- a/tests/test_13654_pre_merge_body_neutralize.py
+++ b/tests/test_13654_pre_merge_body_neutralize.py
@@ -41,7 +41,7 @@ class TestNeutralizePrBodyBeforeMerge:
         def side_effect(cmd, check=False):
             if cmd[:3] == ["gh", "pr", "view"]:
                 return _mk(0, json.dumps({"body": "Summary.\nFixes #13531"}))
-            if cmd[:3] == ["gh", "pr", "edit"]:
+            if cmd[:3] == ["gh", "api", "-X"]:
                 return _mk(0)
             return _mk(1)
         mock_rl.side_effect = side_effect
@@ -49,11 +49,33 @@ class TestNeutralizePrBodyBeforeMerge:
         git_ops._neutralize_pr_body_before_merge(13624)
 
         edit_calls = [c.args[0] for c in mock_rl.call_args_list
-                      if c.args[0][:3] == ["gh", "pr", "edit"]]
+                      if c.args[0][:3] == ["gh", "api", "-X"]]
         assert len(edit_calls) == 1
-        body_arg = edit_calls[0][edit_calls[0].index("--body") + 1]
+        # #13654 verifier round 2: gh pr edit unconditionally fails in this
+        # environment (old gh CLI querying a GraphQL field GitHub removed);
+        # the REST PATCH endpoint via `gh api` is the live-confirmed
+        # working path. Must never regress back to `gh pr edit`.
+        assert edit_calls[0][:4] == ["gh", "api", "-X", "PATCH"]
+        assert "pulls/13624" in edit_calls[0][4]
+        body_arg = edit_calls[0][edit_calls[0].index("-f") + 1]
         assert "Fixes #13531" not in body_arg
         assert "Addresses #13531" in body_arg
+
+    @patch("git_ops._run_list")
+    def test_never_calls_gh_pr_edit(self, mock_rl):
+        """The specific command whose live failure caused the #13654 round-2
+        rejection must never be invoked again."""
+        def side_effect(cmd, check=False):
+            if cmd[:3] == ["gh", "pr", "view"]:
+                return _mk(0, json.dumps({"body": "Fixes #1"}))
+            return _mk(0)
+        mock_rl.side_effect = side_effect
+
+        git_ops._neutralize_pr_body_before_merge(13624)
+
+        pr_edit_calls = [c.args[0] for c in mock_rl.call_args_list
+                          if c.args[0][:3] == ["gh", "pr", "edit"]]
+        assert not pr_edit_calls
 
     @patch("git_ops._run_list")
     def test_already_clean_body_no_edit_call(self, mock_rl):
@@ -66,7 +88,7 @@ class TestNeutralizePrBodyBeforeMerge:
         git_ops._neutralize_pr_body_before_merge(13624)
 
         edit_calls = [c.args[0] for c in mock_rl.call_args_list
-                      if c.args[0][:3] == ["gh", "pr", "edit"]]
+                      if c.args[0][:3] == ["gh", "api", "-X"]]
         assert not edit_calls
 
     @patch("git_ops._run_list")
@@ -74,7 +96,7 @@ class TestNeutralizePrBodyBeforeMerge:
         mock_rl.return_value = _mk(1, stderr="not found")
         git_ops._neutralize_pr_body_before_merge(13624)  # must not raise
         edit_calls = [c.args[0] for c in mock_rl.call_args_list
-                      if c.args[0][:3] == ["gh", "pr", "edit"]]
+                      if c.args[0][:3] == ["gh", "api", "-X"]]
         assert not edit_calls
 
     @patch("git_ops._run_list")
@@ -87,7 +109,7 @@ class TestNeutralizePrBodyBeforeMerge:
 
         git_ops._neutralize_pr_body_before_merge(13624)  # must not raise
         edit_calls = [c.args[0] for c in mock_rl.call_args_list
-                      if c.args[0][:3] == ["gh", "pr", "edit"]]
+                      if c.args[0][:3] == ["gh", "api", "-X"]]
         assert not edit_calls
 
     @patch("git_ops._run_list")
@@ -95,7 +117,7 @@ class TestNeutralizePrBodyBeforeMerge:
         def side_effect(cmd, check=False):
             if cmd[:3] == ["gh", "pr", "view"]:
                 return _mk(0, json.dumps({"body": "Fixes #1"}))
-            if cmd[:3] == ["gh", "pr", "edit"]:
+            if cmd[:3] == ["gh", "api", "-X"]:
                 return _mk(1, stderr="edit failed")
             return _mk(1)
         mock_rl.side_effect = side_effect

--- a/tests/test_feat_1074_auto_merge.py
+++ b/tests/test_feat_1074_auto_merge.py
@@ -49,11 +49,13 @@ class TestPrMergeSquashStrategy:
         """#1074: pr_merge defaults to squash strategy and passes --delete-branch."""
         # First call: gh pr view (state check)
         state_json = json.dumps({"state": "OPEN"})
-        # Second call: gh pr merge (success)
-        # Third call: gh pr view (branch name extraction)
+        # Second call: gh pr view (#13654 pre-merge closing-keyword neutralize)
+        # Third call: gh pr merge (success)
+        # Fourth call: gh pr view (branch name extraction)
         branch_json = json.dumps({"headRefName": "squidsquad/skill/42"})
         mock_run_list.side_effect = itertools.chain([
-            _mock_result(stdout=state_json),   # state check
+            _mock_result(stdout=state_json),                          # state check
+            _mock_result(stdout=json.dumps({"body": "no keyword"})),  # #13654 body view
             _mock_result(),                     # merge
             _mock_result(stdout=branch_json),   # branch name
             _mock_result(),                     # ship transition (#3747)
@@ -64,7 +66,7 @@ class TestPrMergeSquashStrategy:
         assert success is True
         assert msg == "merged"
         # Verify merge command includes --squash and --delete-branch
-        merge_call = mock_run_list.call_args_list[1]
+        merge_call = mock_run_list.call_args_list[2]
         merge_cmd = merge_call[0][0]
         assert "--squash" in merge_cmd
         assert "--delete-branch" in merge_cmd
@@ -77,6 +79,7 @@ class TestPrMergeSquashStrategy:
         branch_json = json.dumps({"headRefName": "squidsquad/skill/99"})
         mock_run_list.side_effect = itertools.chain([
             _mock_result(stdout=state_json),
+            _mock_result(stdout=json.dumps({"body": "no keyword"})),  # #13654 body view
             _mock_result(),
             _mock_result(stdout=branch_json),
             _mock_result(),                     # ship transition (#3747)
@@ -84,7 +87,7 @@ class TestPrMergeSquashStrategy:
         # #13447: tail repeat() covers the post-merge sync probe calls
         success, msg = git_ops.pr_merge(99, strategy="rebase")
         assert success is True
-        merge_call = mock_run_list.call_args_list[1]
+        merge_call = mock_run_list.call_args_list[2]
         merge_cmd = merge_call[0][0]
         assert "--rebase" in merge_cmd
 
@@ -126,6 +129,7 @@ class TestPrMergConflict:
         state_json = json.dumps({"state": "OPEN"})
         mock_run_list.side_effect = [
             _mock_result(stdout=state_json),
+            _mock_result(stdout=json.dumps({"body": "no keyword"})),  # #13654 body view
             _mock_result(returncode=1, stderr="Pull request is not mergeable: merge conflict"),
         ]
         success, msg = git_ops.pr_merge(20)
@@ -143,6 +147,7 @@ class TestPrMergeIssueExtraction:
         branch_json = json.dumps({"headRefName": "squidsquad/skill/475"})
         mock_run_list.side_effect = itertools.chain([
             _mock_result(stdout=state_json),
+            _mock_result(stdout=json.dumps({"body": "no keyword"})),  # #13654 body view
             _mock_result(),
             _mock_result(stdout=branch_json),
             _mock_result(),                     # ship transition (#3747)

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -574,7 +574,8 @@ class TestPrMerge:
                 patch("git_ops._pr_state_scope_violations", return_value=[]), \
                 patch("git_ops._post_merge_scope_audit"), \
                 patch("git_ops._revert_composed_state_contamination"), \
-                patch("git_ops._checkout_and_ff_working_after_merge"):
+                patch("git_ops._checkout_and_ff_working_after_merge"), \
+                patch("git_ops._neutralize_pr_body_before_merge"):
             yield
 
     @patch("git_ops._run_list")
@@ -3369,7 +3370,8 @@ class TestPrMergeDraftSelfHeal:
                 patch("git_ops._pr_state_scope_violations", return_value=[]), \
                 patch("git_ops._post_merge_scope_audit"), \
                 patch("git_ops._revert_composed_state_contamination"), \
-                patch("git_ops._checkout_and_ff_working_after_merge"):
+                patch("git_ops._checkout_and_ff_working_after_merge"), \
+                patch("git_ops._neutralize_pr_body_before_merge"):
             yield
 
     @patch("git_ops.pr_ready", return_value=True)


### PR DESCRIPTION
Addresses #13654

### Summary
pr_create()'s #13371 closing-keyword neutralization is bypassed entirely by a bare `gh pr create` -- the documented-but-unenforced anti-pattern pr-protocol.md already warns against. The class recurred at scale this session: 12 issues auto-closed by GitHub at merge time via hand-rolled gh pr create calls, stranding them outside DM's pending-ship gate.

### Acceptance Criteria
- [x] Add an unconditional pre-merge checkpoint in pr_merge() that neutralizes any closing keyword in the PR body immediately before merge, regardless of how the PR was created
- [x] Fail-open on gh hiccups -- never wedge a merge that already passed every other gate
- [x] Regression tests confirming fail-without-fix / pass-with-fix

### Changes
- **Files**: references/scripts/git_ops.py, tests/test_13654_pre_merge_body_neutralize.py, tests/test_feat_1074_auto_merge.py, tests/test_git_ops.py, tests/test_13447_pr_merge_post_merge_sync.py
- **What**: New `_neutralize_pr_body_before_merge(pr_number)` called from `pr_merge()` right after the draft self-heal; fetches the PR body via `gh pr view`, patches it via `gh pr edit` if a closing keyword survives, before the merge attempt proceeds.
- **Why**: this is the last sanctioned checkpoint before GitHub's own merge-time auto-close fires -- unlike pr_create()'s guard, it cannot be bypassed by skipping the canonical creation path.

### Verifier Status
- [ ] Unit tests passing
- [ ] Smoke tests passing
- [ ] Acceptance criteria met