### PR TITLE
#13831: extend stash-protected fast-forward to all 3 git_ops.py call sites

### DIFF
--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -318,6 +318,32 @@ def _safe_stash_pop():
     return False
 
 
+def _stash_guarded_ff_only_merge(target_ref):
+    """Run ``git merge --ff-only <target_ref>``, stash-guarded (#13819/#13831).
+
+    A bare ``git merge --ff-only`` refuses to run when uncommitted local
+    changes touch a file the fast-forward would also update ("Your local
+    changes ... would be overwritten by merge") — routine mid-cycle state for
+    an event-mode agent. This mirrors ``_safe_checkout()``'s stash-before/
+    pop-after pattern so every fast-forward call site gets the same
+    protection instead of reimplementing it independently (#13819 fixed only
+    one of three identical call sites; this factors it out so a future fourth
+    site doesn't reintroduce the same gap). #13167-safe: only pops a stash
+    this call actually created, never a pre-existing unrelated one.
+
+    Returns the ``CompletedProcess`` from the merge attempt; callers keep
+    their own success/failure handling (fail-loud vs fail-open differs by
+    call site).
+    """
+    pre_stash_ref = _stash_top_ref()
+    _run("git stash -q", check=False)
+    stashed = _stash_top_ref() != pre_stash_ref
+    ff = _run_list(["git", "merge", "--ff-only", target_ref], check=False)
+    if stashed:
+        _safe_stash_pop()
+    return ff
+
+
 def pull(role=None):
     """Pull with merge (#5378, #5445).
 
@@ -897,7 +923,7 @@ def _checkout_and_ff_working_after_merge(working):
         # Ahead (unpushed local commits) or diverged — only a fast-forward is
         # safe here; leave it for a human/task-begin to reconcile.
         return
-    ff = _run_list(["git", "merge", "--ff-only", f"origin/{working}"], check=False)
+    ff = _stash_guarded_ff_only_merge(f"origin/{working}")
     if ff.returncode != 0:
         print(
             f"WARNING: could not fast-forward local {working} to origin/"
@@ -1719,7 +1745,7 @@ def _sync_working_branch_to_origin(working):
         # Something switched us away between the caller's checkout and here
         # — never merge onto the wrong branch.
         return
-    ff = _run_list(["git", "merge", "--ff-only", f"origin/{working}"], check=False)
+    ff = _stash_guarded_ff_only_merge(f"origin/{working}")
     if ff.returncode != 0:
         print(
             f"WARNING: could not fast-forward local {working} to origin/"
@@ -2125,19 +2151,13 @@ def _sync_local_branch_to_origin(branch):
         ["git", "merge-base", "--is-ancestor", local_sha, origin_sha], check=False
     ).returncode == 0
     if behind:
-        # #13819: stash-before/pop-after, mirroring _safe_checkout() -- a
-        # bare `git merge --ff-only` refuses to run when uncommitted local
-        # changes touch a file the fast-forward would also update ("Your
-        # local changes ... would be overwritten by merge"), which is
-        # routine mid-cycle state for an event-mode agent (this is the
-        # verifier re-verification path). #13167-safe: only pop a stash we
-        # actually created, never a pre-existing unrelated one.
-        pre_stash_ref = _stash_top_ref()
-        _run("git stash -q", check=False)
-        stashed = _stash_top_ref() != pre_stash_ref
-        ff = _run_list(["git", "merge", "--ff-only", f"origin/{branch}"], check=False)
-        if stashed:
-            _safe_stash_pop()
+        # #13819/#13831: stash-guarded fast-forward (see
+        # _stash_guarded_ff_only_merge) -- a bare `git merge --ff-only`
+        # refuses to run when uncommitted local changes touch a file the
+        # fast-forward would also update ("Your local changes ... would be
+        # overwritten by merge"), which is routine mid-cycle state for an
+        # event-mode agent (this is the verifier re-verification path).
+        ff = _stash_guarded_ff_only_merge(f"origin/{branch}")
         if ff.returncode != 0:
             print(
                 f"ERROR: task-begin could not fast-forward {branch} to origin/"

--- a/tests/test_13447_pr_merge_post_merge_sync.py
+++ b/tests/test_13447_pr_merge_post_merge_sync.py
@@ -41,6 +41,50 @@ def _mk(rc=0, stdout="", stderr=""):
     return m
 
 
+def _fake_run_no_stash_activity(calls):
+    """A `git_ops._run` fake (string-command form) for the `_stash_top_ref`/
+    `git stash -q` calls the #13819/#13831 shared stash guard makes.
+    Simulates a perpetually clean tree: `_stash_top_ref()` always returns the
+    same (empty) value, so `stashed` computes False and no pop is ever
+    attempted."""
+    def side_effect(cmd, check=False):
+        calls.append(cmd)
+        if "refs/stash" in cmd:
+            return _mk(1, "")  # no stash ref exists -- never changes
+        if cmd.strip() == "git stash -q":
+            return _mk(0)  # no-op stash on a clean tree
+        return _mk(1)
+
+    return side_effect
+
+
+def _fake_run_creates_and_pops_stash(calls, *, pop_rc=0):
+    """A `git_ops._run` fake simulating a REAL uncommitted change: the first
+    `_stash_top_ref()` call (pre-stash) sees no stash, `git stash -q`
+    creates one (dirty tree), the second `_stash_top_ref()` call (post-
+    stash) sees it -- so `stashed` computes True and `_safe_stash_pop()`'s
+    `git stash pop` is expected to fire."""
+    state = {"stash_sha": ""}
+
+    def side_effect(cmd, check=False):
+        calls.append(cmd)
+        if "refs/stash" in cmd:
+            return _mk(0 if state["stash_sha"] else 1, state["stash_sha"])
+        if cmd.strip() == "git stash -q":
+            state["stash_sha"] = "c" * 40
+            return _mk(0)
+        if cmd.strip() == "git stash pop":
+            if pop_rc == 0:
+                state["stash_sha"] = ""
+            return _mk(pop_rc)
+        if cmd.strip() == "git stash drop":
+            state["stash_sha"] = ""
+            return _mk(0)
+        return _mk(1)
+
+    return side_effect
+
+
 class TestRevertComposedStateContamination:
     @patch("git_ops._run_list")
     @patch("git_ops._run")
@@ -97,9 +141,10 @@ class TestRevertComposedStateContamination:
 
 
 class TestCheckoutAndFfWorkingAfterMerge:
+    @patch("git_ops._run")
     @patch("git_ops._run_list")
     @patch("git_ops._safe_checkout", return_value=True)
-    def test_behind_fast_forwards(self, mock_checkout, mock_rl):
+    def test_behind_fast_forwards(self, mock_checkout, mock_rl, mock_run):
         def side_effect(cmd, check=False):
             s = str(cmd)
             if cmd[:2] == ["git", "fetch"]:
@@ -114,6 +159,7 @@ class TestCheckoutAndFfWorkingAfterMerge:
                 return _mk(0)
             return _mk(1)
         mock_rl.side_effect = side_effect
+        mock_run.side_effect = _fake_run_no_stash_activity([])
         git_ops._checkout_and_ff_working_after_merge(WORKING)
         mock_checkout.assert_called_once_with(WORKING)
         ff_calls = [c.args[0] for c in mock_rl.call_args_list
@@ -146,9 +192,10 @@ class TestCheckoutAndFfWorkingAfterMerge:
                     if "merge" in c.args[0] and "--ff-only" in c.args[0]]
         assert not ff_calls
 
+    @patch("git_ops._run")
     @patch("git_ops._run_list")
     @patch("git_ops._safe_checkout", return_value=True)
-    def test_ff_failure_warns_never_raises(self, mock_checkout, mock_rl, capsys):
+    def test_ff_failure_warns_never_raises(self, mock_checkout, mock_rl, mock_run, capsys):
         def side_effect(cmd, check=False):
             s = str(cmd)
             if cmd[:2] == ["git", "fetch"]:
@@ -163,6 +210,7 @@ class TestCheckoutAndFfWorkingAfterMerge:
                 return _mk(1, stderr="ff failed")
             return _mk(1)
         mock_rl.side_effect = side_effect
+        mock_run.side_effect = _fake_run_no_stash_activity([])
         git_ops._checkout_and_ff_working_after_merge(WORKING)  # must not raise
         err = capsys.readouterr().err
         assert "WARNING" in err
@@ -173,6 +221,67 @@ class TestCheckoutAndFfWorkingAfterMerge:
     def test_origin_unreachable_noop(self, mock_checkout, mock_rl):
         mock_rl.return_value = _mk(1)  # rev-parse --verify remotes fails
         git_ops._checkout_and_ff_working_after_merge(WORKING)  # must not raise
+
+
+class TestCheckoutAndFfWorkingAfterMergeStashGuard13831:
+    """#13831: this call site's fast-forward was 1 of 3 identical fast-
+    forwards missing #13819's stash-before/pop-after protection -- now
+    routed through the shared _stash_guarded_ff_only_merge helper."""
+
+    def _rl_side_effect(self, ff_rc=0):
+        def side_effect(cmd, check=False):
+            s = str(cmd)
+            if cmd[:2] == ["git", "fetch"]:
+                return _mk(0)
+            if "rev-parse" in cmd and "refs/remotes/" in s:
+                return _mk(0, ORIGIN + "\n")
+            if "rev-parse" in cmd and "refs/heads/" in s:
+                return _mk(0, LOCAL + "\n")
+            if "merge-base" in cmd:
+                return _mk(0 if cmd[3] == LOCAL else 1)
+            if "merge" in cmd and "--ff-only" in cmd:
+                return _mk(ff_rc, stderr="ff failed" if ff_rc else "")
+            return _mk(1)
+        return side_effect
+
+    @patch("git_ops._run")
+    @patch("git_ops._run_list")
+    @patch("git_ops._safe_checkout", return_value=True)
+    def test_dirty_tree_stashes_before_and_pops_after_successful_ff(
+        self, mock_checkout, mock_rl, mock_run
+    ):
+        calls = []
+        mock_rl.side_effect = self._rl_side_effect(ff_rc=0)
+        mock_run.side_effect = _fake_run_creates_and_pops_stash(calls)
+        git_ops._checkout_and_ff_working_after_merge(WORKING)
+        assert any(c.strip() == "git stash -q" for c in calls)
+        assert any(c.strip() == "git stash pop" for c in calls)
+
+    @patch("git_ops._run")
+    @patch("git_ops._run_list")
+    @patch("git_ops._safe_checkout", return_value=True)
+    def test_clean_tree_never_pops_a_preexisting_stash(
+        self, mock_checkout, mock_rl, mock_run
+    ):
+        calls = []
+        mock_rl.side_effect = self._rl_side_effect(ff_rc=0)
+        mock_run.side_effect = _fake_run_no_stash_activity(calls)
+        git_ops._checkout_and_ff_working_after_merge(WORKING)
+        assert any(c.strip() == "git stash -q" for c in calls)
+        assert not any(c.strip() == "git stash pop" for c in calls)
+
+    @patch("git_ops._run")
+    @patch("git_ops._run_list")
+    @patch("git_ops._safe_checkout", return_value=True)
+    def test_ff_still_fails_after_stash_restores_work_before_returning(
+        self, mock_checkout, mock_rl, mock_run
+    ):
+        calls = []
+        mock_rl.side_effect = self._rl_side_effect(ff_rc=1)
+        mock_run.side_effect = _fake_run_creates_and_pops_stash(calls)
+        git_ops._checkout_and_ff_working_after_merge(WORKING)  # must not raise (fail-open)
+        assert any(c.strip() == "git stash pop" for c in calls), \
+            "stashed work must be restored even when the fail-open ff-only merge still fails"
 
 
 class TestPrMergePostMergeSync13447:

--- a/tests/test_13613_working_branch_sync.py
+++ b/tests/test_13613_working_branch_sync.py
@@ -64,6 +64,34 @@ def _dispatch(*, origin_exists=True, behind=False, ahead=False, ff_rc=0,
     return side_effect, calls
 
 
+def _fake_run_working_branch(calls, *, current=WORKING, stash_activity=False, pop_rc=0):
+    """A `git_ops._run` fake (string-command form) covering both the
+    `git branch --show-current` check and the #13819/#13831 shared
+    `_stash_guarded_ff_only_merge` stash-guard calls this function makes."""
+    state = {"stash_sha": ""}
+
+    def side_effect(cmd, check=False):
+        calls.append(cmd)
+        if cmd.strip() == "git branch --show-current":
+            return _mk(0, current + "\n")
+        if "refs/stash" in cmd:
+            return _mk(0 if state["stash_sha"] else 1, state["stash_sha"])
+        if cmd.strip() == "git stash -q":
+            if stash_activity:
+                state["stash_sha"] = "c" * 40
+            return _mk(0)
+        if cmd.strip() == "git stash pop":
+            if pop_rc == 0:
+                state["stash_sha"] = ""
+            return _mk(pop_rc)
+        if cmd.strip() == "git stash drop":
+            state["stash_sha"] = ""
+            return _mk(0)
+        return _mk(1)
+
+    return side_effect
+
+
 class TestSyncWorkingBranchToOrigin:
     @patch("git_ops._run", return_value=_mk(0, WORKING + "\n"))
     @patch("git_ops._run_list")
@@ -134,6 +162,46 @@ class TestSyncWorkingBranchToOrigin:
         mock_rl.side_effect = side_effect
         git_ops._sync_working_branch_to_origin(WORKING)
         assert not [c for c in calls if "merge" in c and "--ff-only" in c]
+
+
+class TestSyncWorkingBranchToOriginStashGuard13831:
+    """#13831: this call site's fast-forward was 1 of 3 identical fast-
+    forwards missing #13819's stash-before/pop-after protection -- now
+    routed through the shared _stash_guarded_ff_only_merge helper."""
+
+    @patch("git_ops._run")
+    @patch("git_ops._run_list")
+    def test_dirty_tree_stashes_before_and_pops_after_successful_ff(self, mock_rl, mock_run):
+        calls = []
+        rl_side_effect, rl_calls = _dispatch(origin_exists=True, behind=True, ff_rc=0)
+        mock_rl.side_effect = rl_side_effect
+        mock_run.side_effect = _fake_run_working_branch(calls, stash_activity=True)
+        git_ops._sync_working_branch_to_origin(WORKING)
+        assert any(c.strip() == "git stash -q" for c in calls)
+        assert any(c.strip() == "git stash pop" for c in calls)
+        assert [c for c in rl_calls if "merge" in c and "--ff-only" in c]
+
+    @patch("git_ops._run")
+    @patch("git_ops._run_list")
+    def test_clean_tree_never_pops_a_preexisting_stash(self, mock_rl, mock_run):
+        calls = []
+        rl_side_effect, rl_calls = _dispatch(origin_exists=True, behind=True, ff_rc=0)
+        mock_rl.side_effect = rl_side_effect
+        mock_run.side_effect = _fake_run_working_branch(calls, stash_activity=False)
+        git_ops._sync_working_branch_to_origin(WORKING)
+        assert any(c.strip() == "git stash -q" for c in calls)
+        assert not any(c.strip() == "git stash pop" for c in calls)
+
+    @patch("git_ops._run")
+    @patch("git_ops._run_list")
+    def test_ff_failure_still_restores_work_never_raises(self, mock_rl, mock_run):
+        calls = []
+        rl_side_effect, rl_calls = _dispatch(origin_exists=True, behind=True, ff_rc=1)
+        mock_rl.side_effect = rl_side_effect
+        mock_run.side_effect = _fake_run_working_branch(calls, stash_activity=True)
+        git_ops._sync_working_branch_to_origin(WORKING)  # must not raise (fail-open, #13613)
+        assert any(c.strip() == "git stash pop" for c in calls), \
+            "stashed work must be restored even when the fail-open ff-only merge still fails"
 
 
 class TestCheckoutAndSyncWorking:

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -321,6 +321,81 @@ class TestStashTopRef:
         assert git_ops._stash_top_ref() == ""
 
 
+class TestStashGuardedFfOnlyMerge:
+    """#13819/#13831: the shared stash-before/pop-after wrapper around
+    `git merge --ff-only <ref>`. Factored out of _sync_local_branch_to_origin
+    (#13819, the first of 3 identical call sites fixed) so
+    _checkout_and_ff_working_after_merge (#13447) and
+    _sync_working_branch_to_origin (#13613) get the same protection instead
+    of reimplementing it independently -- and so a future 4th fast-forward
+    call site inherits the fix automatically."""
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_clean_tree_no_stash_no_pop(self, mock_run, mock_rl):
+        # _stash_top_ref() returns "" both before and after `git stash -q`
+        # (a no-op stash on a clean tree never creates an entry) -> stashed
+        # is False -> no pop attempted.
+        mock_run.side_effect = [
+            _mock_result(returncode=1),   # _stash_top_ref pre -> ""
+            _mock_result(),               # git stash -q
+            _mock_result(returncode=1),   # _stash_top_ref post -> "" (unchanged)
+        ]
+        mock_rl.return_value = _mock_result(returncode=0)
+        ff = git_ops._stash_guarded_ff_only_merge("origin/main")
+        assert ff.returncode == 0
+        mock_rl.assert_called_once_with(
+            ["git", "merge", "--ff-only", "origin/main"], check=False
+        )
+        assert mock_run.call_count == 3  # pre, stash, post -- no pop/drop
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_dirty_tree_stashes_and_pops_after_success(self, mock_run, mock_rl):
+        mock_run.side_effect = [
+            _mock_result(returncode=1),          # _stash_top_ref pre -> ""
+            _mock_result(),                      # git stash -q (creates one)
+            _mock_result(stdout="newsha"),       # _stash_top_ref post -> changed
+            _mock_result(),                      # _safe_stash_pop: git stash pop (clean)
+        ]
+        mock_rl.return_value = _mock_result(returncode=0)
+        ff = git_ops._stash_guarded_ff_only_merge("origin/main")
+        assert ff.returncode == 0
+        pop_calls = [c for c in mock_run.call_args_list if c.args[0] == "git stash pop"]
+        assert len(pop_calls) == 1
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_preexisting_unrelated_stash_never_popped(self, mock_run, mock_rl):
+        # A pre-existing stash present both before and after `git stash -q`
+        # (which no-ops on a clean tree) -> stashed=False -> must never pop.
+        mock_run.side_effect = [
+            _mock_result(stdout="oldsha"),   # _stash_top_ref pre: pre-existing
+            _mock_result(),                  # git stash -q (no-op, clean tree)
+            _mock_result(stdout="oldsha"),   # _stash_top_ref post: unchanged
+        ]
+        mock_rl.return_value = _mock_result(returncode=0)
+        git_ops._stash_guarded_ff_only_merge("origin/main")
+        pop_calls = [c for c in mock_run.call_args_list if c.args[0] == "git stash pop"]
+        assert not pop_calls
+
+    @patch("git_ops._run_list")
+    @patch("git_ops._run")
+    def test_ff_failure_still_restores_stash_before_returning(self, mock_run, mock_rl):
+        mock_run.side_effect = [
+            _mock_result(returncode=1),          # _stash_top_ref pre -> ""
+            _mock_result(),                      # git stash -q (creates one)
+            _mock_result(stdout="newsha"),       # _stash_top_ref post -> changed
+            _mock_result(),                      # _safe_stash_pop: git stash pop (clean)
+        ]
+        mock_rl.return_value = _mock_result(returncode=1, stderr="ff failed")
+        ff = git_ops._stash_guarded_ff_only_merge("origin/main")
+        assert ff.returncode == 1
+        pop_calls = [c for c in mock_run.call_args_list if c.args[0] == "git stash pop"]
+        assert len(pop_calls) == 1, \
+            "uncommitted work must be restored even when the ff-only merge still fails"
+
+
 # ---------------------------------------------------------------------------
 # add_all()
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses #13831.

#13819 gave `_sync_local_branch_to_origin`'s fast-forward stash-before/pop-after protection, but #13831 (filed by verifier-lead as a direct follow-up) pointed out this was only 1 of 3 identical `git merge --ff-only` call sites in git_ops.py:

1. `_sync_local_branch_to_origin` (#13373/#13819) — task-begin's fast-forward, fails loudly (sys.exit).
2. `_checkout_and_ff_working_after_merge` (#13447) — post pr-merge sync, fail-open (WARNING).
3. `_sync_working_branch_to_origin` (#13613) — post commit-code sync, fail-open (WARNING).

All three refuse the same way when uncommitted local changes touch a file the fast-forward would also update ("Your local changes ... would be overwritten by merge") — routine mid-cycle state for an event-mode agent.

## Fix

Factored the stash-before/pop-after pattern out of `_sync_local_branch_to_origin` into a new shared `_stash_guarded_ff_only_merge(target_ref)` helper (git_ops.py, next to `_stash_top_ref`/`_safe_stash_pop`). All three call sites now route through it; each keeps its own success/failure handling (fail-loud vs fail-open) unchanged. #13167-safe: only pops a stash the call itself created, never a pre-existing unrelated one.

This also protects a future 4th call site from reintroducing the same gap independently, per the issue's own suggested-fix framing.

## Tests

- New `TestStashGuardedFfOnlyMerge` (tests/test_git_ops.py) — 4 tests exercising the helper directly (clean tree no-op, dirty tree stash+pop, pre-existing unrelated stash left alone, ff-failure still restores stash).
- `TestCheckoutAndFfWorkingAfterMergeStashGuard13831` (tests/test_13447_pr_merge_post_merge_sync.py) — 3 new tests for call site 2; existing tests updated to mock `_run` (previously unmocked, which would have hit real git stash commands now that the fast-forward path calls through it).
- `TestSyncWorkingBranchToOriginStashGuard13831` (tests/test_13613_working_branch_sync.py) — 3 new tests for call site 3.
- Existing #13373/#13819 coverage in tests/test_13373_task_begin_local_sync.py (incl. the 2 real-git repro tests) passes unchanged.

Full static gate: 5933 gated tests passed.