### PR TITLE
#13863: flip-proof fleet push credentials + boot-time push-capability gate

### DIFF
--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -28,6 +28,7 @@ Usage:
     python scripts/git_ops.py guard-galaxy-frontmatter   # pre-commit hook: block a staged galaxy note missing YAML frontmatter (fail-closed on violation, fail-open on error)
     python scripts/git_ops.py install-hooks              # activate the pre-commit + post-merge + post-commit guards (core.hooksPath)
     python scripts/git_ops.py restore-merge-dropped-state [role]  # post-merge hook: restore protected state/vault a merge silently dropped (#13556; fail-open)
+    python scripts/git_ops.py push-doctor       # heal clone credential path + verify non-interactive push capability (#13863; boot gate via tracker.py check-gh)
     python scripts/git_ops.py --help
 """
 
@@ -173,16 +174,93 @@ def _gh_credential_helper_available():
     return _GH_AVAILABLE_CACHE
 
 
+_PUSH_IDENTITY_CACHE = "unset"
+_PINNED_HELPER_CACHE = "unset"
+
+# check_gh (tracker.py) keys its boot block on THIS marker, not on push-doctor's
+# exit code -- a module-level crash also exits non-zero, and exit-code keying
+# would let a doctor bug brick every boot fleet-wide (same rationale as the
+# galaxy-frontmatter guard's __SQUIDSQUAD_GALAXY_FM_BLOCK__, DS-12905 F1).
+PUSH_DOCTOR_BLOCK_MARKER = "__SQUIDSQUAD_PUSH_DOCTOR_BLOCK__"
+
+
+def _resolve_push_identity():
+    """The GitHub account this clone's pushes must authenticate as (#13863).
+
+    Derived from the origin URL (https form only): an embedded userinfo
+    (``https://USER@github.com/owner/repo``) wins; otherwise the owner path
+    segment. Returns None for non-https remotes (ssh does not use credential
+    helpers), token-bearing userinfo (``user:token@``), or anything that does
+    not look like a GitHub username. Cached for the process lifetime.
+    """
+    global _PUSH_IDENTITY_CACHE
+    if _PUSH_IDENTITY_CACHE != "unset":
+        return _PUSH_IDENTITY_CACHE
+    ident = None
+    result = _run_list(["git", "remote", "get-url", "origin"],
+                       check=False, timeout=10)
+    url = (result.stdout or "").strip()
+    if result.returncode == 0 and url.startswith("https://"):
+        rest = url[len("https://"):]
+        host_part, _, path_part = rest.partition("/")
+        userinfo, at_sep, _host = host_part.rpartition("@")
+        if at_sep and userinfo and ":" not in userinfo:
+            candidate = userinfo
+        else:
+            candidate = path_part.split("/", 1)[0] if path_part else ""
+        if re.fullmatch(r"[A-Za-z0-9-]+", candidate or ""):
+            ident = candidate
+    _PUSH_IDENTITY_CACHE = ident
+    return ident
+
+
+def _pinned_credential_helper():
+    """A ``credential.helper`` value serving the pinned push identity's keyring
+    token regardless of gh's mutable active account (#13863).
+
+    ``!gh auth git-credential`` (the #9890 defense) only answers for the
+    ACTIVE gh account -- machine-global state any process can flip with
+    ``gh auth switch``. In #13863 the active account flipped to a read-only
+    identity within a minute of being corrected, and every non-interactive
+    push died at a /dev/tty prompt. ``gh auth token --user X`` is
+    flip-independent (verified against a live flipped state), so this helper
+    pins the user explicitly. Only the *command* lands in git config -- the
+    token itself is fetched from gh's keyring at each push.
+
+    Returns None (callers fall back to the generic gh helper) when no identity
+    is derivable from the origin URL or its token is not in gh's keyring.
+    Cached for the process lifetime.
+    """
+    global _PINNED_HELPER_CACHE
+    if _PINNED_HELPER_CACHE != "unset":
+        return _PINNED_HELPER_CACHE
+    helper = None
+    user = _resolve_push_identity()
+    if user and _gh_credential_helper_available():
+        probe = _run_list(["gh", "auth", "token", "--user", user],
+                          check=False, timeout=10)
+        if probe.returncode == 0 and (probe.stdout or "").strip():
+            helper = (
+                '!f() { if [ "$1" = get ]; then '
+                'echo username=%s; '
+                'echo "password=$(gh auth token --user %s)"; '
+                'fi; }; f' % (user, user)
+            )
+    _PINNED_HELPER_CACHE = helper
+    return helper
+
+
 def _git_push(push_args, timeout=60):
-    """Run `git push <push_args...>` with anti-wedge defenses (#9890).
+    """Run `git push <push_args...>` with anti-wedge defenses (#9890, #13863).
 
-    Two defenses against the silent-wedge mode observed in cycle 1244:
+    Defenses against the silent-wedge mode observed in cycle 1244:
 
-    1. **Credential helper override**: when `gh` is available and authenticated
-       (cached via `_gh_credential_helper_available()`), prepend
-       `-c credential.helper=` + `-c credential.helper=!gh auth git-credential`
-       so the push routes through the `gh` token rather than the inherited
-       helper (which on Windows defaults to GCM and can wedge on agent sessions).
+    1. **Credential helper override**: prefer the pinned-user helper
+       (`_pinned_credential_helper()`, #13863 -- immune to gh active-account
+       flips); fall back to `!gh auth git-credential` when no identity can be
+       pinned (#9890 -- still sidesteps GCM's interactive dialog). Either way
+       the inherited helper list is reset first with an empty `-c
+       credential.helper=` entry.
     2. **Timeout**: subprocess.run is called with a `timeout` so a wedge fails
        fast with a synthetic non-zero CompletedProcess (returncode 124, matching
        GNU `timeout` convention) rather than accumulating zombie git processes.
@@ -198,7 +276,13 @@ def _git_push(push_args, timeout=60):
         callers continue to work without changes.
     """
     cmd = ["git"]
-    if _gh_credential_helper_available():
+    pinned = _pinned_credential_helper()
+    if pinned:
+        cmd.extend([
+            "-c", "credential.helper=",
+            "-c", "credential.helper=" + pinned,
+        ])
+    elif _gh_credential_helper_available():
         cmd.extend([
             "-c", "credential.helper=",
             "-c", "credential.helper=!gh auth git-credential",
@@ -217,6 +301,92 @@ def _git_push(push_args, timeout=60):
             args=cmd, returncode=124, stdout="",
             stderr=f"git push timed out after {timeout}s (wedge defense per #9890)",
         )
+
+
+def push_doctor(persist=True, heal_active=False):
+    """Boot-time push-capability check + per-clone credential self-heal (#13863).
+
+    The #13574 write probe covers gh-API writes; nothing covered the *git push*
+    path, where two independent machine-global failure modes stayed invisible
+    until mid-work: the credential-manager entry vanishing (GCM prompts on a
+    nonexistent tty and dies) and gh's active account flipping to a read-only
+    identity (``!gh auth git-credential`` then answers for the wrong user).
+
+    Self-heal (``persist=True``): rewrite this clone's LOCAL helper list --
+    an empty reset entry (drops the inherited wedge-prone ``manager``) plus the
+    pinned-user helper (or the generic gh helper when no pin is derivable).
+    Persisting into ``.git/config`` matters because bare ``git push`` call
+    sites (cycle_post.py, harness.py ``_git_in_clone``) bypass ``_git_push``'s
+    per-invocation ``-c`` override entirely -- the local config is the only
+    layer that covers every push path in the clone, including a harness
+    process still running older code.
+
+    Active-account heal (``heal_active=True``): additionally run ``gh auth
+    switch --user <pinned>`` -- the FIRST of the two manual remediation steps
+    from the #13863 report (the helper persist above is the second). gh's
+    active account gates every gh-API write (tracker transitions, labels),
+    not just pushes, and it is machine-global mutable state that was observed
+    flipping to a read-only identity minutes after being corrected. The
+    switch is intentionally NOT unconditional: callers (tracker.py check_gh)
+    request it only after the #13574 write probe has *proven* the active
+    account read-only, so a working operator-chosen account is never fought.
+
+    Verdict via ``git push --dry-run`` (authenticates + permission-checks
+    without mutating the remote). Mirrors check-gh's #13574 contract: only a
+    definitive auth/permission signature blocks (returns ``(False, msg)`` with
+    ``PUSH_DOCTOR_BLOCK_MARKER`` in the message); anything inconclusive --
+    network blip, non-fast-forward, detached HEAD -- warns and passes.
+
+    Returns (ok: bool, message: str).
+    """
+    result = _run_list(["git", "remote", "get-url", "origin"],
+                       check=False, timeout=10)
+    url = (result.stdout or "").strip()
+    if result.returncode != 0 or not url.startswith("https://"):
+        return True, (f"push-doctor: origin is not an https remote ({url!r}) "
+                      f"-- credential-helper doctoring only applies to https "
+                      f"pushes; nothing to heal.")
+    pinned = _pinned_credential_helper()
+    if heal_active and pinned:
+        user = _resolve_push_identity()
+        switch = _run_list(["gh", "auth", "switch", "--user", user],
+                           check=False, timeout=15)
+        if switch.returncode != 0:
+            print(f"WARNING: push-doctor could not switch gh active account "
+                  f"to {user} (rc={switch.returncode}): "
+                  f"{(switch.stderr or '').strip()} (#13863)",
+                  file=sys.stderr)
+    if persist and (pinned or _gh_credential_helper_available()):
+        helper = pinned or "!gh auth git-credential"
+        _run_list(["git", "config", "--local", "--replace-all",
+                   "credential.helper", ""], check=False, timeout=10)
+        _run_list(["git", "config", "--local", "--add",
+                   "credential.helper", helper], check=False, timeout=10)
+    probe = _run_list(["git", "push", "--dry-run", "origin", "HEAD"],
+                      check=False, timeout=90)
+    who = _resolve_push_identity() or "(active gh account)"
+    if probe.returncode == 0:
+        return True, f"push-doctor: OK -- non-interactive push verified as {who}."
+    stderr = (probe.stderr or "").strip()
+    lowered = stderr.lower()
+    definitive = ("403" in lowered or "denied" in lowered
+                  or "could not read password" in lowered
+                  or "authentication failed" in lowered)
+    if definitive:
+        return False, (
+            f"{PUSH_DOCTOR_BLOCK_MARKER}\n"
+            f"ERROR: git push capability check failed definitively as {who} "
+            f"(#13863 signature): {stderr.splitlines()[-1] if stderr else '(no stderr)'}\n"
+            f"Every branch push and state commit from this clone will fail "
+            f"while health stays green.\n"
+            f"Remediation (operator): 'gh auth login' as an account with push "
+            f"rights to this repo (its keyring token is what the healed "
+            f"credential helper serves), or restore that account's write role "
+            f"on the repo; confirm with 'git push --dry-run origin HEAD'.")
+    return True, (f"WARNING: push-doctor probe inconclusive (rc={probe.returncode}): "
+                  f"{stderr.splitlines()[-1] if stderr else '(no stderr)'} "
+                  f"-- proceeding on the healed helper config alone (fail-open, "
+                  f"#13863).")
 
 
 def _log_diagnostic(severity, message):
@@ -2839,6 +3009,20 @@ def main():
     elif cmd == "install-hooks":
         ok = install_hooks()
         sys.exit(0 if ok else 1)
+    elif cmd == "push-doctor":
+        # #13863 boot gate: heal this clone's credential path and verify
+        # non-interactive push capability. Definitive failure carries
+        # PUSH_DOCTOR_BLOCK_MARKER on stderr; callers (tracker.py check_gh)
+        # key their block on the marker, never on the exit code alone.
+        # --heal-active additionally switches gh's active account to the
+        # pinned push identity (requested by check_gh only after the #13574
+        # probe proved the current active account read-only).
+        ok, msg = push_doctor(heal_active="--heal-active" in rest)
+        if ok:
+            print(msg)
+            sys.exit(0)
+        print(msg, file=sys.stderr)
+        sys.exit(1)
     elif cmd == "restore-merge-dropped-state":
         # #13556 post-merge hook entry point: restore any protected state/vault
         # path the just-completed merge silently dropped (modify-vs-delete).

--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -694,17 +694,7 @@ def check_gh():
     perm = _run_list_timeout(["gh", "api", "repos/:owner/:repo",
                               "-q", ".permissions.push"], timeout=15)
     verdict = (perm.stdout or "").strip().lower()
-    if perm.returncode == 0 and verdict == "false":
-        print("ERROR: forge WRITE access check failed (#13574): the gh "
-              "identity has READ but not PUSH permission on this repo - the "
-              "#13570 read-only-downgrade signature. Every transition, label "
-              "write, and git push will fail while health stays green.",
-              file=sys.stderr)
-        print("Remediation (operator): restore the identity's write role on "
-              "the repo (Settings > Collaborators), or 'gh auth login' as an "
-              "account with push access; confirm with 'git push' (403 = still "
-              "read-only).", file=sys.stderr)
-        return False
+    read_only = (perm.returncode == 0 and verdict == "false")
     if perm.returncode != 0 or verdict not in ("true", "false"):
         # Inconclusive (network blip, API shape change): the read check above
         # already proved connectivity — warn, do not block boot (fail-open on
@@ -712,6 +702,50 @@ def check_gh():
         print(f"WARNING: forge write-permission probe inconclusive "
               f"(exit={perm.returncode}, out={verdict!r}) - proceeding on the "
               f"read check alone (#13574).", file=sys.stderr)
+    # #13863: the checks above prove nothing about the *git push* path — the
+    # credential-manager entry can vanish and gh's active account can flip to
+    # a read-only identity while reads and API writes stay green. Delegate to
+    # git_ops.py push-doctor: it persists a flip-proof per-clone credential
+    # helper and dry-run-verifies non-interactive push capability, so this
+    # class fails loudly at boot instead of mid-work. When the #13574 probe
+    # above PROVED the active account read-only, also pass --heal-active so
+    # the doctor switches gh back to the pinned push identity (the first of
+    # the two manual remediation steps from the #13863 report) — then re-probe
+    # before deciding to block. Block ONLY on the doctor's explicit
+    # definitive-failure marker or a still-read-only re-probe (never on exit
+    # code alone — a doctor crash must not brick every boot; fail-open on
+    # uncertainty, same contract as #13574).
+    doctor_cmd = [sys.executable, str(SCRIPT_DIR / "git_ops.py"),
+                  "push-doctor"]
+    if read_only:
+        doctor_cmd.append("--heal-active")
+    doctor = _run_list_timeout(doctor_cmd, timeout=120)
+    doctor_err = (doctor.stderr or "")
+    if "__SQUIDSQUAD_PUSH_DOCTOR_BLOCK__" in doctor_err:
+        print(doctor_err.strip(), file=sys.stderr)
+        return False
+    if read_only:
+        reprobe = _run_list_timeout(["gh", "api", "repos/:owner/:repo",
+                                     "-q", ".permissions.push"], timeout=15)
+        if (reprobe.stdout or "").strip().lower() == "true":
+            print("NOTE: gh active account was read-only (#13570 signature); "
+                  "push-doctor healed it back to the pinned push identity "
+                  "(#13863) - write capability re-verified.", file=sys.stderr)
+        else:
+            print("ERROR: forge WRITE access check failed (#13574): the gh "
+                  "identity has READ but not PUSH permission on this repo - "
+                  "the #13570 read-only-downgrade signature. Every "
+                  "transition, label write, and git push will fail while "
+                  "health stays green. Auto-heal (#13863) did not recover it.",
+                  file=sys.stderr)
+            print("Remediation (operator): restore the identity's write role "
+                  "on the repo (Settings > Collaborators), or 'gh auth login' "
+                  "as an account with push access; confirm with 'git push' "
+                  "(403 = still read-only).", file=sys.stderr)
+            return False
+    for stream in (doctor.stdout or "", doctor_err):
+        if "WARNING" in stream:
+            print(stream.strip(), file=sys.stderr)
     print("OK")
     return True
 

--- a/tests/test_git_push_doctor_13863.py
+++ b/tests/test_git_push_doctor_13863.py
@@ -1,0 +1,365 @@
+"""#13863 -- flip-proof push credentials + boot-time push-capability gate.
+
+Fleet git pushes broke when (a) the Windows credential-manager entry for the
+push identity vanished and (b) gh's machine-global active account flipped to a
+read-only identity. `!gh auth git-credential` (#9890) only answers for the
+ACTIVE account, so the flip defeated it and every non-interactive push died at
+a /dev/tty prompt. The fix pins the push identity derived from the origin URL
+via `gh auth token --user X` (flip-independent), persists the healed helper
+into each clone's local git config (covers bare `git push` call sites that
+bypass _git_push), and gates boot on a dry-run push capability check keyed on
+an explicit definitive-failure marker.
+
+All subprocess calls are mocked -- no real git/gh runs here.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import git_ops
+
+
+def _mock_result(stdout="", stderr="", returncode=0):
+    r = MagicMock()
+    r.stdout = stdout
+    r.stderr = stderr
+    r.returncode = returncode
+    return r
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    """The identity/helper/gh-availability caches are process-lifetime; tests
+    must not leak resolutions into each other."""
+    git_ops._PUSH_IDENTITY_CACHE = "unset"
+    git_ops._PINNED_HELPER_CACHE = "unset"
+    git_ops._GH_AVAILABLE_CACHE = None
+    yield
+    git_ops._PUSH_IDENTITY_CACHE = "unset"
+    git_ops._PINNED_HELPER_CACHE = "unset"
+    git_ops._GH_AVAILABLE_CACHE = None
+
+
+def _arm_run_list(monkeypatch, responses):
+    """Route git_ops._run_list by command shape. `responses` maps a matcher
+    key to a result: 'get-url', 'gh-token', 'config', 'dry-run'."""
+    calls = []
+
+    def fake_run_list(cmd, check=True, timeout=None):
+        calls.append(cmd)
+        joined = " ".join(cmd)
+        if "remote get-url" in joined:
+            return responses.get("get-url", _mock_result(returncode=1))
+        if cmd[:3] == ["gh", "auth", "token"]:
+            return responses.get("gh-token", _mock_result(returncode=1))
+        if cmd[:3] == ["gh", "auth", "switch"]:
+            return responses.get("gh-switch", _mock_result())
+        if "config --local" in joined:
+            return responses.get("config", _mock_result())
+        if "push --dry-run" in joined:
+            return responses.get("dry-run", _mock_result())
+        raise AssertionError(f"unexpected _run_list call: {cmd}")
+
+    monkeypatch.setattr(git_ops, "_run_list", fake_run_list)
+    return calls
+
+
+HTTPS_USERINFO = _mock_result(stdout="https://WallyDoodlez@github.com/WallyDoodlez/SquidSquad.git\n")
+HTTPS_PLAIN = _mock_result(stdout="https://github.com/SomeOwner/SomeRepo.git\n")
+
+
+# ---------------------------------------------------------------------------
+# _resolve_push_identity
+# ---------------------------------------------------------------------------
+
+class TestResolvePushIdentity:
+    def test_userinfo_wins_over_owner(self, monkeypatch):
+        _arm_run_list(monkeypatch, {"get-url": _mock_result(
+            stdout="https://PushUser@github.com/OtherOwner/Repo.git\n")})
+        assert git_ops._resolve_push_identity() == "PushUser"
+
+    def test_owner_segment_when_no_userinfo(self, monkeypatch):
+        _arm_run_list(monkeypatch, {"get-url": HTTPS_PLAIN})
+        assert git_ops._resolve_push_identity() == "SomeOwner"
+
+    def test_ssh_remote_returns_none(self, monkeypatch):
+        _arm_run_list(monkeypatch, {"get-url": _mock_result(
+            stdout="git@github.com:Owner/Repo.git\n")})
+        assert git_ops._resolve_push_identity() is None
+
+    def test_token_bearing_userinfo_rejected(self, monkeypatch):
+        # https://user:ghp_secret@github.com/... -- never treat the token pair
+        # as a username; fall through to the owner segment instead.
+        _arm_run_list(monkeypatch, {"get-url": _mock_result(
+            stdout="https://user:ghp_secret@github.com/RealOwner/Repo.git\n")})
+        assert git_ops._resolve_push_identity() == "RealOwner"
+
+    def test_invalid_username_chars_rejected(self, monkeypatch):
+        _arm_run_list(monkeypatch, {"get-url": _mock_result(
+            stdout="https://bad$user@github.com/bad$owner/Repo.git\n")})
+        assert git_ops._resolve_push_identity() is None
+
+    def test_get_url_failure_returns_none(self, monkeypatch):
+        _arm_run_list(monkeypatch, {"get-url": _mock_result(returncode=1)})
+        assert git_ops._resolve_push_identity() is None
+
+    def test_cached_after_first_resolution(self, monkeypatch):
+        calls = _arm_run_list(monkeypatch, {"get-url": HTTPS_USERINFO})
+        git_ops._resolve_push_identity()
+        git_ops._resolve_push_identity()
+        assert len([c for c in calls if "get-url" in " ".join(c)]) == 1
+
+
+# ---------------------------------------------------------------------------
+# _pinned_credential_helper
+# ---------------------------------------------------------------------------
+
+class TestPinnedCredentialHelper:
+    def test_pins_user_when_token_available(self, monkeypatch):
+        _arm_run_list(monkeypatch, {
+            "get-url": HTTPS_USERINFO,
+            "gh-token": _mock_result(stdout="gho_abc123\n"),
+        })
+        monkeypatch.setattr(git_ops, "_gh_credential_helper_available",
+                            lambda: True)
+        helper = git_ops._pinned_credential_helper()
+        assert helper is not None
+        assert "username=WallyDoodlez" in helper
+        assert "gh auth token --user WallyDoodlez" in helper
+        # Only the command goes in config -- never a literal token.
+        assert "gho_abc123" not in helper
+
+    def test_none_when_token_missing_from_keyring(self, monkeypatch):
+        _arm_run_list(monkeypatch, {
+            "get-url": HTTPS_USERINFO,
+            "gh-token": _mock_result(returncode=1, stderr="no oauth token"),
+        })
+        monkeypatch.setattr(git_ops, "_gh_credential_helper_available",
+                            lambda: True)
+        assert git_ops._pinned_credential_helper() is None
+
+    def test_none_when_no_identity(self, monkeypatch):
+        _arm_run_list(monkeypatch, {"get-url": _mock_result(
+            stdout="git@github.com:Owner/Repo.git\n")})
+        monkeypatch.setattr(git_ops, "_gh_credential_helper_available",
+                            lambda: True)
+        assert git_ops._pinned_credential_helper() is None
+
+    def test_none_when_gh_unavailable(self, monkeypatch):
+        _arm_run_list(monkeypatch, {"get-url": HTTPS_USERINFO})
+        monkeypatch.setattr(git_ops, "_gh_credential_helper_available",
+                            lambda: False)
+        assert git_ops._pinned_credential_helper() is None
+
+
+# ---------------------------------------------------------------------------
+# _git_push helper-choice ladder
+# ---------------------------------------------------------------------------
+
+class TestGitPushHelperChoice:
+    def _push_argv(self, monkeypatch, pinned, gh_available):
+        monkeypatch.setattr(git_ops, "_pinned_credential_helper",
+                            lambda: pinned)
+        monkeypatch.setattr(git_ops, "_gh_credential_helper_available",
+                            lambda: gh_available)
+        captured = {}
+
+        def fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            return _mock_result()
+
+        monkeypatch.setattr(git_ops.subprocess, "run", fake_run)
+        git_ops._git_push(["origin", "some-branch"])
+        return captured["cmd"]
+
+    def test_pinned_helper_preferred(self, monkeypatch):
+        pinned = '!f() { echo username=X; }; f'
+        cmd = self._push_argv(monkeypatch, pinned, True)
+        assert "credential.helper=" in cmd            # reset entry
+        assert "credential.helper=" + pinned in cmd
+        assert "credential.helper=!gh auth git-credential" not in cmd
+
+    def test_falls_back_to_generic_gh_helper(self, monkeypatch):
+        cmd = self._push_argv(monkeypatch, None, True)
+        assert "credential.helper=!gh auth git-credential" in cmd
+
+    def test_no_override_without_gh(self, monkeypatch):
+        cmd = self._push_argv(monkeypatch, None, False)
+        assert not any("credential.helper" in str(a) for a in cmd)
+
+
+# ---------------------------------------------------------------------------
+# push_doctor
+# ---------------------------------------------------------------------------
+
+class TestPushDoctor:
+    def _arm(self, monkeypatch, responses, pinned="unset", gh_available=True):
+        calls = _arm_run_list(monkeypatch, responses)
+        if pinned != "unset":
+            monkeypatch.setattr(git_ops, "_pinned_credential_helper",
+                                lambda: pinned)
+        monkeypatch.setattr(git_ops, "_gh_credential_helper_available",
+                            lambda: gh_available)
+        return calls
+
+    def test_non_https_remote_is_noop_pass(self, monkeypatch):
+        calls = self._arm(monkeypatch, {"get-url": _mock_result(
+            stdout="git@github.com:Owner/Repo.git\n")})
+        ok, msg = git_ops.push_doctor()
+        assert ok is True
+        assert "nothing to heal" in msg
+        assert not any("config --local" in " ".join(c) for c in calls)
+
+    def test_persists_reset_plus_pinned_helper(self, monkeypatch):
+        pinned = '!f() { echo username=X; }; f'
+        calls = self._arm(monkeypatch, {
+            "get-url": HTTPS_USERINFO,
+            "dry-run": _mock_result(),
+        }, pinned=pinned)
+        ok, _ = git_ops.push_doctor()
+        assert ok is True
+        config_calls = [c for c in calls if "config --local" in " ".join(c)]
+        assert len(config_calls) == 2
+        # First: reset the inherited helper list (empty-string entry).
+        assert config_calls[0][-2:] == ["credential.helper", ""]
+        assert "--replace-all" in config_calls[0]
+        # Second: add the pinned helper.
+        assert config_calls[1][-1] == pinned
+        assert "--add" in config_calls[1]
+
+    def test_falls_back_to_generic_gh_helper_when_no_pin(self, monkeypatch):
+        calls = self._arm(monkeypatch, {
+            "get-url": HTTPS_PLAIN,
+            "dry-run": _mock_result(),
+        }, pinned=None, gh_available=True)
+        ok, _ = git_ops.push_doctor()
+        assert ok is True
+        config_calls = [c for c in calls if "config --local" in " ".join(c)]
+        assert config_calls[1][-1] == "!gh auth git-credential"
+
+    def test_no_persist_when_gh_absent(self, monkeypatch):
+        calls = self._arm(monkeypatch, {
+            "get-url": HTTPS_PLAIN,
+            "dry-run": _mock_result(),
+        }, pinned=None, gh_available=False)
+        ok, _ = git_ops.push_doctor()
+        assert ok is True
+        assert not any("config --local" in " ".join(c) for c in calls)
+
+    def test_persist_false_skips_config_writes(self, monkeypatch):
+        pinned = '!f() { echo username=X; }; f'
+        calls = self._arm(monkeypatch, {
+            "get-url": HTTPS_USERINFO,
+            "dry-run": _mock_result(),
+        }, pinned=pinned)
+        git_ops.push_doctor(persist=False)
+        assert not any("config --local" in " ".join(c) for c in calls)
+
+    def test_definitive_auth_failure_blocks_with_marker(self, monkeypatch):
+        self._arm(monkeypatch, {
+            "get-url": HTTPS_USERINFO,
+            "dry-run": _mock_result(returncode=128, stderr=(
+                "fatal: could not read Password for "
+                "'https://WallyDoodlez@github.com': No such file or directory")),
+        }, pinned=None, gh_available=False)
+        ok, msg = git_ops.push_doctor()
+        assert ok is False
+        assert git_ops.PUSH_DOCTOR_BLOCK_MARKER in msg
+        assert "Remediation" in msg
+
+    def test_permission_denied_blocks_with_marker(self, monkeypatch):
+        self._arm(monkeypatch, {
+            "get-url": HTTPS_USERINFO,
+            "dry-run": _mock_result(returncode=128, stderr=(
+                "remote: Permission to WallyDoodlez/SquidSquad.git denied "
+                "to Naahtec.\nfatal: unable to access '...': The requested "
+                "URL returned error: 403")),
+        }, pinned=None, gh_available=False)
+        ok, msg = git_ops.push_doctor()
+        assert ok is False
+        assert git_ops.PUSH_DOCTOR_BLOCK_MARKER in msg
+
+    def test_non_fast_forward_is_inconclusive_fail_open(self, monkeypatch):
+        # A behind-main dry-run rejection is NOT an auth failure -- must pass.
+        self._arm(monkeypatch, {
+            "get-url": HTTPS_USERINFO,
+            "dry-run": _mock_result(returncode=1, stderr=(
+                "! [rejected]  main -> main (non-fast-forward)")),
+        }, pinned=None, gh_available=False)
+        ok, msg = git_ops.push_doctor()
+        assert ok is True
+        assert "inconclusive" in msg
+        assert git_ops.PUSH_DOCTOR_BLOCK_MARKER not in msg
+
+    def test_timeout_is_inconclusive_fail_open(self, monkeypatch):
+        self._arm(monkeypatch, {
+            "get-url": HTTPS_USERINFO,
+            "dry-run": _mock_result(returncode=124, stderr="timed out"),
+        }, pinned=None, gh_available=False)
+        ok, msg = git_ops.push_doctor()
+        assert ok is True
+        assert "inconclusive" in msg
+
+
+class TestPushDoctorHealActive:
+    """#13863 --heal-active: gh auth switch back to the pinned identity --
+    the first of the two manual remediation steps, run only when the caller
+    (check_gh) has proven the active account read-only."""
+
+    PINNED = '!f() { echo username=X; }; f'
+
+    def _arm(self, monkeypatch, responses, pinned):
+        calls = _arm_run_list(monkeypatch, responses)
+        monkeypatch.setattr(git_ops, "_pinned_credential_helper",
+                            lambda: pinned)
+        monkeypatch.setattr(git_ops, "_gh_credential_helper_available",
+                            lambda: True)
+        return calls
+
+    def test_switches_to_pinned_identity(self, monkeypatch):
+        calls = self._arm(monkeypatch, {
+            "get-url": HTTPS_USERINFO,
+            "dry-run": _mock_result(),
+        }, pinned=self.PINNED)
+        ok, _ = git_ops.push_doctor(heal_active=True)
+        assert ok is True
+        switch_calls = [c for c in calls if c[:3] == ["gh", "auth", "switch"]]
+        assert switch_calls == [
+            ["gh", "auth", "switch", "--user", "WallyDoodlez"]]
+        # The switch must precede the dry-run verdict probe.
+        assert (calls.index(switch_calls[0])
+                < calls.index(next(c for c in calls
+                                   if "push --dry-run" in " ".join(c))))
+
+    def test_no_switch_without_pinned_identity(self, monkeypatch):
+        calls = self._arm(monkeypatch, {
+            "get-url": HTTPS_PLAIN,
+            "dry-run": _mock_result(),
+        }, pinned=None)
+        ok, _ = git_ops.push_doctor(heal_active=True)
+        assert ok is True
+        assert not any(c[:3] == ["gh", "auth", "switch"] for c in calls)
+
+    def test_no_switch_when_heal_not_requested(self, monkeypatch):
+        calls = self._arm(monkeypatch, {
+            "get-url": HTTPS_USERINFO,
+            "dry-run": _mock_result(),
+        }, pinned=self.PINNED)
+        git_ops.push_doctor(heal_active=False)
+        assert not any(c[:3] == ["gh", "auth", "switch"] for c in calls)
+
+    def test_failed_switch_warns_but_proceeds(self, monkeypatch, capsys):
+        self._arm(monkeypatch, {
+            "get-url": HTTPS_USERINFO,
+            "gh-switch": _mock_result(returncode=1, stderr="boom"),
+            "dry-run": _mock_result(),
+        }, pinned=self.PINNED)
+        ok, _ = git_ops.push_doctor(heal_active=True)
+        assert ok is True
+        assert "could not switch" in capsys.readouterr().err

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -51,6 +51,12 @@ class TestCheckGh:
             tracker, "_run_list",
             lambda cmd, **kw: _mock_result(stdout="ok"),
         )
+        # #13863: mock the timeout-bounded path too or the REAL write probe
+        # and push-doctor subprocess fire (the doctor mutates .git/config).
+        monkeypatch.setattr(
+            tracker, "_run_list_timeout",
+            lambda cmd, timeout, **kw: _mock_result(stdout="true\n"),
+        )
         assert tracker.check_gh() is True
 
     def test_failure(self, monkeypatch):
@@ -122,6 +128,121 @@ class TestCheckGhWriteProbe13574:
         res = tracker._run_list_timeout(["gh", "api", "x"], timeout=1)
         assert res.returncode == 124
         assert "TIMEOUT" in res.stderr
+
+
+class TestCheckGhPushDoctor13863:
+    """#13863: check_gh delegates the *git push* path to git_ops.py
+    push-doctor. The boot block is keyed on the doctor's explicit
+    definitive-failure marker on stderr -- NEVER on its exit code alone (a
+    doctor crash exits non-zero too and must not brick every boot)."""
+
+    MARKER = "__SQUIDSQUAD_PUSH_DOCTOR_BLOCK__"
+
+    def _arm(self, monkeypatch, doctor_result):
+        """Read check and write probe pass; the doctor subprocess (routed by
+        argv shape -- it is the only non-gh _run_list_timeout call) returns
+        doctor_result."""
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(tracker, "_run_list",
+                            lambda cmd, **kw: _mock_result(stdout="ok"))
+
+        def route(cmd, timeout, **kw):
+            if cmd and cmd[0] == "gh":
+                return _mock_result(stdout="true\n")   # #13574 write probe
+            assert any("git_ops.py" in str(a) for a in cmd)
+            assert any("push-doctor" in str(a) for a in cmd)
+            return doctor_result
+
+        monkeypatch.setattr(tracker, "_run_list_timeout", route)
+
+    def test_doctor_ok_passes_silently(self, monkeypatch, capsys):
+        self._arm(monkeypatch, _mock_result(stdout="push-doctor: OK\n"))
+        assert tracker.check_gh() is True
+        assert "push-doctor" not in capsys.readouterr().err
+
+    def test_definitive_marker_blocks_boot(self, monkeypatch, capsys):
+        self._arm(monkeypatch, _mock_result(
+            returncode=1,
+            stderr=f"{self.MARKER}\nERROR: push capability failed "
+                   f"definitively\nRemediation (operator): ..."))
+        assert tracker.check_gh() is False
+        err = capsys.readouterr().err
+        assert "Remediation" in err
+
+    def test_nonzero_exit_without_marker_is_fail_open(self, monkeypatch,
+                                                      capsys):
+        # A doctor crash (bad import, traceback) exits non-zero with no
+        # marker -- boot must proceed.
+        self._arm(monkeypatch, _mock_result(
+            returncode=1, stderr="Traceback (most recent call last): ..."))
+        assert tracker.check_gh() is True
+
+    def test_doctor_warning_is_passed_through(self, monkeypatch, capsys):
+        self._arm(monkeypatch, _mock_result(
+            stdout="WARNING: push-doctor probe inconclusive (rc=124): "
+                   "timed out -- proceeding (fail-open, #13863).\n"))
+        assert tracker.check_gh() is True
+        assert "push-doctor probe inconclusive" in capsys.readouterr().err
+
+    def test_write_capable_probe_omits_heal_active(self, monkeypatch):
+        self._arm(monkeypatch, _mock_result(stdout="push-doctor: OK\n"))
+        seen = []
+        orig = tracker._run_list_timeout
+
+        def spy(cmd, timeout, **kw):
+            seen.append(cmd)
+            return orig(cmd, timeout, **kw)
+
+        monkeypatch.setattr(tracker, "_run_list_timeout", spy)
+        assert tracker.check_gh() is True
+        doctor_cmds = [c for c in seen
+                       if any("push-doctor" in str(a) for a in c)]
+        assert doctor_cmds and all(
+            "--heal-active" not in c for c in doctor_cmds)
+
+
+class TestCheckGhActiveAccountHeal13863:
+    """#13863 heal path: when the #13574 probe proves the active account
+    read-only, check_gh asks push-doctor to switch gh back to the pinned
+    push identity, then RE-probes before deciding to block."""
+
+    def _arm(self, monkeypatch, probe_results, doctor_result):
+        """probe_results: successive gh-api write-probe results (a list,
+        consumed in order). The doctor subprocess returns doctor_result;
+        its argv is recorded for assertions."""
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(tracker, "_run_list",
+                            lambda cmd, **kw: _mock_result(stdout="ok"))
+        probes = list(probe_results)
+        recorded = {"doctor_cmds": []}
+
+        def route(cmd, timeout, **kw):
+            if cmd and cmd[0] == "gh":
+                return probes.pop(0)
+            recorded["doctor_cmds"].append(cmd)
+            return doctor_result
+
+        monkeypatch.setattr(tracker, "_run_list_timeout", route)
+        return recorded
+
+    def test_readonly_then_healed_boots_with_note(self, monkeypatch, capsys):
+        recorded = self._arm(
+            monkeypatch,
+            [_mock_result(stdout="false\n"), _mock_result(stdout="true\n")],
+            _mock_result(stdout="push-doctor: OK\n"))
+        assert tracker.check_gh() is True
+        assert "--heal-active" in recorded["doctor_cmds"][0]
+        assert "healed" in capsys.readouterr().err
+
+    def test_readonly_and_heal_fails_blocks_loudly(self, monkeypatch, capsys):
+        recorded = self._arm(
+            monkeypatch,
+            [_mock_result(stdout="false\n"), _mock_result(stdout="false\n")],
+            _mock_result(stdout="push-doctor: OK\n"))
+        assert tracker.check_gh() is False
+        assert "--heal-active" in recorded["doctor_cmds"][0]
+        err = capsys.readouterr().err
+        assert "WRITE" in err and "#13570" in err and "Remediation" in err
 
 
 class TestListIssues:


### PR DESCRIPTION
Fixes the fleet-wide push outage reported in #13863 (do not auto-close; ship gate owns closure).

## Root cause (evidenced live on this clone)

Two independent machine-global failure modes in the push credential path:

1. **Credential-manager entry gone** — the inherited `credential.helper=manager` falls back to an interactive prompt; in agent sessions there is no tty, so every push dies with the exact reported error (`could not read Password ... failed to execute prompt script`).
2. **gh active-account flips to read-only Naahtec** — observed twice during the fix session (01:55:29 and 02:06:17), minutes after being corrected, with a file watcher on gh's hosts.yml. Repo-wide grep confirms no SquidSquad code invokes `gh auth switch`/`login`: the flip source is external to the repo. This defeats the existing #9890 defense because `!gh auth git-credential` only answers for the ACTIVE account; asked for the pinned remote user while the wrong account is active, it returns nothing (verified rc:1) and git falls through to the dead prompt.

## Fix

- **`_resolve_push_identity()`** (git_ops.py): derive the required push account from the origin URL — embedded userinfo wins, owner path segment otherwise; https-only, token-bearing userinfo and non-username shapes rejected.
- **`_pinned_credential_helper()`**: a credential helper that serves the pinned user's keyring token via `gh auth token --user X` — flip-independent (verified against the live flipped state). Only the command lands in git config; tokens are fetched from gh's keyring at push time, never persisted.
- **`_git_push()`**: prefers the pinned helper; falls back to the #9890 generic gh helper; unchanged when gh is absent.
- **`push-doctor`** (new git_ops.py CLI): persists the reset + pinned helper into the clone's **local git config** — this is what covers the bare `git push` call sites (cycle_post.py:517, harness.py `_git_in_clone`) that bypass `_git_push`, including a harness process still running older code — then verifies capability via `git push --dry-run`. Fail-open on anything inconclusive (non-fast-forward, timeout, network); a definitive auth/permission failure blocks with the explicit `__SQUIDSQUAD_PUSH_DOCTOR_BLOCK__` marker.
- **`push-doctor --heal-active`**: `gh auth switch` back to the pinned identity — the first manual remediation step from the report, automated. Only invoked by check_gh after the #13574 write probe has *proven* the active account read-only (never fights a working operator-chosen account), then re-probed before deciding to block.
- **`check_gh()`** (tracker.py): runs push-doctor after the #13574 write probe — every agent boot now heals its own clone and fails loudly with operator remediation only when no recovery is possible. The block is keyed on the doctor's marker, never on exit code alone, so a doctor crash cannot brick fleet boots (same rationale as the galaxy-frontmatter guard).

## Verification

- **Live end-to-end on this clone**: reproduced the original failure (push dying at the tty prompt with the flipped account), then verified `check-gh` heals it: flipped active account to Naahtec deliberately → `check-gh` exits 0, switches back to WallyDoodlez, prints the healed NOTE, and a real branch push succeeds non-interactively.
- **Regression tests**: `tests/test_git_push_doctor_13863.py` (26 cases — identity parsing incl. token-userinfo/ssh/invalid-chars, helper pinning, helper-choice ladder, doctor persist/verdict/heal-active ordering) + `TestCheckGhPushDoctor13863` / `TestCheckGhActiveAccountHeal13863` in `tests/test_tracker.py` (marker-keyed block, crash fail-open, heal-then-reprobe pass and fail).
- **Full static gate**: PASS — 5975 tests, 0 failures.
- **Fleet remediation applied now** (not deferred to next boots): pinned helper persisted in all four clones (skill/pm/qa/dm), dry-run push auth verified in each.

## Residual

The *source* of the external account flips remains unidentified (watcher evidence says it recurs every few minutes from outside the repo — plausibly another tool on the host). The fix is flip-proof regardless: pushes never depend on the active account, and every boot re-heals. If the flipper needs hunting, that is host-level investigation for the operator, not repo code.