### PR TITLE
wizard.py: wire cli_stdio.harden_stdio() into the fleet, fix live em-dash on ERROR-path print (#13760)

### DIFF
--- a/references/scripts/wizard.py
+++ b/references/scripts/wizard.py
@@ -4398,7 +4398,7 @@ def cmd_setup_yes(args):
         print(
             f"\nERROR: {len(failed)} role(s) failed to compose a CLAUDE.md: "
             f"{', '.join(a.get('id', '?') for a in failed)}. The install is NOT "
-            f"bootable for those agents — see the WARNING(s) above for the cause.",
+            f"bootable for those agents -- see the WARNING(s) above for the cause.",
             file=sys.stderr,
         )
         return 1
@@ -4472,6 +4472,8 @@ def cmd_save_spec(args):
 
 
 def main():
+    from cli_stdio import harden_stdio  # #13198: crash-proof CLI stdio (cp1252)
+    harden_stdio()
     args = sys.argv[1:]
     if not args or args[0] in ("--help", "-h"):
         print(__doc__)

--- a/tests/test_cli_stdio_13198.py
+++ b/tests/test_cli_stdio_13198.py
@@ -72,6 +72,7 @@ class TestFleetWiring13198:
         "config", "subloop_driver", "model_router", "scan_index", "compose",
         "boot_remote", "add_role", "migrate_state_branch", "tracker",
         "git_ops",  # #13728: most heavily-invoked fleet CLI, was unswept
+        "wizard",  # #13760: setup/install CLI, was unswept
     ]
 
     @pytest.mark.parametrize("mod", WIRED)


### PR DESCRIPTION
wizard.py is the setup/install CLI (argparse-style dispatch in main(), invoked as 'python references/scripts/wizard.py <cmd>') but was never wired into the #13198 cli_stdio.harden_stdio() fleet -- absent from TestFleetWiring13198.WIRED entirely. Found via improvement scan.

It also had a live, print()-reachable em-dash literal on an ERROR-path print in main()'s post-setup-summary flow (fires when a role fails to compose during setup) -- a strict cp1252 console (default on many Windows terminals) would raise UnicodeEncodeError on that print, turning a clear 'role X failed to compose' error into a confusing crash instead. Same crash class as #13728's git_ops.py finding, different script.

Fix: wired main() with the standard two-line harden_stdio() form used by 8 of the 9 already-WIRED scripts (config/subloop_driver/model_router/scan_index/compose/boot_remote/add_role/migrate_state_branch) -- no try/except fail-open wrapper needed, unlike git_ops.py, since wizard.py carries no post-merge-hook 'never raises' contract. Added 'wizard' to WIRED, which also enrolled it in the TestNoDecorativeNonAsciiInPrints13198 ASCII sweep (SWEPT = WIRED) -- fixed the one em-dash literal that sweep caught (replaced with '--', matching the ASCII convention used across the rest of the fleet).

Full static gate clean: 5909 gated tests passed (was 5901 pre-change; wizard joining both parametrized test sets accounts for the delta).