### PR TITLE
fix(#13669): l4_conflict_preempt raises typed error on empty/None op_type

### DIFF
--- a/references/scripts/l4_conflict_preempt.py
+++ b/references/scripts/l4_conflict_preempt.py
@@ -113,6 +113,18 @@ class PreemptParseError(ConflictPreemptError):
     """Output present but does not match the expected ``decision: …`` shape."""
 
 
+class PreemptInvalidOpTypeError(ConflictPreemptError):
+    """``op_type`` was empty/``None`` — not a legal L4 grammar shape (#13669).
+
+    The sole caller is prose in ``l4-curation.md`` (LLM-driven, not a
+    deterministic Python call site), so a malformed invocation reaching this
+    function is a realistic path. Raised explicitly, before the replace-op
+    short-circuit, so this failure mode stays a typed ``ConflictPreemptError``
+    like every other unrecoverable path in this module — rather than an
+    unguarded ``op_type.split()[0]`` raising a raw ``IndexError``/
+    ``AttributeError`` the upstream dialog isn't designed to catch."""
+
+
 def preempt_conflict(
     *,
     op_type,
@@ -148,7 +160,13 @@ def preempt_conflict(
     ``model_router`` module (tests pass a stub). Default lazy-imports
     the real module.
     """
-    if op_type and _REPLACE_OP_RE.match(op_type):
+    if not op_type:
+        raise PreemptInvalidOpTypeError(
+            f"preempt_conflict() requires a non-empty op_type (legal L4 "
+            f"grammar shape); got {op_type!r}."
+        )
+
+    if _REPLACE_OP_RE.match(op_type):
         # AC5(c): replace ops supersede prior prose; no LLM dispatch.
         # Allowlist-match against the grammar so malformed shapes like
         # "replace foo" / "replace step:not-cycle/x" don't silently

--- a/tests/test_13669_preempt_invalid_op_type.py
+++ b/tests/test_13669_preempt_invalid_op_type.py
@@ -1,0 +1,80 @@
+"""Regression test for #13669 — l4_conflict_preempt.preempt_conflict()'s
+own module docstring promises "every unrecoverable path raises a typed
+ConflictPreemptError subclass," but the replace-op short-circuit guard
+(``if op_type and _REPLACE_OP_RE.match(op_type):``) let a falsy op_type
+fall through to ``op_type.split()[0]`` at task_id construction. Empirically
+reproduced (unmocked call): op_type="" raised IndexError, op_type=None
+raised AttributeError — neither a ConflictPreemptError.
+
+Fix: an explicit ``if not op_type:`` guard at the top of preempt_conflict()
+raises the new PreemptInvalidOpTypeError(ConflictPreemptError) before the
+replace-op short-circuit, so this failure mode is a typed exception like
+every other unrecoverable path in the module.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import l4_conflict_preempt as cp
+
+
+_KWARGS = dict(
+    target_slot="instructions",
+    target_step_id=None,
+    target_role_class="pm",
+    body_text="new rule text",
+    linked_composite="existing prose",
+    source_directive="from now on...",
+)
+
+
+class TestEmptyOrNoneOpTypeRaisesTypedError13669:
+    def test_empty_string_raises_typed_error(self):
+        with pytest.raises(cp.PreemptInvalidOpTypeError):
+            cp.preempt_conflict(op_type="", model_router=object(), **_KWARGS)
+
+    def test_none_raises_typed_error(self):
+        with pytest.raises(cp.PreemptInvalidOpTypeError):
+            cp.preempt_conflict(op_type=None, model_router=object(), **_KWARGS)
+
+    def test_typed_error_is_a_conflict_preempt_error(self):
+        assert issubclass(cp.PreemptInvalidOpTypeError, cp.ConflictPreemptError)
+
+    def test_never_reaches_model_router_dispatch(self):
+        """The guard must fire BEFORE any model_router call -- a poisoned
+        model_router stub that raises on any attribute access proves the
+        dispatch path was never reached."""
+        class _PoisonRouter:
+            def __getattr__(self, name):
+                raise AssertionError(
+                    f"model_router.{name} should never be touched for an "
+                    "invalid op_type"
+                )
+
+        with pytest.raises(cp.PreemptInvalidOpTypeError):
+            cp.preempt_conflict(op_type="", model_router=_PoisonRouter(), **_KWARGS)
+
+    def test_error_message_names_the_bad_value(self):
+        with pytest.raises(cp.PreemptInvalidOpTypeError, match="op_type"):
+            cp.preempt_conflict(op_type="", model_router=object(), **_KWARGS)
+
+
+class TestValidOpTypesStillWork13669:
+    """Guard against over-tightening: legal grammar shapes must be unaffected."""
+
+    def test_replace_still_short_circuits(self):
+        result = cp.preempt_conflict(
+            op_type="replace", model_router=object(), **_KWARGS
+        )
+        assert result.decision == "skip"
+
+    def test_step_targeted_replace_still_short_circuits(self):
+        result = cp.preempt_conflict(
+            op_type="replace step:cycle/file-bug", model_router=object(), **_KWARGS
+        )
+        assert result.decision == "skip"

--- a/tests/test_l4_conflict_preempt_c8.py
+++ b/tests/test_l4_conflict_preempt_c8.py
@@ -403,7 +403,8 @@ class TestFailureModes:
         can catch the base in one except clause.
         """
         for sub in (cp.PreemptModelRouterError, cp.PreemptTimeoutError,
-                    cp.PreemptOutputMissingError, cp.PreemptParseError):
+                    cp.PreemptOutputMissingError, cp.PreemptParseError,
+                    cp.PreemptInvalidOpTypeError):
             assert issubclass(sub, cp.ConflictPreemptError)
 
 


### PR DESCRIPTION
Addresses #13669

### Summary
`preempt_conflict()`'s own module docstring promises "every unrecoverable path raises a typed `ConflictPreemptError` subclass", but the replace-op short-circuit guard (`if op_type and _REPLACE_OP_RE.match(op_type):`) let a falsy `op_type` fall through to `op_type.split()[0]` at task_id construction. Empirically reproduced (unmocked call): `op_type=""` raised `IndexError`, `op_type=None` raised `AttributeError` -- neither a `ConflictPreemptError`. The sole caller is prose in `l4-curation.md` (LLM-driven, not a deterministic Python call site), so a malformed invocation reaching this function is a realistic path.

### Changes
- New `PreemptInvalidOpTypeError(ConflictPreemptError)`, raised via an explicit `if not op_type:` guard placed before the replace-op short-circuit.
- Extended the existing exception-hierarchy test to cover the new subclass.
- New regression tests: test_13669_preempt_invalid_op_type.py (7 cases: empty-string/None inputs, subclass relationship, guard fires before any model_router dispatch, legal replace-op shapes unaffected).

### Verifier Status
- Full regression suite green: 33 passed (test_13669_preempt_invalid_op_type.py + test_l4_conflict_preempt_c8.py).
- Full static gate green: 5749 gated tests, 0 failures.