### PR TITLE
#13561 Phase 0: TUI/observability TRD reconciliation (doc-first, human-review gate)

### DIFF
--- a/.squidsquad/pm/planning/TUI-INTERFACE-DESIGN.md
+++ b/.squidsquad/pm/planning/TUI-INTERFACE-DESIGN.md
@@ -98,3 +98,17 @@ Options menu: ⚙ panel, first item "Change background", extensible.
 
 ## Hand-off (DONE 2026-06-19)
 This doc is the interface contract. #12801 → role:skill, status:approved. Skill decomposes (per TRD→PRD→Stories→Tasks): Story1 TUI foundation (Textual app + harness-HTTP data layer + harness `lag` endpoint + dependency wiring) → Story2 panels (Agents incl. cursor-lag bar + work-state colors, Needs You, Pipeline, Activity) + title-bar branding → Story3 action bar (Reboot/Reboot All/Force, busy-aware) + Options menu (Change background) + Bring-PM-Forward hotkey → Story4 Wake button (gated on #12495).
+
+## v2 amendment — server-authoritative observability (#13561, 2026-07-20)
+
+Origin: operator reported the shipped TUI shows wrong task info, inaccurate agent status, and no context pressure. Root-cause (`GAP-ANALYSIS-TUI-OBSERVABILITY.md`): all three are wiring gaps, not missing subsystems. This amendment supersedes the affected parts of the v1 contract above; the design principle is **the harness computes display truth server-side once; the TUI renders it verbatim — no client-side state derivation.** Full field shapes live in `HARNESS-ARCH.md §4.1.1`.
+
+- **Agents-panel columns become `Role | State | Task | Ctx | Age | Lag | Mode`.** The v1 contract already named work-state / mode / current task / age / health / lag; this fixes the ones that shipped wrong or missing.
+- **Task column** — renders `current_task` (`#N <title>`, `—` when unassigned) from server-side `assigned-to` ingestion. **Not** `current_cycle` (a loop-iteration counter), which the v1 build mis-rendered as the task. The cycle counter, if shown at all, is a small `c41` suffix in the State cell.
+- **State column** — renders server-computed `work_state` + a short `work_state_reason` string (e.g. `● working #13454`, `◌ waiting (perm prompt 3m)`, `✖ crash-loop (2/3, retry 240s)`). The v1 3-color scheme (green working / yellow idle-waiting-compacting-booting / red down) is kept, but the word+reason come from the server. This replaces v1's client-side `derive_work_state()` (which treated `current_cycle is not None` as "working" — a value set once and never cleared, so every agent read "working" forever). `derive_work_state()` survives only as a versioned fallback for pre-#13561 harnesses.
+- **Ctx column (new — v1 never specified context display, an acknowledged contract gap).** Per-agent `context_pressure`: bar + percentage, yellow ≥50%, red ≥ threshold ("restart imminent", since the harness now restarts at threshold — `HARNESS-ARCH.md §15.1`). Unknown/stale (age > 10 min) renders `—`/dim with `?`, **never a fake value**.
+- **Lag column** — renders the real server-computed `lag` (cursor-vs-deque-head). If the server field is deferred, the column is **removed**, not rendered as `0` — a dashboard must not display invented values (v1's `harness_client.py` defaulted the never-implemented field to `0`, so the bar was permanently empty).
+- **Mode column** — `event`/`polling` from the server (v1 contract required it; the shipped `_AGENT_COLUMNS` omitted it).
+- **Context churn** — agents that auto-compacted are dim-flagged; `compactions_this_session` surfaced (Phase 3).
+
+Still out of v2 scope (unchanged from v1's OUT list / #12801 remainder): Needs-You / Pipeline / Activity panels + Wake button, web dashboard (#3963), SSE/websocket push, OTEL exporter.


### PR DESCRIPTION
**#13561 Phase 0 — TRD reconciliation (doc-first). HUMAN-REVIEW GATE: please review before Phase 1 code lands (AC1/AC7).** Do not auto-close.

Doc-only PR. Reconciles the architecture docs to SHIPPED behavior and adds the `/status` contract the observability code (Phases 1-3) will implement. Every change is evidenced against live `harness.py` line numbers.

## Changes (docs/*.md — on this branch)

1. **HARNESS-ARCH §15.1 — context-pressure ownership corrected.** The TRD said "context pressure never causes a restart; the harness only observes it" — contradicting the shipped `_enforce_context_pressure` (harness.py:1549, #13335) that flips `intent=restarting` at `context-threshold` to pre-empt Claude Code's lossy auto-compact. Rewritten to the shipped enforcer (fail-open guards, crash-loop-breaker interaction, fresh-context respawn). §16.2/§16.3 `PreCompact` rows aligned (hooks are observational, not the restart trigger).
2. **HARNESS-ARCH §7.1.1 + §7.5 — status/intent enums reconciled to shipped.** The table documented an aspirational enum (`booting/ready/stopping/stopped/crashed/crash-looping`) the code never produces. Replaced with the real 9-value `status` enum (`unknown/starting/running/stopped/stalled/error/crash-looping/paused/deploying`) with per-value meanings + `harness.py` cite for each; `intent` gains the shipped `deploying`.
3. **HARNESS-ARCH §4.1.1 (new) — per-agent `/status` payload.** Documents the actual `AgentState.to_dict()` (harness.py:647) shape, plus the six display-truth fields #13561 adds: `current_task`, `work_state`, `work_state_reason`, `context_pressure`, `lag`, `mode` (+ `compactions_this_session`). This is the contract Phases 1-3 build to.
4. **HARNESS-ARCH §16.5 (new) — statusline telemetry channel.** Corrects the "no context-% field in any hook payload" constraint (true for *hooks*, but the statusline JSON carries `context_window.used_percentage`, already consumed); documents it as the first-class quantitative source + the Phase 3 `POST /hooks/context` plan.
5. **AGENT-RUNTIME.md:1281 — `/events/recent` → `/events/lifecycle`** (the real endpoint, harness.py:4246).
6. **ARCHITECTURE.md §`.claude-pid`** — corrected from "stores the cmd.exe/wrapper PID" to the shipped "resolved `claude.exe` PID" (thin_launcher.py:644-657, #10101; matches HARNESS-ARCH's emphatic treatment).

## Companion change on main (NOT in this PR)

**`.squidsquad/pm/planning/TUI-INTERFACE-DESIGN.md` v2 amendment** (commit daef22565) — server-authoritative observability section (Ctx column, server-computed work_state+reason, real task identity, honest lag). Committed **direct-to-main** because planning artifacts are main-only (the #11511 state-file guard silently reverts them off a feature branch); it cannot ride this PR mechanically. It's part of the same Phase 0 reconciliation — please review it alongside this PR.

## Verification

Doc-only (no runtime surface to drive). Full static gate PASS (5941, 0 failures); all new cross-refs (§4.1.1, §16.5, §7.1.1, §15.1) resolve; enums cite live harness.py lines; self-audited for internal + cross-doc consistency.

## Next

On approval, #13561 returns to in-progress for Phase 1 (harness truth: assigned-to→current_task ingestion, in_cycle pairing, work_state derivation + exhaustive unit matrix, /status additions, the RED-pre-fix regression test) → Phase 2 (TUI render) → Phase 3 (context channel). Each phase = its own PR on main.