### PR TITLE
skill

### DIFF
--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -1042,18 +1042,31 @@ def _neutralize_pr_body_before_merge(pr_number):
     fails, `gh api -X PATCH repos/:owner/:repo/pulls/<N> -f body=<...>`
     (the REST endpoint, not GraphQL) succeeds against the identical PR.
     Route the patch through `gh api` instead.
+
+    #13691 -- patching the PR body alone is not sufficient: for a
+    single-commit PR, GitHub's squash-merge defaults the squash commit's
+    message to that one commit's OWN message (not the PR body) when the
+    merge call passes no explicit subject/body, so a `Closes #N` sitting in
+    the commit message still reaches `main` verbatim. Returns
+    ``(title, neutralized_body)`` so ``pr_merge`` can pass BOTH explicitly
+    to `gh pr merge --squash`, bypassing GitHub's implicit default-selection
+    entirely (regardless of commit count). Returns ``(None, None)`` on any
+    fetch/parse failure -- fail-open, same as the rest of this function.
     """
     view_result = _run_list(
-        ["gh", "pr", "view", str(pr_number), "--json", "body"], check=False)
+        ["gh", "pr", "view", str(pr_number), "--json", "body,title"],
+        check=False)
     if view_result.returncode != 0:
-        return
+        return None, None
     try:
-        current_body = json.loads(view_result.stdout).get("body", "") or ""
+        pr_data = json.loads(view_result.stdout)
+        current_body = pr_data.get("body", "") or ""
+        title = pr_data.get("title", "") or ""
     except (json.JSONDecodeError, AttributeError):
-        return
+        return None, None
     neutralized_body = _neutralize_closing_keywords(current_body)
     if neutralized_body == current_body:
-        return
+        return title, neutralized_body
     edit_result = _run_list(
         ["gh", "api", "-X", "PATCH", f"repos/:owner/:repo/pulls/{pr_number}",
          "-f", f"body={neutralized_body}"],
@@ -1066,6 +1079,7 @@ def _neutralize_pr_body_before_merge(pr_number):
               f"closing keyword and the pre-merge edit failed: "
               f"{edit_result.stderr.strip()} -- merge proceeding anyway "
               f"(#13654)", file=sys.stderr)
+    return title, neutralized_body
 
 
 def pr_merge(pr_number, strategy="squash", _max_base_retries=3, _base_retry_delay=2.0):
@@ -1158,7 +1172,7 @@ def pr_merge(pr_number, strategy="squash", _max_base_retries=3, _base_retry_dela
     # human/agent must remember to follow is not a guard; this is the last
     # sanctioned checkpoint before GitHub's own merge-time auto-close fires,
     # so it is where the guard must be unconditional and unbypassable.
-    _neutralize_pr_body_before_merge(pr_number)
+    neutralized_title, neutralized_body = _neutralize_pr_body_before_merge(pr_number)
 
     # #13554 (SEV prevention): refuse to merge a PR that DECLARES changes to
     # main-only state/vault paths. These must never ride a feature PR -- the
@@ -1228,6 +1242,21 @@ def pr_merge(pr_number, strategy="squash", _max_base_retries=3, _base_retry_dela
     # Attempt merge, retrying ONLY the transient "Base branch was modified"
     # batch-ship race (#10540). A real merge conflict is terminal.
     merge_args = ["gh", "pr", "merge", str(pr_number), f"--{strategy}", "--delete-branch"]
+    # #13691: for squash, pass an EXPLICIT subject/body built from the
+    # (already-neutralized) PR title+body so GitHub never falls back to its
+    # own default squash-message selection -- which uses the sole commit's
+    # OWN (unneutralized) message for a single-commit PR, letting a stray
+    # "Closes #N" in a `git commit -m` call bypass the #13654 body guard
+    # entirely. Mirrors GitHub's own default subject convention (`<title>
+    # (#<pr_number>)`) so shipped history stays readable. Fail-open: only
+    # added when the pre-merge fetch succeeded (both values non-None) --
+    # otherwise falls through to the prior implicit-default behavior rather
+    # than blocking a merge that already passed every other gate.
+    if strategy == "squash" and neutralized_title is not None:
+        merge_args += [
+            "--subject", f"{neutralized_title} (#{pr_number})",
+            "--body", neutralized_body,
+        ]
     for attempt in range(_max_base_retries + 1):
         result = _run_list(merge_args, check=False)
         if result.returncode == 0:

--- a/tests/test_13447_pr_merge_post_merge_sync.py
+++ b/tests/test_13447_pr_merge_post_merge_sync.py
@@ -184,7 +184,8 @@ class TestPrMergePostMergeSync13447:
         with patch("git_ops._pr_behind_by", return_value=0), \
                 patch("git_ops._pr_state_scope_violations", return_value=[]), \
                 patch("git_ops._post_merge_scope_audit"), \
-                patch("git_ops._neutralize_pr_body_before_merge"):
+                patch("git_ops._neutralize_pr_body_before_merge",
+                      return_value=(None, None)):
             yield
 
     @patch("git_ops._get_working_branch", return_value=WORKING)

--- a/tests/test_13654_pre_merge_body_neutralize.py
+++ b/tests/test_13654_pre_merge_body_neutralize.py
@@ -138,7 +138,7 @@ class TestPrMergeCallsNeutralizeBeforeMerging:
                 patch("git_ops._checkout_and_ff_working_after_merge"):
             yield
 
-    @patch("git_ops._neutralize_pr_body_before_merge")
+    @patch("git_ops._neutralize_pr_body_before_merge", return_value=(None, None))
     @patch("git_ops._run_list")
     def test_success_path_neutralizes_before_merge_call(self, mock_rl, mock_neutralize):
         calls = []
@@ -156,7 +156,7 @@ class TestPrMergeCallsNeutralizeBeforeMerging:
         assert success is True
         mock_neutralize.assert_called_once_with(13654)
 
-    @patch("git_ops._neutralize_pr_body_before_merge")
+    @patch("git_ops._neutralize_pr_body_before_merge", return_value=(None, None))
     @patch("git_ops._run_list")
     def test_already_merged_skips_neutralize(self, mock_rl, mock_neutralize):
         mock_rl.return_value = _mk(0, json.dumps({"state": "MERGED"}))
@@ -164,7 +164,7 @@ class TestPrMergeCallsNeutralizeBeforeMerging:
         assert success is True
         mock_neutralize.assert_not_called()
 
-    @patch("git_ops._neutralize_pr_body_before_merge")
+    @patch("git_ops._neutralize_pr_body_before_merge", return_value=(None, None))
     @patch("git_ops._run_list")
     def test_neutralize_runs_before_state_scope_and_behind_guards(
         self, mock_rl, mock_neutralize

--- a/tests/test_13691_squash_merge_explicit_body.py
+++ b/tests/test_13691_squash_merge_explicit_body.py
@@ -1,0 +1,156 @@
+"""Regression test for #13691 — #13654's `_neutralize_pr_body_before_merge`
+patches closing keywords out of the PR *body* right before merge, but does
+not touch the underlying git commit objects. For a single-commit PR,
+GitHub's squash-merge defaults the squash commit's message to that ONE
+commit's own message (not the PR body) when `gh pr merge --squash` is
+called with no explicit subject/body — so a `Closes #N` sitting in the
+commit message (not the PR body) still reaches `main` verbatim and still
+auto-closes the issue, bypassing the #13654 guard entirely.
+
+Live evidence: shipping #13683, the issue auto-closed despite PR #13689's
+body correctly reading "Addresses #13683" — the actual squash commit on
+main carried "Closes #13683" sourced from the PR's sole commit message.
+
+Fix: `_neutralize_pr_body_before_merge` now returns `(title,
+neutralized_body)`; `pr_merge`'s squash call passes them EXPLICITLY via
+`--subject`/`--body`, so GitHub's implicit default-selection (PR body for
+multi-commit PRs, sole commit message for single-commit PRs) is never
+reached — closing the gap regardless of commit count.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import git_ops
+
+
+def _mk(rc=0, stdout="", stderr=""):
+    m = MagicMock()
+    m.returncode = rc
+    m.stdout = stdout
+    m.stderr = stderr
+    return m
+
+
+class TestNeutralizeReturnsTitleAndBody13691:
+    @patch("git_ops._run_list")
+    def test_returns_title_and_neutralized_body_on_success(self, mock_rl):
+        def side_effect(cmd, check=False):
+            if cmd[:3] == ["gh", "pr", "view"]:
+                return _mk(0, json.dumps(
+                    {"title": "Fix the thing (#13531)", "body": "Summary.\nFixes #13531"}))
+            return _mk(0)
+        mock_rl.side_effect = side_effect
+
+        title, body = git_ops._neutralize_pr_body_before_merge(13624)
+        assert title == "Fix the thing (#13531)"
+        assert "Fixes #13531" not in body
+        assert "Addresses #13531" in body
+
+    @patch("git_ops._run_list")
+    def test_returns_title_and_body_unchanged_when_already_clean(self, mock_rl):
+        mock_rl.side_effect = lambda cmd, check=False: _mk(
+            0, json.dumps({"title": "Clean PR", "body": "Addresses #1"}))
+        title, body = git_ops._neutralize_pr_body_before_merge(13624)
+        assert title == "Clean PR"
+        assert body == "Addresses #1"
+
+    @patch("git_ops._run_list")
+    def test_view_failure_returns_none_none(self, mock_rl):
+        mock_rl.return_value = _mk(1, stderr="not found")
+        title, body = git_ops._neutralize_pr_body_before_merge(13624)
+        assert (title, body) == (None, None)
+
+    @patch("git_ops._run_list")
+    def test_malformed_json_returns_none_none(self, mock_rl):
+        mock_rl.side_effect = lambda cmd, check=False: (
+            _mk(0, "not json") if cmd[:3] == ["gh", "pr", "view"] else _mk(1)
+        )
+        title, body = git_ops._neutralize_pr_body_before_merge(13624)
+        assert (title, body) == (None, None)
+
+    @patch("git_ops._run_list")
+    def test_requests_title_field_alongside_body(self, mock_rl):
+        """#13691: the view call must request title too, so pr_merge can
+        build an explicit --subject without a second gh round-trip."""
+        mock_rl.side_effect = lambda cmd, check=False: _mk(
+            0, json.dumps({"title": "T", "body": "B"}))
+        git_ops._neutralize_pr_body_before_merge(13624)
+        view_call = mock_rl.call_args_list[0].args[0]
+        json_idx = view_call.index("--json")
+        fields = view_call[json_idx + 1].split(",")
+        assert "title" in fields
+        assert "body" in fields
+
+
+class TestSquashMergePassesExplicitSubjectBody13691:
+    @pytest.fixture(autouse=True)
+    def _safe_guards(self):
+        with patch("git_ops._pr_behind_by", return_value=0), \
+                patch("git_ops._pr_state_scope_violations", return_value=[]), \
+                patch("git_ops._post_merge_scope_audit"), \
+                patch("git_ops._revert_composed_state_contamination"), \
+                patch("git_ops._checkout_and_ff_working_after_merge"):
+            yield
+
+    def _run_merge(self, mock_rl, neutralize_return, strategy="squash"):
+        def side_effect(cmd, check=False):
+            if cmd[:3] == ["gh", "pr", "view"] and "state,isDraft" in cmd:
+                return _mk(0, json.dumps({"state": "OPEN", "isDraft": False}))
+            if cmd[:3] == ["gh", "pr", "merge"]:
+                return _mk(0)
+            return _mk(0, json.dumps({"headRefName": "squidsquad/skill/13691"}))
+        mock_rl.side_effect = side_effect
+        with patch("git_ops._neutralize_pr_body_before_merge",
+                    return_value=neutralize_return):
+            success, msg = git_ops.pr_merge(13691, strategy)
+        assert success is True
+        merge_calls = [c.args[0] for c in mock_rl.call_args_list
+                        if c.args[0][:3] == ["gh", "pr", "merge"]]
+        assert len(merge_calls) == 1
+        return merge_calls[0]
+
+    @patch("git_ops._run_list")
+    def test_squash_call_carries_explicit_subject_and_body(self, mock_rl):
+        merge_call = self._run_merge(
+            mock_rl, ("My Fix Title", "Addresses #13531"))
+        assert "--subject" in merge_call
+        assert merge_call[merge_call.index("--subject") + 1] == "My Fix Title (#13691)"
+        assert "--body" in merge_call
+        assert merge_call[merge_call.index("--body") + 1] == "Addresses #13531"
+
+    @patch("git_ops._run_list")
+    def test_squash_call_omits_subject_body_on_fetch_failure(self, mock_rl):
+        """Fail-open: a gh hiccup on the pre-merge fetch must not block the
+        merge — falls through to the prior implicit-default behavior."""
+        merge_call = self._run_merge(mock_rl, (None, None))
+        assert "--subject" not in merge_call
+        assert "--body" not in merge_call
+
+    @patch("git_ops._run_list")
+    def test_merge_strategy_never_gets_explicit_subject_body(self, mock_rl):
+        """Scoped to squash only — a real merge commit doesn't inherit
+        closing keywords from a single commit message the same way."""
+        merge_call = self._run_merge(
+            mock_rl, ("Title", "Body"), strategy="merge")
+        assert "--subject" not in merge_call
+        assert "--body" not in merge_call
+
+    @patch("git_ops._run_list")
+    def test_explicit_body_is_the_neutralized_one_not_raw(self, mock_rl):
+        """The whole point: whatever reaches --body must already be
+        keyword-neutralized, so it can never re-introduce a closing
+        keyword GitHub would act on."""
+        merge_call = self._run_merge(
+            mock_rl, ("Fix", "Summary.\nAddresses #999"))
+        body_arg = merge_call[merge_call.index("--body") + 1]
+        assert "Closes" not in body_arg
+        assert "Fixes" not in body_arg
+        assert "Addresses #999" in body_arg

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -575,7 +575,8 @@ class TestPrMerge:
                 patch("git_ops._post_merge_scope_audit"), \
                 patch("git_ops._revert_composed_state_contamination"), \
                 patch("git_ops._checkout_and_ff_working_after_merge"), \
-                patch("git_ops._neutralize_pr_body_before_merge"):
+                patch("git_ops._neutralize_pr_body_before_merge",
+                      return_value=(None, None)):
             yield
 
     @patch("git_ops._run_list")
@@ -3371,7 +3372,8 @@ class TestPrMergeDraftSelfHeal:
                 patch("git_ops._post_merge_scope_audit"), \
                 patch("git_ops._revert_composed_state_contamination"), \
                 patch("git_ops._checkout_and_ff_working_after_merge"), \
-                patch("git_ops._neutralize_pr_body_before_merge"):
+                patch("git_ops._neutralize_pr_body_before_merge",
+                      return_value=(None, None)):
             yield
 
     @patch("git_ops.pr_ready", return_value=True)


### PR DESCRIPTION
squidsquad/task/13691 pr_merge: pass explicit --subject/--body on squash to close single-commit closing-keyword bypass (#13691) ## Summary
- #13654's `_neutralize_pr_body_before_merge()` patches closing keywords out of a PR's `body` field right before merge — and it works, verified live. But it never touches the underlying git commit objects being merged.
- For a **single-commit PR**, GitHub's squash-merge defaults the squash commit's message to that one commit's OWN message (not the PR body) when `gh pr merge --squash` is called with no explicit subject/body — so a `Closes #N` sitting in the commit message (a very natural thing to write in a `git commit -m` call) still reached `main` verbatim and still auto-closed the issue, completely bypassing the #13654 guard.
- **Live evidence cited in the issue**: shipping #13683 this session, DM found the issue already auto-closed despite PR #13689's body correctly reading "Addresses #13683" — the actual merge commit on `main` (779a708f9) carried "Addresses #13683", sourced from the PR's sole commit message, not its body.

## Fix
- `_neutralize_pr_body_before_merge()` now fetches `title` alongside `body` and returns `(title, neutralized_body)` instead of nothing.
- `pr_merge()`'s squash call now passes both explicitly via `--subject`/`--body`, so GitHub's implicit default-selection logic (PR body for multi-commit PRs, sole commit message for single-commit PRs) is **never reached** — closing the gap regardless of commit count.
- Subject mirrors GitHub's own default convention (`<title> (#<pr_number>)`) so shipped history stays readable and consistent with existing merge commits.
- Scoped to `squash` only — a real merge-commit strategy doesn't inherit closing keywords from a single commit message the same way, and an existing squash-only precedent (#13271's behind-count guard) already lives in this same function.
- Fail-open: when the pre-merge title/body fetch itself fails, falls through to the prior implicit-default behavior rather than blocking a merge that already passed every other gate.

## Test plan
- New `tests/test_13691_squash_merge_explicit_body.py` (9 cases): `_neutralize_pr_body_before_merge` returns `(title, neutralized_body)` on success / `(None, None)` on view failure or malformed JSON / requests `title` alongside `body` in one round-trip; the squash `gh pr merge` call carries explicit `--subject`/`--body` built from the neutralized values, omits them on fetch failure (fail-open) or under the `merge` strategy, and the `--body` value is confirmed to be the already-neutralized text (no `Closes`/`Fixes` keyword survives).
- Updated 3 existing mocks across `test_git_ops.py`/`test_13654_pre_merge_body_neutralize.py`/`test_13447_pr_merge_post_merge_sync.py` that stubbed `_neutralize_pr_body_before_merge` bare (now unpacked as a 2-tuple, so a bare `MagicMock()` unpack would raise) to `return_value=(None, None)`, matching the fail-open path — these merge-flow tests don't assert on subject/body specifics, only that merge succeeds.
- Full suite: `python tests/run_tests.py` — 53/53 OK.
- Static gate: `python tests/run_tests.py static` — 5787 gated tests, 0 failures, 0 errors.

Addresses #13691