### PR TITLE
#13838: clarify TC-coverage ship gate is task-flow-only by design

### DIFF
--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -1587,7 +1587,16 @@ def transition(number, from_status, to_status, role=None, force=False):
             sys.exit(1)
 
     # 4. Guard: TC coverage gate for pending-test -> pending-ship
-    #    (NEVER bypassed, even with --force)
+    #    (NEVER bypassed, even with --force -- but only ACTIVATES when a
+    #    TEST-PLAN-<N>.md is discovered for the issue. TEST-PLAN authorship
+    #    is task-flow-only (verification.md Step 5, AC-derived TCs);
+    #    verification-issue-flow.md's type:issue bug-fix path never produces
+    #    one -- that flow is instead gated by its own Step 4/5 requirements
+    #    (a regression test must exist + the full suite must pass), enforced
+    #    by the verifier directly rather than by this script. #13838: do not
+    #    read the absence of a TC-coverage BLOCKED here as "the gate was
+    #    skipped" for type:issue items -- it structurally never applies to
+    #    them, by design, not as an accidental gap.
     if from_label == "status:pending-test" and to_label == "status:pending-ship":
         try:
             from tc_coverage import _discover_files, check_coverage

--- a/references/sub-skills/roles/verifier/verification-issue-flow.md
+++ b/references/sub-skills/roles/verifier/verification-issue-flow.md
@@ -39,6 +39,7 @@ For each issue:
 3. Run the relevant test or manually verify the fix.
 4. **Test coverage check**: Verify that the fix includes a regression test. Check for new or modified test files corresponding to the changed code. If the fix adds or changes code but includes no tests, reject it.
 5. **Run the full test suite**: `python tests/run_tests.py` — all tests must pass.
+   This flow intentionally never authors a `TEST-PLAN-<N>.md` — issue-flow has no AC-derived TC list to enumerate, so `tracker.py`'s TC-coverage ship gate (task-flow's `TEST-PLAN`/`QA-RESULTS` pairing) structurally never activates for `type:issue` items. Steps 4 and 5 above are this flow's own equivalent guarantee — a required regression test plus a green full suite — enforced directly by the verifier rather than by that script (#13838).
 6. If verified (fix works, regression test exists, all tests pass):
    - If a PR exists for this issue, convert from draft to ready:
      ```bash

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -15,6 +15,7 @@ SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 import tracker
+import tc_coverage
 
 
 def _mock_result(stdout="", stderr="", returncode=0):
@@ -993,3 +994,67 @@ class TestHardenStdio13185:
         src = inspect.getsource(tracker.work_assign)
         assert "→" not in src, "work-assign success print must stay ASCII (#13185)"
         assert "work-assign ->" in src
+
+
+class TestTransitionTcCoverageGateScope13838:
+    """#13838: the TC-coverage gate (transition() step 4) only ACTIVATES
+    when tc_coverage._discover_files() finds a TEST-PLAN. Task-flow items
+    author one (AC-derived TCs); type:issue bug-fix verifications never do
+    (verification-issue-flow.md gates them with its own regression-test +
+    full-suite requirements instead). No TEST-PLAN found must remain a
+    structural no-op forever, not an accidental gap that later "hardens"
+    into blocking every type:issue ship."""
+
+    def _stub_transition_environment(self, monkeypatch):
+        monkeypatch.setattr(tracker, "_check_unread_feedback", lambda *a, **kw: [])
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(tracker, "_run_list",
+                             lambda *a, **kw: _mock_result(stdout="ok"))
+        monkeypatch.setattr(tracker, "_get_issue_status_labels",
+                             lambda n: {"status:pending-test"})
+        monkeypatch.setattr(tracker, "_convert_draft_pr_to_ready", lambda n: None)
+        monkeypatch.setattr(tracker, "_log_diagnostic", lambda *a, **kw: None)
+
+    def test_no_test_plan_never_blocks_pending_ship(self, monkeypatch):
+        """No TEST-PLAN discovered (the type:issue case) -> transition
+        succeeds, no SystemExit. Locks the documented, by-design no-op."""
+        self._stub_transition_environment(monkeypatch)
+        monkeypatch.setattr(tc_coverage, "_discover_files", lambda n: (None, None))
+        try:
+            tracker.transition(13838, "pending-test", "pending-ship",
+                                role="verifier-lead", force=False)
+        except SystemExit:
+            pytest.fail(
+                "TC coverage gate must never block when no TEST-PLAN exists (#13838)"
+            )
+
+    def test_coverage_failure_still_blocks_when_test_plan_exists(
+        self, monkeypatch, tmp_path
+    ):
+        """A TEST-PLAN DOES exist (task-flow) and coverage fails -> the gate
+        still blocks, unaffected by the #13838 scoping clarification."""
+        self._stub_transition_environment(monkeypatch)
+        tp = tmp_path / "TEST-PLAN-13838.md"
+        qr = tmp_path / "QA-RESULTS-13838.md"
+        tp.write_text("dummy", encoding="utf-8")
+        qr.write_text("dummy", encoding="utf-8")
+        monkeypatch.setattr(tc_coverage, "_discover_files", lambda n: (tp, qr))
+        monkeypatch.setattr(tc_coverage, "check_coverage", lambda *a, **kw: 1)
+        with pytest.raises(SystemExit) as exc_info:
+            tracker.transition(13838, "pending-test", "pending-ship",
+                                role="verifier-lead", force=False)
+        assert exc_info.value.code == 1
+
+    def test_missing_qa_results_with_test_plan_still_blocks(
+        self, monkeypatch, tmp_path
+    ):
+        """A TEST-PLAN exists but QA-RESULTS doesn't (task-flow, incomplete)
+        -> still blocks, distinct from the no-TEST-PLAN-at-all no-op case."""
+        self._stub_transition_environment(monkeypatch)
+        tp = tmp_path / "TEST-PLAN-13838.md"
+        tp.write_text("dummy", encoding="utf-8")
+        monkeypatch.setattr(tc_coverage, "_discover_files", lambda n: (tp, None))
+        with pytest.raises(SystemExit) as exc_info:
+            tracker.transition(13838, "pending-test", "pending-ship",
+                                role="verifier-lead", force=False)
+        assert exc_info.value.code == 1


### PR DESCRIPTION
Addresses #13838.

Filed by verifier-lead: ran `tc_coverage.py --issue <N> --debug` against 6 recent `type:issue` verifications from this session and found every single one printed `No test plan found... Gate skipped` and exited 0 -- `tracker.py`'s pending-test -> pending-ship transition documents the TC-coverage gate as "NEVER bypassed, even with --force" without qualifying that it only *activates* when a `TEST-PLAN-<N>.md` is discovered.

## Root cause

`tc_coverage._discover_files()` / `--issue` mode requires BOTH a TEST-PLAN and QA-RESULTS pair to run `check_coverage()`. `verification-issue-flow.md` (the `type:issue` bug-fix protocol) never authors a TEST-PLAN -- it has no AC-derived TC list to enumerate. Its own Step 4/5 already gate every bug fix with a stronger, blanket guarantee instead: a required regression test plus a green full test suite (`python tests/run_tests.py`), enforced directly by the verifier rather than by `tc_coverage.py`.

Investigated the 3 suggested-fix options in the issue:
- (a) QA-RESULTS-only self-consistency mode -- doesn't add real protection: issue-flow doesn't mandate a QA-RESULTS artifact at all today (often just a forge comment), and even if it did, self-consistency against nothing to enumerate against is vacuous.
- (b) minimal TEST-PLAN authorship for issue-flow -- would bolt a parallel TC-enumeration artifact onto a flow whose existing regression-test + full-suite-green requirement is already a stronger check than TC-list bookkeeping provides.
- (c) fix the misleading "never bypassed" documentation -- this is what actually happened here: the gate is correctly scoped by design, the doc claim just overclaimed universality.

Went with (c): this is a documentation-accuracy defect, not a functional coverage gap.

## Fix

- `tracker.py`: expanded the step-4 comment to state the actual activation condition and point to `verification-issue-flow.md`'s own Step 4/5 as the equivalent guarantee for `type:issue` items. No behavior change.
- `verification-issue-flow.md`: added a note after Step 5 explaining why no TEST-PLAN is authored here, so a future reader doesn't mistake the absence for an oversight.
- `tests/test_tracker.py`: added `TestTransitionTcCoverageGateScope13838` (3 tests) -- locks the exact behavior in place at the `tracker.transition()` integration level (previously untested at this level): no-TEST-PLAN never blocks; a TEST-PLAN with failing coverage still blocks; a TEST-PLAN with missing QA-RESULTS still blocks.

Full static gate: 5936 gated tests passed.