### PR TITLE
#13711: improvement-scan.md Step 6 append->prepend wording fix

### DIFF
--- a/references/sub-skills/common/improvement-scan.md
+++ b/references/sub-skills/common/improvement-scan.md
@@ -60,7 +60,7 @@ Write status bar state: `scanning|🔍 Scanning [target description]...`
    ```
    If `scan_index.py` is not available, skip the DB write — the markdown write below is sufficient.
 
-   Also append to `.squidsquad/[your-role]/scan-history.md`:
+   Also record in `.squidsquad/[your-role]/scan-history.md` — **prepend** the new block immediately after any preamble/header line, so it becomes the FIRST `## Scan` block in the file, not the last. Entries are newest-first (#13566/#13711): the improvement-scan fallback read (Step 3 above) and `scan_index.py`'s retention-cap pruning both depend on "the first N blocks" being the newest ones. A literal end-of-file append would silently corrupt that ordering:
 
    ```markdown
    ## Scan — YYYY-MM-DD HH:MM


### PR DESCRIPTION
Step 6 said "append" with no ordering guidance, contradicting the
newest-first convention Step 3's fallback-read text (#13566) and
scan_index.py's retention-cap pruning both depend on. Reworded to
explicitly say prepend the new block after any preamble/header, matching
Step 3's language and citing the #13566 dependency.

Prose-only change, no code. Verified via a real 3-way merge test that it
coexists cleanly with #13566's already-shipped Step 3 text (both survive
a merge with zero conflicts).