### PR TITLE
#13722: subloop_driver.py read_state() coerces hand-edited armed:"false" to True

### DIFF
--- a/references/scripts/subloop_driver.py
+++ b/references/scripts/subloop_driver.py
@@ -112,7 +112,16 @@ def read_state(alias):
     state = dict(_DEFAULT_STATE)
     try:
         if "armed" in data:
-            state["armed"] = bool(data["armed"])
+            # #13722: bare bool(data["armed"]) coerced a hand-edited
+            # {"armed": "false"} (JSON string) to True -- Python's
+            # bool("false") == True gotcha, the exact opposite of an
+            # operator's evident intent. Only an exact JSON `true` counts as
+            # armed; any other type (string, int, etc.) is treated as
+            # corruption and falls to False -- the safer failure direction
+            # for an idle-scan scheduler (a wrongly-disarmed driver just
+            # re-arms on the next idle wake; a wrongly-armed one keeps
+            # scanning against the operator's intent).
+            state["armed"] = data["armed"] is True
         if "scan_count" in data:
             state["scan_count"] = int(data["scan_count"])
         if "last_run" in data:

--- a/tests/test_subloop_driver_12506.py
+++ b/tests/test_subloop_driver_12506.py
@@ -280,3 +280,43 @@ class TestStatePersistence:
         assert state["last_run"] == "1700000000"
         res = sd.tick("skill", drained=True, now=T0)
         assert res["action"] == "scan"
+
+    def test_hand_edited_armed_false_string_coerces_to_false(self, isolated):
+        # #13722: bool("false") == True in Python -- a hand-edited operator
+        # intent to disarm ({"armed": "false"}, a JSON string) must NOT flip
+        # the driver back on. Only an exact JSON `true` counts as armed.
+        path = sd._state_path("skill")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{"armed": "false", "scan_count": 0, "last_run": null}',
+                        encoding="utf-8")
+        assert sd.read_state("skill")["armed"] is False
+
+    def test_hand_edited_armed_true_string_also_coerces_to_false(self, isolated):
+        # #13722: any string value -- even "true" -- is type-corruption, not a
+        # trusted signal. Only the exact JSON boolean `true` is honored.
+        path = sd._state_path("skill")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{"armed": "true", "scan_count": 0, "last_run": null}',
+                        encoding="utf-8")
+        assert sd.read_state("skill")["armed"] is False
+
+    def test_armed_numeric_one_coerces_to_false(self, isolated):
+        # #13722: same class -- a hand-edited {"armed": 1} (numeric, not a
+        # real JSON boolean) is also treated as corruption, not "truthy armed".
+        path = sd._state_path("skill")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{"armed": 1, "scan_count": 0, "last_run": null}',
+                        encoding="utf-8")
+        assert sd.read_state("skill")["armed"] is False
+
+    def test_real_json_booleans_still_honored(self, isolated):
+        # Sanity: the normal programmatic round-trip (write_state always emits
+        # real JSON booleans) is unaffected by the #13722 fix.
+        path = sd._state_path("skill")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{"armed": true, "scan_count": 0, "last_run": null}',
+                        encoding="utf-8")
+        assert sd.read_state("skill")["armed"] is True
+        path.write_text('{"armed": false, "scan_count": 0, "last_run": null}',
+                        encoding="utf-8")
+        assert sd.read_state("skill")["armed"] is False


### PR DESCRIPTION
bool(data["armed"]) coerced any non-empty string to True (Python's
bool("false") == True gotcha) -- opposite of an operator's evident
intent when hand-editing the state file to disarm the driver.
read_state()'s own docstring claims to defend against hand-edited type
corruption; this broke that contract for the armed field specifically.

Fix: only an exact JSON boolean true is honored; any other type falls
to False (safer failure direction for an idle-scan scheduler).

Regression tests cover the reported repro, the mirror "true" string
case, a numeric variant, and the unaffected real-boolean round-trip.