### PR TITLE
skill

### DIFF
--- a/references/scripts/l4_parser.py
+++ b/references/scripts/l4_parser.py
@@ -56,7 +56,19 @@ _OP_RE = re.compile(
 # under ``.squidsquad/project/`` cannot use H3 prose under ``## Soul`` /
 # ``## Instructions`` etc. — which is how every shipped L4 file in
 # production is structured.
-_OP_LIKE_RE = re.compile(r"^(append|replace|insert-before|insert-after)(\s|$)")
+#
+# #13683: matched case-insensitively so a case-varied keyword (e.g.
+# ``### Replace step:cycle/boot``, capitalized by an author used to
+# Title-Case headings) is still recognized as an op ATTEMPT and routed
+# into ``_OP_RE`` below — which stays case-SENSITIVE, so the mismatched
+# case fails loud via the malformed-op diagnostic instead of silently
+# vanishing into the implicit append body as inert prose. No production
+# L4 file under ``.squidsquad/project/`` uses a Title-Case prose H3
+# starting with one of these four words, so widening the op-like net
+# case-insensitively carries no known false-positive risk today.
+_OP_LIKE_RE = re.compile(
+    r"^(append|replace|insert-before|insert-after)(\s|$)", re.IGNORECASE
+)
 # HTML-comment metadata trailer: ``<!-- key: value\n... -->`` at the end
 # of an H3 body. Multiple key:value lines allowed. Both ``<!--`` and
 # ``-->`` must be on their own lines for the trailer to count; comments

--- a/tests/test_13683_case_varied_op_keyword_rejected.py
+++ b/tests/test_13683_case_varied_op_keyword_rejected.py
@@ -1,0 +1,98 @@
+"""Regression test for #13683 — l4_parser.py's H3 op grammar was
+case-sensitive against the reserved op keywords, but the module's own
+docstring and #10987's design intent both promise malformed ops fail
+loud ("that's the 'malformed H3 op' AC bullet"). A case-varied exact
+keyword (``### Append``, ``### Replace step:cycle/boot``) matched
+neither the op-like check (case-sensitive) nor the malformed-diagnostic
+path, and was silently absorbed as inert prose into the slot's implicit
+append body instead: the intended customization never applied, no error
+was raised, and the malformed L4 syntax leaked verbatim into composed
+output.
+
+Fix: ``_OP_LIKE_RE`` now matches case-insensitively, so a case-varied
+keyword is still recognized as an op ATTEMPT and routed into ``_OP_RE``
+(still case-sensitive) — which now rejects it loudly via the existing
+malformed-op diagnostic instead of silently degrading to prose.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import l4_parser as l4  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "bad_h3",
+    [
+        "### Append",
+        "### APPEND",
+        "### Replace",
+        "### Replace step:cycle/boot",
+        "### REPLACE step:cycle/boot",
+        "### Insert-Before step:cycle/boot",
+        "### INSERT-AFTER step:cycle/boot",
+        "### apPEND",
+    ],
+)
+def test_case_varied_op_keyword_rejected_not_silently_absorbed(bad_h3):
+    text = f"## Agent Functions\n\n{bad_h3}\nbody\n"
+    with pytest.raises(l4.L4ParseError) as exc:
+        l4.parse_l4_text(text)
+    assert "malformed H3 op" in str(exc.value)
+
+
+def test_case_varied_op_keyword_error_names_the_offending_heading():
+    text = "## Agent Functions\n\n### Replace step:cycle/boot\nNEW BODY\n"
+    with pytest.raises(l4.L4ParseError) as exc:
+        l4.parse_l4_text(text)
+    assert "### Replace step:cycle/boot" in str(exc.value)
+
+
+class TestExistingBehaviorUnaffected:
+    """The fix widens the op-like net case-insensitively but must not
+    change behavior for canonical-case ops or genuinely unrelated prose.
+    """
+
+    def test_canonical_lowercase_ops_still_parse_normally(self):
+        text = (
+            "## Agent Functions\n\n"
+            "### replace step:cycle/boot\n\nNEW BOOT BODY\n"
+        )
+        doc = l4.parse_l4_text(text)
+        op = doc.slots["instructions"][0]
+        assert op.op_type == "replace"
+        assert op.target_step_id == "boot"
+        assert op.body_text == "NEW BOOT BODY"
+
+    def test_canonical_append_still_parses_normally(self):
+        text = "## Agent Functions\n\n### append\n\nExplicit append body.\n"
+        doc = l4.parse_l4_text(text)
+        op = doc.slots["instructions"][0]
+        assert op.op_type == "append"
+        assert op.body_text == "Explicit append body."
+
+    @pytest.mark.parametrize(
+        "prose_h3",
+        [
+            "### Boot & Queue",
+            "### insert-around step:cycle/foo",
+            "### appendix",
+            "### Zero-gap gate",
+        ],
+    )
+    def test_unrelated_prose_h3_still_treated_as_prose(self, prose_h3):
+        """Existing #10987 prose-H3 cases (none of which is a
+        case-varied reserved keyword) must remain unaffected."""
+        text = f"## Agent Functions\n\n{prose_h3}\n\nfollowing prose\n"
+        doc = l4.parse_l4_text(text)
+        instructions = doc.slots.get("instructions", [])
+        assert len(instructions) == 1
+        op = instructions[0]
+        assert op.op_type == "append"
+        assert op.target_step_id is None
+        assert prose_h3 in op.body_text


### PR DESCRIPTION
squidsquad/task/13683 l4_parser: reject case-varied H3 op keywords instead of silently absorbing as prose (#13683) ## Summary
- `_OP_LIKE_RE` (the L4 H3-op-attempt detector) was case-sensitive against the five reserved op keywords (`append`, `replace`, `insert-before`, `insert-after`), but the module's own docstring and #10987's design intent both promise malformed ops are rejected loudly ("that's the 'malformed H3 op' AC bullet").
- A case-varied exact keyword — e.g. `### Replace step:cycle/boot` — matched neither the op-like check (case-sensitive) nor the malformed-diagnostic path, and was silently absorbed as inert prose into the slot's implicit append body: the intended customization never applied, zero error was raised, and the malformed L4 syntax leaked verbatim into composed `CLAUDE.md` output.
- Fix: `_OP_LIKE_RE` now matches case-insensitively, so a case-varied keyword is still recognized as an op attempt and routed into `_OP_RE` — which stays case-sensitive — so the mismatch now raises the existing malformed-op diagnostic instead of silently degrading to prose.
- Verified no production L4 file under `.squidsquad/project/` has a Title-Case prose H3 heading starting with one of these four words, so the widened net carries no known false-positive risk against shipped content.

## Test plan
- New `tests/test_13683_case_varied_op_keyword_rejected.py` (11 cases): 8 case-varied keyword shapes (`### Append`, `### APPEND`, `### Replace step:cycle/boot`, `### REPLACE step:cycle/boot`, `### Insert-Before ...`, `### INSERT-AFTER ...`, `### apPEND`) all raise `L4ParseError` with "malformed H3 op"; error message names the offending heading verbatim; canonical lowercase `### replace step:cycle/<id>` and `### append` still parse identically to before; existing #10987 prose-H3 cases (`### Boot & Queue`, `### appendix`, `### Zero-gap gate`, etc.) remain treated as prose, unaffected.
- Full existing `tests/test_l4_parser.py` + `tests/test_l4_parser_10987_prose_h3.py` suites: no regressions.
- Full suite: `python tests/run_tests.py` — 53/53 OK.
- Static gate: `python tests/run_tests.py static` — 5778 gated tests, 0 failures, 0 errors.

Addresses #13683