### PR TITLE
#13723/#13724: merge/state guards can't distinguish authoritative deletion from a genuine drop

### DIFF
--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -1462,20 +1462,45 @@ def _merge_dropped_state_paths(pre_ref):
     delete with zero conflict signal (no unmerged path for
     ``_auto_resolve_state_conflicts`` to catch). Returns a sorted list of dropped
     paths (empty if none / on any git uncertainty -> fail-safe: never a spurious
-    restore)."""
+    restore).
+
+    #13723: a path absent/emptied post-merge is only a genuine DROP if the
+    CANONICAL REMOTE (``origin/<working>``) does NOT also confirm the deletion.
+    If ``origin/<working>``'s current tip also has the path absent/empty, the
+    deletion is authoritative (a teammate's own committed fix landing via
+    merge, not something the merge machinery silently ate) -- restoring from
+    ``ORIG_HEAD`` would silently revert that teammate's own fix (observed
+    live: PM's ``git rm --cached`` of two harness log files, landing via
+    merge, got reverted by this guard before the #13723 fix). Deliberately
+    checks ``origin/<working>`` specifically, NOT ``HEAD^2`` (whatever branch
+    happened to be merged in) -- the ORIGINAL #13556 incident this guard
+    protects against is exactly a throwaway/feature branch's deletion
+    silently winning over untouched canonical content, so an arbitrary
+    merged-in branch's deletion must NOT be trusted the same way a confirmed
+    canonical-remote deletion is. Any resolution failure (no ``origin`` remote
+    configured, ref not fetched, detached test repo) falls back to the
+    ORIGINAL #13556 behavior (restore) -- the new check only ever narrows
+    (opts OUT of) a restore with positive confirmation, never the reverse,
+    so an unrelated resolution failure can't defeat the core protection."""
     before = _state_blob_sizes(pre_ref)
     if not before:  # None (git failure) or {} (no protected paths) -> nothing to check
         return []
     after = _state_blob_sizes("HEAD")
     if after is None:  # DS-13556 F2: git failure on HEAD -> unknown, never a mass-restore
         return []
+    origin_state = _state_blob_sizes(f"origin/{_get_working_branch()}")
     dropped = []
     for path, size in before.items():
         if size == 0:
             continue  # was already empty pre-merge -> a later empty isn't a drop
         now = after.get(path)
-        if now is None or now == 0:  # absent, or emptied
-            dropped.append(path)
+        if now is not None and now != 0:
+            continue  # still present post-merge -> not dropped
+        if origin_state is not None:
+            origin_size = origin_state.get(path)
+            if origin_size is None or origin_size == 0:
+                continue  # #13723: canonical remote confirms the deletion -> legitimate
+        dropped.append(path)
     return sorted(dropped)
 
 
@@ -2354,6 +2379,31 @@ def guard_staged_state():
             state_staged.append(p)
     if not state_staged:
         return []
+
+    # #13724: a staged state path whose content already matches
+    # origin/<working>'s current tip produces ZERO diff for that path in the
+    # PR either way -- stripping it back to HEAD (the feature branch's own,
+    # possibly-stale, pre-merge value) actively HURTS here: it turns a
+    # no-op path into a real revert-looking diff against main. This fires on
+    # a legitimate `git merge origin/<working>` conflict-resolution commit
+    # on a stale feature branch, where the merge's index already holds
+    # main's newer state content for these paths -- reported live this
+    # session: guard_staged_state reverting merged-in state content caused
+    # the harness /merge endpoint to reject two otherwise-clean PRs
+    # (#13712, #13713) as carrying "out-of-scope state/vault changes",
+    # when in fact the guard itself introduced that divergence from main.
+    origin_working = f"origin/{working}"
+    to_unstage = []
+    for p in state_staged:
+        matches_main = _run_list(
+            ["git", "diff", "--cached", "--quiet", origin_working, "--", p],
+            check=False)
+        if matches_main.returncode == 0:
+            continue  # identical to origin/<working> already -- leave staged
+        to_unstage.append(p)
+    if not to_unstage:
+        return []
+    state_staged = to_unstage
 
     # Unstage (reset, not restore --staged: works on older git and leaves the
     # working-tree copy untouched). Per-path so one bad path can't drop the lot.

--- a/tests/test_12750_plan_in_pr_guard.py
+++ b/tests/test_12750_plan_in_pr_guard.py
@@ -85,8 +85,13 @@ class TestGuardExemptsPlanBody:
             return _mock_result(stdout="squidsquad/task/12750\n")
 
         def fake_run_list(cmd, check=True):
-            if cmd[:3] == ["git", "diff", "--cached"]:
+            if cmd[:4] == ["git", "diff", "--cached", "--name-only"]:
                 return _mock_result(stdout="\n".join(staged_paths) + "\n")
+            if cmd[:3] == ["git", "diff", "--cached"] and "--quiet" in cmd:
+                # #13724: matches-origin/main check -- differs (returncode=1)
+                # so every state path proceeds to the strip path below,
+                # matching this test's "state siblings get stripped" intent.
+                return _mock_result(returncode=1)
             if cmd[:2] == ["git", "reset"]:
                 reset_calls.append(cmd[-1])  # the path arg
                 return _mock_result()

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1053,6 +1053,59 @@ class TestRestoreMergeDroppedState13556:
         assert restored == []  # ff → no HEAD^2 → guard is a no-op
         assert not (repo / note).exists()
 
+    def test_real_merge_of_canonical_remote_deletion_not_restored(self, tmp_path, monkeypatch):
+        """#13723 end-to-end: origin/main ITSELF deletes a protected path (a
+        teammate's own git rm --cached, exactly PM's #13714 untrack commit
+        this session), our local main is stale and diverged (an unrelated
+        local commit), and `git merge origin/main --no-edit` cleanly adopts
+        the deletion (no conflict -- our side never touched the file). The
+        guard must NOT restore it: origin/main confirms the deletion is
+        authoritative, not something the merge silently lost."""
+        bare = tmp_path / "origin.git"
+        self._git(tmp_path, "init", "--bare", str(bare))
+
+        origin_clone = tmp_path / "origin_clone"
+        self._git(tmp_path, "clone", str(bare), str(origin_clone))
+        self._git(origin_clone, "config", "user.email", "t@t")
+        self._git(origin_clone, "config", "user.name", "t")
+        self._git(origin_clone, "checkout", "-b", "main")
+        log = ".squidsquad/harness-errors.log"
+        (origin_clone / ".squidsquad").mkdir(parents=True)
+        (origin_clone / log).write_text("live log content\n")
+        self._git(origin_clone, "add", "-A")
+        self._git(origin_clone, "commit", "-m", "base: log tracked")
+        self._git(origin_clone, "push", "origin", "HEAD:main")
+
+        # local clones AFTER origin has content on main. The bare repo's HEAD
+        # symref was fixed at `init --bare` time (before "main" existed), so
+        # clone can't auto-checkout it -- explicit checkout instead.
+        local = tmp_path / "local"
+        self._git(tmp_path, "clone", str(bare), str(local))
+        self._git(local, "config", "user.email", "t@t")
+        self._git(local, "config", "user.name", "t")
+        self._git(local, "checkout", "main")
+
+        # origin: a teammate untracks the log (PM's real #13714 fix shape).
+        self._git(origin_clone, "rm", "--cached", log)
+        self._git(origin_clone, "commit", "-m", "untrack log")
+        self._git(origin_clone, "push", "origin", "HEAD:main")
+
+        # local: diverges with an unrelated commit BEFORE fetching the above.
+        (local / "code.py").write_text("x = 1\n")
+        self._git(local, "add", "code.py")
+        self._git(local, "commit", "-m", "local: unrelated code")
+
+        self._git(local, "fetch", "origin")
+        self._git(local, "merge", "origin/main", "--no-edit")
+        assert not (local / log).exists(), "setup failed to reproduce the clean delete"
+
+        monkeypatch.setattr(git_ops, "REPO_ROOT", local)
+        with patch.object(git_ops, "_emit"):
+            restored = git_ops._restore_merge_dropped_state()
+        assert restored == [], (
+            "origin/main confirms the deletion -- must not be restored")
+        assert not (local / log).exists()
+
     def test_no_orig_head_is_noop(self, tmp_path, monkeypatch):
         """A fresh repo with no merge (no ORIG_HEAD) → guard returns [] cleanly."""
         repo = tmp_path / "fresh"
@@ -1091,9 +1144,12 @@ class TestRestoreMergeDroppedState13556:
                   ".squidsquad/skill/working-state.md": 800}
         after = {".squidsquad/vault/galaxy/a.md": 0,     # emptied -> drop
                  ".squidsquad/vault/galaxy/b.md": 0}     # still empty -> not a drop
+        # #13723: incoming side still has real content for both -> genuine drops.
+        incoming = {".squidsquad/vault/galaxy/a.md": 40,
+                    ".squidsquad/skill/working-state.md": 800}
         # working-state.md absent in `after` -> dropped.
         with patch.object(git_ops, "_state_blob_sizes",
-                          side_effect=[before, after]):
+                          side_effect=[before, after, incoming]):
             assert git_ops._merge_dropped_state_paths("ORIG_HEAD") == [
                 ".squidsquad/skill/working-state.md",
                 ".squidsquad/vault/galaxy/a.md",
@@ -1117,13 +1173,58 @@ class TestRestoreMergeDroppedState13556:
 
     def test_dropped_paths_genuine_empty_head_restores_all(self):
         """A merge that deleted ALL protected files (HEAD genuinely empty {}, not
-        a git failure) IS a real mass-drop → all restored."""
+        a git failure) IS a real mass-drop → all restored -- when the canonical
+        remote still has real content for them (#13723: not an upstream deletion)."""
         before = {".squidsquad/vault/galaxy/a.md": 40,
                   ".squidsquad/skill/working-state.md": 800}
+        origin_state = dict(before)  # origin/<working> never deleted these -> genuine drop
         with patch.object(git_ops, "_state_blob_sizes",
-                          side_effect=[before, {}]):  # HEAD genuinely has none
+                          side_effect=[before, {}, origin_state]):  # HEAD genuinely has none
             assert git_ops._merge_dropped_state_paths("ORIG_HEAD") == [
                 ".squidsquad/skill/working-state.md",
+                ".squidsquad/vault/galaxy/a.md",
+            ]
+
+    def test_dropped_paths_origin_confirms_deletion_not_restored(self):
+        """#13723: if origin/<working>'s current tip ALSO has a path
+        absent/emptied, the deletion is authoritative (already landed on the
+        canonical remote, e.g. a teammate's own untrack commit) -- not a drop."""
+        before = {".squidsquad/vault/galaxy/a.md": 40,
+                  ".squidsquad/skill/working-state.md": 800}
+        after = {}  # both absent post-merge
+        origin_state = {".squidsquad/vault/galaxy/a.md": 0,
+                        ".squidsquad/skill/working-state.md": 40}
+        # a.md: origin also has it emptied -> legitimate, not restored.
+        # working-state.md: origin still has real content -> genuine drop.
+        with patch.object(git_ops, "_state_blob_sizes",
+                          side_effect=[before, after, origin_state]):
+            assert git_ops._merge_dropped_state_paths("ORIG_HEAD") == [
+                ".squidsquad/skill/working-state.md",
+            ]
+
+    def test_dropped_paths_origin_absent_entirely_not_restored(self):
+        """#13723: origin/<working> missing the path altogether (not just
+        emptied) is the same signal as an explicit delete -- not a drop."""
+        before = {".squidsquad/vault/galaxy/a.md": 40}
+        after = {}
+        origin_state = {}  # path doesn't exist on the canonical remote at all
+        with patch.object(git_ops, "_state_blob_sizes",
+                          side_effect=[before, after, origin_state]):
+            assert git_ops._merge_dropped_state_paths("ORIG_HEAD") == []
+
+    def test_dropped_paths_origin_unreadable_falls_back_to_restore(self):
+        """#13723: if origin/<working> can't be resolved (no remote configured,
+        ref not fetched, git failure -> None), the new check must NOT defeat
+        the original #13556 protection -- fall back to restoring, exactly as
+        before this fix. This is what keeps the ORIGINAL #13556 scenario
+        (an arbitrary merged-in branch's deletion, e.g. TestRestoreMergeDropped
+        State13556._repo()'s fixture, which has no origin remote at all)
+        correctly protected."""
+        before = {".squidsquad/vault/galaxy/a.md": 40}
+        after = {}
+        with patch.object(git_ops, "_state_blob_sizes",
+                          side_effect=[before, after, None]):
+            assert git_ops._merge_dropped_state_paths("ORIG_HEAD") == [
                 ".squidsquad/vault/galaxy/a.md",
             ]
 
@@ -2899,10 +3000,15 @@ class TestGuardStagedState11511:
     def test_feature_branch_unstages_state_files(self, _wb, mock_run, mock_run_list):
         mock_run.return_value = _mock_result(stdout="squidsquad/task/11511\n")
         # diff --cached lists both code and state; only state should be unstaged.
+        # #13724: each state path is first checked against origin/<working> --
+        # returncode=1 (differs) means it's a genuine own-edit leak, proceed to
+        # unstage as before.
         mock_run_list.side_effect = [
             _mock_result(stdout="references/scripts/git_ops.py\n"
                                 ".squidsquad/skill/working-state.md\n"
                                 ".claude/scheduled_tasks.json\n"),  # diff --cached
+            _mock_result(returncode=1),  # matches-origin check: working-state.md differs
+            _mock_result(returncode=1),  # matches-origin check: scheduled_tasks.json differs
             _mock_result(returncode=0),  # reset working-state.md
             _mock_result(returncode=0),  # reset scheduled_tasks.json
         ]
@@ -2915,6 +3021,24 @@ class TestGuardStagedState11511:
         assert len(reset_calls) == 2
         reset_paths = [c.args[0][-1] for c in reset_calls]
         assert "references/scripts/git_ops.py" not in reset_paths
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    @patch("git_ops._get_working_branch", return_value="main")
+    def test_feature_branch_leaves_origin_matching_state_staged(self, _wb, mock_run, mock_run_list):
+        """#13724: a staged state path identical to origin/main's current
+        content (the merge-brought-main's-own-content case) must be left
+        staged, not reverted to the feature branch's stale HEAD value."""
+        mock_run.return_value = _mock_result(stdout="squidsquad/task/11511\n")
+        mock_run_list.side_effect = [
+            _mock_result(stdout=".squidsquad/qa/working-state.md\n"),  # diff --cached
+            _mock_result(returncode=0),  # matches-origin check: identical -> skip
+        ]
+        unstaged = git_ops.guard_staged_state()
+        assert unstaged == []
+        reset_calls = [c for c in mock_run_list.call_args_list
+                       if c.args[0][:2] == ["git", "reset"]]
+        assert reset_calls == []
 
     @patch("git_ops._run_list")
     @patch("git_ops._run")

--- a/tests/test_git_ops_galaxy_guard_12905.py
+++ b/tests/test_git_ops_galaxy_guard_12905.py
@@ -172,6 +172,10 @@ class TestGuardComposition(unittest.TestCase):
         def fake_run_list(cmd, check=True):
             if cmd[:4] == ["git", "diff", "--cached", "--name-only"]:
                 return _cp(0, galaxy + "\n")
+            if cmd[:3] == ["git", "diff", "--cached"] and "--quiet" in cmd:
+                # #13724: matches-origin/main check -- returncode=1 (differs)
+                # so the note proceeds to the genuine-leak unstage path below.
+                return _cp(1, "")
             if cmd[:2] == ["git", "reset"]:
                 reset_calls.append(cmd[-1])
                 return _cp(0, "")


### PR DESCRIPTION
Both bugs are the same false-positive class in git_ops.py's merge/state-
guard machinery: a guard can't tell "the merge silently lost real
content" from "the incoming/canonical side legitimately deleted or
reset it."

#13723 (_merge_dropped_state_paths, the #13556 post-merge guard):
reproduced live -- PM's git rm --cached of two harness log files
(fixing #13714's own regression) landed via a routine
git merge origin/main and got reverted by this guard. Fix checks
origin/<working>'s current tip before restoring -- if origin confirms
the deletion, it's authoritative. Deliberately checks origin/<working>,
not HEAD^2, so the ORIGINAL #13556 protection (an arbitrary/throwaway
branch's deletion silently winning) still holds. Any resolution failure
falls back to the original restore behavior.

#13724 (guard_staged_state, the #11511 pre-commit guard): reported by
verifier -- the guard's unconditional git reset -q HEAD -- <path> fires
during a legitimate merge-conflict-resolution commit too, reverting
merged-in main content back to the feature branch's stale pre-merge
value, which caused the harness /merge endpoint to reject PRs #13712
and #13713 as carrying out-of-scope changes. Fix leaves a staged state
path alone when it already matches origin/<working>'s content.

Regression tests: 5 new cases (incl. one real end-to-end merge against a
bare-repo origin remote reproducing the exact PM scenario) + 2 new
cases + 3 existing test files' mocked fixtures updated for the new
matches-origin check. Full static gate green.