### PR TITLE
pm/instructions.md: complete the frontmatter step-ids list to all 12 body anchors (#13801)

### DIFF
--- a/references/roles/pm/instructions.md
+++ b/references/roles/pm/instructions.md
@@ -2,7 +2,7 @@
 slot: instructions
 ordinal: 20
 roles: [pm]
-step-ids: [step:cycle/check-in, step:cycle/pipeline-sentinel, step:cycle/task-intake, step:cycle/task-approval, step:cycle/health-check, step:cycle/vault-synthesis]
+step-ids: [step:cycle/check-in, step:cycle/triage-external, step:cycle/task-intake, step:cycle/task-approval, step:cycle/pipeline-sentinel, step:cycle/health-check, step:cycle/boot-remote-agents, step:cycle/own-domain-autofix, step:cycle/soul-shepherd, step:cycle/improvement-scan, step:cycle/vault-optimize, step:cycle/vault-synthesis]
 ---
 
 <!-- sub-skill: file-conventions -->

--- a/tests/comprehension/.staleness-baseline.json
+++ b/tests/comprehension/.staleness-baseline.json
@@ -99,7 +99,7 @@
   "references/sub-skills/common/harness-restart.md": "a43cf57124e8cb35406ae1d0c243f14671e8c5ea"
  },
  "13327_spec.json": {
-  "references/roles/pm/instructions.md": "ed1f3efe19f2fec2281ed30b94d6d049bef49919"
+  "references/roles/pm/instructions.md": "4622738c697086a4b75bc58c1b1a4c2e8b4a9384"
  },
  "13328_spec.json": {
   "docs/INSTALLER-RUNTIME.md": "d345fd45768bc3f8b16420a8b98d6a43d41441ac"
@@ -157,7 +157,7 @@
   "references/sub-skills/roles/pm/improvement-scan.md": "d683d3ad3559aabba27831deaad6fc06ad7f4389"
  },
  "13746_spec.json": {
-  "references/roles/pm/instructions.md": "ed1f3efe19f2fec2281ed30b94d6d049bef49919"
+  "references/roles/pm/instructions.md": "4622738c697086a4b75bc58c1b1a4c2e8b4a9384"
  },
  "13792_spec.json": {
   "references/roles/dm/instructions.md": "5e94728963ace4bdb376d96b0cecff7ceb7825e5",

--- a/tests/comprehension/.staleness-baseline.json
+++ b/tests/comprehension/.staleness-baseline.json
@@ -206,7 +206,7 @@
  "9184_spec.json": {
   ".squidsquad/pm/CLAUDE.md": "48d46f4e6ef81e4491cfef3814d50082a2c4640d",
   ".squidsquad/qa/CLAUDE.md": "047981dd6aaa3338360e0b38a60b4e38ee4dad94",
-  ".squidsquad/skill/CLAUDE.md": "debf87bd00ee3eab1723bdafacc63188cbdb0581",
+  ".squidsquad/skill/CLAUDE.md": "f6a040277df3cd9338880e02e089c70283c6a962",
   "references/sub-skills/roles/pm/task-intake.md": "70fe77ac004801a82ddfe7dd7785f0db394a6607"
  },
  "9588_spec.json": {},


### PR DESCRIPTION
pm-lead found the frontmatter declared only 6 of the 12 step:cycle/* anchors the body actually defines (missing triage-external, boot-remote-agents, own-domain-autofix, soul-shepherd, improvement-scan, vault-optimize). Sibling role files enumerate completely (worker 3/3, verifier 2/2, dm 8/8). The field feeds link_stage_validator.py's R5 check and the #10441 assemble-preservation check -- an under-declared list weakens both for pm, even though compose output itself was unaffected.

Fix: completed step-ids to list all 12 anchors in body order, matching sibling-file convention. Verified programmatically that the declared list now exactly equals the body's anchor sequence.

Also refreshed an unrelated, pre-existing static-gate blocker found while running the gate: 9184_spec.json's baseline was stale against .squidsquad/skill/CLAUDE.md (a DM post-#13792-merge recompose) -- confirmed zero content overlap before refreshing.

Full static gate clean: 5909 gated tests passed.

Note: I initially attempted a generalized cross-role regression test asserting frontmatter step-ids == body step-heading anchors for all 4 role files, but discovered the convention isn't uniform -- dm and worker mix ### -level REPLACE-style overrides of universal L1 steps with #### -level new-step insertions, and the frontmatter field only tracks each file's own newly-introduced steps at whichever level it uses (worker's ### step:cycle/cleanup override is correctly excluded from its declared list, for instance). A naive cross-role test would have encoded a wrong invariant, so I dropped it rather than ship something that could misfire on dm/worker's legitimate usage. This PR is scoped to exactly what the issue asked: pm's own undercounted list.