### PR TITLE
#13714: gitignore harness runtime logs (stop commit-state sweep)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@
 .squidsquad/*/cycle-input.json
 .squidsquad/*/cycle-output.json
 .squidsquad/.harness-port
+.squidsquad/harness-errors.log
+.squidsquad/harness-supervisor.log
+.squidsquad/harness-supervisor.log.err
 
 .claude/commands/squidsquad-*
 .claude/settings.local.json

--- a/tests/test_13714_harness_log_gitignore.py
+++ b/tests/test_13714_harness_log_gitignore.py
@@ -1,0 +1,66 @@
+"""#13714 — harness runtime log files must never enter git.
+
+commit_state()'s sweep (references/scripts/git_ops.py) stages every
+untracked/modified path under .squidsquad/ reported by `git status
+--porcelain`. Live, continuously-growing harness logs (harness-errors.log,
+harness-supervisor.log, harness-supervisor.log.err) got swept into a state
+commit on main because nothing ignored them. Fixed via .gitignore entries —
+git-ignored paths never show up in `git status --porcelain`, so the sweep
+excludes them automatically with no code change needed.
+"""
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+HARNESS_LOG_NAMES = [
+    "harness-errors.log",
+    "harness-supervisor.log",
+    "harness-supervisor.log.err",
+]
+
+
+class TestHarnessLogsGitignored:
+    def test_gitignore_lists_all_three_log_names(self):
+        gitignore = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8")
+        for name in HARNESS_LOG_NAMES:
+            assert f".squidsquad/{name}" in gitignore, (
+                f".gitignore is missing an entry for {name}")
+
+    def test_git_actually_ignores_each_log_path(self):
+        for name in HARNESS_LOG_NAMES:
+            probe = REPO_ROOT / ".squidsquad" / name
+            pre_existing = probe.exists()
+            if not pre_existing:
+                probe.write_text("probe", encoding="utf-8")
+            try:
+                result = subprocess.run(
+                    ["git", "check-ignore", "-q", f".squidsquad/{name}"],
+                    cwd=str(REPO_ROOT),
+                )
+                assert result.returncode == 0, (
+                    f".squidsquad/{name} is NOT git-ignored")
+            finally:
+                if not pre_existing:
+                    probe.unlink()
+
+    def test_untracked_harness_log_absent_from_status_porcelain(self):
+        """The actual failure mode from #13714: a live untracked log file
+        must not appear in `git status --porcelain` (what commit_state's
+        sweep reads), even though the file physically exists on disk."""
+        probe = REPO_ROOT / ".squidsquad" / "harness-errors.log"
+        pre_existing = probe.exists()
+        if not pre_existing:
+            probe.write_text("simulated harness log line\n", encoding="utf-8")
+        try:
+            result = subprocess.run(
+                ["git", "status", "--porcelain", ".squidsquad/harness-errors.log"],
+                cwd=str(REPO_ROOT), capture_output=True, text=True,
+            )
+            assert result.stdout.strip() == "", (
+                "an ignored harness log still shows up in git status --porcelain "
+                f"(would be swept by commit_state): {result.stdout!r}")
+        finally:
+            if not pre_existing:
+                probe.unlink()


### PR DESCRIPTION
commit_state()'s sweep stages everything git status --porcelain reports
under .squidsquad/. Live harness logs (harness-errors.log,
harness-supervisor.log, harness-supervisor.log.err) had no .gitignore
entry, so they got swept into a state commit on main (already reverted
by PM via git rm --cached). Added the three exact filenames to
.gitignore, same pattern as the existing .harness-port entry -- no
code changes needed since git-ignored paths never show up in
git status --porcelain.

Regression test: tests/test_13714_harness_log_gitignore.py.