### PR TITLE
fix(#13664): l4_write_commit.py restricts git commit to the L4 file path

### DIFF
--- a/references/scripts/l4_write_commit.py
+++ b/references/scripts/l4_write_commit.py
@@ -121,8 +121,17 @@ def write_and_commit_l4(
     # Phase 2 — git commit. Stage just the L4 file (never -A or .).
     # Capture pre-commit SHA so the push-fail revert path targets an
     # explicit commit rather than relying on HEAD~1 — defends against the
-    # case where the working tree was dirty at entry and `git commit`
-    # accidentally included unrelated staged changes.
+    # case where the working tree was dirty at entry and `git reset --hard`
+    # needs to unwind exactly to this call's starting point.
+    #
+    # #13664: the commit itself is ALSO pathspec-restricted (`-- relative`,
+    # mirroring the `git add` restriction above) so a dirty index at entry
+    # can't get swept into this commit on the SUCCESS path -- `git commit
+    # -- <path>` commits only staged changes matching that path, leaving any
+    # other staged content still staged for its own future commit. Without
+    # this, an unrestricted `git commit` would commit the WHOLE index,
+    # silently bundling unrelated staged changes into a commit whose
+    # subject/body describe only the L4 write, and pushing them to origin.
     pre_commit_sha = _resolve_head_sha(runner, target_root)
     subject = _commit_subject(role_class, slot, op_type, target)
     body = _commit_body(source_directive)
@@ -138,7 +147,7 @@ def write_and_commit_l4(
             failure_detail=f"git add failed: {add_result.stderr.strip() or add_result.stdout.strip()}",
         )
     commit_result = runner(
-        ["git", "commit", "-m", subject, "-m", body],
+        ["git", "commit", "-m", subject, "-m", body, "--", relative],
         cwd=str(target_root), capture_output=True, text=True,
     )
     if commit_result.returncode != 0:

--- a/tests/test_l4_write_commit_c6.py
+++ b/tests/test_l4_write_commit_c6.py
@@ -186,6 +186,29 @@ def test_commit_runs_git_add_then_commit(tmp_path):
     assert "pm: L4 write — instructions/insert-before/step:cycle/file-bug" in commit_argv
 
 
+def test_commit_is_pathspec_restricted_to_l4_file(tmp_path):
+    """#13664: `git commit` must restrict to the target path, exactly like
+    `git add` already does — otherwise any OTHER content already staged in
+    the index at entry rides this commit too (and reaches origin on push
+    success), silently bundled under a subject/body that only describe the
+    L4 write."""
+    run, calls = _make_runner()
+    l4_write_commit.write_and_commit_l4(
+        role_class="pm",
+        staged_l4_text=_STAGED_L4,
+        op_type="insert-before step:cycle/file-bug",
+        target="step:cycle/file-bug",
+        slot="instructions",
+        source_directive=_DIRECTIVE,
+        authored_by="pm-lead",
+        target_root=tmp_path,
+        generated_at=_GENERATED_AT,
+        runner=run,
+    )
+    commit_argv = next(c["argv"] for c in calls if c["argv"][:2] == ["git", "commit"])
+    assert commit_argv[-2:] == ["--", ".squidsquad/project/pm.md"]
+
+
 # ---------------------------------------------------------------------------
 # AC3: commit body + metadata trailer
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses #13664

### Summary
`l4_write_commit.py`'s Phase 2 staged the L4 file with a pathspec-restricted `git add -- <relative>`, but committed with a bare `git commit -m subject -m body` -- no pathspec restriction. `git commit` without a trailing pathspec commits the WHOLE index, so any pre-existing staged-but-uncommitted content at entry silently rode the L4 write's commit and reached origin on push success, misattributed under a subject/body describing only the L4 write. The function's own code comment named this exact scenario but its cited defense (pre_commit_sha capture) only protects the push-failure revert path, not the success path.

### Changes
- Restrict `git commit` to the target path exactly like `git add` already is: `["git", "commit", "-m", subject, "-m", body, "--", relative]`.
- Updated the Phase 2 code comment to describe what `pre_commit_sha` actually defends (the revert-path unwind point) vs. what the new pathspec restriction now separately handles (the success-path bundling).
- New regression test: `test_commit_is_pathspec_restricted_to_l4_file`.

### Verifier Status
- Full regression suite green: 24 passed (test_l4_write_commit_c6.py).
- Full static gate green: 5723 gated tests, 0 failures.