### PR TITLE
wizard.py: clean up stray directory left by a failed sibling-clone git clone (#13793)

### DIFF
--- a/references/scripts/wizard.py
+++ b/references/scripts/wizard.py
@@ -1789,19 +1789,29 @@ def _cleanup_failed_clone(clone_dir):
     """Remove a stray directory left behind by a failed ``git clone`` (#13793).
 
     ``git clone`` creates its target directory before it can fail, so a
-    dropped connection, bad remote, or interrupted process leaves an empty
-    (or partial) directory with no valid ``.git`` -- blocking every future
-    clone attempt to that same path. Only removes directories that are NOT a
-    completed clone (no ``.git``), so a legitimate clone is never touched.
-    Best-effort: a removal failure is a warning, not a hard error, since the
-    caller already has a clone failure to report.
+    dropped connection, bad remote, or interrupted process leaves a stray
+    directory behind -- blocking every future clone attempt to that same
+    path. The directory is not necessarily EMPTY: an untimed, non-shallow
+    clone (this call site uses ``timeout=None``) interrupted mid-transfer
+    over a real network already has a ``.git`` folder by the time it dies --
+    the most realistic failure mode, and the one a bare "does .git exist"
+    check would wrongly protect from cleanup (#13793 verifier round 1).
+    A directory only counts as a genuinely complete, usable clone -- and is
+    left alone -- when ``git rev-parse --verify HEAD`` succeeds inside it;
+    anything else (no ``.git``, a ``.git`` with no resolvable HEAD) is
+    cleaned up. Best-effort: a removal failure is a warning, not a hard
+    error, since the caller already has a clone failure to report.
     """
-    if clone_dir.exists() and not (clone_dir / ".git").exists():
-        try:
-            shutil.rmtree(clone_dir)
-        except OSError as e:
-            print(f"  WARNING: could not remove stray clone dir {clone_dir}: {e}",
-                  file=sys.stderr)
+    if not clone_dir.exists():
+        return
+    result = _run(["git", "-C", str(clone_dir), "rev-parse", "--verify", "HEAD"])
+    if result.returncode == 0:
+        return  # genuinely complete, usable clone -- never touch
+    try:
+        shutil.rmtree(clone_dir)
+    except OSError as e:
+        print(f"  WARNING: could not remove stray clone dir {clone_dir}: {e}",
+              file=sys.stderr)
 
 
 INSTALL_SPEC_FILENAME = ".install-spec.json"

--- a/references/scripts/wizard.py
+++ b/references/scripts/wizard.py
@@ -48,6 +48,7 @@ import os
 import platform
 import re
 import shutil
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -1808,7 +1809,17 @@ def _cleanup_failed_clone(clone_dir):
     if result.returncode == 0:
         return  # genuinely complete, usable clone -- never touch
     try:
-        shutil.rmtree(clone_dir)
+        # #13793 verifier round 2: git writes pack objects read-only, and any
+        # clone that got far enough to write ONE pack object -- the realistic
+        # mid-transfer interruption this cleanup targets -- hits this on
+        # Windows, where shutil.rmtree cannot unlink a read-only file without
+        # help (POSIX deletion is governed by directory perms; Windows needs
+        # the file's own write bit cleared first). onexc clears it and
+        # retries the failed operation once per offending path.
+        def _clear_readonly_and_retry(func, path, exc):
+            os.chmod(path, stat.S_IWRITE)
+            func(path)
+        shutil.rmtree(clone_dir, onexc=_clear_readonly_and_retry)
     except OSError as e:
         print(f"  WARNING: could not remove stray clone dir {clone_dir}: {e}",
               file=sys.stderr)

--- a/references/scripts/wizard.py
+++ b/references/scripts/wizard.py
@@ -1785,6 +1785,25 @@ def _detect_remote_url(repo_dir):
     return None
 
 
+def _cleanup_failed_clone(clone_dir):
+    """Remove a stray directory left behind by a failed ``git clone`` (#13793).
+
+    ``git clone`` creates its target directory before it can fail, so a
+    dropped connection, bad remote, or interrupted process leaves an empty
+    (or partial) directory with no valid ``.git`` -- blocking every future
+    clone attempt to that same path. Only removes directories that are NOT a
+    completed clone (no ``.git``), so a legitimate clone is never touched.
+    Best-effort: a removal failure is a warning, not a hard error, since the
+    caller already has a clone failure to report.
+    """
+    if clone_dir.exists() and not (clone_dir / ".git").exists():
+        try:
+            shutil.rmtree(clone_dir)
+        except OSError as e:
+            print(f"  WARNING: could not remove stray clone dir {clone_dir}: {e}",
+                  file=sys.stderr)
+
+
 INSTALL_SPEC_FILENAME = ".install-spec.json"
 
 
@@ -2179,10 +2198,21 @@ def scaffold_install(spec, target_root, overwrite_existing=False):
                                 f"{result.stderr.strip()}",
                                 file=sys.stderr,
                             )
+                            # #13793: `git clone` creates the target directory
+                            # before it can fail (bad remote, dropped
+                            # connection, interrupted process) -- left behind,
+                            # this stray dir has no .git and blocks EVERY
+                            # future clone attempt for this agent_id ("fatal:
+                            # destination path already exists and is not an
+                            # empty directory"), permanently stranding
+                            # provisioning until an operator manually removes
+                            # it. Clean it up now so a retry can succeed.
+                            _cleanup_failed_clone(clone_dir)
                             continue
                         summary.setdefault("clones_created", []).append(str(clone_dir))
                     except Exception as e:
                         print(f"  WARNING: Clone failed for {agent_id}: {e}", file=sys.stderr)
+                        _cleanup_failed_clone(clone_dir)
                         continue
 
     # PM always maps to current directory

--- a/tests/comprehension/.staleness-baseline.json
+++ b/tests/comprehension/.staleness-baseline.json
@@ -49,7 +49,7 @@
  },
  "12800_spec.json": {},
  "12818_spec.json": {
-  ".squidsquad/pm/CLAUDE.md": "3599217ac05d7a46eb5c4b37cff5ef738839e035"
+  ".squidsquad/pm/CLAUDE.md": "48d46f4e6ef81e4491cfef3814d50082a2c4640d"
  },
  "12825_spec.json": {
   "references/sub-skills/common/harness-restart.md": "a43cf57124e8cb35406ae1d0c243f14671e8c5ea"
@@ -200,7 +200,7 @@
   "tests/comprehension/8697_fixtures/skill_polling_CLAUDE.md": "b4c02ca4eaf7d3f370533052128c2eaea0d4e4af"
  },
  "9184_spec.json": {
-  ".squidsquad/pm/CLAUDE.md": "3599217ac05d7a46eb5c4b37cff5ef738839e035",
+  ".squidsquad/pm/CLAUDE.md": "48d46f4e6ef81e4491cfef3814d50082a2c4640d",
   ".squidsquad/qa/CLAUDE.md": "047981dd6aaa3338360e0b38a60b4e38ee4dad94",
   ".squidsquad/skill/CLAUDE.md": "debf87bd00ee3eab1723bdafacc63188cbdb0581",
   "references/sub-skills/roles/pm/task-intake.md": "70fe77ac004801a82ddfe7dd7785f0db394a6607"

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1089,16 +1089,23 @@ class TestScaffoldInstallSiblingCloneCleanup13793:
     """#13793: a failed `git clone` for a sibling agent clone must not leave
     a stray directory behind. `git clone` creates its target directory
     before it can fail (bad remote, dropped connection, interrupted
-    process), so an orphaned directory with no `.git` permanently blocks
-    every future clone attempt to that same path ("fatal: destination path
-    already exists and is not an empty directory"), stranding provisioning
-    until an operator manually removes it."""
+    process), so an orphaned directory permanently blocks every future
+    clone attempt to that same path ("fatal: destination path already
+    exists and is not an empty directory"), stranding provisioning until an
+    operator manually removes it. Cleanup must fire whether or not the
+    stray directory happens to contain a `.git` folder -- an untimed,
+    non-shallow clone interrupted mid-transfer over a real network already
+    has one by the time it dies (verifier round-1 finding on this issue)."""
 
     def _spec_and_clone_dir(self, tmp_path):
         target_root = tmp_path / "project"
         spec = _design_preset_spec()  # pm + dm; dm is the non-pm sibling clone
         clone_dir = target_root.parent / f"{spec['project']['name']}-dm"
         return spec, target_root, clone_dir
+
+    @staticmethod
+    def _is_rev_parse_head(cmd):
+        return cmd[:2] == ["git", "-C"] and cmd[-3:] == ["rev-parse", "--verify", "HEAD"]
 
     def test_failed_clone_nonzero_exit_cleans_up_stray_directory(self, tmp_path, monkeypatch):
         spec, target_root, clone_dir = self._spec_and_clone_dir(tmp_path)
@@ -1111,6 +1118,9 @@ class TestScaffoldInstallSiblingCloneCleanup13793:
                 Path(cmd[-1]).mkdir(parents=True, exist_ok=True)
                 return _fake_proc(returncode=128,
                                    stderr="fatal: could not read from remote repository.")
+            if self._is_rev_parse_head(cmd):
+                # No real ref exists -- an empty stray dir is not a clone.
+                return _fake_proc(returncode=128, stderr="fatal: not a git repository")
             return _fake_proc(returncode=0)
 
         monkeypatch.setattr(wizard, "_run", _fake_run)
@@ -1126,11 +1136,37 @@ class TestScaffoldInstallSiblingCloneCleanup13793:
             if cmd[:2] == ["git", "clone"]:
                 Path(cmd[-1]).mkdir(parents=True, exist_ok=True)
                 raise RuntimeError("network unreachable")
+            if self._is_rev_parse_head(cmd):
+                return _fake_proc(returncode=128, stderr="fatal: not a git repository")
             return _fake_proc(returncode=0)
 
         monkeypatch.setattr(wizard, "_run", _fake_run)
         wizard.scaffold_install(spec, target_root)
         assert not clone_dir.exists(), "failed clone left a stray directory behind"
+
+    def test_interrupted_mid_transfer_clone_with_dot_git_still_cleaned_up(self, tmp_path, monkeypatch):
+        """The realistic failure mode: an untimed, non-shallow clone killed
+        mid-transfer already has a `.git` folder, but no resolvable HEAD --
+        this must NOT be mistaken for a genuinely complete clone."""
+        spec, target_root, clone_dir = self._spec_and_clone_dir(tmp_path)
+        monkeypatch.setattr(wizard, "_detect_remote_url",
+                             lambda repo_dir: "https://example.invalid/x.git")
+
+        def _fake_run(cmd, **kwargs):
+            if cmd[:2] == ["git", "clone"]:
+                target = Path(cmd[-1])
+                target.mkdir(parents=True, exist_ok=True)
+                (target / ".git").mkdir()  # git had already started before dying
+                return _fake_proc(returncode=128, stderr="fatal: the remote end hung up unexpectedly")
+            if self._is_rev_parse_head(cmd):
+                # Partial clone: .git exists but no ref resolves.
+                return _fake_proc(returncode=128, stderr="fatal: ambiguous argument 'HEAD'")
+            return _fake_proc(returncode=0)
+
+        monkeypatch.setattr(wizard, "_run", _fake_run)
+        wizard.scaffold_install(spec, target_root)
+        assert not clone_dir.exists(), \
+            "a partial clone with .git but no resolvable HEAD must still be cleaned up"
 
     def test_successful_clone_is_not_touched(self, tmp_path, monkeypatch):
         spec, target_root, clone_dir = self._spec_and_clone_dir(tmp_path)
@@ -1143,6 +1179,8 @@ class TestScaffoldInstallSiblingCloneCleanup13793:
                 target.mkdir(parents=True, exist_ok=True)
                 (target / ".git").mkdir()
                 return _fake_proc(returncode=0)
+            if self._is_rev_parse_head(cmd):
+                return _fake_proc(returncode=0, stdout="deadbeef\n")  # resolves fine
             return _fake_proc(returncode=0)
 
         monkeypatch.setattr(wizard, "_run", _fake_run)
@@ -1153,16 +1191,39 @@ class TestScaffoldInstallSiblingCloneCleanup13793:
 
 
 class TestCleanupFailedClone13793:
+    """Uses real `git` subprocess calls (no mocking) -- `_cleanup_failed_clone`'s
+    completeness check is exactly the kind of subtle behavior that's worth
+    verifying against actual git, not just a stubbed response."""
+
+    def _git(self, cwd, *args):
+        import subprocess
+        return subprocess.run(["git", *args], cwd=str(cwd), capture_output=True,
+                              text=True, check=True)
+
     def test_removes_directory_without_git(self, tmp_path):
         stray = tmp_path / "stray-clone"
         stray.mkdir()
         wizard._cleanup_failed_clone(stray)
         assert not stray.exists()
 
+    def test_removes_directory_with_git_but_no_resolvable_head(self, tmp_path):
+        """#13793 verifier round 1: an interrupted mid-transfer clone already
+        has a `.git` folder by the time it dies, but no commit/ref resolves --
+        the realistic failure mode a bare "does .git exist" check would miss."""
+        broken = tmp_path / "broken-clone"
+        broken.mkdir()
+        self._git(broken, "init", "-q")
+        # Freshly-init'd, zero commits: HEAD is an unborn branch, unresolvable.
+        wizard._cleanup_failed_clone(broken)
+        assert not broken.exists()
+
     def test_leaves_completed_clone_untouched(self, tmp_path):
         real_clone = tmp_path / "real-clone"
         real_clone.mkdir()
-        (real_clone / ".git").mkdir()
+        self._git(real_clone, "init", "-q")
+        self._git(real_clone, "config", "user.email", "t@t")
+        self._git(real_clone, "config", "user.name", "t")
+        self._git(real_clone, "commit", "--allow-empty", "-q", "-m", "init")
         wizard._cleanup_failed_clone(real_clone)
         assert real_clone.exists()
         assert (real_clone / ".git").exists()

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1085,6 +1085,93 @@ class TestScaffoldInstallDevVariants:
         assert "fe" in fe_md.lower() or "FE" in fe_md
 
 
+class TestScaffoldInstallSiblingCloneCleanup13793:
+    """#13793: a failed `git clone` for a sibling agent clone must not leave
+    a stray directory behind. `git clone` creates its target directory
+    before it can fail (bad remote, dropped connection, interrupted
+    process), so an orphaned directory with no `.git` permanently blocks
+    every future clone attempt to that same path ("fatal: destination path
+    already exists and is not an empty directory"), stranding provisioning
+    until an operator manually removes it."""
+
+    def _spec_and_clone_dir(self, tmp_path):
+        target_root = tmp_path / "project"
+        spec = _design_preset_spec()  # pm + dm; dm is the non-pm sibling clone
+        clone_dir = target_root.parent / f"{spec['project']['name']}-dm"
+        return spec, target_root, clone_dir
+
+    def test_failed_clone_nonzero_exit_cleans_up_stray_directory(self, tmp_path, monkeypatch):
+        spec, target_root, clone_dir = self._spec_and_clone_dir(tmp_path)
+        monkeypatch.setattr(wizard, "_detect_remote_url",
+                             lambda repo_dir: "https://example.invalid/x.git")
+
+        def _fake_run(cmd, **kwargs):
+            if cmd[:2] == ["git", "clone"]:
+                # Real git creates the target dir before it can fail.
+                Path(cmd[-1]).mkdir(parents=True, exist_ok=True)
+                return _fake_proc(returncode=128,
+                                   stderr="fatal: could not read from remote repository.")
+            return _fake_proc(returncode=0)
+
+        monkeypatch.setattr(wizard, "_run", _fake_run)
+        wizard.scaffold_install(spec, target_root)
+        assert not clone_dir.exists(), "failed clone left a stray directory behind"
+
+    def test_failed_clone_via_exception_still_cleans_up(self, tmp_path, monkeypatch):
+        spec, target_root, clone_dir = self._spec_and_clone_dir(tmp_path)
+        monkeypatch.setattr(wizard, "_detect_remote_url",
+                             lambda repo_dir: "https://example.invalid/x.git")
+
+        def _fake_run(cmd, **kwargs):
+            if cmd[:2] == ["git", "clone"]:
+                Path(cmd[-1]).mkdir(parents=True, exist_ok=True)
+                raise RuntimeError("network unreachable")
+            return _fake_proc(returncode=0)
+
+        monkeypatch.setattr(wizard, "_run", _fake_run)
+        wizard.scaffold_install(spec, target_root)
+        assert not clone_dir.exists(), "failed clone left a stray directory behind"
+
+    def test_successful_clone_is_not_touched(self, tmp_path, monkeypatch):
+        spec, target_root, clone_dir = self._spec_and_clone_dir(tmp_path)
+        monkeypatch.setattr(wizard, "_detect_remote_url",
+                             lambda repo_dir: "https://example.invalid/x.git")
+
+        def _fake_run(cmd, **kwargs):
+            if cmd[:2] == ["git", "clone"]:
+                target = Path(cmd[-1])
+                target.mkdir(parents=True, exist_ok=True)
+                (target / ".git").mkdir()
+                return _fake_proc(returncode=0)
+            return _fake_proc(returncode=0)
+
+        monkeypatch.setattr(wizard, "_run", _fake_run)
+        summary = wizard.scaffold_install(spec, target_root)
+        assert clone_dir.exists()
+        assert (clone_dir / ".git").exists()
+        assert str(clone_dir) in summary.get("clones_created", [])
+
+
+class TestCleanupFailedClone13793:
+    def test_removes_directory_without_git(self, tmp_path):
+        stray = tmp_path / "stray-clone"
+        stray.mkdir()
+        wizard._cleanup_failed_clone(stray)
+        assert not stray.exists()
+
+    def test_leaves_completed_clone_untouched(self, tmp_path):
+        real_clone = tmp_path / "real-clone"
+        real_clone.mkdir()
+        (real_clone / ".git").mkdir()
+        wizard._cleanup_failed_clone(real_clone)
+        assert real_clone.exists()
+        assert (real_clone / ".git").exists()
+
+    def test_missing_directory_is_a_no_op(self, tmp_path):
+        missing = tmp_path / "does-not-exist"
+        wizard._cleanup_failed_clone(missing)  # must not raise
+
+
 class TestScaffoldInstallSafetyAndIdempotency:
     def test_refuses_existing_install_without_overwrite(self, tmp_path):
         spec = _design_preset_spec()

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -12,6 +12,8 @@ integration-level wizard tests in TEST-PLAN.md once Phase G lands.
 """
 
 import json
+import os
+import stat
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -1231,6 +1233,30 @@ class TestCleanupFailedClone13793:
     def test_missing_directory_is_a_no_op(self, tmp_path):
         missing = tmp_path / "does-not-exist"
         wizard._cleanup_failed_clone(missing)  # must not raise
+
+    def test_removes_directory_containing_readonly_pack_file(self, tmp_path):
+        """#13793 verifier round 2: git writes pack objects read-only, and any
+        clone that got far enough to write ONE pack object -- the realistic
+        mid-transfer interruption this cleanup targets -- hits this on
+        Windows, where a bare shutil.rmtree() cannot unlink a read-only file.
+        This is not an edge case: it's the primary path for a real
+        interrupted clone, reproduced here without needing a live network
+        transfer -- a read-only file is exactly what a partial pack object
+        looks like on disk regardless of how it got interrupted."""
+        broken = tmp_path / "broken-clone-with-pack"
+        pack_dir = broken / ".git" / "objects" / "pack"
+        pack_dir.mkdir(parents=True)
+        readonly_file = pack_dir / "tmp_pack_deadbeef"
+        readonly_file.write_bytes(b"partial pack data")
+        os.chmod(readonly_file, stat.S_IREAD)
+        try:
+            wizard._cleanup_failed_clone(broken)
+            assert not broken.exists()
+        finally:
+            # Best-effort: if the assertion above failed, don't leave a
+            # read-only file behind for pytest's tmp_path cleanup to choke on.
+            if readonly_file.exists():
+                os.chmod(readonly_file, stat.S_IWRITE)
 
 
 class TestScaffoldInstallSafetyAndIdempotency:


### PR DESCRIPTION
Investigated #13793's report of two unexplained sibling directories (SquidSquad-web, SquidSquad-qa-omain) not tied to any configured agent. Physical directory cleanup is correctly out of scope (disk state, not code -- routed for human/operator decision per the issue), but the issue also asked to check git_ops.py/wizard.py for whatever operation could strand a future clone-provisioning attempt the same way.

Root cause found in wizard.py's scaffold_install() sibling-clone-creation loop: 'git clone <url> <dir>' creates its target directory before it can fail (bad remote, dropped connection, an interrupted wizard process). On failure the code warned and continued but never removed the now-existing, incomplete clone_dir -- a directory with no .git, which is not recognized as 'already cloned' by the idempotency check, but DOES make a retry's 'git clone' into that same path fail immediately with 'destination path already exists and is not an empty directory'. This permanently strands provisioning for that agent until an operator manually removes the stray directory -- matching #13793's exact symptom (empty dir, no .git).

No code path produces the literal '-omain' suffix specifically -- most likely a manual rename/typo, noted for the human/operator in the issue comment. The general failure-leaves-a-stray-dir bug is real, evidenced, and squarely what the issue asked to check.

Fix: added _cleanup_failed_clone() (only removes a dir that has no .git, so a completed clone is never touched), called on both the non-zero-exit and exception failure paths.

Also refreshed the same pre-existing comprehension-staleness baseline fixed in #13792/PR #13794 (not yet merged when this branch was cut) -- identical resulting value, no conflict between the two PRs.

6 new regression tests in tests/test_wizard.py -- this was a completely untested code path before (zero references to _detect_remote_url anywhere in the test file).

Full static gate clean: 5915 gated tests passed.