### PR TITLE
fix(#13660): raise tracker.py issue-list --limit 50 -> 500 + warn at cap

### DIFF
--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -716,6 +716,27 @@ def check_gh():
     return True
 
 
+# #13660: shared bound for list_issues/list_by_labels/list_all_open, the same
+# gh --limit truncation class #13555 fixed for harness.py's EAD poll and #13602
+# fixed for pipeline-sentinel.md. list_all_open() was hard-capped at 50 while
+# the live open-issue count reached 150 (gh orders newest-first, so the
+# OLDEST 100 open issues -- mostly the status:pending backlog -- were silently
+# invisible). list_issues()/list_by_labels() carried the identical cap,
+# latent only because current role/status-filtered counts stay under 50. 500
+# gives headroom over today's count without pagination; the warning below
+# makes the cap self-diagnosing if the backlog outgrows it (no silent caps).
+_OPEN_ISSUE_LIST_LIMIT = 500
+
+
+def _warn_if_capped(issues, limit, caller):
+    """#13660: print a WARNING when a gh issue-list result hit its --limit
+    cap -- a silently-truncated result is otherwise invisible to the caller."""
+    if len(issues) >= limit:
+        print(f"WARNING: {caller} returned {len(issues)} = the --limit cap; "
+              f"older/additional issues may be INVISIBLE (#13660). Raise "
+              f"_OPEN_ISSUE_LIST_LIMIT.", file=sys.stderr)
+
+
 def list_issues(role, issue_type="bug", status=None):
     """List issues by role and optional type/status filter.
 
@@ -753,7 +774,9 @@ def list_issues(role, issue_type="bug", status=None):
 
     adapter = _get_forge_adapter()
     if adapter:
-        issues = adapter.list_issues(labels=label_list, state=gh_state, limit=50)
+        issues = adapter.list_issues(
+            labels=label_list, state=gh_state, limit=_OPEN_ISSUE_LIST_LIMIT)
+        _warn_if_capped(issues, _OPEN_ISSUE_LIST_LIMIT, "list_issues")
         print(json.dumps(issues, indent=2))
         return issues
 
@@ -761,13 +784,14 @@ def list_issues(role, issue_type="bug", status=None):
     labels = ",".join(label_list)
     result = _run_list(
         ["gh", "issue", "list", "--label", labels, "--state", gh_state,
-         "--json", "number,title,labels", "--limit", "50"],
+         "--json", "number,title,labels", "--limit", str(_OPEN_ISSUE_LIST_LIMIT)],
         check=False,
     )
     if result.returncode != 0:
         print(f"ERROR: gh failed: {result.stderr}", file=sys.stderr)
         return []
     issues = json.loads(result.stdout) if result.stdout.strip() else []
+    _warn_if_capped(issues, _OPEN_ISSUE_LIST_LIMIT, "list_issues")
     print(json.dumps(issues, indent=2))
     return issues
 
@@ -783,20 +807,23 @@ def list_by_labels(labels_str, state="open"):
 
     adapter = _get_forge_adapter()
     if adapter:
-        issues = adapter.list_issues(labels=label_list, state=state, limit=50)
+        issues = adapter.list_issues(
+            labels=label_list, state=state, limit=_OPEN_ISSUE_LIST_LIMIT)
+        _warn_if_capped(issues, _OPEN_ISSUE_LIST_LIMIT, "list_by_labels")
         print(json.dumps(issues, indent=2))
         return issues
 
     # Default: gh CLI
     result = _run_list(
         ["gh", "issue", "list", "--label", labels_str, "--state", state,
-         "--json", "number,title,labels", "--limit", "50"],
+         "--json", "number,title,labels", "--limit", str(_OPEN_ISSUE_LIST_LIMIT)],
         check=False,
     )
     if result.returncode != 0:
         print(f"ERROR: gh failed: {result.stderr}", file=sys.stderr)
         return []
     issues = json.loads(result.stdout) if result.stdout.strip() else []
+    _warn_if_capped(issues, _OPEN_ISSUE_LIST_LIMIT, "list_by_labels")
     print(json.dumps(issues, indent=2))
     return issues
 
@@ -937,20 +964,24 @@ def list_all_open():
     """List all open issues (for ingestion/triage of external issues)."""
     adapter = _get_forge_adapter()
     if adapter:
-        issues = adapter.list_issues(labels=None, state="open", limit=50)
+        issues = adapter.list_issues(
+            labels=None, state="open", limit=_OPEN_ISSUE_LIST_LIMIT)
+        _warn_if_capped(issues, _OPEN_ISSUE_LIST_LIMIT, "list_all_open")
         print(json.dumps(issues, indent=2))
         return issues
 
     # Default: gh CLI
     result = _run_list(
         ["gh", "issue", "list", "--state", "open",
-         "--json", "number,title,labels,body", "--limit", "50"],
+         "--json", "number,title,labels,body",
+         "--limit", str(_OPEN_ISSUE_LIST_LIMIT)],
         check=False,
     )
     if result.returncode != 0:
         print(f"ERROR: gh failed: {result.stderr}", file=sys.stderr)
         return []
     issues = json.loads(result.stdout) if result.stdout.strip() else []
+    _warn_if_capped(issues, _OPEN_ISSUE_LIST_LIMIT, "list_all_open")
     print(json.dumps(issues, indent=2))
     return issues
 

--- a/tests/test_13660_list_limit_truncation.py
+++ b/tests/test_13660_list_limit_truncation.py
@@ -1,0 +1,180 @@
+"""Regression tests for #13660 — list_issues()/list_by_labels()/list_all_open()
+in references/scripts/tracker.py shared the #13555/#13602 gh --limit 50
+truncation class. list_all_open() was hard-capped at 50 while the live
+open-issue count reached 150 (gh orders newest-first, so the OLDEST 100 open
+issues -- mostly the status:pending backlog -- were silently invisible).
+list_issues()/list_by_labels() carried the identical cap, latent only because
+current role/status-filtered counts stay under 50.
+
+Fix (per #13555's precedent): raise the shared limit to 500
+(_OPEN_ISSUE_LIST_LIMIT) and warn via _warn_if_capped() when a result hits the
+cap, so a silently-truncated result becomes self-diagnosing instead of
+invisible.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import tracker
+
+
+def _mock_result(stdout="", stderr="", returncode=0):
+    r = MagicMock()
+    r.stdout = stdout
+    r.stderr = stderr
+    r.returncode = returncode
+    return r
+
+
+class TestWarnIfCapped:
+    def test_warns_when_at_cap(self, capsys):
+        tracker._warn_if_capped([{"number": i} for i in range(5)], 5, "list_issues")
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+        assert "list_issues" in err
+        assert "#13660" in err
+
+    def test_no_warning_under_cap(self, capsys):
+        tracker._warn_if_capped([{"number": 1}], 5, "list_issues")
+        err = capsys.readouterr().err
+        assert err == ""
+
+    def test_no_warning_on_empty(self, capsys):
+        tracker._warn_if_capped([], 5, "list_all_open")
+        err = capsys.readouterr().err
+        assert err == ""
+
+
+class TestListIssuesLimit13660:
+    def test_gh_cli_uses_raised_limit(self, monkeypatch):
+        calls = []
+
+        def fake_run(cmd, **kw):
+            calls.append(cmd)
+            return _mock_result(stdout="[]")
+
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(tracker, "_run_list", fake_run)
+        tracker.list_issues("skill")
+        limit_arg = calls[0][calls[0].index("--limit") + 1]
+        assert limit_arg == str(tracker._OPEN_ISSUE_LIST_LIMIT)
+        assert tracker._OPEN_ISSUE_LIST_LIMIT > 50
+
+    def test_adapter_passed_raised_limit(self, monkeypatch):
+        adapter = MagicMock()
+        adapter.list_issues.return_value = []
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: adapter)
+        tracker.list_issues("skill")
+        _, kwargs = adapter.list_issues.call_args
+        assert kwargs["limit"] == tracker._OPEN_ISSUE_LIST_LIMIT
+
+    def test_warns_on_capped_result(self, monkeypatch, capsys):
+        issues = [{"number": i, "title": "t", "labels": []}
+                  for i in range(tracker._OPEN_ISSUE_LIST_LIMIT)]
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(
+            tracker, "_run_list",
+            lambda cmd, **kw: _mock_result(stdout=json.dumps(issues)),
+        )
+        tracker.list_issues("skill")
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+        assert "#13660" in err
+
+    def test_no_warning_under_cap(self, monkeypatch, capsys):
+        issues = [{"number": 1, "title": "t", "labels": []}]
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(
+            tracker, "_run_list",
+            lambda cmd, **kw: _mock_result(stdout=json.dumps(issues)),
+        )
+        tracker.list_issues("skill")
+        err = capsys.readouterr().err
+        assert "WARNING" not in err
+
+
+class TestListByLabelsLimit13660:
+    def test_gh_cli_uses_raised_limit(self, monkeypatch):
+        calls = []
+
+        def fake_run(cmd, **kw):
+            calls.append(cmd)
+            return _mock_result(stdout="[]")
+
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(tracker, "_run_list", fake_run)
+        tracker.list_by_labels("type:issue,role:skill")
+        limit_arg = calls[0][calls[0].index("--limit") + 1]
+        assert limit_arg == str(tracker._OPEN_ISSUE_LIST_LIMIT)
+
+    def test_adapter_passed_raised_limit(self, monkeypatch):
+        adapter = MagicMock()
+        adapter.list_issues.return_value = []
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: adapter)
+        tracker.list_by_labels("type:issue,role:skill")
+        _, kwargs = adapter.list_issues.call_args
+        assert kwargs["limit"] == tracker._OPEN_ISSUE_LIST_LIMIT
+
+    def test_warns_on_capped_result(self, monkeypatch, capsys):
+        issues = [{"number": i} for i in range(tracker._OPEN_ISSUE_LIST_LIMIT)]
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(
+            tracker, "_run_list",
+            lambda cmd, **kw: _mock_result(stdout=json.dumps(issues)),
+        )
+        tracker.list_by_labels("type:issue,role:skill")
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+
+
+class TestListAllOpenLimit13660:
+    def test_gh_cli_uses_raised_limit(self, monkeypatch):
+        calls = []
+
+        def fake_run(cmd, **kw):
+            calls.append(cmd)
+            return _mock_result(stdout="[]")
+
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(tracker, "_run_list", fake_run)
+        tracker.list_all_open()
+        limit_arg = calls[0][calls[0].index("--limit") + 1]
+        assert limit_arg == str(tracker._OPEN_ISSUE_LIST_LIMIT)
+
+    def test_adapter_passed_raised_limit(self, monkeypatch):
+        adapter = MagicMock()
+        adapter.list_issues.return_value = []
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: adapter)
+        tracker.list_all_open()
+        _, kwargs = adapter.list_issues.call_args
+        assert kwargs["limit"] == tracker._OPEN_ISSUE_LIST_LIMIT
+
+    def test_warns_on_capped_result(self, monkeypatch, capsys):
+        issues = [{"number": i} for i in range(tracker._OPEN_ISSUE_LIST_LIMIT)]
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(
+            tracker, "_run_list",
+            lambda cmd, **kw: _mock_result(stdout=json.dumps(issues)),
+        )
+        tracker.list_all_open()
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+        assert "list_all_open" in err
+
+    def test_no_warning_under_cap(self, monkeypatch, capsys):
+        issues = [{"number": 1}, {"number": 2}]
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(
+            tracker, "_run_list",
+            lambda cmd, **kw: _mock_result(stdout=json.dumps(issues)),
+        )
+        tracker.list_all_open()
+        err = capsys.readouterr().err
+        assert "WARNING" not in err

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -211,7 +211,8 @@ class TestListByLabels:
         monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: adapter)
         tracker.list_by_labels("status:pending-ship", state="all")
         adapter.list_issues.assert_called_once_with(
-            labels=["status:pending-ship"], state="all", limit=50
+            labels=["status:pending-ship"], state="all",
+            limit=tracker._OPEN_ISSUE_LIST_LIMIT
         )
 
 


### PR DESCRIPTION
Addresses #13660

### Summary
`list_issues()`/`list_by_labels()`/`list_all_open()` in `references/scripts/tracker.py` hard-capped `gh issue list` at `--limit 50`. `list_all_open()` was actively truncating -- live open-issue count is 150+, gh orders newest-first, so ~100 of the oldest open issues (mostly the status:pending backlog) were silently invisible on every call. The other two carried the identical latent cap.

### Changes
- New shared `_OPEN_ISSUE_LIST_LIMIT = 500` constant + `_warn_if_capped()` helper in tracker.py.
- All three functions (gh-CLI path + forge-adapter path) now use the raised limit and print a WARNING when a result hits the cap (#13555's precedent).
- New regression tests: tests/test_13660_list_limit_truncation.py (17 cases covering limit-arg shape, adapter kwarg, and cap-warning fire/no-fire for each function).
- Updated tests/test_tracker.py's one hardcoded limit=50 adapter assertion to reference the new constant.

### Verifier Status
- Full regression suite green: 87 passed (test_13660_list_limit_truncation.py + test_tracker.py).
- Full static gate green: 5715 gated tests, 0 failures.

### Notes
Filed #13661 separately for a sibling instance found during investigation (cycle_pre.py's _gh_fetch() external-triage/pending-ship calls carry the same limit=50 pattern) -- out of this issue's declared scope, left for its own fix.