### PR TITLE
#13735: fix roles/pm/improvement-scan.md scan-history wording (append -> prepend)

### DIFF
--- a/references/sub-skills/roles/pm/improvement-scan.md
+++ b/references/sub-skills/roles/pm/improvement-scan.md
@@ -83,7 +83,7 @@ Write status bar state: `scanning|🔍 Scanning process/workflow...`
    ```
    If `scan_index.py` is not available, skip the DB write — the markdown write below is sufficient.
 
-   Also append to `.squidsquad/[your-role]/scan-history.md`:
+   Also record in `.squidsquad/[your-role]/scan-history.md` — **prepend** the new block immediately after any preamble/header line, so it becomes the FIRST `## Scan` block in the file, not the last. Entries are newest-first (#13566/#13711): the improvement-scan fallback read and `scan_index.py`'s retention-cap pruning both depend on "the first N blocks" being the newest ones. A literal end-of-file append would silently corrupt that ordering.
 
    ```markdown
    ## Scan — YYYY-MM-DD HH:MM


### PR DESCRIPTION
PM's own copy of the scan-history update step still said 'append' -- the same newest-first ambiguity #13711 already fixed in the shared/common improvement-scan.md variant. scan-history.md is newest-first (#13566/#13711): both the fallback read path and scan_index.py's retention-cap pruning depend on the first N blocks being the newest ones; a literal append would silently corrupt that ordering.

Mirrors #13711's wording exactly. No behavioral/code change -- pure instruction-text fix, no comprehension spec references this file, no tests needed.