### PR TITLE
pm: wire step:cycle/improvement-scan into instructions.md (#13746)

### DIFF
--- a/references/roles/pm/instructions.md
+++ b/references/roles/pm/instructions.md
@@ -103,6 +103,12 @@ When PM detects an issue in PM's own domain (BRIEFING.md staleness, config count
 
 For each new task or bug processed this cycle, evaluate against the 5-category character-signal checklist (deliverable-type, tech-stack, domain-vocabulary, quality-preference, user-persona). If a new signal appears that isn't already in the role adaptations, flag for human in check-in (if contradicting) or add it silently (if non-contradicting).
 
+#### step:cycle/improvement-scan
+
+→ run sub-skill: roles/pm/improvement-scan
+
+On quiet cycles (no task picked up): run a scan for process/workflow improvements per the sub-skill's rules. PM's variant is process-focused only — never scan for or suggest code changes. File findings as issues per the sub-skill's cap and severity rules.
+
 #### step:cycle/vault-optimize
 
 → run sub-skill: vault-optimize

--- a/tests/comprehension/.staleness-baseline.json
+++ b/tests/comprehension/.staleness-baseline.json
@@ -99,7 +99,7 @@
   "references/sub-skills/common/harness-restart.md": "a43cf57124e8cb35406ae1d0c243f14671e8c5ea"
  },
  "13327_spec.json": {
-  "references/roles/pm/instructions.md": "d28aa4b117d9be5aed8589690a9ac2922e8bfd6f"
+  "references/roles/pm/instructions.md": "ed1f3efe19f2fec2281ed30b94d6d049bef49919"
  },
  "13328_spec.json": {
   "docs/INSTALLER-RUNTIME.md": "d345fd45768bc3f8b16420a8b98d6a43d41441ac"


### PR DESCRIPTION
Fixes an orphaned sub-skill: references/sub-skills/roles/pm/improvement-scan.md was listed in includes.yml, but includes.yml's loader (_load_manifest_v2 in compose.py) is a confirmed TOMBSTONE (#13264), unreachable from production compose post-E6 (#10685). The real production compose path (v2_link_stage.emit_v2_linked) reads references/roles/pm/instructions.md directly via step:cycle/* markers -- and instructions.md had zero reference to improvement-scan, despite the existing step:cycle/vault-optimize section's own gating text presupposing an improvement-scan step already ran this cycle ('AND no improvement scan ran this cycle').

Root cause confirmed by direct code reading (compose.py docstring, v2_link_stage.py module docstring, and grep across instructions.md's full step list) -- not a guess.

Fix: added a new step:cycle/improvement-scan section to instructions.md, positioned immediately before step:cycle/vault-optimize (matching the ordering vault-optimize's own text already assumes), with a '-> run sub-skill: roles/pm/improvement-scan' marker and prose describing PM's process-only, max-2-item-cap scan behavior per the sub-skill's actual rules.

Scope note: includes.yml itself is left untouched -- it is a wholesale-unreachable loader affecting far more than this one entry, and retiring it is a separate, broader decision outside this issue's scope.

Composed .squidsquad/pm/CLAUDE.md output was NOT regenerated as part of this PR -- recomposition is driven by the repo's deploy-signal/compose_freshness pipeline (see #12912-pattern deploy commits), not by the source-editing PR itself.

Full static gate clean: 5892 gated tests passed.