### PR TITLE
fix(#13666): task-intake commits CONTEXT.md immediately + task-approval gates on origin/main

### DIFF
--- a/references/sub-skills/roles/pm/task-approval.md
+++ b/references/sub-skills/roles/pm/task-approval.md
@@ -27,7 +27,12 @@ To approve a task for planning:
    2. Read the GitHub issue body: `gh issue view <N> --json body`.
    3. Compare the body's scope bullets against those three CONTEXT sections (structured comparison, NOT a raw text diff — the body and CONTEXT intentionally have different formats). If any **locked decision** or **scope boundary** is missing, outdated, or contradicted in the body, update the body via `gh issue edit <N> --body-file <new-body>` BEFORE the transition.
    4. Confirmation: re-read `gh issue view <N> --json body`; the AUTHORITATIVE SCOPE banner is present AND the body bullets are consistent with the CONTEXT sections.
-7. Only after human explicitly approves execution AND the pre-approval body-vs-CONTEXT check is clean, update status to `Approved`.
+   5. **Confirm the CONTEXT artifact reached `origin/main`** (#13666): a CONTEXT.md/CONTEXT-<NUMBER>.md written earlier in this same cycle can still be uncommitted or unpushed in PM's own clone — in event mode the mechanical post-cycle commit/push runs at cycle END, but the `Approved` transition itself fires a nudge that wakes the worker on the very next cycle, which can race ahead of it. A worker that can't find the file the issue body's AUTHORITATIVE SCOPE banner points at bails immediately. Before the transition, run:
+      ```bash
+      git log origin/main -- .squidsquad/[PM_ALIAS]/planning/CONTEXT-<NUMBER>.md
+      ```
+      (or the bundle `CONTEXT.md` path). If the output is empty, the artifact is NOT yet on `origin/main` — commit and push it now (`git add <path> && git commit -m "..." && git push`) before proceeding. Never transition to `Approved` with the artifact still unpushed.
+7. Only after human explicitly approves execution AND the pre-approval body-vs-CONTEXT check is clean (including the origin/main artifact confirmation above), update status to `Approved`.
 
 Light mode (trivial tasks): PM can fast-track through planning with abbreviated research, but status still transitions through `Planning` → `Planned` → `Approved`.
 

--- a/references/sub-skills/roles/pm/task-intake.md
+++ b/references/sub-skills/roles/pm/task-intake.md
@@ -213,6 +213,13 @@ Continue until all questions are resolved. Capture decisions in `.squidsquad/[RO
 - [Thing]: [explicitly excluded]
 ```
 
+**Commit and push CONTEXT.md immediately** (#13666): don't rely on the mechanical post-cycle commit/push to land this file on `origin/main` — in event mode that wrapper runs at cycle END, but Phase 3B's `Approved` transition (later in this same cycle) fires a nudge that can wake the worker before the wrapper commits, so a same-session CONTEXT.md write can race ahead of its own push and leave the worker unable to find the file the issue body points at. Commit it now, the same way Phase 3B already commits the plan body explicitly rather than trusting the wrapper:
+```bash
+git add .squidsquad/[PM_ALIAS]/planning/FEAT-[ROLE_UPPER]-XXX-CONTEXT.md  # or CONTEXT-<NUMBER>.md
+git commit -m "context(#<NUMBER>): [title]"
+git push
+```
+
 **Open in editor**: After CONTEXT.md is created, offer to open it (see "Open Artifacts in Editor" below).
 
 **Sync issue body when CONTEXT scope is (re)written** (#8917 Change 1): When Phase 2 (deepseek review, discussion locks, scope discussion) rewrites scope on `CONTEXT.md` (or per-task `CONTEXT-<NUMBER>.md`), the corresponding GitHub Issue body MUST be updated in the same PM step. Use `gh issue edit <N> --body-file <new-body>`. The issue body and CONTEXT.md must always agree at the time of the `planned → approved` transition.

--- a/tests/test_13666_context_commit_push_race.py
+++ b/tests/test_13666_context_commit_push_race.py
@@ -1,0 +1,92 @@
+"""Regression test for #13666 — task-intake.md's Phase 2 wrote CONTEXT.md to
+disk but never explicitly committed+pushed it, relying on the mechanical
+post-cycle commit/push that runs at cycle END. In event mode, a task filed,
+planned, and approved within one PM cycle fires the `Approved` transition's
+nudge BEFORE that end-of-cycle commit lands — the worker wakes on the very
+next cycle and can't find the CONTEXT file the issue body's AUTHORITATIVE
+SCOPE banner points at. Live-reproduced this session: #13563 was filed/
+planned/approved in one PM sitting, skill picked it up on the next event and
+immediately bailed because CONTEXT-13563.md didn't exist on origin/main yet.
+
+Two-part fix:
+1. task-intake.md Phase 2 now commits+pushes CONTEXT.md immediately after
+   writing it (mirrors Phase 3B, which already commits the plan body
+   explicitly rather than trusting the wrapper).
+2. task-approval.md's pre-approval body-vs-CONTEXT sync check (step 6) now
+   also confirms the CONTEXT artifact is present in `git log origin/main`
+   before allowing the `planned -> approved` transition -- a hard gate, not
+   just a should-do instruction, so the race class is caught even if a
+   future PM session skips the Phase 2 commit step.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TASK_INTAKE = REPO_ROOT / "references" / "sub-skills" / "roles" / "pm" / "task-intake.md"
+TASK_APPROVAL = REPO_ROOT / "references" / "sub-skills" / "roles" / "pm" / "task-approval.md"
+
+
+@pytest.fixture
+def task_intake_text():
+    assert TASK_INTAKE.exists(), f"task-intake.md missing: {TASK_INTAKE}"
+    return TASK_INTAKE.read_text(encoding="utf-8")
+
+
+@pytest.fixture
+def task_approval_text():
+    assert TASK_APPROVAL.exists(), f"task-approval.md missing: {TASK_APPROVAL}"
+    return TASK_APPROVAL.read_text(encoding="utf-8")
+
+
+class TestTaskIntakeCommitsContextImmediately13666:
+    def test_explicit_commit_step_present(self, task_intake_text):
+        idx = task_intake_text.index("#13666")
+        section = task_intake_text[idx:idx + 800]
+        assert "git add" in section
+        assert "git commit" in section
+        assert "git push" in section
+
+    def test_commit_step_placed_right_after_context_written(self, task_intake_text):
+        """The commit step must come between CONTEXT.md's template block and
+        the 'Open in editor' step -- immediately after the write, not later."""
+        context_template_idx = task_intake_text.index("## Out of Scope")
+        commit_idx = task_intake_text.index("#13666")
+        open_editor_idx = task_intake_text.index(
+            '**Open in editor**: After CONTEXT.md is created'
+        )
+        assert context_template_idx < commit_idx < open_editor_idx
+
+    def test_explains_the_race(self, task_intake_text):
+        idx = task_intake_text.index("#13666")
+        section = task_intake_text[idx:idx + 600]
+        assert "race" in section.lower()
+        assert "nudge" in section.lower()
+
+
+class TestTaskApprovalGatesOnOriginMain13666:
+    def test_origin_main_check_present(self, task_approval_text):
+        idx = task_approval_text.index("#13666")
+        section = task_approval_text[idx:idx + 900]
+        assert "git log origin/main" in section
+
+    def test_check_is_inside_pre_approval_sync_step(self, task_approval_text):
+        """The origin/main confirmation must be a sub-step of step 6 (the
+        pre-approval body-vs-CONTEXT sync), not a disconnected addition."""
+        step6_idx = task_approval_text.index("Pre-approval body-vs-CONTEXT sync check")
+        gate_idx = task_approval_text.index("#13666")
+        step7_idx = task_approval_text.index(
+            "Only after human explicitly approves execution"
+        )
+        assert step6_idx < gate_idx < step7_idx
+
+    def test_step7_references_the_new_check(self, task_approval_text):
+        idx = task_approval_text.index("Only after human explicitly approves execution")
+        line = task_approval_text[idx:idx + 300]
+        assert "origin/main" in line.lower() or "artifact confirmation" in line.lower()
+
+    def test_never_approve_with_artifact_unpushed(self, task_approval_text):
+        idx = task_approval_text.index("#13666")
+        section = task_approval_text[idx:idx + 900]
+        assert "never transition" in section.lower() or "before proceeding" in section.lower()


### PR DESCRIPTION
Addresses #13666

### Summary
Live-reproduced this session: #13563 was filed/planned/approved in one PM sitting, wrote CONTEXT-13563.md, transitioned to Approved -- skill picked it up on the very next event and immediately bailed because CONTEXT-13563.md wasn't on origin/main yet (only in PM's own clone). In event mode PM's mechanical post-cycle commit/push runs at cycle END, but the Approved transition fires a nudge that can wake the worker before that commit lands -- a same-session write races ahead of its own push.

### Changes
- `task-intake.md` Phase 2 now explicitly commits+pushes CONTEXT.md right after writing it, mirroring how Phase 3B already commits the plan body explicitly rather than trusting the wrapper.
- `task-approval.md`'s pre-approval body-vs-CONTEXT sync check (step 6) now also confirms the CONTEXT artifact is present via `git log origin/main` before allowing `planned -> approved` -- a hard gate, not just a should-do instruction, so the race class is caught even if the Phase 2 commit step is skipped in a future session.

### Verifier Status
- New regression tests: test_13666_context_commit_push_race.py (7 cases).
- Full static gate green: 5730 gated tests, 0 failures.
- CQ note: this is a type:issue fix (not type:task), so per the #13551 precedent the CQ spec is authored by the verifier during their own verification pass, not pre-arranged by skill.