### PR TITLE
skill: #14054 -- gitignore the wizard-deployed .claude/skills/ live copies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,10 @@ references/scripts/migrate_*.py.bak
 # versioned. Tracked gitlinks here caused persistent tracked-but-missing
 # noise (#13557) and a restore-guard false positive (#13556).
 .claude/worktrees/
+
+# Wizard-deployed live Skill packages (#14054): install_vault_engine
+# materializes references/skills/ -> .claude/skills/ per clone; the copy is
+# regenerable deployment output (refreshed on upgrade), never versioned --
+# same class as .claude/worktrees/ above. Confirmed never committed in repo
+# history before this entry.
+.claude/skills/

--- a/tests/test_14054_claude_skills_gitignore.py
+++ b/tests/test_14054_claude_skills_gitignore.py
@@ -1,0 +1,39 @@
+"""#14054 -- wizard-deployed .claude/skills/ must be gitignored.
+
+install_vault_engine() materializes references/skills/ -> .claude/skills/ on
+every clone that runs it; the copy is regenerable deployment output (never
+committed anywhere in repo history), but nothing ignored it, so `git status`
+on any installed clone permanently showed it as untracked noise -- the kind
+that buries genuinely important untracked files. Same class (and fix) as the
+.claude/worktrees/ entry.
+"""
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestClaudeSkillsGitignored:
+    def test_gitignore_carries_the_entry_as_its_own_line(self):
+        lines = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
+        assert ".claude/skills/" in lines
+
+    def test_git_actually_ignores_a_deployed_skill_path(self):
+        result = subprocess.run(
+            ["git", "check-ignore", "-q", ".claude/skills/vault-search/SKILL.md"],
+            cwd=str(REPO_ROOT), capture_output=True, timeout=30,
+        )
+        assert result.returncode == 0, (
+            ".claude/skills/ paths are not actually ignored by git")
+
+    def test_engine_source_of_truth_stays_tracked(self):
+        """The committed source under references/skills/ must NOT be caught
+        by the new pattern -- only the deployed live copy is ignored."""
+        result = subprocess.run(
+            ["git", "check-ignore", "-q",
+             "references/skills/vault-search/SKILL.md"],
+            cwd=str(REPO_ROOT), capture_output=True, timeout=30,
+        )
+        assert result.returncode != 0, (
+            "the engine SOURCE package must never be gitignored")


### PR DESCRIPTION
Addresses #14054 (verifier-filed): `install_vault_engine()` deploys the vault-search Skill package to `.claude/skills/` on every installed clone, but nothing ignored the directory -- permanent untracked noise in `git status` that can bury genuinely important untracked files.

## Change

`.gitignore` gains `.claude/skills/` at the `.claude/worktrees/` block (same class: machine-local regenerable output, refreshed on upgrade, confirmed never committed in repo history). Live-verified on this clone: the noise line is gone from status.

## Tests

3 (`tests/test_14054_claude_skills_gitignore.py`): entry pinned per-line, `git check-ignore` confirms a deployed path is actually ignored, and the negative control -- the committed engine SOURCE under `references/skills/` must never be caught by the pattern. Full static gate PASS 6208/0.

Verifies #14054 (.claude/skills gitignore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZRqH6H3YJaiY1tKEdzqMR