### PR TITLE
#13890: stale guard-test reconciliation -- retire/rewrite guards pinning deliberately-removed inventory; empty KNOWN_FAILURES; superseded-spec skip

### DIFF
--- a/tests/comprehension/2183_spec.json
+++ b/tests/comprehension/2183_spec.json
@@ -32,5 +32,7 @@
       "question": "The wrapper detects that claude crashed after only 5 seconds of runtime. What happens?",
       "expected": "The wrapper retries once (one crash retry). If the retry also crashes immediately, the wrapper exits. PM will detect the dead heartbeat on its next health check and handle the persistent failure."
     }
-  ]
+  ],
+  "superseded_by": 13890,
+  "superseded_reason": "lifecycle model overruled: intent-driven restarts (#13077/#13335) + progress-liveness (#12443) replaced the heartbeat/self-restart answers this spec records"
 }

--- a/tests/comprehension/2195_spec.json
+++ b/tests/comprehension/2195_spec.json
@@ -16,5 +16,7 @@
       "question": "QA just verified issue #123 on branch squidsquad/skill/123. Where do QA's verification commits go?",
       "expected": "QA's verification results go on the issue's existing feature branch (squidsquad/skill/123) using git_ops.py commit-code. State changes (.squidsquad/ iteration logs, working state) go on main using git_ops.py commit-state."
     }
-  ]
+  ],
+  "superseded_by": 13890,
+  "superseded_reason": "both quizzed fragments deleted: roles/dm/git-commit.md and roles/qa/git-commit.md no longer exist (qa->verifier rename + sub-skill reorg)"
 }

--- a/tests/comprehension_helpers.py
+++ b/tests/comprehension_helpers.py
@@ -46,6 +46,22 @@ def run_comprehension_or_skip(spec_path, output_dir, timeout=600):
     spec_path = Path(spec_path)
     output_dir = Path(output_dir)
 
+    # #13890: a spec marked ``"superseded_by": <issue>`` is an overruled
+    # historical record (the #13575 staleness convention) — later commits
+    # deliberately changed or deleted the content it quizzes, so running it
+    # live can only re-prove a known mismatch. The staleness gate already
+    # ignores such specs; the live harness must agree or every bare pytest
+    # run drags permanent failures (the #13890 signal-degradation class).
+    try:
+        spec_data = json.loads(spec_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        spec_data = {}
+    if spec_data.get("superseded_by"):
+        pytest.skip(
+            f"spec superseded by #{spec_data['superseded_by']} "
+            f"(overruled historical record, #13575 convention)"
+        )
+
     if not claude_available():
         pytest.skip("claude CLI not available")
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -82,15 +82,22 @@ KNOWN_NON_STATIC = {
 # Currently-red files quarantined out of the gate. The post-cutover stale-test
 # debt (gate went dead at the v0.44.0 cutover, masking these; full detail in
 # .squidsquad/skill/planning/11394-reasons.txt) has been worked down under
-# #11503. The REMAINING two entries are NOT stale-test debt: they are tests
-# that correctly fail on genuinely-incomplete work tracked by OPEN #10360
-# (Implement Responsibility compose slot per COMPOSE-ARCHITECTURE §5.2). They
-# clear only once #10360 lands the Responsibility slot — do NOT paper over by
-# weakening assertions. See the #11503 comment for the full triage.
-KNOWN_FAILURES = {
-    "test_compose_author_comments_11142": "test_10360_cleanup_markers_preserved: #10360-cleanup breadcrumbs (future-work pointers for OPEN #10360) dropped by #11331 rewrite — blocked on #10360 (the stale boot-bootstrap-marker half is fixed)",
-    "test_agent_boundaries": "test_ac7: 20 L3 variant responsibility stubs missing (COMPOSE-ARCH §5.2) — blocked on OPEN #10360. The other 19 assertions (ac4/ac6/ac11) are superseded by the agent-boundaries sub-skill retirement; rewrite the file together once #10360 unblocks it",
-}
+# #11503 established this registry; #13890 emptied it. The two long-standing
+# entries (test_agent_boundaries, test_compose_author_comments_11142) framed
+# their failures as "genuinely-incomplete #10360 work — hold red until #10360
+# lands". #13890's root-cause traced every failing assertion to a DELIBERATE
+# later cleanup that shipped without retiring its guard (#10366 deleted the 20
+# L3 stubs as pure orphans; #13006 deleted the pm/dm L4 seeds; f8d867a9d
+# removed the #10360-cleanup breadcrumbs after their migration completed; the
+# lineage-tag and roster conventions retired with the agent-boundaries
+# sub-skill). The guards were reconciled to the current contract in #13890 —
+# assertions rewritten or retired with per-item evidence, NOT weakened-to-
+# green — and #10360 remains tracked on its own issue, which is where future
+# work belongs (a permanently-red test is signal debt, not a reminder). If
+# #10360's slot migration reintroduces stub inventories, its PR ships its own
+# guards. Add new entries here ONLY with an issue reference and a removal
+# condition.
+KNOWN_FAILURES = {}
 
 
 def discover_static_modules():

--- a/tests/test_agent_boundaries.py
+++ b/tests/test_agent_boundaries.py
@@ -1,9 +1,38 @@
-"""#9925 regression tests — L1+L2+L3+L4 responsibility-layering machinery.
+"""#9925 regression tests — responsibility-layering machinery, reconciled.
 
-Covers AC4 (compose-time roster + L2 content), AC6 (memory absorption
-lineage tags), AC7 (L3 stub files), AC8 (L4 stub files in both seed
-and live locations), AC9 (L4 prefix-filtered inclusion), AC10 (byte-
-identical re-runs with agent_compose disabled), AC11 (degraded modes).
+Originally covered AC4 (compose-time roster + L2 content), AC6 (memory
+absorption lineage tags), AC7 (L3 stub files), AC8 (L4 stub files), AC10
+(byte-identical re-runs), AC11 (degraded modes).
+
+#13890 reconciliation: every retired assertion below pinned an inventory or
+behavior that a LATER, deliberate, correctly-scoped cleanup removed without
+retiring the guard in the same PR (the verifier's root-cause pattern):
+
+- **AC6 (13 params) RETIRED** — asserted ``<!-- absorbed from X -->``
+  lineage tags in ``references/sub-skills/roles/<role>/responsibility.md``.
+  Those files were deleted in #11087 (orphan sub-skill sources, D1-inlined
+  per #11049); the successor files at ``references/roles/<role>/
+  responsibility.md`` carry NO lineage tags (the #11331 polish rewrite
+  dropped the convention repo-wide — grep confirms zero occurrences under
+  references/). The absorbed CONTENT lives on; the tag convention does not.
+- **AC7 (20 params) RETIRED** — asserted 20 L3 variant responsibility
+  stubs; all deliberately deleted as pure orphans by #10366 (5b6977922).
+  If #10360's slot migration reintroduces L3 stubs it ships its own guard.
+- **AC8 seed pm/dm params RETIRED** — deleted by #13006 (0995f246d, "6
+  dead pm-/dm- L4 seed stubs"); verifier/worker/shared seeds survive and
+  stay pinned below.
+- **AC4 REWRITTEN, roster-count RETIRED** — the ``agent-boundaries``
+  sub-skill (rendered ``## Your Teammates' Responsibilities`` roster block)
+  was retired per #10360/#11331: team awareness is now inlined prose in the
+  L1 Identity slot and the marker is intentionally absent (see
+  ``compose._inject_role_roster``'s docstring). The surviving invariants —
+  teammate awareness present, L2 does/does-NOT-do sections present — are
+  asserted against the current composed shape.
+- **AC11 missing-marker warning RETIRED, replaced** — the warning was
+  intentionally removed: marker absence is the documented steady state
+  (``_inject_role_roster`` docstring). The replacement pins the documented
+  behavior (content unchanged, NO warning) so a regression that starts
+  warning on every compose is caught.
 """
 
 from __future__ import annotations
@@ -22,25 +51,20 @@ from _v2_test_helpers import v2_compose_for as _v2_compose_for  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
-# AC4 — composed CLAUDE.md contains L1 awareness + roster + L2 content
+# AC4 (reconciled) — composed CLAUDE.md carries team awareness + L2 content
 # ---------------------------------------------------------------------------
 
 
 # #10156: post-#6274.2 rename — qa→verifier, dev→worker. "skill" remains
-# as the variant name (config.md's `Workers: skill`); the role behind it
-# is now `worker` after composition.
+# as the variant name (config.md's `Workers: skill`).
 @pytest.mark.parametrize("role", ["pm", "verifier", "dm", "skill"])
-def test_ac4_composed_contains_l1_awareness_and_l2(role):
-    """For each of pm/verifier/dm/worker (skill is the worker variant), the
-    composed output must contain the L1 awareness instruction, the roster
-    header, and the role's own L2 'What this role does' header (#9925 AC4).
-    """
+def test_ac4_composed_contains_identity_awareness_and_l2(role):
+    """Post-#10360/#11331 shape: team awareness is L1 Identity prose (the
+    rendered roster block is retired), and the role's own Responsibility
+    slot carries the does / does-NOT-do sections."""
     composed = _v2_compose_for(role)
-    assert "Know each other's responsibilities" in composed, (
-        f"L1 awareness instruction missing from composed {role}"
-    )
-    assert "## Your Teammates' Responsibilities" in composed, (
-        f"L1 roster header missing from composed {role}"
+    assert "Your teammates run in parallel on their own clones" in composed, (
+        f"L1 Identity teammate-awareness prose missing from composed {role}"
     )
     assert "What this role does" in composed, (
         f"L2 'What this role does' header missing from composed {role}"
@@ -50,97 +74,15 @@ def test_ac4_composed_contains_l1_awareness_and_l2(role):
     )
 
 
-def test_ac4_roster_has_exactly_active_roles():
-    """AC4: for the current install (`Workers: skill` + mandatory
-    PM/Verifier/DM), the roster MUST contain exactly 4 entries — one per
-    pm/verifier/dm/worker. Roles whose manifest exists but are NOT active
-    in config.md must NOT appear (F4 lock). #10156: post-#6274.2 rename."""
-    composed = _v2_compose_for("pm")
-    # Each rendered entry uses a `### <DisplayName>` header inside the
-    # 'Your Teammates' Responsibilities' block. Slice the roster section
-    # and count its level-3 headers.
-    start = composed.find("## Your Teammates' Responsibilities")
-    assert start != -1
-    # Roster ends at the next h2 (or the L1 closing marker).
-    end_candidates = [
-        composed.find("\n## ", start + 5),
-        composed.find("<!-- /sub-skill: agent-boundaries -->", start),
-    ]
-    end = min(c for c in end_candidates if c != -1)
-    roster_block = composed[start:end]
-    h3_count = roster_block.count("\n### ")
-    assert h3_count == 4, (
-        f"AC4: expected exactly 4 roster entries (one per pm/verifier/dm/worker), "
-        f"saw {h3_count}. Roster block:\n{roster_block}"
-    )
-
-
 # ---------------------------------------------------------------------------
-# AC6 — memory absorption lineage tags present in predicted L2 files
+# AC8 (reconciled) — surviving L4 stub files in seed and live locations
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("source,filename", [
-    # PM L2 absorptions
-    ("feedback_dont_do_qa_job", "references/sub-skills/roles/pm/responsibility.md"),
-    ("feedback_bugs_behavior_only", "references/sub-skills/roles/pm/responsibility.md"),
-    ("feedback_auto_approve_bugs", "references/sub-skills/roles/pm/responsibility.md"),
-    ("feedback_dm_optional", "references/sub-skills/roles/pm/responsibility.md"),
-    # Verifier L2 absorptions (#10156: was "QA" pre-#6274.2)
-    ("feedback_no_ship_failed_tc", "references/sub-skills/roles/verifier/responsibility.md"),
-    ("feedback_no_ship_with_gaps", "references/sub-skills/roles/verifier/responsibility.md"),
-    # DM L2 absorptions
-    ("feedback_dm_optional", "references/sub-skills/roles/dm/responsibility.md"),
-    ("feedback_no_ship_failed_tc", "references/sub-skills/roles/dm/responsibility.md"),
-    ("feedback_no_ship_with_gaps", "references/sub-skills/roles/dm/responsibility.md"),
-    # Cross-role test_workflow_separation
-    ("feedback_test_workflow_separation", "references/sub-skills/roles/pm/responsibility.md"),
-    ("feedback_test_workflow_separation", "references/sub-skills/roles/verifier/responsibility.md"),
-    ("feedback_test_workflow_separation", "references/sub-skills/roles/dm/responsibility.md"),
-    ("feedback_test_workflow_separation", "references/sub-skills/roles/worker/responsibility.md"),
-])
-def test_ac6_memory_absorption_lineage_tag(source, filename):
-    """AC6: each memory entry from D5 is absorbed into the indicated L2
-    file with an HTML-comment lineage tag `<!-- absorbed from <name> -->`.
-    """
-    path = REPO / filename
-    assert path.exists(), f"L2 file missing: {filename}"
-    content = path.read_text(encoding="utf-8")
-    assert f"<!-- absorbed from {source} -->" in content, (
-        f"AC6: lineage tag for {source} not found in {filename}"
-    )
-
-
-# ---------------------------------------------------------------------------
-# AC7 — 20 L3 stub files exist with the locked template content
-# ---------------------------------------------------------------------------
-
-
-# #10156: post-#6274.2 rename — dev→worker, qa→verifier.
-@pytest.mark.parametrize("role", ["worker", "dm", "pm", "verifier"])
-@pytest.mark.parametrize("variant", ["android", "fullstack", "ios", "skill", "web"])
-def test_ac7_l3_stub_exists_and_matches_template(role, variant):
-    """AC7: all 20 L3 stub files exist and match the D6a template
-    (literal string match for 'No variant-specific responsibility
-    narrowing'). None are wired into includes_yml's additional_includes.
-    """
-    stub = REPO / "references" / "roles" / role / variant / "responsibility.md"
-    assert stub.exists(), f"L3 stub missing: {stub}"
-    content = stub.read_text(encoding="utf-8")
-    assert "No variant-specific responsibility narrowing" in content, (
-        f"AC7: L3 stub at {stub} doesn't match the locked template"
-    )
-
-
-# ---------------------------------------------------------------------------
-# AC8 — 5 L4 stub files in BOTH seed (references/) and live (.squidsquad/)
-# ---------------------------------------------------------------------------
-
-
-# #10156: post-#6274.2 rename — dev→worker, qa→verifier prefix.
-@pytest.mark.parametrize("prefix", ["pm", "verifier", "dm", "worker", "shared"])
+# pm/dm seed params retired (#13006 deleted them — see module docstring).
+@pytest.mark.parametrize("prefix", ["verifier", "worker", "shared"])
 def test_ac8_l4_seed_stub_exists(prefix):
-    """AC8 (seed half): seed templates at references/sub-skills/project/."""
+    """AC8 (seed half): surviving seed templates at references/sub-skills/project/."""
     seed = REPO / "references" / "sub-skills" / "project" / f"{prefix}-responsibility.md"
     assert seed.exists(), f"L4 seed stub missing: {seed}"
     content = seed.read_text(encoding="utf-8")
@@ -191,17 +133,7 @@ def test_ac11_missing_display_name_raises_systemexit(capsys):
     """AC11: a role manifest missing the required `display_name` field
     must produce a build error with exit code != 0.
     """
-    # Build a fake manifest dict without display_name by mocking the
-    # cache read for one of the active roles.
-    def fake_read_manifest(role_id):
-        if role_id == "pm":
-            return {"id": "pm", "tagline": "x", "description": "y"}  # no display_name
-        # Pass through to real read for others by clearing cache once
-        return compose._read_role_manifest.__wrapped__(role_id) if hasattr(
-            compose._read_role_manifest, "__wrapped__"
-        ) else compose._ROLE_MANIFEST_CACHE.get(role_id)
-
-    # Simpler: directly seed the cache so PM has no display_name.
+    # Directly seed the cache so PM has no display_name.
     compose._ROLE_MANIFEST_CACHE.clear()
     try:
         compose._ROLE_MANIFEST_CACHE["pm"] = {
@@ -216,16 +148,19 @@ def test_ac11_missing_display_name_raises_systemexit(capsys):
         compose._ROLE_MANIFEST_CACHE.clear()
 
 
-def test_ac11_missing_marker_emits_warning_and_continues(capsys):
-    """AC11/D8: if `{{role-roster}}` marker is absent from composed
-    content, compose emits a stderr warning and continues (does NOT
-    crash). This covers the agent-boundaries-not-included edge case.
-    """
+def test_ac11_marker_absent_is_silent_steady_state(capsys):
+    """#13890 (replaces the retired warn-on-missing-marker assertion):
+    per ``_inject_role_roster``'s documented contract, `{{role-roster}}`
+    is intentionally absent from every composed CLAUDE.md since the
+    agent-boundaries retirement — content passes through unchanged with
+    NO warning. A compose that starts warning on every run (or mutating
+    marker-less content) is the regression this now catches."""
     out = compose._inject_role_roster("hello world\n", "pm")
     assert out == "hello world\n", "no marker → content unchanged"
     captured = capsys.readouterr()
-    assert "WARNING" in captured.err
-    assert "role-roster" in captured.err
+    assert captured.err == "", (
+        "marker absence is the documented steady state — no warning expected"
+    )
 
 
 def test_ac11_missing_tagline_or_description_warns_but_succeeds(capsys):

--- a/tests/test_compose_author_comments_11142.py
+++ b/tests/test_compose_author_comments_11142.py
@@ -140,15 +140,12 @@ def test_sub_skill_wrapper_markers_preserved(_deploy_all):
     )
 
 
-def test_10360_cleanup_markers_preserved(_deploy_all):
-    """``<!-- #10360-cleanup: ... -->`` future-work pointers (preserved
-    in #11137 R0 as load-bearing breadcrumbs) must survive #11142."""
-    path = REPO_ROOT / "references" / "roles" / "worker" / "instructions.md"
-    text = path.read_text(encoding="utf-8")
-    assert "#10360-cleanup:" in text, (
-        "#10360-cleanup markers missing from worker/instructions.md — "
-        "#11142 strip should not touch the #10360 future-work pointers."
-    )
+# RETIRED (#13890): test_10360_cleanup_markers_preserved asserted the
+# ``<!-- #10360-cleanup: ... -->`` breadcrumbs survive in
+# worker/instructions.md. The breadcrumbs were deliberately removed by
+# f8d867a9d (DS Audit Iter 16 M4, 2026-06-12) once the migration they
+# pointed at completed — the guard pinned inventory a later legitimate
+# cleanup deleted, and was never retired with it (the #13890 pattern).
 
 
 def test_l4_curation_code_fence_examples_preserved():


### PR DESCRIPTION
Fixes the 47 pre-existing bare-pytest failures on main (#13890, verifier-triaged): every failure was a guard test pinning inventory (files/markers/behavior) that a deliberate later cleanup removed without retiring the guard in the same PR.

Changes:
- tests/test_agent_boundaries.py: ac4 REWRITTEN to the current composed contract (Identity-inlined teammate awareness + L2 does/does-NOT-do; the rendered roster block + marker were retired per #10360/#11331 -- compose._inject_role_roster's docstring documents marker absence as the intentional steady state, so the AC11 warn-on-missing-marker claim in the issue is answered: intentionally dropped, not a regression). Retired with per-item evidence: ac6 lineage tags (13 params; #11087 deleted the source files, the #11331 polish dropped the tag convention repo-wide -- zero occurrences under references/), ac7 L3 stubs (20 params; #10366/5b6977922 deleted them as pure orphans), ac8 pm/dm seed params (#13006/0995f246d), roster-count test. AC11 marker test REPLACED with a pin of the documented silent behavior. verifier/worker/shared seeds + all live L4 stubs + ac10 determinism + ac11 display-name/tagline stay pinned. 102/102 green (was 42 failures).
- tests/test_compose_author_comments_11142.py: 10360-breadcrumb guard retired (f8d867a9d removed the breadcrumbs once their migration completed); tombstone comment.
- tests/run_tests.py: KNOWN_FAILURES emptied -- the old entries framed these as blocked-on-OPEN-#10360; the #13890 root-cause (deliberate deletion commits) supersedes that framing, #10360 stays tracked on its own issue, and the registry comment now sets add-conditions (issue reference + removal condition). Both files rejoin the fail-closed static gate: PASS 6110/0 (was 6008 with 2 exclusions).
- CQ 2183/2195: marked superseded_by 13890 per the #13575 convention (2195's two quizzed fragments are deleted outright; 2183 quizzes the pre-intent-machine lifecycle that #13077/#13335/#12443 replaced) -- specs stay as historical records. comprehension_helpers.run_comprehension_or_skip now skips superseded specs CLASS-WIDE: the live harness previously ignored the #13575 marker, which would have left these failing bare runs forever.

Evidence: 102/102 on the two reconciled files; staleness gate green; full static gate PASS 6110/0 with the reconciled files INCLUDED. External review NO_FINDINGS (Sonnet fallback after model_router iteration-cap error; artifact CODE-REVIEW-13890.md). A full bare-pytest baseline run is in flight; its count will be appended on the issue.

Relates to issue 13890 (static ship-gate signal degradation).