### PR TITLE
#13865: GH_TOKEN-pinned gh API calls -- forge writes survive active-account flips

### DIFF
--- a/references/installer-files.txt
+++ b/references/installer-files.txt
@@ -1,7 +1,7 @@
 # SquidSquad installer file manifest
 # Every file the wizard needs, fetched by npx squidsquad before
 # launching Claude. One path per line, relative to repo root.
-# Total: 264 files
+# Total: 265 files
 #
 # Maintained alongside the wizard - when you add a new role,
 # capability, preset, or sub-skill, add its files here too.
@@ -39,6 +39,7 @@ references/scripts/event_poll.py
 references/scripts/event_validator.py
 references/scripts/forge_adapter.py
 references/scripts/forgejo_setup.py
+references/scripts/gh_identity.py
 references/scripts/git_ops.py
 references/scripts/harness.py
 references/scripts/health_check.py

--- a/references/scripts/gh_identity.py
+++ b/references/scripts/gh_identity.py
@@ -1,0 +1,144 @@
+"""#13865 -- pin gh API calls to the repo's push identity via GH_TOKEN.
+
+gh's "active account" is machine-global mutable state (its hosts.yml `user`
+field): any process can flip it with `gh auth switch`, and during the #13863
+incident something external to SquidSquad kept flipping it to a read-only
+identity every few minutes -- live-observed breaking a `pr-create` mid-cycle
+with "GraphQL: must be a collaborator". #13863 made *git pushes* flip-proof
+(pinned credential helper) and heals the active account at *boot*; this module
+closes the remaining exposure: every mid-session gh API call (tracker
+transitions, label writes, comments, PR operations) rode the active account.
+
+The pin: resolve the identity the origin remote requires, fetch that user's
+keyring token via `gh auth token --user X` (flip-independent -- it reads the
+keyring entry, not the active-account pointer), and hand callers a subprocess
+env with GH_TOKEN set. The gh CLI prefers GH_TOKEN over the active account,
+so the flip becomes irrelevant to the call.
+
+Leaf module by design: imported by tracker.py and git_ops.py; imports nothing
+of theirs (they cannot import each other). Fail-open everywhere -- any
+resolution failure returns None and the caller inherits the ambient env,
+which is exactly today's behavior.
+"""
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+
+# Process-lifetime caches ("unset" sentinel distinguishes "never resolved"
+# from a resolved None).
+_IDENTITY_CACHE = "unset"
+_TOKEN_CACHE = "unset"
+
+
+def pinned_identity():
+    """The GitHub account the origin remote requires for writes.
+
+    Same derivation as git_ops._resolve_push_identity (#13863), duplicated
+    here so this stays a leaf module: embedded https userinfo wins
+    (``https://USER@github.com/owner/repo``), else the owner path segment.
+    None for non-https remotes, token-bearing userinfo, or non-username
+    shapes. Cached for the process lifetime.
+    """
+    global _IDENTITY_CACHE
+    if _IDENTITY_CACHE != "unset":
+        return _IDENTITY_CACHE
+    ident = None
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True, text=True, encoding="utf-8",
+            errors="replace", check=False, cwd=str(REPO_ROOT), timeout=10,
+        )
+        url = (result.stdout or "").strip()
+        if result.returncode == 0 and url.startswith("https://"):
+            rest = url[len("https://"):]
+            host_part, _, path_part = rest.partition("/")
+            userinfo, at_sep, _host = host_part.rpartition("@")
+            if at_sep and userinfo and ":" not in userinfo:
+                candidate = userinfo
+            else:
+                candidate = path_part.split("/", 1)[0] if path_part else ""
+            if re.fullmatch(r"[A-Za-z0-9-]+", candidate or ""):
+                ident = candidate
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    _IDENTITY_CACHE = ident
+    return ident
+
+
+def pinned_token():
+    """The pinned identity's keyring token via ``gh auth token --user X``.
+
+    Flip-independent: reads the named keyring entry regardless of which
+    account is currently "active". None (fail-open) when no identity is
+    derivable, gh is missing, or the identity has no keyring entry. Cached
+    for the process lifetime -- one gh subprocess per process, not per call.
+    """
+    global _TOKEN_CACHE
+    if _TOKEN_CACHE != "unset":
+        return _TOKEN_CACHE
+    token = None
+    user = pinned_identity()
+    if user:
+        try:
+            result = subprocess.run(
+                ["gh", "auth", "token", "--user", user],
+                capture_output=True, text=True, encoding="utf-8",
+                errors="replace", check=False, cwd=str(REPO_ROOT), timeout=10,
+            )
+            out = (result.stdout or "").strip()
+            if result.returncode == 0 and out:
+                token = out
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+    _TOKEN_CACHE = token
+    return token
+
+
+def gh_env(cmd_list):
+    """Subprocess env for a gh invocation, GH_TOKEN-pinned to the repo's
+    identity -- or None, meaning "inherit the ambient env unchanged".
+
+    Callers pass the result straight to ``subprocess.run(..., env=...)``
+    (env=None IS the inherit contract). Returns None -- never injects -- when:
+
+    - ``cmd_list`` is not a gh command (first element neither ``"gh"`` nor a
+      resolved path whose basename starts with ``gh``);
+    - it is a ``gh auth ...`` subcommand: auth operations must see the real
+      keyring/hosts state, and gh refuses or bypasses keyring writes when a
+      GH_TOKEN env var is present (injecting would break the very
+      ``gh auth token``/``gh auth switch`` machinery the pin relies on);
+    - the ambient env already carries GH_TOKEN or GITHUB_TOKEN: an
+      operator-set token is an explicit override this module must not fight;
+    - no identity/token is resolvable (fail-open -- today's behavior).
+    """
+    if not cmd_list:
+        return None
+    head = os.path.basename(str(cmd_list[0])).lower()
+    if not (head == "gh" or head.startswith("gh.")):
+        return None
+    if len(cmd_list) > 1 and cmd_list[1] == "auth":
+        return None
+    if os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN"):
+        return None
+    token = pinned_token()
+    if not token:
+        return None
+    env = dict(os.environ)
+    env["GH_TOKEN"] = token
+    return env
+
+
+if __name__ == "__main__":
+    # Tiny diagnostic CLI: print the pinned identity and whether a token is
+    # resolvable (never the token itself).
+    user = pinned_identity()
+    print(f"pinned identity: {user or '(none)'}")
+    print(f"keyring token: {'available' if pinned_token() else 'unavailable'}")
+    sys.exit(0)

--- a/references/scripts/git_ops.py
+++ b/references/scripts/git_ops.py
@@ -40,6 +40,20 @@ import threading
 import time
 from pathlib import Path
 
+# #13865: GH_TOKEN-pinned env for gh calls. Import is DEFENSIVE, not hard:
+# git_ops.py must keep working when copied standalone (the post-merge hook
+# copies only this file into scratch/consumer repos — the "stdlib-only"
+# contract exercised by test_bare_merge_fires_hook_end_to_end). Without the
+# sibling module every gh call simply inherits the ambient env, which is the
+# pre-#13865 behavior (fail-open).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    import gh_identity  # noqa: E402
+    _gh_env = gh_identity.gh_env
+except ImportError:  # standalone copy — pinning unavailable, inherit env
+    def _gh_env(_cmd_list):
+        return None
+
 # #13211 — serialize ensure_main_and_pull across ALL in-process callers (the
 # L4 watcher's per-role-class freshen bursts AND the post-merge deploy-all path,
 # both in the harness process). Concurrent main-checkout + pull on the SAME
@@ -134,7 +148,13 @@ def _run(cmd, check=True, timeout=None):
 
 
 def _run_list(cmd_list, check=True, timeout=None):
-    """Run a command from repo root using list form (safe for variable args)."""
+    """Run a command from repo root using list form (safe for variable args).
+
+    #13865: gh invocations get a GH_TOKEN-pinned env (gh_identity.gh_env)
+    so forge writes don't ride the flippable machine-global active account;
+    non-gh commands and every fail-open case inherit the ambient env
+    (env=None) exactly as before.
+    """
     if timeout is None:
         timeout = _git_timeout()
     try:
@@ -142,6 +162,7 @@ def _run_list(cmd_list, check=True, timeout=None):
             cmd_list, capture_output=True, text=True,
             encoding="utf-8", errors="replace",
             check=check, cwd=str(REPO_ROOT), timeout=timeout,
+            env=_gh_env(cmd_list),
         )
     except subprocess.TimeoutExpired:
         return _timeout_failure(cmd_list, check, timeout)

--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -54,6 +54,9 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent
 
+sys.path.insert(0, str(SCRIPT_DIR))
+import gh_identity  # noqa: E402  — #13865: GH_TOKEN-pinned env for gh calls
+
 # === FORGE ADAPTER (optional — falls back to direct gh calls if unavailable) ===
 
 _forge_adapter = None
@@ -571,6 +574,7 @@ def _run_list(cmd_list, check=True):
         cmd_list, capture_output=True, text=True,
         encoding="utf-8", errors="replace",
         check=check, cwd=str(REPO_ROOT),
+        env=gh_identity.gh_env(cmd_list),  # #13865: pin gh calls to the repo identity (None = inherit)
     )
 
 
@@ -588,6 +592,7 @@ def _run_list_timeout(cmd_list, timeout, check=False):
             cmd_list, capture_output=True, text=True,
             encoding="utf-8", errors="replace",
             check=check, cwd=str(REPO_ROOT), timeout=timeout,
+            env=gh_identity.gh_env(cmd_list),  # #13865
         )
     except subprocess.TimeoutExpired:
         return subprocess.CompletedProcess(
@@ -621,6 +626,7 @@ def _run_gh_with_body(cmd_list, body, check=True):
         capture_output=True, text=True,
         encoding="utf-8", errors="replace",
         check=check, cwd=str(REPO_ROOT),
+        env=gh_identity.gh_env(cmd_list),  # #13865
     )
 
 

--- a/tests/test_gh_identity_13865.py
+++ b/tests/test_gh_identity_13865.py
@@ -1,0 +1,261 @@
+"""#13865 -- GH_TOKEN-pinned env for gh API calls.
+
+gh's active account is machine-global mutable state that kept flipping to a
+read-only identity during the #13863 incident (live-observed breaking a
+pr-create mid-cycle with "GraphQL: must be a collaborator"). #13863 made git
+pushes flip-proof; this covers the remaining exposure -- gh API writes
+(tracker transitions, labels, comments, PR operations). gh_identity.gh_env()
+hands the subprocess wrappers in tracker.py and git_ops.py an env with
+GH_TOKEN set to the pinned identity's keyring token (which the gh CLI prefers
+over the active account), or None (= inherit, today's behavior) in every
+fail-open case.
+
+All subprocess calls mocked -- no real git/gh runs here.
+"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "references" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import gh_identity
+import git_ops
+import tracker
+
+
+def _mock_result(stdout="", stderr="", returncode=0):
+    r = MagicMock()
+    r.stdout = stdout
+    r.stderr = stderr
+    r.returncode = returncode
+    return r
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches(monkeypatch):
+    """Identity/token caches are process-lifetime; isolate tests from each
+    other and from any ambient operator token."""
+    gh_identity._IDENTITY_CACHE = "unset"
+    gh_identity._TOKEN_CACHE = "unset"
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    yield
+    gh_identity._IDENTITY_CACHE = "unset"
+    gh_identity._TOKEN_CACHE = "unset"
+
+
+def _arm_subprocess(monkeypatch, get_url=None, token=None):
+    """Route gh_identity's own subprocess calls."""
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+        if cmd[:3] == ["git", "remote", "get-url"]:
+            return get_url if get_url is not None else _mock_result(returncode=1)
+        if cmd[:3] == ["gh", "auth", "token"]:
+            return token if token is not None else _mock_result(returncode=1)
+        raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+    monkeypatch.setattr(gh_identity.subprocess, "run", fake_run)
+    return calls
+
+
+URL_USERINFO = _mock_result(
+    stdout="https://WallyDoodlez@github.com/WallyDoodlez/SquidSquad.git\n")
+URL_PLAIN = _mock_result(stdout="https://github.com/SomeOwner/SomeRepo.git\n")
+TOKEN_OK = _mock_result(stdout="gho_abc123\n")
+
+
+class TestPinnedIdentity:
+    def test_userinfo_wins(self, monkeypatch):
+        _arm_subprocess(monkeypatch, get_url=_mock_result(
+            stdout="https://PushUser@github.com/OtherOwner/Repo.git\n"))
+        assert gh_identity.pinned_identity() == "PushUser"
+
+    def test_owner_fallback(self, monkeypatch):
+        _arm_subprocess(monkeypatch, get_url=URL_PLAIN)
+        assert gh_identity.pinned_identity() == "SomeOwner"
+
+    def test_ssh_remote_none(self, monkeypatch):
+        _arm_subprocess(monkeypatch, get_url=_mock_result(
+            stdout="git@github.com:Owner/Repo.git\n"))
+        assert gh_identity.pinned_identity() is None
+
+    def test_token_userinfo_rejected_falls_to_owner(self, monkeypatch):
+        _arm_subprocess(monkeypatch, get_url=_mock_result(
+            stdout="https://user:ghp_secret@github.com/RealOwner/Repo.git\n"))
+        assert gh_identity.pinned_identity() == "RealOwner"
+
+    def test_subprocess_error_is_fail_open(self, monkeypatch):
+        def boom(cmd, **kw):
+            raise OSError("no git")
+        monkeypatch.setattr(gh_identity.subprocess, "run", boom)
+        assert gh_identity.pinned_identity() is None
+
+    def test_cached(self, monkeypatch):
+        calls = _arm_subprocess(monkeypatch, get_url=URL_USERINFO)
+        gh_identity.pinned_identity()
+        gh_identity.pinned_identity()
+        assert len(calls) == 1
+
+
+class TestPinnedToken:
+    def test_token_resolved_and_cached(self, monkeypatch):
+        calls = _arm_subprocess(monkeypatch, get_url=URL_USERINFO,
+                                token=TOKEN_OK)
+        assert gh_identity.pinned_token() == "gho_abc123"
+        gh_identity.pinned_token()
+        assert len([c for c in calls if c[:2] == ["gh", "auth"]]) == 1
+
+    def test_no_identity_no_token_subprocess(self, monkeypatch):
+        calls = _arm_subprocess(monkeypatch, get_url=_mock_result(
+            stdout="git@github.com:Owner/Repo.git\n"))
+        assert gh_identity.pinned_token() is None
+        assert not any(c[:2] == ["gh", "auth"] for c in calls)
+
+    def test_keyring_miss_is_fail_open(self, monkeypatch):
+        _arm_subprocess(monkeypatch, get_url=URL_USERINFO,
+                        token=_mock_result(returncode=1, stderr="no token"))
+        assert gh_identity.pinned_token() is None
+
+
+class TestGhEnv:
+    def _arm_token(self, monkeypatch, token="gho_abc123"):
+        monkeypatch.setattr(gh_identity, "pinned_token", lambda: token)
+
+    def test_injects_for_gh_command(self, monkeypatch):
+        self._arm_token(monkeypatch)
+        env = gh_identity.gh_env(["gh", "issue", "list"])
+        assert env is not None
+        assert env["GH_TOKEN"] == "gho_abc123"
+        # Full ambient env is preserved alongside the injection.
+        for k in os.environ:
+            assert k in env
+
+    def test_resolved_gh_path_also_matches(self, monkeypatch):
+        # tracker.py substitutes cmd[0] with a resolved absolute gh path
+        # (_resolve_gh_bin, #9398) BEFORE building the env -- the matcher
+        # must recognize gh.exe/gh.cmd basenames, not just the literal "gh".
+        self._arm_token(monkeypatch)
+        assert gh_identity.gh_env(
+            [r"C:\Program Files\GitHub CLI\gh.exe", "issue", "list"]
+        ) is not None
+        assert gh_identity.gh_env(["/usr/bin/gh", "api", "x"]) is not None
+
+    def test_non_gh_command_inherits(self, monkeypatch):
+        self._arm_token(monkeypatch)
+        assert gh_identity.gh_env(["git", "push"]) is None
+        assert gh_identity.gh_env([]) is None
+        # "ghost" must not be mistaken for gh.
+        assert gh_identity.gh_env(["ghost", "run"]) is None
+
+    def test_gh_auth_subcommands_exempt(self, monkeypatch):
+        """gh auth switch/token/status must see the real keyring state --
+        an injected GH_TOKEN would shadow exactly the machinery the pin
+        relies on."""
+        self._arm_token(monkeypatch)
+        assert gh_identity.gh_env(["gh", "auth", "switch", "--user", "X"]) is None
+        assert gh_identity.gh_env(["gh", "auth", "token", "--user", "X"]) is None
+        assert gh_identity.gh_env(["gh", "auth", "status"]) is None
+
+    def test_operator_env_token_wins(self, monkeypatch):
+        self._arm_token(monkeypatch)
+        monkeypatch.setenv("GH_TOKEN", "operator-token")
+        assert gh_identity.gh_env(["gh", "issue", "list"]) is None
+        monkeypatch.delenv("GH_TOKEN")
+        monkeypatch.setenv("GITHUB_TOKEN", "operator-token")
+        assert gh_identity.gh_env(["gh", "issue", "list"]) is None
+
+    def test_no_token_is_fail_open(self, monkeypatch):
+        self._arm_token(monkeypatch, token=None)
+        assert gh_identity.gh_env(["gh", "issue", "list"]) is None
+
+
+class TestTrackerWiring:
+    """tracker.py's three gh subprocess wrappers pass gh_identity.gh_env's
+    result as env=. None (inherit) must reach subprocess.run unchanged."""
+
+    def _spy_run(self, monkeypatch, module):
+        seen = {}
+
+        def fake_run(cmd, **kw):
+            seen["cmd"] = cmd
+            seen["env"] = kw.get("env", "MISSING")
+            return _mock_result(stdout="[]")
+
+        monkeypatch.setattr(module.subprocess, "run", fake_run)
+        return seen
+
+    def test_run_list_passes_pinned_env(self, monkeypatch):
+        seen = self._spy_run(monkeypatch, tracker)
+        monkeypatch.setattr(gh_identity, "pinned_token", lambda: "gho_x")
+        tracker._run_list(["gh", "issue", "list"], check=False)
+        assert seen["env"] is not None and seen["env"] != "MISSING"
+        assert seen["env"]["GH_TOKEN"] == "gho_x"
+
+    def test_run_list_inherits_when_unpinnable(self, monkeypatch):
+        seen = self._spy_run(monkeypatch, tracker)
+        monkeypatch.setattr(gh_identity, "pinned_token", lambda: None)
+        tracker._run_list(["gh", "issue", "list"], check=False)
+        assert seen["env"] is None
+
+    def test_run_list_timeout_passes_pinned_env(self, monkeypatch):
+        seen = self._spy_run(monkeypatch, tracker)
+        monkeypatch.setattr(gh_identity, "pinned_token", lambda: "gho_x")
+        tracker._run_list_timeout(["gh", "api", "x"], timeout=5)
+        assert seen["env"]["GH_TOKEN"] == "gho_x"
+
+    def test_run_gh_with_body_passes_pinned_env(self, monkeypatch):
+        seen = self._spy_run(monkeypatch, tracker)
+        monkeypatch.setattr(gh_identity, "pinned_token", lambda: "gho_x")
+        tracker._run_gh_with_body(["gh", "issue", "comment", "1"], "hi",
+                                  check=False)
+        assert seen["env"]["GH_TOKEN"] == "gho_x"
+
+    def test_git_ops_run_list_passes_pinned_env(self, monkeypatch):
+        seen = self._spy_run(monkeypatch, git_ops)
+        monkeypatch.setattr(gh_identity, "pinned_token", lambda: "gho_x")
+        git_ops._run_list(["gh", "pr", "view", "1"], check=False)
+        assert seen["env"]["GH_TOKEN"] == "gho_x"
+
+    def test_git_ops_run_list_git_cmd_inherits(self, monkeypatch):
+        seen = self._spy_run(monkeypatch, git_ops)
+        monkeypatch.setattr(gh_identity, "pinned_token", lambda: "gho_x")
+        git_ops._run_list(["git", "status"], check=False)
+        assert seen["env"] is None
+
+
+class TestGitOpsStandaloneContract:
+    """git_ops.py must keep working when copied WITHOUT gh_identity.py --
+    the post-merge hook copies only git_ops.py into scratch/consumer repos
+    (the stdlib-only contract test_bare_merge_fires_hook_end_to_end
+    exercises end-to-end). The import is therefore defensive."""
+
+    def test_import_is_wrapped_in_try_except(self):
+        src = (SCRIPTS / "git_ops.py").read_text(encoding="utf-8")
+        idx = src.index("import gh_identity")
+        preceding = src[:idx].rsplit("\n", 3)
+        assert any("try:" in line for line in preceding), (
+            "git_ops.py's gh_identity import must be defensive (try/except "
+            "ImportError) -- a hard import breaks the standalone-copy "
+            "post-merge hook path (#13865)"
+        )
+
+    def test_fallback_env_fn_inherits(self, monkeypatch):
+        # Simulate the standalone copy: force the fallback and confirm gh
+        # calls inherit the ambient env rather than crashing.
+        seen = {}
+
+        def fake_run(cmd, **kw):
+            seen["env"] = kw.get("env", "MISSING")
+            return _mock_result(stdout="[]")
+
+        monkeypatch.setattr(git_ops.subprocess, "run", fake_run)
+        monkeypatch.setattr(git_ops, "_gh_env", lambda _cmd: None)
+        git_ops._run_list(["gh", "pr", "view", "1"], check=False)
+        assert seen["env"] is None


### PR DESCRIPTION
Fixes the mid-session forge-write exposure reported in #13865 (do not auto-close; ship gate owns closure). Companion to #13863 / PR #13864 (which covers git pushes + boot heal; this covers gh API calls — the two PRs touch disjoint regions and merge cleanly in either order).

## Change

New leaf module `gh_identity.py` + wiring:

- **`pinned_identity()`** — the account the origin remote requires (userinfo wins, owner segment fallback; https-only; token-userinfo and non-username shapes rejected).
- **`pinned_token()`** — that identity's keyring token via `gh auth token --user X`, which reads the named keyring entry rather than the flippable active-account pointer. Cached once per process.
- **`gh_env(cmd)`** — `os.environ` + `GH_TOKEN` for gh invocations (the gh CLI prefers `GH_TOKEN` over the active account, making the flip irrelevant), or `None` (= inherit, today's behavior) when: not a gh command; a `gh auth` subcommand (must see real keyring state); an operator already set `GH_TOKEN`/`GITHUB_TOKEN`; or resolution fails (fail-open everywhere).
- **tracker.py**: `_run_list`, `_run_list_timeout`, `_run_gh_with_body` pass `env=gh_env(cmd)`.
- **git_ops.py**: `_run_list` ditto — via a **defensive import**: the post-merge hook copies git_ops.py standalone into scratch repos (the stdlib-only contract `test_bare_merge_fires_hook_end_to_end` exercises end-to-end); without the sibling module the fallback inherits the ambient env.
- **installer-files.txt**: ships the new module (264 → 265).

## Verification

- **Live end-to-end**: with the active account deliberately flipped to read-only Naahtec, a `tracker.py comment` on #13865 posted successfully and was authored as **WallyDoodlez** (`gh issue view --jq .comments[-1].author.login`) — pre-fix, this exact operation class failed live ("GraphQL: must be a collaborator" during #13863's pr-create).
- **Regression tests**: `tests/test_gh_identity_13865.py` — 30 cases covering identity/token resolution + caching + fail-open, all four `gh_env` exemption rules, resolved-gh-path matching (tracker substitutes an absolute gh path before env construction), tracker/git_ops wiring (pinned env reaches `subprocess.run`; `None` inherit for non-gh and unpinnable), and the standalone-copy contract (defensive import asserted + fallback exercised).
- **Full static gate**: PASS — 5964 tests, 0 failures (including the hook end-to-end test that caught the hard-import regression during development).