### PR TITLE
#13944: tc_coverage TC-table regex -- parse the merged-cell + bold-bullet shapes real verification artifacts use

### DIFF
--- a/references/scripts/tc_coverage.py
+++ b/references/scripts/tc_coverage.py
@@ -28,9 +28,25 @@ _TC_HEADING_RE = re.compile(
     r"^#{1,6}\s+TC[\s\-]?(\d+)\s*:", re.IGNORECASE
 )
 
-# Table row pattern: | TC-1 | RESULT | ... | (TC at start of a table cell)
+# Table row pattern: the first cell STARTS with TC-N. Matches both the
+# isolated-cell shape `| TC-1 | PASS |` and the merged-cell convention
+# verifier sessions actually write -- `| TC1 -- core repro | PASS |` (#13944:
+# four independent verification sessions converged on TC-N-plus-description
+# in one cell; requiring the cell to BE exactly TC-N left the ship-integrity
+# gate parsing 0 TCs from every conforming QA-RESULTS). The trailing \b keeps
+# `TC123abc` from matching a partial number.
 _TC_TABLE_RE = re.compile(
-    r"^\|\s*TC[\s\-]?(\d+)\s*\|", re.IGNORECASE
+    r"^\|\s*TC[\s\-]?(\d+)\b", re.IGNORECASE
+)
+
+# Bold-bullet TC declaration: `- **TC1 -- description**: ...` -- the shape
+# real TEST-PLANs actually use for issue-flow TC lists (#13944: both
+# TEST-PLAN-13863.md and TEST-PLAN-13865.md declare every TC this way; with
+# only heading/table patterns the plan side parsed 0 TCs and the gate
+# skipped). The `**` requirement keeps prose mentions ("- TC3 is covered by
+# ...") from registering as declarations.
+_TC_BULLET_RE = re.compile(
+    r"^[-*]\s*\*\*TC[\s\-]?(\d+)\b", re.IGNORECASE
 )
 
 # Valid result tokens (case-insensitive matching)
@@ -52,6 +68,19 @@ def _normalize_tc_id(raw_num: str) -> int:
     return int(raw_num)
 
 
+def _after_tc_cell(line: str, match_end: int) -> str:
+    """Return the table-row content after the TC cell (#13944).
+
+    ``match_end`` is where the TC-N token ended; the rest of that cell (a
+    free-text description under the merged-cell convention) runs to the next
+    ``|``. A malformed row with no closing pipe returns '' -- no result cell
+    exists, which parse_tc_results reports as UNKNOWN rather than guessing
+    a result out of description prose.
+    """
+    cell_end = line.find("|", match_end)
+    return line[cell_end:] if cell_end != -1 else ""
+
+
 def parse_tc_ids(text: str) -> list[int]:
     """Extract TC IDs from a markdown file in heading or table-row position.
 
@@ -59,7 +88,7 @@ def parse_tc_ids(text: str) -> list[int]:
     """
     ids = []
     for line in text.splitlines():
-        m = _TC_HEADING_RE.match(line) or _TC_TABLE_RE.match(line)
+        m = _TC_HEADING_RE.match(line) or _TC_TABLE_RE.match(line) or _TC_BULLET_RE.match(line)
         if m:
             ids.append(_normalize_tc_id(m.group(1)))
     return ids
@@ -89,7 +118,15 @@ def parse_tc_results(text: str) -> dict[int, str]:
         for j in range(start, min(i + 5, len(lines))):
             if j != i and (_TC_HEADING_RE.match(lines[j]) or _TC_TABLE_RE.match(lines[j])):
                 break
-            result_lines.append(lines[j])
+            if j == i and is_table:
+                # Merged-cell rows (#13944) carry a free-text description in
+                # the TC cell itself; search only the cells AFTER it so
+                # description words ("deferred cleanup", "N/A handling")
+                # can't register as the result -- the same hazard #2469
+                # fixed for heading titles.
+                result_lines.append(_after_tc_cell(lines[j], m.end()))
+            else:
+                result_lines.append(lines[j])
         search_block = "\n".join(result_lines)
 
         # Check for invalid results first

--- a/tests/test_tc_coverage.py
+++ b/tests/test_tc_coverage.py
@@ -479,3 +479,76 @@ class TestCheckCoverageFileErrors:
             str(tmp_path / "nonexistent-results.md"),
         )
         assert result == 1
+
+
+# --- #13944: merged-cell table rows + bold-bullet plan declarations ---
+
+
+class TestMergedCellTableRows13944:
+    """The QA-RESULTS convention verifier sessions actually write puts TC-N
+    plus a free-text description in ONE cell (`| TC1 -- repro | PASS |`).
+    The old regex required the cell to BE exactly TC-N, so every conforming
+    QA-RESULTS parsed as 0 TCs and the ship-integrity gate skipped (#13944)."""
+
+    def test_merged_cell_id_and_result(self):
+        text = "| TC1 — core repro under real flipped state | PASS | evidence |\n"
+        assert tc_coverage.parse_tc_ids(text) == [1]
+        assert tc_coverage.parse_tc_results(text) == {1: "PASS"}
+
+    def test_merged_cell_description_words_do_not_pollute_result(self):
+        """Description prose containing invalid-result vocabulary must not
+        register: only cells AFTER the TC cell are searched (the table-row
+        analog of the #2469 heading fix)."""
+        text = "| TC2 — deferred cleanup and N/A handling | PASS | e |\n"
+        assert tc_coverage.parse_tc_results(text) == {2: "PASS"}
+
+    def test_isolated_cell_backcompat(self):
+        text = "| TC-3 | FAIL | notes |\n"
+        assert tc_coverage.parse_tc_results(text) == {3: "FAIL"}
+
+    def test_malformed_row_without_closing_pipe_is_unknown(self):
+        """A TC cell that never closes has no result cell -- UNKNOWN, never a
+        result guessed out of description prose."""
+        text = "| TC4 — description only, row never closes PASS\n"
+        assert tc_coverage.parse_tc_results(text) == {4: "UNKNOWN"}
+
+    def test_partial_number_not_matched(self):
+        """TC123abc must not parse as TC-123 (word boundary)."""
+        text = "| TC123abc | PASS |\n"
+        assert tc_coverage.parse_tc_ids(text) == []
+
+    def test_real_qa_results_shape_end_to_end(self, tmp_path):
+        """Round-trip the real #13863-era artifact shapes: bold-bullet
+        TEST-PLAN declarations + merged-cell QA-RESULTS table -> full
+        coverage, gate pass (was: 'No TCs found, gate skipped 0/0')."""
+        plan = tmp_path / "TEST-PLAN-9999.md"
+        plan.write_text(
+            "## TCs\n\n"
+            "- **TC1 — core repro**: does the fix hold?\n"
+            "- **TC2 — gate fails loudly**: does boot block?\n",
+            encoding="utf-8",
+        )
+        results = tmp_path / "QA-RESULTS-9999.md"
+        results.write_text(
+            "## TC Results\n\n"
+            "| TC | Result | Evidence |\n"
+            "|---|---|---|\n"
+            "| TC1 — core repro | PASS | live push succeeded |\n"
+            "| TC2 — gate fails loudly | PASS | marker-keyed block |\n",
+            encoding="utf-8",
+        )
+        assert tc_coverage.check_coverage(str(plan), str(results)) == 0
+
+
+class TestBulletDeclarations13944:
+    """Real TEST-PLANs declare TCs as bold bullets (`- **TC1 -- x**: ...`);
+    with only heading/table patterns the plan side parsed 0 TCs."""
+
+    def test_bold_bullet_ids(self):
+        text = "- **TC1 — override proof**: works?\n- **TC-2 — resolves**: yes?\n* **TC 3 — star bullet**: also\n"
+        assert tc_coverage.parse_tc_ids(text) == [1, 2, 3]
+
+    def test_plain_bullet_prose_not_matched(self):
+        """Un-bolded prose mentions are references, not declarations."""
+        text = "- TC3 is covered by the integration run\n- see **the TC4 notes** above\n"
+        assert tc_coverage.parse_tc_ids(text) == []


### PR DESCRIPTION
Fixes the ship-integrity TC gate being structurally inert for issue-flow verifications (#13944, verifier-diagnosed): the TC-table regex required a table cell to BE exactly TC-N, while the established QA-RESULTS convention writes TC-N plus a description in one cell -- so every conforming artifact parsed as 0 TCs and the gate skipped.

Changes (references/scripts/tc_coverage.py):
- _TC_TABLE_RE: first cell STARTS with TC-N (word boundary) instead of being exactly TC-N; TC123abc still rejected.
- Result extraction for merged-cell rows searches only the cells AFTER the TC cell (_after_tc_cell), so description prose (deferred, N/A) cannot register as the result -- the table analog of the #2469 heading fix. Malformed rows without a closing pipe -> UNKNOWN.
- NEW _TC_BULLET_RE for plan-side bold-bullet declarations (- **TC1 -- x**:) -- discovered during live verification: real TEST-PLANs (13863/13865) declare every TC this way, so fixing only the table half left the plan side at 0 TCs and the gate still skipped. Un-bolded prose mentions do not match. Scope note: this extends the issue's direction (a) to the plan side; without it the stated impact (gate inert) remains.

Live evidence: tc_coverage.py --issue 13863 and --issue 13865 both now report 9/9 (100%) gate passed, previously 'No TCs found in TEST-PLAN. Gate skipped (0/0)' -- against the untouched real artifacts in .squidsquad/qa/planning/.

Tests: 10 new (merged-cell id+result, description-pollution guard, back-compat isolated cell, malformed row, partial number, real-shape end-to-end, bullet ids, prose non-match) -- 56 total in test_tc_coverage.py, full static gate PASS 6016/0.

Relates to issue 13944 (tc_coverage TC-table regex mismatch).