### PR TITLE
#13742: health_check.py detects .local-config path collisions instead of silently trusting them

### DIFF
--- a/references/scripts/health_check.py
+++ b/references/scripts/health_check.py
@@ -76,6 +76,19 @@ def _read_interval():
     return 30
 
 
+# #13742 verifier round 1: raw (pre-resolution) .local-config values from the
+# most recent _parse_local_config() call, keyed by role. "." is compose.py's
+# ONE special-cased default (only ever assigned to "pm") -- a NON-pm role
+# storing raw "." is always a stale/misconfigured entry by construction, so
+# its resolution to REPO_ROOT must never be trusted as ground truth, even
+# when it happens to numerically match. A role with a genuine sibling-
+# relative raw value (e.g. "../SquidSquad-qa") that ALSO resolves to
+# REPO_ROOT (via legitimate sibling-symmetric self-reference) is NOT
+# ambiguous the same way. check_all_agents() consults this to distinguish
+# the two cases when exempting a role from collision-flagging.
+_LAST_PARSED_RAW = {}
+
+
 def _parse_local_config():
     """Parse clone paths → {role: Path(clone_root)}.
 
@@ -96,6 +109,7 @@ def _parse_local_config():
         sys.exit(2)
 
     result = {}
+    raw = {}
 
     # .local-config (project-scoped, always correct)
     # Format: `- **role**: <path>` — relative paths resolve against repo root.
@@ -105,7 +119,9 @@ def _parse_local_config():
             m = re.match(r"-\s*\*\*([\w-]+)\*\*:\s*(.+)", line)
             if m:
                 role = m.group(1).strip()
-                raw_path = Path(m.group(2).strip())
+                raw_str = m.group(2).strip()
+                raw[role] = raw_str
+                raw_path = Path(raw_str)
                 # Resolve relative paths against repo root
                 if not raw_path.is_absolute():
                     raw_path = (REPO_ROOT / raw_path).resolve()
@@ -126,6 +142,8 @@ def _parse_local_config():
         )
         sys.exit(2)
 
+    global _LAST_PARSED_RAW
+    _LAST_PARSED_RAW = raw
     return result
 
 
@@ -328,12 +346,17 @@ def check_agent_health(role, clone_root, interval_minutes, now=None):
     return result
 
 
-def check_all_agents(local_config_overrides=None):
+def check_all_agents(local_config_overrides=None, local_config_raw_overrides=None):
     """Check health of every agent found in .local-config.
 
     Args:
         local_config_overrides: optional dict {role: Path} to use instead
             of reading .local-config (for testing)
+        local_config_raw_overrides: optional dict {role: str} of the raw
+            (pre-resolution) .local-config value per role, paired with
+            local_config_overrides (for testing the #13742 exemption below).
+            Ignored when local_config_overrides is None (a real read
+            populates _LAST_PARSED_RAW from the actual file).
 
     Returns:
         {
@@ -348,8 +371,10 @@ def check_all_agents(local_config_overrides=None):
 
     if local_config_overrides is not None:
         agents_map = local_config_overrides
+        raw_map = local_config_raw_overrides or {}
     else:
         agents_map = _parse_local_config()
+        raw_map = _LAST_PARSED_RAW
 
     # #13742: a misconfigured/stale .local-config can resolve two DIFFERENT
     # roles' relative paths to the SAME clone_path (most commonly: pm's "."
@@ -369,6 +394,26 @@ def check_all_agents(local_config_overrides=None):
         role
         for roles in path_to_roles.values() if len(roles) > 1
         for role in roles
+    }
+    # #13742 verifier round 1: a role whose OWN resolved path equals
+    # REPO_ROOT (this script's own execution root) is independently
+    # ground-truthed -- this process IS running from that root -- BUT ONLY
+    # when its raw (pre-resolution) value isn't "." itself. "." is
+    # compose.py's ONE special-cased default (assigned only to "pm"); any
+    # OTHER role storing raw "." is always a stale/misconfigured entry by
+    # construction, and its coincidental resolution to REPO_ROOT is exactly
+    # the untrustworthy case this whole check exists to catch -- exempting
+    # it would silently re-trust the very data that's broken. A role with a
+    # genuine sibling-relative raw value (e.g. "../SquidSquad-qa") that also
+    # resolves to REPO_ROOT via legitimate sibling-symmetric self-reference
+    # is not ambiguous the same way, and is safe to exempt. Without this
+    # distinction, a role whose entry is genuinely correct could get swept
+    # into "don't trust this" purely because a DIFFERENT role's broken "."
+    # entry happens to collide onto the same path -- a regression from a
+    # previously-accurate reading.
+    colliding_roles -= {
+        role for role in colliding_roles
+        if agents_map[role] == REPO_ROOT and raw_map.get(role) != "."
     }
 
     results = []

--- a/references/scripts/health_check.py
+++ b/references/scripts/health_check.py
@@ -351,10 +351,53 @@ def check_all_agents(local_config_overrides=None):
     else:
         agents_map = _parse_local_config()
 
+    # #13742: a misconfigured/stale .local-config can resolve two DIFFERENT
+    # roles' relative paths to the SAME clone_path (most commonly: pm's "."
+    # shorthand only resolves correctly when read from pm's own clone --
+    # every other clone reading "pm: ." resolves it to ITS OWN root instead,
+    # colliding with whichever OTHER role also maps there). A collision like
+    # this produces a health verdict built from the WRONG agent's on-disk
+    # files -- confirmed live to sometimes read as a confident but false
+    # "stalled" (a stray/unrelated .claude-pid under the wrong clone), not
+    # merely "unknown". Detect collisions up front and flag every affected
+    # role loudly instead of silently running the normal check against data
+    # that structurally cannot be trusted.
+    path_to_roles = {}
+    for role, clone_root in agents_map.items():
+        path_to_roles.setdefault(Path(clone_root), []).append(role)
+    colliding_roles = {
+        role
+        for roles in path_to_roles.values() if len(roles) > 1
+        for role in roles
+    }
+
     results = []
     for role in sorted(agents_map):
         clone_root = agents_map[role]
-        result = check_agent_health(role, clone_root, interval, now=now)
+        if role in colliding_roles:
+            other_roles = sorted(
+                r for r in path_to_roles[Path(clone_root)] if r != role
+            )
+            result = {
+                "role": role,
+                "health": UNKNOWN,
+                "health_source": "local-config-collision",
+                "clone_path": str(clone_root),
+                "current_state_phase": "",
+                "current_state_desc": "",
+                "current_state_stale": False,
+                "task": "unknown",
+                "last_active_minutes_ago": None,
+                "reason": (
+                    f".local-config error: '{role}' resolves to the same "
+                    f"clone_path as {other_roles} ({clone_root}) -- this is "
+                    f"a misconfigured/stale .local-config entry, not a "
+                    f"genuine health reading. Fix .local-config before "
+                    f"trusting this result."
+                ),
+            }
+        else:
+            result = check_agent_health(role, clone_root, interval, now=now)
         results.append(result)
 
     all_healthy = all(r["health"] == HEALTHY for r in results) if results else True

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -319,6 +319,62 @@ class TestCheckAgentHealth:
         assert result["last_active_minutes_ago"] >= 119
 
 
+class TestCheckAllAgentsCollision13742:
+    """#13742: a misconfigured .local-config can resolve two different roles
+    to the same clone_path (most commonly pm's "." shorthand read from a
+    non-pm clone) -- confirmed live to produce a false-confident "stalled"
+    verdict off the WRONG agent's files, not just "unknown". check_all_agents
+    must detect the collision up front and flag every affected role loudly,
+    never running the normal pid/mtime check against untrustworthy data."""
+
+    def _setup_agent(self, tmp_path, role, claude_pid=None, state_text=None):
+        squid = tmp_path / ".squidsquad" / role
+        squid.mkdir(parents=True, exist_ok=True)
+        if claude_pid is not None:
+            (squid / ".claude-pid").write_text(str(claude_pid))
+        if state_text is not None:
+            (squid / "current-state").write_text(state_text)
+        return tmp_path
+
+    def test_two_roles_same_path_flagged_as_collision(self, tmp_path):
+        shared = self._setup_agent(tmp_path, "pm", claude_pid=99999)
+        overrides = {"pm": shared, "dm": shared}
+        report = health_check.check_all_agents(local_config_overrides=overrides)
+        by_role = {a["role"]: a for a in report["agents"]}
+        assert by_role["pm"]["health"] == "unknown"
+        assert by_role["pm"]["health_source"] == "local-config-collision"
+        assert "dm" in by_role["pm"]["reason"]
+        assert by_role["dm"]["health"] == "unknown"
+        assert by_role["dm"]["health_source"] == "local-config-collision"
+        assert "pm" in by_role["dm"]["reason"]
+
+    def test_collision_does_not_read_the_others_pid(self, tmp_path):
+        """The bug this locks: a collision must NOT fall through to a normal
+        pid-check that reports a confident (but meaningless) health verdict
+        using data that belongs to a different role's process."""
+        with patch.object(health_check, "_is_process_alive", return_value=False):
+            shared = self._setup_agent(tmp_path, "pm", claude_pid=12345)
+            overrides = {"pm": shared, "dm": shared}
+            report = health_check.check_all_agents(local_config_overrides=overrides)
+        by_role = {a["role"]: a for a in report["agents"]}
+        assert by_role["pm"]["health"] != "stalled"
+        assert "pid" not in by_role["pm"]
+
+    def test_three_way_collision_all_flagged(self, tmp_path):
+        shared = self._setup_agent(tmp_path, "qa")
+        overrides = {"pm": shared, "skill": shared, "dm": shared}
+        report = health_check.check_all_agents(local_config_overrides=overrides)
+        assert all(a["health_source"] == "local-config-collision" for a in report["agents"])
+
+    def test_no_collision_when_paths_distinct(self, tmp_path):
+        pm_dir = self._setup_agent(tmp_path / "pm-clone", "pm", claude_pid=1)
+        skill_dir = self._setup_agent(tmp_path / "skill-clone", "skill", claude_pid=2)
+        with patch.object(health_check, "_is_process_alive", return_value=True):
+            overrides = {"pm": pm_dir, "skill": skill_dir}
+            report = health_check.check_all_agents(local_config_overrides=overrides)
+        assert all(a["health_source"] != "local-config-collision" for a in report["agents"])
+
+
 class TestNoLegacyReads:
     """#4792 §5.4 source-grep guards: legacy sentinel reads must be gone."""
 

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -374,6 +374,46 @@ class TestCheckAllAgentsCollision13742:
             report = health_check.check_all_agents(local_config_overrides=overrides)
         assert all(a["health_source"] != "local-config-collision" for a in report["agents"])
 
+    def test_self_role_exempted_from_collision_verifier_round1(self, tmp_path):
+        """#13742 verifier round 1 regression: when this script's OWN
+        REPO_ROOT is one of the colliding paths (e.g. two OTHER roles' broken
+        "." entries both collide onto the executing clone's own root), the
+        role whose resolved path equals REPO_ROOT AND whose raw value is a
+        genuine sibling-relative path (not the ambiguous ".") is
+        independently ground-truthed -- this process IS running from there --
+        and must NOT be flagged. Only the genuinely-unverifiable other
+        role(s) sharing that path stay flagged."""
+        qa_dir = self._setup_agent(tmp_path, "qa", claude_pid=42)
+        pm_dir = self._setup_agent(tmp_path.parent / "pm-elsewhere", "pm")
+        with patch.object(health_check, "REPO_ROOT", tmp_path), \
+                patch.object(health_check, "_is_process_alive", return_value=True):
+            overrides = {"qa": qa_dir, "pm": pm_dir, "dm": qa_dir}
+            raw_overrides = {"qa": "../SquidSquad-qa", "pm": "../SquidSquad", "dm": "."}
+            report = health_check.check_all_agents(
+                local_config_overrides=overrides,
+                local_config_raw_overrides=raw_overrides,
+            )
+        by_role = {a["role"]: a for a in report["agents"]}
+        assert by_role["qa"]["health_source"] != "local-config-collision"
+        assert by_role["qa"]["health"] == "healthy"
+        assert by_role["dm"]["health_source"] == "local-config-collision"
+        assert by_role["pm"]["health_source"] != "local-config-collision"
+
+    def test_dot_raw_value_never_exempted_even_at_repo_root(self, tmp_path):
+        """#13742 verifier round 1: if BOTH colliding roles' raw values are
+        "." (both coincidentally resolve to REPO_ROOT, e.g. two broken
+        entries), neither is exempted -- "." is never trustworthy evidence
+        on its own, regardless of which role stores it."""
+        shared = self._setup_agent(tmp_path, "dm")
+        with patch.object(health_check, "REPO_ROOT", tmp_path):
+            overrides = {"pm": shared, "dm": shared}
+            raw_overrides = {"pm": ".", "dm": "."}
+            report = health_check.check_all_agents(
+                local_config_overrides=overrides,
+                local_config_raw_overrides=raw_overrides,
+            )
+        assert all(a["health_source"] == "local-config-collision" for a in report["agents"])
+
 
 class TestNoLegacyReads:
     """#4792 §5.4 source-grep guards: legacy sentinel reads must be gone."""


### PR DESCRIPTION
Fixes the reported symptom: a stale/misconfigured .local-config can resolve two different roles to the same clone_path (the reported case: pm and dm both resolving to "."), and health_check.py silently ran its normal pid/mtime check against that data anyway.

Confirmed live against my own clone's .local-config: pm's own './ shorthand, resolved from a non-pm clone, silently collapsed to that clone's own root -- which in one reproduction produced a false-confident 'stalled' health verdict built from an unrelated stray .claude-pid file, not merely an ambiguous 'unknown'. That's a strictly worse failure mode than the issue's own report.

Fix: check_all_agents() now detects when two or more roles resolve to the identical clone_path and flags every affected role with a distinct local-config-collision health_source and an explicit reason, instead of falling through to a pid/mtime check that can't be trusted. 4 regression tests added, including one that directly locks the false-stalled-verdict bug (asserts no pid data is read/reported for a colliding role).

**Scope disclosed, not fixed here** (posted in full detail on the issue): the deeper root cause -- compose.py's generate_local_config() defaults to a naming-convention GUESS () that doesn't match this install's actual ad-hoc clone directory names, and can silently write wrong entries if triggered from a non-primary clone -- is a separate, riskier fix I'm not taking on unilaterally in this pass (touches the shared regeneration path other roles' new-role-addition flow depends on, and .local-config is gitignored per-clone so I can't verify or fix other clones' copies from here). Self-healed my own clone's local file directly as a local-only, zero-risk demonstration (not part of this PR -- gitignored, no commit possible).