### PR TITLE
#13855: ship-gate merged-PR check queries the branch directly (--head), not a small recency window

### DIFF
--- a/references/scripts/tracker.py
+++ b/references/scripts/tracker.py
@@ -1322,36 +1322,80 @@ def _check_merged_pr(number):
     # Mirror the gh CLI path: fetch the recent merged PRs unfiltered and
     # rely on the local `parts[-1] == str(number)` check below to match
     # by branch suffix.
+    # #13855: do NOT rely on a small global "most-recent-N merged" window.
+    # GitHub's search-backed `pr list` has brief eventual-consistency lag for
+    # a JUST-merged PR plus a boundary sort that isn't strictly mergedAt-desc,
+    # so a freshly-merged PR — the case the ship-gate hits MOST (it runs right
+    # after the merge) — can be absent from the newest 20 (live-observed on
+    # #10003/PR #13708). Query the SPECIFIC branch server-side instead
+    # (recency-independent), then fall back to a larger global scan only for
+    # non-standard branch prefixes.
+    branch = f"squidsquad/task/{number}"
+
     adapter = _get_forge_adapter()
     if adapter:
         try:
-            prs = adapter.list_prs(state="merged")
-            for pr in prs:
-                head = pr.get("headRefName", "")
-                parts = head.split("/")
-                if len(parts) >= 2 and parts[-1] == str(number):
-                    return pr.get("number"), pr.get("url", "")
+            # Exact head filter first (recency-independent). ForgejoAdapter's
+            # `search` is a client-side headRefName substring match, so the
+            # full branch name matches exactly the one PR (unlike #9999's
+            # space-bearing `squidsquad/ N`, which matched nothing).
+            hit = _scan_merged_prs(adapter.list_prs(state="merged",
+                                                    search=branch), number)
+            if hit:
+                return hit
+            # Fallback: larger global window for any non-`task` prefix.
+            hit = _scan_merged_prs(adapter.list_prs(state="merged", limit=100),
+                                   number)
+            if hit:
+                return hit
         except Exception:
             pass
         return None
 
-    # Default: gh CLI
+    # Default: gh CLI — exact server-side head filter first (#13855). `--head`
+    # matches the head branch exactly on the server, so a just-merged PR is
+    # returned regardless of its position in the global recency window.
     result = _run_list(
-        ["gh", "pr", "list", "--state", "merged",
-         "--json", "number,headRefName,url", "--limit", "20"],
+        ["gh", "pr", "list", "--head", branch, "--state", "merged",
+         "--json", "number,headRefName,url", "--limit", "10"],
         check=False,
     )
-    if result.returncode != 0:
-        return None
+    hit = _scan_merged_prs(_parse_pr_list(result), number)
+    if hit:
+        return hit
+    # Fallback: larger global window catches any non-standard branch prefix
+    # the `--head` convention above misses (the local suffix check stays the
+    # authority on what counts as a match).
+    result = _run_list(
+        ["gh", "pr", "list", "--state", "merged",
+         "--json", "number,headRefName,url", "--limit", "100"],
+        check=False,
+    )
+    return _scan_merged_prs(_parse_pr_list(result), number)
+
+
+def _parse_pr_list(result):
+    """Parse a `gh pr list --json` subprocess result into a list of PR dicts;
+    [] on any error (non-zero exit, empty, malformed JSON)."""
+    if result.returncode != 0 or not (result.stdout or "").strip():
+        return []
     try:
-        prs = json.loads(result.stdout) if result.stdout.strip() else []
-        for pr in prs:
-            head = pr.get("headRefName", "")
-            parts = head.split("/")
-            if len(parts) >= 2 and parts[-1] == str(number):
-                return pr["number"], pr.get("url", "")
-    except (json.JSONDecodeError, KeyError):
-        pass
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return []
+
+
+def _scan_merged_prs(prs, number):
+    """Return (pr_number, pr_url) for the first PR whose branch suffix (the
+    last `/`-separated segment of headRefName) equals ``number``, else None.
+    The suffix check is the authority on a match — it stays prefix-agnostic
+    so a non-`task` branch convention still resolves once the PR is in the
+    fetched set."""
+    for pr in prs or []:
+        head = pr.get("headRefName", "")
+        parts = head.split("/")
+        if len(parts) >= 2 and parts[-1] == str(number):
+            return pr.get("number"), pr.get("url", "")
     return None
 
 

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -843,11 +843,11 @@ class TestCheckMergedPr:
     # --- DS 9999 F2: forge-adapter path coverage ---
 
     def test_adapter_path_happy_path(self, monkeypatch):
-        """When a forge adapter is configured (e.g. Forgejo), the
-        adapter path must invoke list_prs(state='merged') and return
-        the matching branch's PR. DS 9999 F1 regression: the call must
-        NOT pass a broken `search=` substring that would discard all
-        results client-side."""
+        """When a forge adapter is configured (e.g. Forgejo), the adapter
+        path must invoke list_prs(state='merged') and return the matching
+        branch's PR. #13855: the exact-branch search is tried FIRST (the
+        full branch name is a valid substring match, unlike #9999 F1's
+        space-bearing `squidsquad/ N` that matched nothing)."""
         adapter = MagicMock()
         adapter.list_prs.return_value = [
             {"number": 9997,
@@ -857,7 +857,10 @@ class TestCheckMergedPr:
         monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: adapter)
         result = tracker._check_merged_pr(9967)
         assert result == (9997, "https://forge.example/owner/repo/pulls/9997")
-        adapter.list_prs.assert_called_once_with(state="merged")
+        # First call is the exact-branch search (#13855, recency-independent).
+        first = adapter.list_prs.call_args_list[0]
+        assert first.kwargs["state"] == "merged"
+        assert first.kwargs["search"] == "squidsquad/task/9967"
 
     def test_adapter_path_returns_none_when_exception(self, monkeypatch):
         """If the adapter raises (network, auth, schema mismatch), the
@@ -867,6 +870,108 @@ class TestCheckMergedPr:
         adapter.list_prs.side_effect = RuntimeError("forge unreachable")
         monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: adapter)
         assert tracker._check_merged_pr(9967) is None
+
+
+class TestCheckMergedPrFreshMergeMiss13855:
+    """#13855: a just-merged squash PR the small global merged window misses
+    (GitHub search consistency lag + non-mergedAt boundary sort) must still
+    be found, because `_check_merged_pr` now queries the specific branch
+    server-side FIRST rather than paging the global recency list."""
+
+    def test_gh_primary_uses_exact_head_filter(self, monkeypatch):
+        calls = []
+
+        def fake_run(cmd, **kw):
+            calls.append(cmd)
+            return _mock_result(stdout="[]")
+
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(tracker, "_run_list", fake_run)
+        tracker._check_merged_pr(10003)
+        # First query is the exact server-side head filter for THIS branch.
+        assert "--head" in calls[0]
+        assert calls[0][calls[0].index("--head") + 1] == "squidsquad/task/10003"
+        assert calls[0][calls[0].index("--state") + 1] == "merged"
+
+    def test_gh_head_filter_finds_freshly_merged_pr(self, monkeypatch):
+        """The live #10003 shape: the global recency window (2nd call) would
+        MISS the PR, but the exact head filter (1st call) returns it."""
+        def fake_run(cmd, **kw):
+            if "--head" in cmd:
+                return _mock_result(stdout=json.dumps([{
+                    "number": 13708,
+                    "headRefName": "squidsquad/task/10003",
+                    "url": "https://github.com/example/repo/pull/13708",
+                }]))
+            return _mock_result(stdout="[]")  # global list misses it
+
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(tracker, "_run_list", fake_run)
+        assert tracker._check_merged_pr(10003) == (
+            13708, "https://github.com/example/repo/pull/13708")
+
+    def test_gh_fallback_catches_nonstandard_branch_prefix(self, monkeypatch):
+        """A non-`task` branch prefix isn't matched by `--head
+        squidsquad/task/N`; the larger global fallback (with the
+        prefix-agnostic suffix check) still resolves it."""
+        def fake_run(cmd, **kw):
+            if "--head" in cmd:
+                return _mock_result(stdout="[]")  # exact filter misses prefix
+            return _mock_result(stdout=json.dumps([{
+                "number": 5000,
+                "headRefName": "squidsquad/hotfix/9967",
+                "url": "https://github.com/example/repo/pull/5000",
+            }]))
+
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(tracker, "_run_list", fake_run)
+        assert tracker._check_merged_pr(9967) == (
+            5000, "https://github.com/example/repo/pull/5000")
+
+    def test_gh_fallback_limit_raised_above_20(self, monkeypatch):
+        calls = []
+
+        def fake_run(cmd, **kw):
+            calls.append(cmd)
+            return _mock_result(stdout="[]")
+
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: None)
+        monkeypatch.setattr(tracker, "_run_list", fake_run)
+        tracker._check_merged_pr(9967)
+        # Global fallback (the call WITHOUT --head) must fetch >20.
+        fallback = [c for c in calls if "--head" not in c][0]
+        assert int(fallback[fallback.index("--limit") + 1]) >= 100
+
+    def test_adapter_fallback_after_empty_head_search(self, monkeypatch):
+        """Adapter path: exact-branch search returns nothing (non-task
+        prefix), the larger unfiltered fetch resolves it via the suffix
+        check."""
+        adapter = MagicMock()
+        adapter.list_prs.side_effect = [
+            [],  # exact-branch search: miss
+            [{"number": 5000,
+              "headRefName": "squidsquad/hotfix/9967",
+              "url": "https://forge.example/owner/repo/pulls/5000"}],
+        ]
+        monkeypatch.setattr(tracker, "_get_forge_adapter", lambda: adapter)
+        assert tracker._check_merged_pr(9967) == (
+            5000, "https://forge.example/owner/repo/pulls/5000")
+        assert adapter.list_prs.call_args_list[1].kwargs["limit"] >= 100
+
+    def test_parse_pr_list_helper_fail_open(self):
+        assert tracker._parse_pr_list(_mock_result(returncode=1)) == []
+        assert tracker._parse_pr_list(_mock_result(stdout="")) == []
+        assert tracker._parse_pr_list(_mock_result(stdout="not json")) == []
+        assert tracker._parse_pr_list(_mock_result(stdout='[{"number":1}]')) \
+            == [{"number": 1}]
+
+    def test_scan_merged_prs_suffix_match_is_prefix_agnostic(self):
+        prs = [{"number": 7, "headRefName": "squidsquad/anything/9967",
+                "url": "u"}]
+        assert tracker._scan_merged_prs(prs, 9967) == (7, "u")
+        assert tracker._scan_merged_prs(prs, 1234) is None
+        assert tracker._scan_merged_prs([], 9967) is None
+        assert tracker._scan_merged_prs(None, 9967) is None
 
 
 # --- DS 9999 F3: integration test for the full ship-transition path ---


### PR DESCRIPTION
Fixes the ship-gate blind spot reported in #13855 (do not auto-close; ship gate owns closure).

## Root cause

`_check_merged_pr()` (the squash-merge-aware second opinion that lets `transition pending-ship shipped` succeed when local ancestry shows the branch as unmerged) fetched `gh pr list --state merged --limit 20` and scanned the result. GitHub's search-backed PR listing has brief eventual-consistency lag for a *just*-merged PR plus a boundary sort that isn't strictly `mergedAt`-descending — so a freshly-merged PR (the case the ship-gate hits most, since it runs right after the merge) can be absent from the newest 20. Live-observed on #10003 / PR #13708: `gh pr view 13708` said `state=MERGED` but `--limit 20` didn't list it. Because `--force` doesn't bypass ship-integrity gates, a legitimately-merged item caught by this had no recourse short of a human editing labels.

## Change

Query the *specific branch* server-side instead of paging the global recency list:

- **gh path**: primary `gh pr list --head squidsquad/task/<n> --state merged` — `--head` filters by exact head branch on the server, so the PR is returned regardless of its position in the global window (recency-independent). Fallback: a `--limit 100` global scan (was 20) for any non-standard branch prefix the `task` convention misses.
- **adapter path**: exact-branch `search=<full-branch-name>` first (the full name is a valid substring match, unlike #9999 F1's space-bearing `squidsquad/ N` that matched nothing), then a `limit=100` unfiltered fetch fallback.
- Factored the parse + prefix-agnostic suffix-scan into `_parse_pr_list()` / `_scan_merged_prs()` (the suffix check stays the authority on a match, so non-`task` prefixes still resolve once the PR is in the fetched set).

## Verification

- **Live against the actual forge**: `gh pr list --head squidsquad/task/10003 --state merged` returns PR #13708 directly and instantly — the exact case the reporter hit — while `--limit 20` still omits it (confirmed both, this session).
- **Regression tests** (`tests/test_tracker.py`): new `TestCheckMergedPrFreshMergeMiss13855` (8 cases: exact-head primary query shape, fresh-merge found via head filter while global list misses it, non-task-prefix fallback, fallback limit ≥100, adapter fallback ordering, and the two extracted helpers), plus the existing `TestCheckMergedPr` / `TestTransitionShipGateSquashMerge` / force-bypass suites still green (36 passed).
- **Full static gate**: PASS — 5948 tests, 0 failures.