### PR TITLE
#13737: fix tc_coverage.py file discovery for the current #9184 TEST-PLAN/QA-RESULTS naming convention

### DIFF
--- a/references/scripts/tc_coverage.py
+++ b/references/scripts/tc_coverage.py
@@ -117,42 +117,54 @@ def parse_tc_results(text: str) -> dict[int, str]:
 def _discover_files(issue_number: int) -> tuple[Path | None, Path | None]:
     """Auto-discover TEST-PLAN and QA-RESULTS files for an issue number.
 
-    Searches .squidsquad/*/planning/ directories.
-    PM planning dir is preferred over other roles.
-    For QA-RESULTS, picks highest -RN revision.
+    Searches .squidsquad/*/planning/ directories. Verifier ('qa') planning dir
+    is preferred (#9184 moved TEST-PLAN/QA-RESULTS ownership from PM to
+    verifier). Tries the current #9184 naming convention (TEST-PLAN-<N>.md /
+    QA-RESULTS-<N>.md, number last) first; falls back to the pre-#9184 legacy
+    convention (*-<N>-TEST-PLAN.md / *-<N>-QA-RESULTS[-RN].md) for in-flight
+    tasks filed before the rename (verification.md documents this fallback as
+    intentionally kept, not removed) (#13737).
     """
     planning_dirs = sorted(SQUID_DIR.glob("*/planning"))
 
-    # Sort to put pm first (PM owns test plans)
+    # Sort to put qa/verifier first (owns TEST-PLAN/QA-RESULTS per #9184)
     planning_dirs = sorted(
-        planning_dirs, key=lambda p: (0 if p.parent.name == "pm" else 1, p.parent.name)
+        planning_dirs, key=lambda p: (0 if p.parent.name == "qa" else 1, p.parent.name)
     )
 
     test_plan = None
     qa_results = None
 
     for pdir in planning_dirs:
-        # Find TEST-PLAN
+        # Find TEST-PLAN: current convention first, legacy as fallback
         if test_plan is None:
-            matches = list(pdir.glob(f"*-{issue_number}-TEST-PLAN.md"))
+            matches = list(pdir.glob(f"TEST-PLAN-{issue_number}.md"))
+            if not matches:
+                matches = list(pdir.glob(f"*-{issue_number}-TEST-PLAN.md"))
             if matches:
                 test_plan = matches[0]
 
-        # Find QA-RESULTS (prefer highest -RN revision)
+        # Find QA-RESULTS: current convention first (round revisions live as
+        # sections within the single file, not separate -RN.md files under
+        # #9184), legacy -RN.md revision fallback second.
         if qa_results is None:
-            base_matches = list(pdir.glob(f"*-{issue_number}-QA-RESULTS.md"))
-            rev_matches = list(pdir.glob(f"*-{issue_number}-QA-RESULTS-R*.md"))
+            matches = list(pdir.glob(f"QA-RESULTS-{issue_number}.md"))
+            if matches:
+                qa_results = matches[0]
+            else:
+                base_matches = list(pdir.glob(f"*-{issue_number}-QA-RESULTS.md"))
+                rev_matches = list(pdir.glob(f"*-{issue_number}-QA-RESULTS-R*.md"))
 
-            if rev_matches:
-                # Sort by revision number, pick highest
-                def _rev_num(p):
-                    m = re.search(r"-R(\d+)\.md$", p.name)
-                    return int(m.group(1)) if m else 0
+                if rev_matches:
+                    # Sort by revision number, pick highest
+                    def _rev_num(p):
+                        m = re.search(r"-R(\d+)\.md$", p.name)
+                        return int(m.group(1)) if m else 0
 
-                rev_matches.sort(key=_rev_num)
-                qa_results = rev_matches[-1]
-            elif base_matches:
-                qa_results = base_matches[0]
+                    rev_matches.sort(key=_rev_num)
+                    qa_results = rev_matches[-1]
+                elif base_matches:
+                    qa_results = base_matches[0]
 
     return test_plan, qa_results
 

--- a/tests/test_tc_coverage.py
+++ b/tests/test_tc_coverage.py
@@ -374,6 +374,91 @@ class TestAutoDiscovery:
         assert tp is None
 
 
+class TestAutoDiscoveryCurrentConvention13737:
+    """#13737: the #9184 convention is TEST-PLAN-<N>.md / QA-RESULTS-<N>.md
+    (number last, no dashes sandwiching it, no role prefix) under the
+    verifier ('qa') planning dir -- _discover_files() previously only
+    recognized the pre-#9184 *-<N>-TEST-PLAN.md shape and silently found
+    nothing for every real post-#9184 issue, making the 'never bypassed' TC
+    coverage ship gate a permanent no-op."""
+
+    def _setup_planning(self, tmp_path, role, files):
+        planning = tmp_path / ".squidsquad" / role / "planning"
+        planning.mkdir(parents=True, exist_ok=True)
+        for fname, content in files.items():
+            (planning / fname).write_text(content, encoding="utf-8")
+        return planning
+
+    def test_discovers_current_convention_pair(self, tmp_path, monkeypatch):
+        """A real TEST-PLAN-<N>.md/QA-RESULTS-<N>.md pair is found."""
+        self._setup_planning(tmp_path, "qa", {
+            "TEST-PLAN-13735.md": "| TC | Maps to |\n| TC1 | AC1 |\n",
+            "QA-RESULTS-13735.md": "### TC-1\n- **Result**: PASS\n",
+        })
+        monkeypatch.setattr(tc_coverage, "SQUID_DIR", tmp_path / ".squidsquad")
+
+        tp, qr = tc_coverage._discover_files(13735)
+        assert tp is not None and tp.name == "TEST-PLAN-13735.md"
+        assert qr is not None and qr.name == "QA-RESULTS-13735.md"
+
+    def test_qa_preferred_over_pm_for_current_convention(self, tmp_path, monkeypatch):
+        """qa (verifier) planning dir wins -- #9184 moved TEST-PLAN/QA-RESULTS
+        ownership from PM to verifier, unlike the pre-#9184 PM-first order."""
+        self._setup_planning(tmp_path, "pm", {
+            "TEST-PLAN-500.md": "### TC-1: PM copy\n",
+        })
+        self._setup_planning(tmp_path, "qa", {
+            "TEST-PLAN-500.md": "### TC-1: QA copy\n",
+        })
+        monkeypatch.setattr(tc_coverage, "SQUID_DIR", tmp_path / ".squidsquad")
+
+        tp, _ = tc_coverage._discover_files(500)
+        assert tp is not None
+        assert tp.parent.parent.name == "qa"
+
+    def test_current_convention_does_not_require_rn_file(self, tmp_path, monkeypatch):
+        """Round revisions live as sections inside the single QA-RESULTS-<N>.md
+        under #9184 -- no separate -RN.md file needed or expected."""
+        self._setup_planning(tmp_path, "qa", {
+            "TEST-PLAN-777.md": "### TC-1: A\n",
+            "QA-RESULTS-777.md": (
+                "## Round 1\n### TC-1\n- **Result**: FAIL\n\n"
+                "## Round 2\n### TC-1\n- **Result**: PASS\n"
+            ),
+        })
+        monkeypatch.setattr(tc_coverage, "SQUID_DIR", tmp_path / ".squidsquad")
+
+        tp, qr = tc_coverage._discover_files(777)
+        assert tp is not None
+        assert qr is not None and qr.name == "QA-RESULTS-777.md"
+
+    def test_legacy_convention_still_falls_back(self, tmp_path, monkeypatch):
+        """Pre-#9184 in-flight issues (legacy *-<N>-TEST-PLAN.md shape) must
+        still resolve -- verification.md documents this as a kept fallback,
+        not a removed path."""
+        self._setup_planning(tmp_path, "pm", {
+            "FEAT-PM-42-TEST-PLAN.md": "### TC-1: A\n",
+            "FEAT-PM-42-QA-RESULTS.md": "### TC-1: A\n- **Result**: PASS\n",
+        })
+        monkeypatch.setattr(tc_coverage, "SQUID_DIR", tmp_path / ".squidsquad")
+
+        tp, qr = tc_coverage._discover_files(42)
+        assert tp is not None and "FEAT-PM-42-TEST-PLAN" in tp.name
+        assert qr is not None and "FEAT-PM-42-QA-RESULTS" in qr.name
+
+    def test_current_convention_preferred_over_legacy_in_same_dir(self, tmp_path, monkeypatch):
+        """If both shapes somehow exist for the same issue, the current
+        convention wins (it's checked first)."""
+        self._setup_planning(tmp_path, "qa", {
+            "TEST-PLAN-88.md": "### TC-1: current\n",
+            "FEAT-PM-88-TEST-PLAN.md": "### TC-1: legacy\n",
+        })
+        monkeypatch.setattr(tc_coverage, "SQUID_DIR", tmp_path / ".squidsquad")
+
+        tp, _ = tc_coverage._discover_files(88)
+        assert tp is not None and tp.name == "TEST-PLAN-88.md"
+
+
 class TestCheckCoverageFileErrors:
     """#7622: check_coverage must handle unreadable files gracefully."""
 


### PR DESCRIPTION
The 'never bypassed' TC coverage ship gate has been a silent no-op for ~2 months. tracker.py's pending-test -> pending-ship transition calls tc_coverage._discover_files(number) to locate an issue's TEST-PLAN/QA-RESULTS files; that function only recognized the pre-#9184 legacy shape (*-<N>-TEST-PLAN.md), which never matches the current TEST-PLAN-<N>.md/QA-RESULTS-<N>.md convention (number last). Since tp came back None for every real post-#9184 issue, the gate's entire check_coverage() call never ran.

Fix: try the current convention first (also switches planning-dir preference to qa/verifier first, matching #9184's TEST-PLAN/QA-RESULTS ownership move from PM), fall back to the legacy shape for pre-#9184 in-flight tasks (kept per verification.md's documented fallback, not removed). Added 5 regression tests locking current-convention discovery, qa-preference, no-separate-RN-file-needed (rounds now live as sections inside one QA-RESULTS-<N>.md), and legacy fallback.

**Important disclosed risk**: while validating this fix, found that real QA-RESULTS files use an 'AC Walk' table with zero TC-N-labeled rows -- so once this fix lands, check_coverage() will report 0/N TC coverage (hard gate failure) against essentially every current QA-RESULTS file, since none use the TC-N-keyed format the gate (correctly) expects per verification-templates.md. Filed as a separate high-severity issue to verifier (#13738) since reconciling QA-RESULTS authorship format vs. the parser is a decision outside this fix's scope (verifier's artifact-authorship practice, not tc_coverage.py's file-discovery bug). Recommend #13738 gets urgent attention alongside this merging.