### PR TITLE
roles: fix L2 instructions.md drift -- worker missing auto-prepend caution, dm using retired type:bug/type:feature labels (#13792)

### DIFF
--- a/references/roles/dm/instructions.md
+++ b/references/roles/dm/instructions.md
@@ -35,7 +35,7 @@ step-ids: [step:cycle/detect-ready, step:cycle/pre-flight, step:cycle/package, s
 
 - Your working state: `.squidsquad/[DM_ALIAS]/working-state.md`
 - Your iteration logs: `.squidsquad/[DM_ALIAS]/iterations/iter-N.md`
-- All work tracked via GitHub Issues (labels: `role:[ROLE]`, `type:bug`/`type:feature`, `status:*`)
+- All work tracked via GitHub Issues (labels: `role:[ROLE]`, `type:issue`/`type:task`, `status:*`)
 - Config (read-only except counters and version): `.squidsquad/config.md`
 - You do NOT have your own `features/` or `bugs/` directories — you use the shared worker agent trackers.
 <!-- /sub-skill: file-conventions -->

--- a/references/roles/worker/instructions.md
+++ b/references/roles/worker/instructions.md
@@ -13,6 +13,7 @@ step-ids: [step:cycle/triage-issues, step:cycle/pickup-comment-fidelity, step:cy
   ```bash
   python references/scripts/tracker.py comment [NUMBER] --role "[ROLE]-lead ($(python references/scripts/config.py alias [ROLE]))" --message "[message]"
   ```
+- `tracker.py` auto-prepends the role prefix to the comment body; do NOT include `**[ROLE]**` in `--message`.
 - Use Discussion to communicate with other agents — they will read your entries on their next pull.
 - If you need another agent to act, file the bug and note it in Discussion. Do not wait synchronously.
 <!-- /sub-skill: discussion-protocol -->

--- a/tests/comprehension/.staleness-baseline.json
+++ b/tests/comprehension/.staleness-baseline.json
@@ -49,7 +49,7 @@
  },
  "12800_spec.json": {},
  "12818_spec.json": {
-  ".squidsquad/pm/CLAUDE.md": "3599217ac05d7a46eb5c4b37cff5ef738839e035"
+  ".squidsquad/pm/CLAUDE.md": "48d46f4e6ef81e4491cfef3814d50082a2c4640d"
  },
  "12825_spec.json": {
   "references/sub-skills/common/harness-restart.md": "a43cf57124e8cb35406ae1d0c243f14671e8c5ea"
@@ -200,7 +200,7 @@
   "tests/comprehension/8697_fixtures/skill_polling_CLAUDE.md": "b4c02ca4eaf7d3f370533052128c2eaea0d4e4af"
  },
  "9184_spec.json": {
-  ".squidsquad/pm/CLAUDE.md": "3599217ac05d7a46eb5c4b37cff5ef738839e035",
+  ".squidsquad/pm/CLAUDE.md": "48d46f4e6ef81e4491cfef3814d50082a2c4640d",
   ".squidsquad/qa/CLAUDE.md": "047981dd6aaa3338360e0b38a60b4e38ee4dad94",
   ".squidsquad/skill/CLAUDE.md": "debf87bd00ee3eab1723bdafacc63188cbdb0581",
   "references/sub-skills/roles/pm/task-intake.md": "70fe77ac004801a82ddfe7dd7785f0db394a6607"


### PR DESCRIPTION
Two small drifts pm-lead found: (1) worker/instructions.md's discussion-protocol block was missing the 'tracker.py auto-prepends the role prefix; do NOT include **[ROLE]** in --message' caution that verifier and dm's blocks both already carry -- risked double-prefixed Discussion comments from workers. (2) dm/instructions.md's file-conventions block documented the retired type:bug/type:feature labels instead of the live type:issue/type:task taxonomy (confirmed correct wording already exists in pm/instructions.md).

Also fixed an unrelated but currently-blocking static-gate failure surfaced while running the gate: 9184_spec.json/12818_spec.json's comprehension baselines were stale against .squidsquad/pm/CLAUDE.md's committed HEAD (DM's post-#13746 deploy-signal recompose shifted the blob sha). Verified both specs' quizzed content has zero overlap with the changed region before refreshing -- same failure class as #13731, a prior occurrence. Disclosing explicitly since it's outside #13792's own scope, but the full static gate cannot pass right now without it.

Full static gate clean: 5909 gated tests passed. No new comprehension spec required -- pure wording/label fixes mirroring already-tested existing patterns (#13354 covers the auto-prepend caution's own correctness), not new behavior.