### PR TITLE
skill

### DIFF
--- a/references/git-hooks/post-commit
+++ b/references/git-hooks/post-commit
@@ -1,0 +1,24 @@
+#!/bin/sh
+# SquidSquad post-commit L4-recompose hook (#13672) -- FAIL-OPEN.
+#
+# l4_file_watcher.py's own module docstring documents recompose_path() as the
+# "optional" redundancy trigger for human-driven L4 edits made outside the
+# agent dialog (PRD-E Q-E2): the primary trigger is the live watchdog-based
+# file-watch running inside the harness process, which covers most cases
+# since a filesystem write fires regardless of a later commit. This hook is
+# the backstop for when that watcher isn't running (harness down, bare mode,
+# watcher crashed) at the moment of the commit -- the recompose still happens
+# deterministically on the next commit instead of silently waiting for the
+# watcher to notice.
+#
+# recompose_path() existed and was fully unit-tested since PRD-E, but this
+# hook script -- its documented entry point -- never shipped (#13672: zero
+# callers anywhere in the repo). Fully fail-open: a post-commit hook cannot
+# abort a commit that already happened, so this always exits 0 regardless of
+# what the underlying recompose does.
+
+python references/scripts/git_ops.py recompose-committed-l4-files \
+  || python3 references/scripts/git_ops.py recompose-committed-l4-files \
+  || true
+
+exit 0

--- a/references/installer-files.txt
+++ b/references/installer-files.txt
@@ -1,7 +1,7 @@
 # SquidSquad installer file manifest
 # Every file the wizard needs, fetched by npx squidsquad before
 # launching Claude. One path per line, relative to repo root.
-# Total: 257 files
+# Total: 258 files
 #
 # Maintained alongside the wizard - when you add a new role,
 # capability, preset, or sub-skill, add its files here too.
@@ -82,6 +82,7 @@ references/scripts/vault_remember.py
 references/scripts/wizard.py
 references/git-hooks/pre-commit
 references/git-hooks/post-merge
+references/git-hooks/post-commit
 references/roles/worker/android/includes.yml
 references/roles/worker/android/instructions.md
 references/roles/worker/android/SOUL.md

--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -26,7 +26,7 @@ Usage:
     python scripts/git_ops.py check-real-conflict <base> <head>  # real conflict? exit 0=clean/1=conflict/2=err
     python scripts/git_ops.py guard-staged-state         # pre-commit hook: unstage state files on a feature branch (fail-open)
     python scripts/git_ops.py guard-galaxy-frontmatter   # pre-commit hook: block a staged galaxy note missing YAML frontmatter (fail-closed on violation, fail-open on error)
-    python scripts/git_ops.py install-hooks              # activate the pre-commit + post-merge guards (core.hooksPath)
+    python scripts/git_ops.py install-hooks              # activate the pre-commit + post-merge + post-commit guards (core.hooksPath)
     python scripts/git_ops.py restore-merge-dropped-state [role]  # post-merge hook: restore protected state/vault a merge silently dropped (#13556; fail-open)
     python scripts/git_ops.py --help
 """
@@ -1533,6 +1533,63 @@ def _restore_merge_dropped_state(role=None):
         return []
 
 
+def _recompose_committed_l4_files():
+    """#13672 -- post-commit hook entry point: recompose any L4 project files
+    (``.squidsquad/project/<role-class>.md``) touched by the just-created
+    commit, via ``l4_file_watcher.recompose_path()``.
+
+    ``l4_file_watcher.py``'s own module docstring documents this as the
+    "optional" redundancy trigger for human-driven L4 edits made outside the
+    agent dialog (PRD-E Q-E2) -- the primary trigger is the live
+    ``watchdog``-based file-watch running inside the harness process, which
+    covers most cases since a filesystem write fires regardless of a later
+    commit. This hook is the backstop for when that watcher isn't running
+    (harness down, bare mode, watcher crashed) at the moment of the commit --
+    the recompose still happens deterministically on the next commit, rather
+    than silently waiting for the watcher to notice on its own.
+
+    Fully fail-open: a post-commit hook cannot abort a commit that already
+    happened, but an unguarded crash would print a scary traceback on every
+    commit -- every step here is wrapped so a failure here degrades to "no
+    recompose this commit" rather than a broken git operation.
+    """
+    try:
+        result = _run_list(
+            ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"],
+            check=False)
+        if result.returncode != 0:
+            return
+        changed = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        l4_files = [
+            f for f in changed
+            if f.startswith(".squidsquad/project/") and f.endswith(".md")
+        ]
+        if not l4_files:
+            return
+
+        import l4_file_watcher
+        import config as _cfg
+        from event_bus import emit as _emit_event
+
+        registry = _cfg.parse_aliases_registry()
+        for f in l4_files:
+            try:
+                l4_file_watcher.recompose_path(
+                    REPO_ROOT / f,
+                    repo_root=REPO_ROOT,
+                    registry=registry,
+                    emit_event=_emit_event,
+                )
+            except Exception as e:  # noqa: BLE001 -- one file's failure must
+                # not skip the rest, and must never propagate past this hook.
+                print(f"WARNING: post-commit L4 recompose failed for {f}: "
+                      f"{type(e).__name__}: {e}", file=sys.stderr)
+    except Exception as e:  # noqa: BLE001 -- fail-open, see docstring.
+        print(f"WARNING: post-commit L4 recompose hook raised: "
+              f"{type(e).__name__}: {e} (fail-open -- commit unaffected)",
+              file=sys.stderr)
+
+
 def _safe_checkout(target_branch):
     """Switch to target branch, stashing unstaged changes if needed.
 
@@ -2382,8 +2439,9 @@ def install_hooks():
     """Activate the tracked pre-commit guard by pointing core.hooksPath at it (#11511).
 
     Idempotent. Sets ``core.hooksPath`` to the in-repo ``references/git-hooks``
-    directory (tracked, version-controlled) and makes the ``pre-commit`` shim
-    executable. Because the hooks live in-repo, there is nothing to copy into
+    directory (tracked, version-controlled) and makes the ``pre-commit``,
+    ``post-merge`` (#13556), and ``post-commit`` (#13672) shims executable.
+    Because the hooks live in-repo, there is nothing to copy into
     ``.git/hooks`` and the activation survives a fresh clone the moment this
     runs.
 
@@ -2400,8 +2458,10 @@ def install_hooks():
         return False
     # #13556: the post-merge guard lives in the same hooksPath dir, so it is
     # auto-active the moment core.hooksPath points here -- it just needs its exec
-    # bit set alongside pre-commit (below).
+    # bit set alongside pre-commit (below). #13672: same for the post-commit
+    # L4-recompose hook.
     post_merge_hook = REPO_ROOT / _HOOKS_DIR_REL / "post-merge"
+    post_commit_hook = REPO_ROOT / _HOOKS_DIR_REL / "post-commit"
 
     current = _run("git config --get core.hooksPath", check=False).stdout.strip()
     if current and current != _HOOKS_DIR_REL:
@@ -2429,12 +2489,13 @@ def install_hooks():
     # Executable bit. On POSIX git only fires a hook whose exec bit is set, so a
     # chmod failure means the guard is installed but won't run -- report False
     # and warn. On Windows git ignores the exec bit (the shim runs via sh), so a
-    # chmod failure there is benign and the guard is still active. Chmod BOTH the
-    # pre-commit (#11511) and post-merge (#13556) hooks; a missing post-merge is
-    # tolerated (older installs) so it never regresses the pre-commit activation.
+    # chmod failure there is benign and the guard is still active. Chmod the
+    # pre-commit (#11511), post-merge (#13556), and post-commit (#13672) hooks;
+    # a missing post-merge/post-commit is tolerated (older installs) so it
+    # never regresses the pre-commit activation.
     import os
     import stat
-    for h in (hook, post_merge_hook):
+    for h in (hook, post_merge_hook, post_commit_hook):
         if not h.exists():
             continue
         try:
@@ -2658,6 +2719,13 @@ def main():
         # non-zero exit from a post-merge hook does not abort the merge (it is
         # already done) but keying it 0 keeps logs clean.
         _restore_merge_dropped_state(role=rest[0] if rest else None)
+        sys.exit(0)
+    elif cmd == "recompose-committed-l4-files":
+        # #13672 post-commit hook entry point: recompose any L4 project file
+        # touched by the just-created commit. FAIL-OPEN -- a post-commit hook
+        # cannot abort a commit that already happened; a non-zero exit here
+        # would only pollute logs, so this always exits 0.
+        _recompose_committed_l4_files()
         sys.exit(0)
     else:
         print(f"Unknown command: {cmd}", file=sys.stderr)

--- a/tests/test_13672_post_commit_l4_recompose_hook.py
+++ b/tests/test_13672_post_commit_l4_recompose_hook.py
@@ -1,0 +1,195 @@
+"""Regression test for #13672 — l4_file_watcher.py's own module docstring
+documents recompose_path() as the "public entry point for both the file-watch
+handler AND the optional .git/hooks/post-commit script" (PRD-E Q-E2), but
+that post-commit hook never shipped: zero callers anywhere in the repo,
+confirmed via grep and by listing references/git-hooks/ (only pre-commit and
+post-merge existed).
+
+Fix: a new references/git-hooks/post-commit shell hook (mirroring
+pre-commit/post-merge's shape) dispatches to a new git_ops.py subcommand,
+recompose-committed-l4-files, which finds any .squidsquad/project/*.md files
+touched by the just-created commit and calls l4_file_watcher.recompose_path()
+for each. install_hooks() now also chmods the new hook. Fully fail-open
+throughout — a post-commit hook cannot abort a commit that already happened.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import git_ops
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOK_FILE = REPO_ROOT / "references" / "git-hooks" / "post-commit"
+
+
+def _mock_result(stdout="", stderr="", returncode=0):
+    r = MagicMock()
+    r.stdout = stdout
+    r.stderr = stderr
+    r.returncode = returncode
+    return r
+
+
+class TestPostCommitHookFileShippedExecutable13672:
+    def test_hook_file_exists(self):
+        assert HOOK_FILE.exists()
+
+    def test_hook_tracked_executable(self):
+        import subprocess
+        out = subprocess.run(
+            ["git", "ls-files", "-s", "--", "references/git-hooks/post-commit"],
+            cwd=str(git_ops.REPO_ROOT), capture_output=True, text=True)
+        assert out.returncode == 0, out.stderr
+        line = out.stdout.strip()
+        assert line, "post-commit hook is not tracked in git"
+        mode = line.split()[0]
+        assert mode == "100755", (
+            f"post-commit hook tracked as mode {mode}, expected 100755 "
+            f"(POSIX needs the exec bit or git silently skips the hook)")
+
+    def test_hook_dispatches_to_recompose_subcommand(self):
+        text = HOOK_FILE.read_text(encoding="utf-8")
+        assert "recompose-committed-l4-files" in text
+
+    def test_hook_always_exits_zero(self):
+        text = HOOK_FILE.read_text(encoding="utf-8")
+        assert text.rstrip().endswith("exit 0")
+
+    def test_hook_in_installer_manifest(self):
+        manifest = REPO_ROOT / "references" / "installer-files.txt"
+        lines = [l.strip() for l in manifest.read_text().splitlines()]
+        assert "references/git-hooks/post-commit" in lines
+
+
+class TestInstallHooksChmodsPostCommitToo13672:
+    def test_install_hooks_chmods_all_three(self, tmp_path, monkeypatch):
+        import os
+        hook_dir = tmp_path / git_ops._HOOKS_DIR_REL
+        hook_dir.mkdir(parents=True)
+        (hook_dir / "pre-commit").write_text("#!/bin/sh\nexit 0\n")
+        (hook_dir / "post-merge").write_text("#!/bin/sh\nexit 0\n")
+        (hook_dir / "post-commit").write_text("#!/bin/sh\nexit 0\n")
+        monkeypatch.setattr(git_ops, "REPO_ROOT", tmp_path)
+        chmodded = []
+        monkeypatch.setattr(os, "chmod",
+                            lambda p, m, *a, **k: chmodded.append(Path(p).name))
+        with patch.object(git_ops, "_run",
+                          return_value=_mock_result(stdout="\n")), \
+                patch.object(git_ops, "_run_list",
+                             return_value=_mock_result(returncode=0)):
+            assert git_ops.install_hooks() is True
+        assert set(chmodded) == {"pre-commit", "post-merge", "post-commit"}
+
+    def test_missing_post_commit_does_not_break_activation(self, tmp_path, monkeypatch):
+        """Older installs / partial checkouts without the new hook must not
+        regress pre-commit activation."""
+        import os
+        hook_dir = tmp_path / git_ops._HOOKS_DIR_REL
+        hook_dir.mkdir(parents=True)
+        (hook_dir / "pre-commit").write_text("#!/bin/sh\nexit 0\n")
+        monkeypatch.setattr(git_ops, "REPO_ROOT", tmp_path)
+        monkeypatch.setattr(os, "chmod", lambda *a, **k: None)
+        with patch.object(git_ops, "_run",
+                          return_value=_mock_result(stdout="\n")), \
+                patch.object(git_ops, "_run_list",
+                             return_value=_mock_result(returncode=0)):
+            assert git_ops.install_hooks() is True
+
+
+class TestRecomposeCommittedL4Files13672:
+    def test_no_l4_files_in_commit_noop(self, monkeypatch):
+        monkeypatch.setattr(
+            git_ops, "_run_list",
+            lambda cmd, **kw: _mock_result(
+                stdout="references/scripts/foo.py\nREADME.md\n"),
+        )
+        # Must not raise, must not import l4_file_watcher's dependencies.
+        git_ops._recompose_committed_l4_files()
+
+    def test_diff_tree_failure_is_a_noop(self, monkeypatch):
+        monkeypatch.setattr(
+            git_ops, "_run_list", lambda cmd, **kw: _mock_result(returncode=1))
+        git_ops._recompose_committed_l4_files()  # must not raise
+
+    def test_l4_file_dispatches_to_recompose_path(self, monkeypatch):
+        monkeypatch.setattr(
+            git_ops, "_run_list",
+            lambda cmd, **kw: _mock_result(
+                stdout=".squidsquad/project/pm.md\n"),
+        )
+        fake_lfw = SimpleNamespace(recompose_path=MagicMock())
+        fake_cfg = SimpleNamespace(
+            parse_aliases_registry=MagicMock(return_value={"pm": ("pm", None)}))
+        with patch.dict(sys.modules, {
+            "l4_file_watcher": fake_lfw,
+            "config": fake_cfg,
+            "event_bus": SimpleNamespace(emit=MagicMock()),
+        }):
+            git_ops._recompose_committed_l4_files()
+        fake_lfw.recompose_path.assert_called_once()
+        call_kwargs = fake_lfw.recompose_path.call_args.kwargs
+        assert call_kwargs["registry"] == {"pm": ("pm", None)}
+
+    def test_non_project_squidsquad_files_ignored(self, monkeypatch):
+        """Only .squidsquad/project/*.md is watched -- a .squidsquad/pm/
+        working-state.md change must not trigger a recompose dispatch."""
+        monkeypatch.setattr(
+            git_ops, "_run_list",
+            lambda cmd, **kw: _mock_result(
+                stdout=".squidsquad/pm/working-state.md\n"),
+        )
+        fake_lfw = SimpleNamespace(recompose_path=MagicMock())
+        with patch.dict(sys.modules, {"l4_file_watcher": fake_lfw}):
+            git_ops._recompose_committed_l4_files()
+        fake_lfw.recompose_path.assert_not_called()
+
+    def test_one_file_failure_does_not_skip_the_rest(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            git_ops, "_run_list",
+            lambda cmd, **kw: _mock_result(
+                stdout=".squidsquad/project/pm.md\n"
+                       ".squidsquad/project/worker.md\n"),
+        )
+        calls = []
+
+        def _recompose(path, **kw):
+            calls.append(path)
+            if "pm.md" in str(path):
+                raise RuntimeError("boom")
+
+        fake_lfw = SimpleNamespace(recompose_path=_recompose)
+        fake_cfg = SimpleNamespace(parse_aliases_registry=MagicMock(return_value={}))
+        with patch.dict(sys.modules, {
+            "l4_file_watcher": fake_lfw,
+            "config": fake_cfg,
+            "event_bus": SimpleNamespace(emit=MagicMock()),
+        }):
+            git_ops._recompose_committed_l4_files()  # must not raise
+        assert len(calls) == 2
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+
+    def test_never_raises_on_unexpected_error(self, monkeypatch):
+        def _raise(*a, **k):
+            raise RuntimeError("unexpected")
+        monkeypatch.setattr(git_ops, "_run_list", _raise)
+        git_ops._recompose_committed_l4_files()  # must not raise
+
+
+class TestCliDispatch13672:
+    def test_recompose_committed_l4_files_cmd_exits_zero(self, monkeypatch):
+        monkeypatch.setattr(
+            sys, "argv", ["git_ops.py", "recompose-committed-l4-files"])
+        with patch.object(git_ops, "_recompose_committed_l4_files") as fn, \
+                patch.object(git_ops, "_ensure_hooks_installed"):
+            with pytest.raises(SystemExit) as exc:
+                git_ops.main()
+        assert exc.value.code == 0
+        fn.assert_called_once()


### PR DESCRIPTION
squidsquad/task/13672 Wire up unwired l4_file_watcher.recompose_path() via post-commit hook (#13672) ## Summary
- `l4_file_watcher.recompose_path()` was documented as the entry point for BOTH the live file-watch handler AND an 'optional `.git/hooks/post-commit` script' (PRD-E Q-E2), but that hook never shipped -- zero callers anywhere in the repo (found via improvement scan of `l4_file_watcher.py`, flagged hot by BRIEFING.md's own incident history).
- Adds `references/git-hooks/post-commit`, a fail-open shell hook mirroring `pre-commit`/`post-merge`'s shape, dispatching to a new `git_ops.py recompose-committed-l4-files` subcommand.
- New `_recompose_committed_l4_files()` in `git_ops.py`: inspects `git diff-tree` for the just-created commit, filters to `.squidsquad/project/*.md` files, and calls `l4_file_watcher.recompose_path()` per file via `event_bus.emit` (the external-process-safe emit path, not harness.py's in-process `_emit_event`). Fully fail-open at every layer -- a post-commit hook cannot abort a commit that already happened.
- `install_hooks()` now chmods all three tracked hooks (pre-commit, post-merge, post-commit).
- `references/installer-files.txt` updated (257 -> 258 files).

## Test plan
- New `tests/test_13672_post_commit_l4_recompose_hook.py` (14 cases): hook file exists/tracked-executable/in-manifest/dispatches/exits-0; `install_hooks()` chmods all three hooks and degrades gracefully when post-commit is absent; `_recompose_committed_l4_files()` no-ops on no L4 files / diff-tree failure / unexpected error, dispatches per-file to `recompose_path`, ignores non-project `.squidsquad/` files, and isolates one file's failure from the rest; CLI dispatch always exits 0.
- Full suite: `python tests/run_tests.py` -- 53/53 OK.
- Static gate: `python tests/run_tests.py static` -- 5763 gated tests, 0 failures, 0 errors.

Addresses #13672