### PR TITLE
#13846: correct false-positive cp1252-crash claim, add regression coverage for the existing (different) protection

### DIFF
--- a/tests/comprehension/.staleness-baseline.json
+++ b/tests/comprehension/.staleness-baseline.json
@@ -3,15 +3,15 @@
   "references/sub-skills/common/l4-curation.md": "638aff62b51b3aeb14124e420d614c5ea43f92b8"
  },
  "10678_spec.json": {
-  "docs/COMPOSE-ARCHITECTURE.md": "3f7e41e0b17704371bdd9ef2e0f4b266226d8e76",
-  "docs/sub-skill-catalog.md": "b2165c46b6f9dc9fd3d93446d76223622a31b388"
+  "docs/COMPOSE-ARCHITECTURE.md": "e50c3b0af405f37fb311c4fd213d35b8d11ae5e2",
+  "docs/sub-skill-catalog.md": "a9c426936b2e75f103d71cfd672fe9bbcbe8dec4"
  },
  "11140_spec.json": {
   "references/roles/SOUL.md": "123a7e0c083d236fdd1f20ebacd02420fe0642b8",
   "references/roles/responsibility.md": "8495bfec35fdabb092bdf164a356922c92f5e4df"
  },
  "11227_spec.json": {
-  "docs/COMPOSE-ARCHITECTURE.md": "3f7e41e0b17704371bdd9ef2e0f4b266226d8e76",
+  "docs/COMPOSE-ARCHITECTURE.md": "e50c3b0af405f37fb311c4fd213d35b8d11ae5e2",
   "references/scripts/l4_op_processor.py": "af384ef9937b94944cfd1a75ecf504bb5f30e6a0",
   "references/scripts/v2_link_stage.py": "797f2794f6987178385d0ecb3d2b7834e5617210"
  },

--- a/tests/test_cli_stdio_13198.py
+++ b/tests/test_cli_stdio_13198.py
@@ -8,6 +8,7 @@ into every CLI `main()`.
 
 import ast
 import io
+import re
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -64,9 +65,16 @@ class TestFleetWiring13198:
     """Every agent-facing CLI script must invoke the hardening at its entry so
     no script can reintroduce the cp1252 crash. tracker.py routes through its
     `_harden_stdio` delegate (which calls the shared helper); the other 8 call
-    `harden_stdio()` directly in main(). cycle.py is intentionally excluded — it
-    already force-reconfigures stdout to UTF-8 (a different but equally
-    crash-safe approach; aligning it is an optional cosmetic follow-on)."""
+    `harden_stdio()` directly in main(). cycle.py, cycle_pre.py, and
+    cycle_post.py are intentionally excluded — they already force-reconfigure
+    stdout/stderr to UTF-8 at import time (a different but equally crash-safe
+    approach; aligning them onto harden_stdio() is an optional cosmetic
+    follow-on). See TestUtf8ReconfigureAlternative13846 below, which verifies
+    that alternative actually holds rather than just asserting it in this
+    docstring (#13846: an improvement-scan pass initially misread the absence
+    of the `harden_stdio()` string as "unprotected" for cycle_pre.py/
+    cycle_post.py — investigation proved that false; this test class is the
+    correction, so the same false alarm doesn't get re-filed)."""
 
     WIRED = [
         "config", "subloop_driver", "model_router", "scan_index", "compose",
@@ -90,6 +98,78 @@ class TestFleetWiring13198:
 
     def test_shared_helper_module_exists(self):
         assert (SCRIPTS / "cli_stdio.py").exists()
+
+
+class TestUtf8ReconfigureAlternative13846:
+    """#13846: cycle.py, cycle_pre.py, and cycle_post.py use a DIFFERENT but
+    equally crash-safe strategy than `harden_stdio()` — they force
+    stdout/stderr to real UTF-8 via `.reconfigure(encoding="utf-8",
+    errors="replace")` at import time, rather than keeping the console's own
+    encoding and backstopping with `errors="backslashreplace"`.
+
+    An improvement-scan pass grepped for the literal string `harden_stdio()`
+    across every `references/scripts/*.py` with a `__main__` block, found it
+    absent from cycle_pre.py/cycle_post.py, and initially filed that as "the
+    harness's every-cycle wrapper scripts are unprotected against the cp1252
+    crash" (high severity). Investigation disproved the crash claim — see
+    `test_reconfigure_actually_prevents_the_crash` below, which reproduces
+    the exact failure mode `TestHardenStdio.test_baseline_cp1252_arrow_raises`
+    guards against and confirms the alternative guard prevents it too — but
+    surfaced a real, much narrower, lower-severity note: this alternative
+    runs at IMPORT TIME, which `cli_stdio.py`'s own module docstring flags as
+    the wrong place for stdio hardening ("these modules are also imported as
+    libraries, and reconfiguring a library consumer's global stdio would be
+    wrong") — and cycle_pre.py IS imported as a library, both by
+    cycle_post.py itself (`from cycle_pre import WS_RAW_CAP_BYTES`) and by
+    at least 9 test files. Tracked separately (not a crash, just an
+    architectural inconsistency with the documented contract) rather than
+    fixed inline here, to keep this correction narrowly scoped.
+    """
+
+    RECONFIGURE_GUARDED = ["cycle", "cycle_pre", "cycle_post"]
+
+    _RECONFIGURE_STDOUT_RE = re.compile(
+        r"""sys\.stdout\.reconfigure\(\s*encoding\s*=\s*['"]utf-8['"]"""
+    )
+
+    @pytest.mark.parametrize("mod", RECONFIGURE_GUARDED)
+    def test_module_has_utf8_reconfigure_guard(self, mod):
+        src = (SCRIPTS / f"{mod}.py").read_text(encoding="utf-8")
+        assert self._RECONFIGURE_STDOUT_RE.search(src), (
+            f"{mod}.py relies on a UTF-8 reconfigure guard instead of "
+            f"harden_stdio() (#13198/#13846) — if this guard was "
+            f"intentionally removed, add harden_stdio() to main() instead "
+            f"and move {mod!r} from TestUtf8ReconfigureAlternative13846."
+            f"RECONFIGURE_GUARDED into TestFleetWiring13198.WIRED so the "
+            f"cp1252 crash-proofing isn't silently dropped"
+        )
+
+    def test_cycle_pre_and_post_also_guard_stderr(self):
+        """cycle_pre.py/cycle_post.py reconfigure BOTH streams (unlike
+        cycle.py, which only guards stdout — its CLI never prints decorative
+        Unicode to stderr, so that gap is a documented non-issue there, not a
+        pattern to enforce on all three)."""
+        for mod in ("cycle_pre", "cycle_post"):
+            src = (SCRIPTS / f"{mod}.py").read_text(encoding="utf-8")
+            assert re.search(
+                r"""sys\.stderr\.reconfigure\(\s*encoding\s*=\s*['"]utf-8['"]""",
+                src,
+            ), f"{mod}.py must also guard stderr, not just stdout"
+
+    def test_reconfigure_actually_prevents_the_crash(self):
+        """Real reproduction (not a string match): apply the exact guard
+        these modules use to a genuinely cp1252-encoded stream — the same
+        stream shape `TestHardenStdio.test_baseline_cp1252_arrow_raises`
+        proves crashes without protection — and confirm decorative Unicode
+        (the arrow AND the squid emoji these modules print on every cycle)
+        writes without raising."""
+        stream = _cp1252_stream()
+        assert stream.encoding.lower() != "utf-8"
+        # Mirrors the exact guard: `if sys.stdout.encoding != "utf-8": ...`
+        if stream.encoding.lower() != "utf-8":
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        stream.write("[\U0001F991 12:00:00] cycle_post → done — ok\n")
+        stream.flush()  # must not raise
 
 
 class TestHarnessWiring13236:


### PR DESCRIPTION
Addresses #13846.

## Correcting my own finding

While investigating this issue (filed by myself during an improvement-scan sweep), I discovered the original claim was a false positive.

**Original claim**: `cycle_pre.py`/`cycle_post.py` -- the harness's every-cycle mechanical wrapper scripts -- have no `harden_stdio()` call, so they'd crash with `UnicodeEncodeError` printing decorative Unicode (→, —, 🦑) on a strict cp1252 Windows console, same class as #13728/#13760.

**What investigation found**: both files already have a module-level guard (`if sys.stdout.encoding != "utf-8": sys.stdout.reconfigure(encoding="utf-8", errors="replace")`, same for stderr) that runs at import time. I reproduced the exact crash scenario `TestHardenStdio.test_baseline_cp1252_arrow_raises` guards against and confirmed the alternative guard prevents it -- see the new `test_reconfigure_actually_prevents_the_crash`. `tests/test_cli_stdio_13198.py`'s own `TestFleetWiring13198` docstring already documented this exact alternative for `cycle.py`; it just never mentioned `cycle_pre.py`/`cycle_post.py` by name, which is presumably why my grep-for-`harden_stdio()` sweep missed the equivalence and mis-filed this as unprotected.

Per [[feedback_test_before_filing_substring_claims]] (test before filing string-match bugs) -- exactly the mistake that memory warns about, now reinforced with a concrete instance.

## What I actually shipped

Not code changes (the existing protection already works and adding `harden_stdio()` on top would be redundant). Instead:

- Extended `TestFleetWiring13198`'s docstring to name `cycle_pre.py`/`cycle_post.py` alongside `cycle.py` as the deliberately-excluded alternative-guard scripts, with a pointer to the new verification class -- so a future sweep doesn't re-file the same false alarm.
- Added `TestUtf8ReconfigureAlternative13846`: asserts all 3 scripts (`cycle`, `cycle_pre`, `cycle_post`) actually contain the reconfigure guard (regex-based, tolerant of the two different quoting/parameter styles the 3 files happen to use), plus the live-reproduction test proving the guard prevents the crash.
- Filed #13847 (low severity, separate/narrower): the guard runs at **import time**, which `cli_stdio.py`'s own module docstring flags as the wrong place ("these modules are also imported as libraries, and reconfiguring a library consumer's global stdio would be wrong") -- and `cycle_pre.py` genuinely is imported as a library, both by `cycle_post.py` itself and by 9 test files. Not a live break today, but a real contract deviation worth tracking separately from this false-positive correction.
- Refreshed 2 comprehension-staleness baselines (`10678_spec.json`, `11227_spec.json`) that PM's #13845 anchor-link fix staled in the meantime (link-fragment-only change, zero content overlap with the quizzed prose -- verified before refreshing).

Full static gate: 5941 gated tests passed.