### PR TITLE
fix(#13661): cycle_pre.py _gh_fetch() limit=50 -> 500 + cap-warning

### DIFF
--- a/references/scripts/cycle_pre.py
+++ b/references/scripts/cycle_pre.py
@@ -800,6 +800,11 @@ def _gh_fetch(label_filter, state, with_comments=False, with_body=False, limit=2
                   triage fetch).
     state:        "open" | "closed" | "all".
     Returns parsed JSON list, or [] on any failure.
+
+    #13661: warns (once per distinct cache key) when a result hits `limit` --
+    the same silent-truncation class #13555/#13602/#13660 fixed elsewhere.
+    Centralized here so every caller gets the self-diagnosing behavior for
+    free, regardless of what `limit` it passes.
     """
     cache_key = (label_filter, state, with_comments, with_body, limit)
     if cache_key in _GH_FETCH_CACHE:
@@ -823,6 +828,11 @@ def _gh_fetch(label_filter, state, with_comments=False, with_body=False, limit=2
                 items = parsed
         except (json.JSONDecodeError, ValueError):
             pass
+    if len(items) >= limit:
+        print(f"WARNING: _gh_fetch(label_filter={label_filter!r}, "
+              f"state={state!r}) returned {len(items)} = the --limit cap "
+              f"({limit}); older/additional issues may be INVISIBLE (#13661).",
+              file=sys.stderr)
     _GH_FETCH_CACHE[cache_key] = items
     return items
 
@@ -997,7 +1007,7 @@ def _build_pm_input(role):
     # auto-close; the old tracker.list_by_labels path explicitly defaults to
     # state=open for exactly this reason.
     pending_ship_open = _gh_fetch(
-        "squidsquad,status:pending-ship", "open", with_comments=True, limit=50
+        "squidsquad,status:pending-ship", "open", with_comments=True, limit=500
     )
 
     pending_test_issues = []
@@ -1045,7 +1055,7 @@ def _build_pm_input(role):
     pending_ship_tasks = list(pending_ship_open)
 
     # External (non-squidsquad) issues — single broad query, then filter.
-    all_open = _gh_fetch(None, "open", with_body=True, limit=50)
+    all_open = _gh_fetch(None, "open", with_body=True, limit=500)
     external_issues = [
         i for i in all_open if "squidsquad" not in _item_label_names(i)
     ]
@@ -1243,7 +1253,7 @@ def _build_dm_input(role):
     # auto-close; the old tracker.list_by_labels path explicitly defaults to
     # state=open for exactly this reason.
     pending_ship_open = _gh_fetch(
-        "squidsquad,status:pending-ship", "open", with_comments=True, limit=50
+        "squidsquad,status:pending-ship", "open", with_comments=True, limit=500
     )
 
     # Bugs assigned to DM — type:issue (or legacy type:bug) + role:dm

--- a/tests/test_13661_gh_fetch_limit_truncation.py
+++ b/tests/test_13661_gh_fetch_limit_truncation.py
@@ -1,0 +1,117 @@
+"""Regression tests for #13661 — cycle_pre.py's _gh_fetch() call sites for
+external-issue triage and pending-ship queries shared the #13555/#13602/#13660
+gh --limit 50 silent-truncation class. Live open-issue count is 150+ and gh
+orders newest-first, so the external-triage fetch (line ~1058) was silently
+missing the oldest ~100 open issues on every triage-external pass.
+
+Fix: raised the three limit=50 call sites to 500 (matching the #13555/#13660
+precedent), and centralized a cap-hit WARNING inside _gh_fetch() itself so
+every caller — including the pre-existing limit=200 call sites — gets the
+self-diagnosing behavior for free.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import cycle_pre
+
+
+def _mock_result(stdout="", stderr="", returncode=0):
+    r = MagicMock()
+    r.stdout = stdout
+    r.stderr = stderr
+    r.returncode = returncode
+    return r
+
+
+@pytest.fixture(autouse=True)
+def _clear_gh_fetch_cache():
+    cycle_pre._GH_FETCH_CACHE.clear()
+    yield
+    cycle_pre._GH_FETCH_CACHE.clear()
+
+
+class TestGhFetchCapWarning13661:
+    def test_warns_when_result_hits_limit(self, monkeypatch, capsys):
+        items = [{"number": i} for i in range(5)]
+        monkeypatch.setattr(
+            cycle_pre, "_run",
+            lambda cmd, **kw: _mock_result(stdout=__import__("json").dumps(items)),
+        )
+        cycle_pre._gh_fetch(None, "open", limit=5)
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+        assert "#13661" in err
+
+    def test_no_warning_under_limit(self, monkeypatch, capsys):
+        items = [{"number": 1}]
+        monkeypatch.setattr(
+            cycle_pre, "_run",
+            lambda cmd, **kw: _mock_result(stdout=__import__("json").dumps(items)),
+        )
+        cycle_pre._gh_fetch(None, "open", limit=5)
+        err = capsys.readouterr().err
+        assert "WARNING" not in err
+
+    def test_no_warning_on_empty_result(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            cycle_pre, "_run", lambda cmd, **kw: _mock_result(stdout="[]"),
+        )
+        cycle_pre._gh_fetch(None, "open", limit=500)
+        err = capsys.readouterr().err
+        assert "WARNING" not in err
+
+    def test_warning_fires_for_any_limit_value(self, monkeypatch, capsys):
+        """The warning is generic to _gh_fetch, not special-cased to the
+        raised 500 -- a caller still passing a small limit is still warned."""
+        items = [{"number": i} for i in range(200)]
+        monkeypatch.setattr(
+            cycle_pre, "_run",
+            lambda cmd, **kw: _mock_result(stdout=__import__("json").dumps(items)),
+        )
+        cycle_pre._gh_fetch("squidsquad", "open", with_comments=True, limit=200)
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+
+
+class TestRaisedLimits13661:
+    def test_pending_ship_query_uses_raised_limit(self, monkeypatch):
+        calls = []
+
+        def fake_run(cmd, **kw):
+            calls.append(cmd)
+            return _mock_result(stdout="[]")
+
+        monkeypatch.setattr(cycle_pre, "_run", fake_run)
+        cycle_pre._gh_fetch(
+            "squidsquad,status:pending-ship", "open", with_comments=True, limit=500
+        )
+        limit_arg = calls[0][calls[0].index("--limit") + 1]
+        assert limit_arg == "500"
+        assert int(limit_arg) > 50
+
+    def test_external_triage_query_uses_raised_limit(self, monkeypatch):
+        calls = []
+
+        def fake_run(cmd, **kw):
+            calls.append(cmd)
+            return _mock_result(stdout="[]")
+
+        monkeypatch.setattr(cycle_pre, "_run", fake_run)
+        cycle_pre._gh_fetch(None, "open", with_body=True, limit=500)
+        limit_arg = calls[0][calls[0].index("--limit") + 1]
+        assert limit_arg == "500"
+        assert int(limit_arg) > 50
+
+    def test_source_no_longer_hardcodes_limit_50(self):
+        """#13661: none of _gh_fetch's call sites in cycle_pre.py should still
+        pass the old truncating limit=50."""
+        source = (SCRIPTS / "cycle_pre.py").read_text(encoding="utf-8")
+        assert "limit=50)" not in source
+        assert "limit=50\n" not in source


### PR DESCRIPTION
Addresses #13661

### Summary
`cycle_pre.py`'s `_gh_fetch()` external-triage and pending-ship call sites hardcoded `limit=50` (vs. the function's own `limit=200` default used elsewhere) -- same silent-truncation class as #13555/#13602/#13660. Live open-issue count is 150+, so the external-triage fetch was silently missing the oldest ~100 open issues on every triage-external pass.

### Changes
- Raised the three `limit=50` call sites (external-triage fetch + 2 pending-ship fetches) to `limit=500`.
- Added a cap-hit WARNING inside `_gh_fetch()` itself (per the issue's suggested fix (b)) so every caller -- including the pre-existing `limit=200` sites -- gets the self-diagnosing behavior for free, not just the three raised sites.
- New regression tests: tests/test_13661_gh_fetch_limit_truncation.py (7 cases: warning fire/no-fire, raised-limit-arg shape, source-level guard against a hardcoded limit=50 regression).

### Verifier Status
- Full regression suite green: 150 passed (test_13661_gh_fetch_limit_truncation.py + test_cycle_pre.py).
- Full static gate green: 5722 gated tests, 0 failures.

### Notes
Confirms the open question from #13660's filing comment: cycle_pre.py's `_gh_fetch(None, "open", with_body=True, ...)` -- not `tracker.list_all_open()` -- is the code path that actually feeds `external_issues` into cycle-input.json for the triage-external step.