### PR TITLE
#13990: tc_coverage scans the Result cell only -- Evidence prose can no longer false-INVALID a passing TC

### DIFF
--- a/references/scripts/tc_coverage.py
+++ b/references/scripts/tc_coverage.py
@@ -68,17 +68,29 @@ def _normalize_tc_id(raw_num: str) -> int:
     return int(raw_num)
 
 
-def _after_tc_cell(line: str, match_end: int) -> str:
-    """Return the table-row content after the TC cell (#13944).
+def _result_cell(line: str, match_end: int) -> str:
+    """Return ONLY the Result cell of a TC table row (#13944 → #13990).
 
     ``match_end`` is where the TC-N token ended; the rest of that cell (a
     free-text description under the merged-cell convention) runs to the next
-    ``|``. A malformed row with no closing pipe returns '' -- no result cell
-    exists, which parse_tc_results reports as UNKNOWN rather than guessing
-    a result out of description prose.
+    ``|``, and the RESULT cell is the one cell after that. #13944's first cut
+    returned the whole row remainder, so the invalid-result check also
+    scanned the Evidence column — evidence prose *describing* a scenario
+    with the words "deferred"/"N/A" misclassified a genuine PASS as INVALID
+    and blocked shipping (#13990, hit live on QA-RESULTS-13944 TC5). A
+    result is only ever declared in the Result cell; Evidence is prose.
+
+    A malformed row with no closing pipe (or no result cell at all) returns
+    '' -- parse_tc_results reports UNKNOWN rather than guessing a result out
+    of description or evidence prose.
     """
-    cell_end = line.find("|", match_end)
-    return line[cell_end:] if cell_end != -1 else ""
+    cell_start = line.find("|", match_end)
+    if cell_start == -1:
+        return ""
+    cell_end = line.find("|", cell_start + 1)
+    if cell_end == -1:
+        return line[cell_start + 1:]
+    return line[cell_start + 1:cell_end]
 
 
 def parse_tc_ids(text: str) -> list[int]:
@@ -109,25 +121,25 @@ def parse_tc_results(text: str) -> dict[int, str]:
             continue
         tc_id = _normalize_tc_id(m.group(1))
 
-        # For table rows, result is on the same line (| TC-1 | PASS |).
-        # For headings, skip the heading line to avoid matching words in
-        # the TC title like "not-applicable" (#2469). Stop at the next
-        # TC marker to avoid bleeding into adjacent TCs.
-        start = i if is_table else i + 1
-        result_lines = []
-        for j in range(start, min(i + 5, len(lines))):
-            if j != i and (_TC_HEADING_RE.match(lines[j]) or _TC_TABLE_RE.match(lines[j])):
-                break
-            if j == i and is_table:
-                # Merged-cell rows (#13944) carry a free-text description in
-                # the TC cell itself; search only the cells AFTER it so
-                # description words ("deferred cleanup", "N/A handling")
-                # can't register as the result -- the same hazard #2469
-                # fixed for heading titles.
-                result_lines.append(_after_tc_cell(lines[j], m.end()))
-            else:
+        if is_table:
+            # Table rows declare the result in the RESULT cell and nowhere
+            # else (#13990): scanning the TC-description cell (#13944/#2469
+            # hazard), the Evidence column (#13990 live false-INVALID), or
+            # subsequent lines can only misread prose as a result. This
+            # also fixes the pre-#13944 latent form: isolated-cell rows
+            # (| TC-1 | PASS | notes |) used to scan their notes column too.
+            search_block = _result_cell(line, m.end())
+        else:
+            # Headings: skip the heading line to avoid matching words in
+            # the TC title like "not-applicable" (#2469); scan the next few
+            # lines, stopping at the next TC marker to avoid bleeding into
+            # adjacent TCs.
+            result_lines = []
+            for j in range(i + 1, min(i + 5, len(lines))):
+                if _TC_HEADING_RE.match(lines[j]) or _TC_TABLE_RE.match(lines[j]):
+                    break
                 result_lines.append(lines[j])
-        search_block = "\n".join(result_lines)
+            search_block = "\n".join(result_lines)
 
         # Check for invalid results first
         if _INVALID_RESULTS_RE.search(search_block):

--- a/tests/test_tc_coverage.py
+++ b/tests/test_tc_coverage.py
@@ -552,3 +552,44 @@ class TestBulletDeclarations13944:
         """Un-bolded prose mentions are references, not declarations."""
         text = "- TC3 is covered by the integration run\n- see **the TC4 notes** above\n"
         assert tc_coverage.parse_tc_ids(text) == []
+
+
+# --- #13990: result-cell-only scan for table rows ---
+
+
+class TestResultCellOnly13990:
+    """#13944's first cut scanned the whole row remainder, so Evidence-column
+    prose mentioning deferred/N-A misclassified a genuine PASS as INVALID
+    (live-hit shipping QA-RESULTS-13944 itself). A result is only ever
+    declared in the Result cell; Evidence is prose."""
+
+    def test_evidence_prose_with_invalid_words_does_not_block(self):
+        """The live repro shape: PASS in the Result cell, deferred/N-A
+        wording inside the Evidence cell."""
+        text = ('| TC5 — description-pollution guard | PASS | a TC cell '
+                'description containing the literal words "deferred" and "N/A" |\n')
+        assert tc_coverage.parse_tc_results(text) == {5: "PASS"}
+
+    def test_isolated_cell_notes_column_no_longer_scanned(self):
+        """Pre-#13944 latent form of the same bug: isolated TC cell, notes
+        column mentioning an invalid token."""
+        text = "| TC-1 | PASS | scenario covers the deferred cleanup path |\n"
+        assert tc_coverage.parse_tc_results(text) == {1: "PASS"}
+
+    def test_invalid_token_in_result_cell_still_blocks(self):
+        """The invalid check still fires where it should: in the Result
+        cell itself."""
+        text = "| TC2 — edge case | deferred | will do later |\n"
+        assert tc_coverage.parse_tc_results(text) == {2: "INVALID"}
+
+    def test_empty_result_cell_is_unknown_not_scavenged(self):
+        """An empty Result cell must not scavenge a result from Evidence
+        or from subsequent lines."""
+        text = "| TC3 — desc | | evidence says PASS somewhere |\nPASS on the next line\n"
+        assert tc_coverage.parse_tc_results(text) == {3: "UNKNOWN"}
+
+    def test_result_cell_with_qualifier_prose_still_parses(self):
+        """Real-artifact shape: 'PASS (by code inspection + TC1)' in the
+        Result cell."""
+        text = "| TC2 — credential-manager-independent | PASS (by code inspection + TC1) | evidence |\n"
+        assert tc_coverage.parse_tc_results(text) == {2: "PASS"}


### PR DESCRIPTION
Fixes the #13944 follow-up the verifier hit live shipping #13944 itself: _after_tc_cell returned everything after the TC cell, so the invalid-result check scanned the Evidence column too -- evidence prose DESCRIBING a deferred/N-A scenario misclassified a genuine PASS row as INVALID and blocked pending-ship (#13990, QA-RESULTS-13944 TC5).

Fix (references/scripts/tc_coverage.py): _result_cell returns only the first cell after the TC cell; table rows search that cell alone for both the invalid tokens and the result token. Consequences pinned by tests: Evidence prose is inert (the live repro shape); the pre-#13944 latent form is fixed too (isolated-cell rows | TC-1 | PASS | notes-mentioning-deferred | always scanned their notes column); an invalid token IN the Result cell still blocks; an empty/malformed Result cell is UNKNOWN -- never scavenged from Evidence or subsequent lines; qualifier prose in the Result cell (PASS (by code inspection)) still parses. Heading-TC behavior unchanged.

Evidence: 5 new regression tests (61 total in test_tc_coverage.py); live: --issue 13944 now 7/7 gate passed (the exact blocking artifact), --issue 13863 still 9/9; full static gate PASS 6021/0.

Relates to issue 13990 (evidence-column false-INVALID).