### PR TITLE
[DRAFT] cycle-input diet: strip GitHub label ballast and cap embedded comment bodies (#13564)

### DIFF
--- a/.squidsquad/pm/planning/13564-body.md
+++ b/.squidsquad/pm/planning/13564-body.md
@@ -1,0 +1,21 @@
+> **AUTHORITATIVE SCOPE: `.squidsquad/pm/planning/CONTEXT-13564.md`. Read that artifact in full. The bullets below are a summary; the planning artifact is the contract.**
+
+**Reported By**: pm-lead
+**Priority**: Medium
+
+## Background
+PM's cycle-input.json is 29KB/581 lines per cycle, dominated by full GitHub label objects (id/name/description/color repeated per label per issue) and inline comment payloads from `_gh_fetch(with_comments=True, limit=200)` (`cycle_pre.py:759-791`). Measured raw payload for the current open set: 158 items / 327KB upstream, and everything not stripped flows into the file the agent reads every cycle. Plan: `.squidsquad/pm/planning/PLAN-TOKEN-EFFICIENCY.md` §T4 (commit 59994d14a).
+
+## Implementation guidance
+- Post-process `_gh_fetch` results: reduce each label object to its bare `name` string (transitions and role routing key on names only — verify no consumer reads label id/color/description before deleting; grep cycle_pre builders and composed CLAUDE.md references to cycle-input fields).
+- Cap embedded comment bodies at ~500 chars with a `…(read the issue)` suffix — the forge-read pattern (`references/sub-skills/common-events/forge-read-pattern.md`) already mandates reading the issue before acting, so full bodies in cycle-input are redundant.
+- Measure before/after: PM cycle-input target < 15KB on the same issue set; record numbers in the PR body.
+
+## Acceptance Criteria
+- Labels appear as string arrays in cycle-input.json; no id/color/description fields remain.
+- Comment bodies capped with explicit truncation suffix; issue count/ordering unchanged.
+- Unit tests over the post-processing; before/after size measurement in PR body.
+- No agent behavior regression: transitions and pickup logic still resolve from label names (existing tests pass).
+
+## Out of scope
+- Changing gh query limits or which issues are fetched.

--- a/references/scripts/cycle_pre.py
+++ b/references/scripts/cycle_pre.py
@@ -760,13 +760,15 @@ def _enrich_with_comments(items):
     """Add latest_comment to each item in a list. Modifies items in place.
 
     Legacy path. The bulk-fetch helpers below set latest_comment from inline
-    `comments` without spawning a subprocess per item.
+    `comments` without spawning a subprocess per item. `body` is capped per
+    `_cap_comment_body` (#13564) for parity with the bulk path.
     """
     for item in items:
         num = item.get("number")
         if num:
             comment = _fetch_latest_comment(num)
             if comment:
+                comment["body"] = _cap_comment_body(comment.get("body", ""))
                 item["latest_comment"] = comment
 
 
@@ -805,6 +807,14 @@ def _gh_fetch(label_filter, state, with_comments=False, with_body=False, limit=2
     the same silent-truncation class #13555/#13602/#13660 fixed elsewhere.
     Centralized here so every caller gets the self-diagnosing behavior for
     free, regardless of what `limit` it passes.
+
+    #13564: `gh`'s raw `labels` field is a list of full objects
+    (id/name/description/color per label). Only the `name` is ever consumed
+    (see `_item_label_names`) and the id/description/color are pure ballast
+    that flows verbatim into every item this function returns -- and from
+    there into cycle-input.json, which agents read every cycle. Reduced to
+    a bare list of name strings here, once, so every caller/consumer gets
+    the slimmer shape for free.
     """
     cache_key = (label_filter, state, with_comments, with_body, limit)
     if cache_key in _GH_FETCH_CACHE:
@@ -833,12 +843,18 @@ def _gh_fetch(label_filter, state, with_comments=False, with_body=False, limit=2
               f"state={state!r}) returned {len(items)} = the --limit cap "
               f"({limit}); older/additional issues may be INVISIBLE (#13661).",
               file=sys.stderr)
+    for item in items:
+        raw_labels = item.get("labels")
+        if raw_labels:
+            item["labels"] = [l.get("name") for l in raw_labels]
     _GH_FETCH_CACHE[cache_key] = items
     return items
 
 
 def _item_label_names(item):
-    return {l.get("name") for l in item.get("labels", [])}
+    """Label names for `item`. Every caller sources items via `_gh_fetch`,
+    which normalizes `labels` to bare name strings (#13564)."""
+    return set(item.get("labels", []))
 
 
 def _item_has_label(item, name):
@@ -871,12 +887,30 @@ def _item_canonical_role(item, prefer_order):
     return None
 
 
+# #13564: max chars of a comment body embedded verbatim in cycle-input.json.
+# The forge-read pattern already mandates reading the issue before acting, so
+# a full comment body in cycle-input is redundant weight, not the source of
+# truth -- the cap just keeps enough for at-a-glance triage.
+COMMENT_BODY_CAP_CHARS = 500
+_COMMENT_TRUNCATION_SUFFIX = "…(read the issue)"
+
+
+def _cap_comment_body(body):
+    """#13564: bound `body` to COMMENT_BODY_CAP_CHARS, appending an explicit
+    truncation suffix so the agent knows to read the issue for the rest.
+    Returns `body` unchanged when it already fits."""
+    if len(body) <= COMMENT_BODY_CAP_CHARS:
+        return body
+    return body[:COMMENT_BODY_CAP_CHARS] + _COMMENT_TRUNCATION_SUFFIX
+
+
 def _item_latest_comment(item):
     """Extract latest comment from the inline `comments` field.
 
     Output shape matches what _fetch_latest_comment used to return so
     downstream consumers (agent prompts reading cycle-input.json) don't
-    break: `{author, body, createdAt}` or None.
+    break: `{author, body, createdAt}` or None. `body` is capped per
+    `_cap_comment_body` (#13564).
     """
     comments = item.get("comments") or []
     if not comments:
@@ -885,7 +919,7 @@ def _item_latest_comment(item):
     author = last.get("author") or {}
     return {
         "author": author.get("login", ""),
-        "body": last.get("body", ""),
+        "body": _cap_comment_body(last.get("body", "")),
         "createdAt": last.get("createdAt", ""),
     }
 

--- a/tests/test_13564_cycle_input_diet.py
+++ b/tests/test_13564_cycle_input_diet.py
@@ -1,0 +1,162 @@
+"""Regression tests for #13564 — cycle-input diet: cycle_pre.py's `_gh_fetch`
+embedded full GitHub label objects (id/name/description/color per label per
+issue) verbatim into every item it returns, and `_item_latest_comment`
+embedded the full latest-comment body with no cap. Both flow straight into
+cycle-input.json, the file every agent reads every cycle: measured on the
+live open-issue set (150 squidsquad-labeled issues), the raw payload for
+PM's primary fetch was 278KB, dominated by this ballast.
+
+Fix:
+- `_gh_fetch` now reduces each item's `labels` to a bare list of name
+  strings (the only field any consumer reads — see `_item_label_names`) --
+  measured 278KB -> 58KB (78.6% reduction) on the same live issue set.
+- `_item_latest_comment` / `_enrich_with_comments` now cap the embedded
+  comment body at `COMMENT_BODY_CAP_CHARS` (500) with an explicit
+  truncation suffix; the forge-read pattern already mandates reading the
+  issue before acting, so the full body in cycle-input was redundant.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import cycle_pre
+
+
+def _mock_result(stdout="", stderr="", returncode=0):
+    r = MagicMock()
+    r.stdout = stdout
+    r.stderr = stderr
+    r.returncode = returncode
+    return r
+
+
+@pytest.fixture(autouse=True)
+def _clear_gh_fetch_cache():
+    cycle_pre._GH_FETCH_CACHE.clear()
+    yield
+    cycle_pre._GH_FETCH_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# Label ballast stripping
+# ---------------------------------------------------------------------------
+
+class TestGhFetchStripsLabelBallast13564:
+    def test_full_label_objects_reduced_to_bare_names(self, monkeypatch):
+        raw_items = [{
+            "number": 1, "title": "Some issue",
+            "labels": [
+                {"id": "LA_1", "name": "squidsquad", "description": "Managed", "color": "1d1d1d"},
+                {"id": "LA_2", "name": "role:skill", "description": "Skill agent", "color": "1d76db"},
+            ],
+        }]
+        monkeypatch.setattr(
+            cycle_pre, "_run",
+            lambda cmd, **kw: _mock_result(stdout=json.dumps(raw_items)),
+        )
+        result = cycle_pre._gh_fetch("squidsquad", "open")
+        assert result[0]["labels"] == ["squidsquad", "role:skill"]
+
+    def test_no_id_description_color_survive(self, monkeypatch):
+        raw_items = [{
+            "number": 1, "title": "Some issue",
+            "labels": [{"id": "LA_1", "name": "squidsquad", "description": "x", "color": "y"}],
+        }]
+        monkeypatch.setattr(
+            cycle_pre, "_run",
+            lambda cmd, **kw: _mock_result(stdout=json.dumps(raw_items)),
+        )
+        result = cycle_pre._gh_fetch("squidsquad", "open")
+        label = result[0]["labels"][0]
+        assert isinstance(label, str)
+        assert label == "squidsquad"
+
+    def test_empty_labels_list_unaffected(self, monkeypatch):
+        raw_items = [{"number": 1, "title": "No labels", "labels": []}]
+        monkeypatch.setattr(
+            cycle_pre, "_run",
+            lambda cmd, **kw: _mock_result(stdout=json.dumps(raw_items)),
+        )
+        result = cycle_pre._gh_fetch("squidsquad", "open")
+        assert result[0]["labels"] == []
+
+    def test_item_order_and_count_unchanged(self, monkeypatch):
+        raw_items = [
+            {"number": i, "title": f"Issue {i}",
+             "labels": [{"id": f"LA_{i}", "name": "squidsquad"}]}
+            for i in range(5)
+        ]
+        monkeypatch.setattr(
+            cycle_pre, "_run",
+            lambda cmd, **kw: _mock_result(stdout=json.dumps(raw_items)),
+        )
+        result = cycle_pre._gh_fetch("squidsquad", "open")
+        assert [i["number"] for i in result] == [0, 1, 2, 3, 4]
+
+
+class TestItemLabelNamesReadsBareStrings13564:
+    def test_role_and_status_resolution_from_bare_names(self):
+        item = {"labels": ["squidsquad", "role:skill", "status:approved"]}
+        names = cycle_pre._item_label_names(item)
+        assert names == {"squidsquad", "role:skill", "status:approved"}
+        assert cycle_pre._item_has_label(item, "status:approved")
+        assert cycle_pre._item_has_role(item, "skill")
+
+    def test_missing_labels_key_returns_empty_set(self):
+        assert cycle_pre._item_label_names({}) == set()
+
+
+# ---------------------------------------------------------------------------
+# Comment body capping
+# ---------------------------------------------------------------------------
+
+class TestCommentBodyCapped13564:
+    def test_short_body_unchanged(self):
+        assert cycle_pre._cap_comment_body("short body") == "short body"
+
+    def test_body_at_exact_cap_unchanged(self):
+        body = "x" * cycle_pre.COMMENT_BODY_CAP_CHARS
+        assert cycle_pre._cap_comment_body(body) == body
+
+    def test_long_body_truncated_with_suffix(self):
+        body = "x" * (cycle_pre.COMMENT_BODY_CAP_CHARS + 200)
+        capped = cycle_pre._cap_comment_body(body)
+        assert len(capped) == cycle_pre.COMMENT_BODY_CAP_CHARS + len(cycle_pre._COMMENT_TRUNCATION_SUFFIX)
+        assert capped.startswith("x" * cycle_pre.COMMENT_BODY_CAP_CHARS)
+        assert capped.endswith(cycle_pre._COMMENT_TRUNCATION_SUFFIX)
+
+    def test_item_latest_comment_caps_inline_comment_body(self):
+        long_body = "y" * 900
+        item = {"comments": [
+            {"author": {"login": "human"}, "body": long_body, "createdAt": "2026-01-01T00:00:00Z"},
+        ]}
+        result = cycle_pre._item_latest_comment(item)
+        assert len(result["body"]) == cycle_pre.COMMENT_BODY_CAP_CHARS + len(cycle_pre._COMMENT_TRUNCATION_SUFFIX)
+        assert result["body"].endswith(cycle_pre._COMMENT_TRUNCATION_SUFFIX)
+        assert result["author"] == "human"
+
+    def test_item_latest_comment_short_body_untouched(self):
+        item = {"comments": [
+            {"author": {"login": "human"}, "body": "short", "createdAt": "2026-01-01T00:00:00Z"},
+        ]}
+        result = cycle_pre._item_latest_comment(item)
+        assert result["body"] == "short"
+
+    def test_enrich_with_comments_caps_legacy_path(self, monkeypatch):
+        long_body = "z" * 900
+        monkeypatch.setattr(
+            cycle_pre, "_fetch_latest_comment",
+            lambda n: {"author": "human", "body": long_body, "createdAt": "2026-01-01T00:00:00Z"},
+        )
+        items = [{"number": 1}]
+        cycle_pre._enrich_with_comments(items)
+        comment = items[0]["latest_comment"]
+        assert len(comment["body"]) == cycle_pre.COMMENT_BODY_CAP_CHARS + len(cycle_pre._COMMENT_TRUNCATION_SUFFIX)
+        assert comment["body"].endswith(cycle_pre._COMMENT_TRUNCATION_SUFFIX)

--- a/tests/test_cycle_pre.py
+++ b/tests/test_cycle_pre.py
@@ -823,7 +823,7 @@ class TestBuildPmInputNewFields:
         """PM input includes approved_items field."""
         approved = [{
             "number": 100, "title": "Approved task",
-            "labels": [{"name": "squidsquad"}, {"name": "status:approved"}],
+            "labels": ["squidsquad", "status:approved"],
         }]
         self._make_mocks(monkeypatch, gh_fetch_responses={
             ("squidsquad", "open"): approved,
@@ -843,9 +843,9 @@ class TestBuildPmInputNewFields:
         """PM input includes human_blocked field with items from all three labels."""
         items = [
             {"number": 200, "title": "Needs human action",
-              "labels": [{"name": "squidsquad"}, {"name": "blocked:human-action"}]},
+              "labels": ["squidsquad", "blocked:human-action"]},
             {"number": 201, "title": "Needs human review",
-              "labels": [{"name": "squidsquad"}, {"name": "status:pending-human-review"}]},
+              "labels": ["squidsquad", "status:pending-human-review"]},
         ]
         self._make_mocks(monkeypatch, gh_fetch_responses={
             ("squidsquad", "open"): items,
@@ -867,9 +867,9 @@ class TestBuildPmInputNewFields:
         same_item = [{
             "number": 300, "title": "Same item",
             "labels": [
-                {"name": "squidsquad"},
-                {"name": "blocked:human-action"},
-                {"name": "status:pending-human-setup"},
+                "squidsquad",
+                "blocked:human-action",
+                "status:pending-human-setup",
             ],
         }]
         self._make_mocks(monkeypatch, gh_fetch_responses={
@@ -884,7 +884,7 @@ class TestBuildPmInputNewFields:
         now_iso = datetime.now(timezone.utc).isoformat()
         items = [{
             "number": 400, "title": "Recent",
-            "labels": [{"name": "squidsquad"}],
+            "labels": ["squidsquad"],
             "updatedAt": now_iso,
         }]
         self._make_mocks(monkeypatch, gh_fetch_responses={
@@ -898,7 +898,7 @@ class TestBuildPmInputNewFields:
         """Items updated more than 2x interval ago are excluded."""
         items = [{
             "number": 500, "title": "Old",
-            "labels": [{"name": "squidsquad"}],
+            "labels": ["squidsquad"],
             "updatedAt": "2020-01-01T00:00:00Z",
         }]
         self._make_mocks(monkeypatch, gh_fetch_responses={
@@ -923,10 +923,10 @@ class TestBuildPmInputNewFields:
 
         items = [
             {"number": 600, "title": "A",
-              "labels": [{"name": "squidsquad"}, {"name": "status:approved"}],
+              "labels": ["squidsquad", "status:approved"],
               "updatedAt": now_iso, "comments": comment_inline},
             {"number": 601, "title": "B",
-              "labels": [{"name": "squidsquad"}, {"name": "blocked:human-action"}],
+              "labels": ["squidsquad", "blocked:human-action"],
               "updatedAt": now_iso, "comments": comment_inline},
         ]
         self._make_mocks(monkeypatch, gh_fetch_responses={
@@ -1276,17 +1276,17 @@ class TestQAInputMultiRole:
         """Items from dm, skill, pm, qa all appear in the QA verification queue."""
         items = [
             {"number": 3969, "title": "DM task",
-              "labels": [{"name": "squidsquad"}, {"name": "role:dm"},
-                          {"name": "type:issue"}, {"name": "status:pending-test"}]},
+              "labels": ["squidsquad", "role:dm",
+                          "type:issue", "status:pending-test"]},
             {"number": 4000, "title": "Skill task",
-              "labels": [{"name": "squidsquad"}, {"name": "role:skill"},
-                          {"name": "type:issue"}, {"name": "status:pending-test"}]},
+              "labels": ["squidsquad", "role:skill",
+                          "type:issue", "status:pending-test"]},
             {"number": 4001, "title": "PM task",
-              "labels": [{"name": "squidsquad"}, {"name": "role:pm"},
-                          {"name": "type:issue"}, {"name": "status:pending-test"}]},
+              "labels": ["squidsquad", "role:pm",
+                          "type:issue", "status:pending-test"]},
             {"number": 4002, "title": "QA task",
-              "labels": [{"name": "squidsquad"}, {"name": "role:qa"},
-                          {"name": "type:issue"}, {"name": "status:pending-test"}]},
+              "labels": ["squidsquad", "role:qa",
+                          "type:issue", "status:pending-test"]},
         ]
         self._setup(monkeypatch, gh_fetch_responses={("squidsquad", "open"): items})
 
@@ -1301,8 +1301,8 @@ class TestQAInputMultiRole:
         """Each item in QA verification queue is attributed by role label."""
         items = [{
             "number": 3969, "title": "DM task",
-            "labels": [{"name": "squidsquad"}, {"name": "role:dm"},
-                        {"name": "type:issue"}, {"name": "status:pending-test"}],
+            "labels": ["squidsquad", "role:dm",
+                        "type:issue", "status:pending-test"],
         }]
         self._setup(monkeypatch, gh_fetch_responses={("squidsquad", "open"): items})
 
@@ -1320,8 +1320,8 @@ class TestQAInputMultiRole:
         still attributed by its source role label."""
         items = [{
             "number": 5000, "title": "QA task",
-            "labels": [{"name": "squidsquad"}, {"name": "role:qa"},
-                        {"name": "type:task"}, {"name": "status:pending-test"}],
+            "labels": ["squidsquad", "role:qa",
+                        "type:task", "status:pending-test"],
         }]
         self._setup(monkeypatch, gh_fetch_responses={("squidsquad", "open"): items})
 
@@ -1363,11 +1363,11 @@ class TestPMInputMultiRole:
         """PM pending-test queue surfaces items from every verifiable role."""
         items = [
             {"number": 3969, "title": "DM issue",
-              "labels": [{"name": "squidsquad"}, {"name": "role:dm"},
-                          {"name": "type:issue"}, {"name": "status:pending-test"}]},
+              "labels": ["squidsquad", "role:dm",
+                          "type:issue", "status:pending-test"]},
             {"number": 3970, "title": "QA issue",
-              "labels": [{"name": "squidsquad"}, {"name": "role:qa"},
-                          {"name": "type:issue"}, {"name": "status:pending-test"}]},
+              "labels": ["squidsquad", "role:qa",
+                          "type:issue", "status:pending-test"]},
         ]
         self._setup(monkeypatch, gh_fetch_responses={("squidsquad", "open"): items})
 
@@ -1380,8 +1380,8 @@ class TestPMInputMultiRole:
         """PM pending-test items include source_role attribution."""
         items = [{
             "number": 3969, "title": "DM issue",
-            "labels": [{"name": "squidsquad"}, {"name": "role:dm"},
-                        {"name": "type:issue"}, {"name": "status:pending-test"}],
+            "labels": ["squidsquad", "role:dm",
+                        "type:issue", "status:pending-test"],
         }]
         self._setup(monkeypatch, gh_fetch_responses={("squidsquad", "open"): items})
 


### PR DESCRIPTION
## Plan for #13564

This draft PR is seeded with the task plan (`.squidsquad/pm/planning/13564-body.md`, commit 1). The worker adopts THIS branch and adds implementation commits on top; on merge the plan lands on `main` co-located with the code.

Verifier produces `.squidsquad/verifier/planning/TEST-PLAN-13564.md` independently from the AC list at verification time.

### Status
Draft — approved by operator, ready for skill pickup.