### PR TITLE
skill: #14038 -- real-run scaffold assertion for vault-engine wiring (getsource guard retired)

### DIFF
--- a/tests/test_14038_scaffold_engine_real_run.py
+++ b/tests/test_14038_scaffold_engine_real_run.py
@@ -1,0 +1,100 @@
+"""#14038 -- the REAL scaffold_install must produce the vault-engine
+artifacts, asserted on the result, not on source text.
+
+Prior guard was `inspect.getsource(scaffold_install)` string-matching the
+install_vault_engine call -- a refactor that renames/moves the step could
+keep the string green while the real deploy silently stops firing (the
+shipped-unwired audit pattern). This drives the REAL `scaffold_install`
+(same offline harness as the #13514 seam tests: default spec, stubbed
+deploy_role_v2, no gh/network) with the engine sources seeded into the
+scaffold target, and asserts the step-5b outputs exist on disk afterwards:
+the deployed skill package, the .telemetry merge=union seed, and
+vault-schema.json. Supersedes
+test_vault_engine_installer_13857::test_scaffold_install_wires_the_step.
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..",
+                                "references", "scripts"))
+
+import compose  # noqa: E402
+import wizard  # noqa: E402
+
+
+class _GhMiss:
+    """gh not consulted -- repo_info falls back to the target dir name."""
+    returncode = 1
+    stdout = ""
+    stderr = ""
+
+
+def _offline(monkeypatch):
+    monkeypatch.setattr(wizard, "ensure_labels", lambda dry_run=False: {"created": 0})
+    monkeypatch.setattr(wizard, "_run", lambda *a, **k: _GhMiss())
+    # Compose is out of scope here -- record a plausible path, never fail.
+    def ok(compose_name, target_root=None, output_name=None):
+        return os.path.join(str(target_root), ".squidsquad", output_name, "CLAUDE.md")
+    monkeypatch.setattr(compose, "deploy_role_v2", ok)
+
+
+def _seed_engine_sources(target_root):
+    """What a real fetched install carries before the wizard runs: the
+    packaged skill sources + the schema seed (per installer-files.txt)."""
+    skill = target_root / "references" / "skills" / "vault-search"
+    (skill / "scripts" / "lib").mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: vault-search\n---\n", encoding="utf-8")
+    (skill / "scripts" / "vault-query.mjs").write_text("// engine\n", encoding="utf-8")
+    (skill / "scripts" / "lib" / "consumption.mjs").write_text("// lib\n", encoding="utf-8")
+    (target_root / "references" / "vault-schema-default.json").write_text(
+        json.dumps({"types": {"learning": {"folder": "galaxy",
+                                           "traversal": "budgeted",
+                                           "weight": 1.0}}}),
+        encoding="utf-8")
+
+
+def test_real_scaffold_install_produces_engine_artifacts(tmp_path, monkeypatch):
+    _offline(monkeypatch)
+    _seed_engine_sources(tmp_path)
+
+    spec = wizard.generate_default_spec({}, {"name": "engineprobe"})
+    result = wizard.scaffold_install(spec, tmp_path, overwrite_existing=True)
+
+    # 1. The result records the step ran (production-caller wiring).
+    ve = result.get("vault_engine")
+    assert ve is not None, (
+        "scaffold_install result carries no vault_engine summary -- "
+        "the install_vault_engine step did not fire")
+    assert ve["deployed"] == ["vault-search"]
+
+    # 2. The artifacts exist on disk in the scaffold target.
+    deployed = tmp_path / ".claude" / "skills" / "vault-search"
+    assert (deployed / "SKILL.md").is_file()
+    assert (deployed / "scripts" / "vault-query.mjs").is_file()
+    assert (deployed / "scripts" / "lib" / "consumption.mjs").is_file()
+
+    ga = tmp_path / ".squidsquad" / "vault" / ".telemetry" / ".gitattributes"
+    assert ga.is_file()
+    assert "merge=union" in ga.read_text(encoding="utf-8")
+
+    schema = tmp_path / ".squidsquad" / "vault" / "vault-schema.json"
+    assert schema.is_file()
+    assert "learning" in schema.read_text(encoding="utf-8")
+
+
+def test_real_scaffold_install_engine_step_degrades_without_sources(tmp_path, monkeypatch):
+    """Negative control: a target with NO engine sources (the pre-existing
+    test_wizard.py fixtures' shape) must still scaffold -- the step no-ops
+    gracefully (deployed: []) rather than failing the install. This is the
+    exact silent shape that made the old real-run tests assert nothing."""
+    _offline(monkeypatch)
+
+    spec = wizard.generate_default_spec({}, {"name": "bareprobe"})
+    result = wizard.scaffold_install(spec, tmp_path, overwrite_existing=True)
+
+    ve = result.get("vault_engine")
+    assert ve is not None
+    assert ve["deployed"] == []
+    assert not (tmp_path / ".claude" / "skills" / "vault-search").exists()

--- a/tests/test_vault_engine_installer_13857.py
+++ b/tests/test_vault_engine_installer_13857.py
@@ -9,7 +9,6 @@ dir's merge=union .gitattributes (8.5: installer work, not engine work).
 No real node/subprocess dependency: preflight is exercised through mocks.
 """
 
-import inspect
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -98,12 +97,11 @@ class TestInstallVaultEngine:
         result = wizard.install_vault_engine(root)
         assert result["deployed"] == []
 
-    def test_scaffold_install_wires_the_step(self):
-        """The production caller actually invokes the deploy (the
-        shipped-unwired audit pattern: check at the caller level)."""
-        src = inspect.getsource(wizard.scaffold_install)
-        assert "install_vault_engine(target_root)" in src
-        assert 'summary["vault_engine"]' in src
+    # test_scaffold_install_wires_the_step retired (#14038): the wiring is
+    # now guarded by a REAL scaffold_install run asserting the deployed
+    # artifacts on disk -- tests/test_14038_scaffold_engine_real_run.py --
+    # which a rename/move refactor cannot fool the way a getsource string
+    # match could.
 
 
 class TestConfigFlag:


### PR DESCRIPTION
Fixes #14038 (self-filed test-design gap on my own #13857/#13858 work): the only wiring guard for `install_vault_engine` inside `scaffold_install` was an `inspect.getsource` string match, while the existing REAL scaffold_install test runs used fixtures without `references/skills` -- the step no-oped gracefully and those runs asserted nothing about it.

## Change (test-only)

- `tests/test_14038_scaffold_engine_real_run.py`: real `scaffold_install` (the #13514 offline harness -- default spec, stubbed `compose.deploy_role_v2`, gh-miss stub) with engine sources seeded into the scaffold target; asserts the result records the step AND the artifacts exist on disk (deployed skill package, `.telemetry/.gitattributes` with merge=union, `vault-schema.json`). Negative control pins the bare-target graceful no-op (`deployed: []`) -- the silent shape that hid the gap.
- `test_scaffold_install_wires_the_step` (getsource string match) retired with a pointer note; dangling `inspect` import removed.

## Tests

2 new real-run tests; installer/wizard suites 296 green; full static gate PASS 6206/0.

Verifies #14038 (real-run engine wiring guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZRqH6H3YJaiY1tKEdzqMR
