### PR TITLE
#13743: add --extra-label passthrough so improvement-scan findings actually get labeled

### DIFF
--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -7,8 +7,8 @@ Agents call this instead of constructing gh commands from prose.
 Usage:
     python scripts/tracker.py list-issues <role>           (alias: list-bugs)
     python scripts/tracker.py list-tasks <role> [--status] (alias: list-features)
-    python scripts/tracker.py create-issue --title <t> --body <b> --role <r> --severity <s> [--reporter <name>]  (alias: create-bug)
-    python scripts/tracker.py create-task --title <t> --body <b> --role <r> --priority <p> [--reporter <name>]   (alias: create-feature)
+    python scripts/tracker.py create-issue --title <t> --body <b> --role <r> --severity <s> [--reporter <name>] [--extra-label <label>]  (alias: create-bug)
+    python scripts/tracker.py create-task --title <t> --body <b> --role <r> --priority <p> [--reporter <name>] [--extra-label <label>]   (alias: create-feature)
     python scripts/tracker.py transition <number> <from-status> <to-status> --role <r> [--force]
     python scripts/tracker.py comment <number> --role <r> --message <m>
     python scripts/tracker.py work-assign --target-alias <alias> [--caller <alias>] [--issue <n>] [--event-context <ctx>] [--payload <json>]  # #12495 manual wake (no transition)
@@ -1072,13 +1072,20 @@ def add_labels(number, labels_str):
     print(f"#{number}: added labels {labels_str}")
 
 
-def create_issue(title, body, role, severity, reporter=None):
+def create_issue(title, body, role, severity, reporter=None, extra_label=None):
     """Create an issue with correct label format.
 
     #6274 D3 dual-aware: also emits the alias `role:*` label during the
     migration window. role=dev/qa adds role:worker/role:verifier and
     vice-versa. The doubling is removed in 6274.3 (`cleanup_labels_6274.py`
     deletes the role:dev/role:qa label classes altogether).
+
+    extra_label (#13743): an additional free-form label to tag alongside the
+    fixed type/severity/role/status set — e.g. `improvement-scan`, which
+    every documented improvement-scan finding template is instructed to
+    apply but had no way to pass through (create_issue accepted no label
+    parameter at all, so the labeled outcome the neighboring instruction
+    promised could only be achieved by a manual follow-up `gh issue edit`).
     """
     sev_label = SEVERITY_LABELS.get(severity, f"severity:{severity}")
     role_label = _filter_role_labels_to_existing(
@@ -1089,6 +1096,8 @@ def create_issue(title, body, role, severity, reporter=None):
     # issues — if issues started at `pending`, they'd sit in limbo because
     # agents interpret `pending` as "awaiting human approval".
     labels = f"type:issue,{sev_label},{role_label},squidsquad,status:open"
+    if extra_label:
+        labels = f"{labels},{extra_label}"
 
     full_body = body
     if reporter:
@@ -1131,16 +1140,20 @@ def create_issue(title, body, role, severity, reporter=None):
 create_bug = create_issue
 
 
-def create_task(title, body, role, priority, reporter=None):
+def create_task(title, body, role, priority, reporter=None, extra_label=None):
     """Create a task with correct label format.
 
     #6274 D3 dual-aware: also emits the alias `role:*` label during the
     migration window — see create_issue.
+
+    extra_label (#13743): see create_issue — same passthrough for tasks.
     """
     pri_label = PRIORITY_LABELS.get(priority, f"priority:{priority}")
     role_label = _filter_role_labels_to_existing(
         _build_dual_role_labels_6274(role), role)  # #13465
     labels = f"type:task,{pri_label},{role_label},squidsquad,status:pending"
+    if extra_label:
+        labels = f"{labels},{extra_label}"
 
     full_body = body
     if reporter:
@@ -2035,7 +2048,8 @@ def main():
                 print(f"Missing --{req}", file=sys.stderr)
                 sys.exit(1)
         create_issue(opts["title"], opts["body"], opts["role"],
-                     opts["severity"], opts.get("reporter"))
+                     opts["severity"], opts.get("reporter"),
+                     opts.get("extra-label"))
 
     elif cmd in ("create-task", "create-feature"):
         for req in ("title", "body", "role", "priority"):
@@ -2043,7 +2057,8 @@ def main():
                 print(f"Missing --{req}", file=sys.stderr)
                 sys.exit(1)
         create_task(opts["title"], opts["body"], opts["role"],
-                    opts["priority"], opts.get("reporter"))
+                    opts["priority"], opts.get("reporter"),
+                    opts.get("extra-label"))
 
     elif cmd == "transition":
         if len(pos) < 3:

--- a/references/sub-skills/common/tracker-protocol.md
+++ b/references/sub-skills/common/tracker-protocol.md
@@ -137,8 +137,11 @@ python references/scripts/tracker.py create-issue \
   --body "**Observation**: [what the scan found]
 **Location**: [file:line or symbol]
 **Suggested fix**: [one-line approach]" \
-  --role [owning-role] --severity low --reporter [ROLE]-lead
+  --role [owning-role] --severity low --reporter [ROLE]-lead \
+  --extra-label improvement-scan
 ```
+
+`--extra-label improvement-scan` (#13743) is what actually applies the `improvement-scan` label the neighboring improvement-scan sub-skill instructs you to tag — `create-issue` has no other way to attach a label beyond the fixed type/severity/role/status set.
 
 **Cross-role issue** — root cause is in another agent's domain (`--role` differs from `--reporter`):
 

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -264,6 +264,50 @@ class TestCreateIssue:
         assert title_arg == "ISSUE: already prefixed"
         assert not title_arg.startswith("ISSUE: ISSUE:")
 
+    def test_extra_label_appended_13743(self, monkeypatch):
+        """#13743: create_issue must be able to tag an extra label (e.g.
+        improvement-scan) alongside the fixed type/severity/role/status set."""
+        calls = []
+
+        def fake_gwb(cmd, body, **kw):
+            calls.append((cmd, body))
+            return _mock_result(stdout="https://github.com/org/repo/issues/1\n")
+
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(tracker, "_run_gh_with_body", fake_gwb)
+        tracker.create_issue("test", "body", "skill", "low",
+                              extra_label="improvement-scan")
+        cmd = calls[0][0]
+        label_arg = cmd[cmd.index("--label") + 1]
+        assert "improvement-scan" in label_arg.split(",")
+
+    def test_no_extra_label_by_default(self, monkeypatch):
+        calls = []
+
+        def fake_gwb(cmd, body, **kw):
+            calls.append((cmd, body))
+            return _mock_result(stdout="https://github.com/org/repo/issues/1\n")
+
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(tracker, "_run_gh_with_body", fake_gwb)
+        tracker.create_issue("test", "body", "skill", "low")
+        cmd = calls[0][0]
+        label_arg = cmd[cmd.index("--label") + 1]
+        assert "improvement-scan" not in label_arg.split(",")
+
+    def test_extra_label_via_forge_adapter(self, monkeypatch):
+        adapter_calls = []
+
+        class FakeAdapter:
+            def create_issue(self, title, body, labels=None):
+                adapter_calls.append({"labels": labels})
+                return {"number": 1, "url": "http://forge/issues/1"}
+
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: FakeAdapter())
+        tracker.create_issue("test", "body", "skill", "low",
+                              extra_label="improvement-scan")
+        assert "improvement-scan" in adapter_calls[0]["labels"]
+
 
 class TestCreateTask:
     def test_creates_with_pending_status(self, monkeypatch):

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -357,6 +357,49 @@ class TestCreateTask:
         # #13370: the reporter-annotated body is now passed as the stdin body arg.
         assert "**Reported By**: skill-lead" in calls[0][1]
 
+    def test_extra_label_appended_13743(self, monkeypatch):
+        """#13743: create_task mirrors create_issue's extra_label passthrough."""
+        calls = []
+
+        def fake_gwb(cmd, body, **kw):
+            calls.append((cmd, body))
+            return _mock_result(stdout="https://github.com/org/repo/issues/52\n")
+
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(tracker, "_run_gh_with_body", fake_gwb)
+        tracker.create_task("feat", "body", "skill", "low",
+                             extra_label="improvement-scan")
+        cmd = calls[0][0]
+        label_arg = cmd[cmd.index("--label") + 1]
+        assert "improvement-scan" in label_arg.split(",")
+
+    def test_no_extra_label_by_default(self, monkeypatch):
+        calls = []
+
+        def fake_gwb(cmd, body, **kw):
+            calls.append((cmd, body))
+            return _mock_result(stdout="https://github.com/org/repo/issues/53\n")
+
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(tracker, "_run_gh_with_body", fake_gwb)
+        tracker.create_task("feat", "body", "skill", "low")
+        cmd = calls[0][0]
+        label_arg = cmd[cmd.index("--label") + 1]
+        assert "improvement-scan" not in label_arg.split(",")
+
+    def test_extra_label_via_forge_adapter(self, monkeypatch):
+        adapter_calls = []
+
+        class FakeAdapter:
+            def create_issue(self, title, body, labels=None):
+                adapter_calls.append({"labels": labels})
+                return {"number": 54, "url": "http://forge/issues/54"}
+
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: FakeAdapter())
+        tracker.create_task("feat", "body", "skill", "low",
+                             extra_label="improvement-scan")
+        assert "improvement-scan" in adapter_calls[0]["labels"]
+
 
 class TestCommentNoRedundantImport:
     """#6849: comment() must use module-level re, not import re as _re."""


### PR DESCRIPTION
tracker.py's `create_issue()`/`create_task()` had no way to attach a label beyond the fixed type/severity/role/status set. The documented improvement-scan finding template (`tracker-protocol.md`) is the exact command every role is told to run for a quiet-cycle finding, and the very next instruction (`improvement-scan-slim.md`) says to tag it with the `improvement-scan` label -- but following the documented command literally could never produce that label; only an undocumented manual `gh issue edit --add-label` follow-up ever applied it in practice.

Fix: added an optional `extra_label` parameter to `create_issue()`/`create_task()` (both the gh-CLI and forge-adapter paths), wired through the CLI as `--extra-label <name>`, and updated `tracker-protocol.md`'s improvement-scan template to pass `--extra-label improvement-scan`.

6 regression tests added (extra-label appended on both create_issue and create_task, absent by default, and the forge-adapter path). Full static gate clean: 5895 passed.