### PR TITLE
dm: #13946 -- flag sub-skill authoring docs as internal-maintainer-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ This project is developed by SquidSquad itself. The [CHANGELOG](./CHANGELOG.md) 
 | [Configuration Reference](docs/CONFIGURATION.md) | Every `config.md` setting explained — what to set at install vs tune later |
 | [Agent Runtime](docs/AGENT-RUNTIME.md) | How agents coordinate in real-time (event bus, lifecycle, triggers) |
 | [DM Architecture](docs/DM-ARCH.md) | The Delivery Manager as a layered role: generic delivery spine (L2), domain mechanics (L3), project release policy (L4) |
-| [Sub-Skill Guide](docs/sub-skill-guide.md) | Creating and contributing sub-skills |
+| [Sub-Skill Guide](docs/sub-skill-guide.md) | Creating and contributing sub-skills (internal maintainer reference — not a user-facing workflow) |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | How to report bugs, propose features, submit PRs |
 | [CHANGELOG.md](CHANGELOG.md) | Version history (maintained by agents) |
 | [SKILL.md](SKILL.md) | Full skill specification (the source of truth) |

--- a/docs/sub-skill-guide.md
+++ b/docs/sub-skill-guide.md
@@ -1,5 +1,7 @@
 # Sub-Skill Developer Guide
 
+> **Internal maintainer reference.** Sub-skill authoring is not an open or user-facing workflow — sub-skills are an internal compose artifact, authored only by SquidSquad maintainers (operator decision 2026-06-09). This guide will retire once the new architecture cutover lands (#11400).
+
 This guide explains how to create, test, and contribute sub-skills for SquidSquad.
 
 ---


### PR DESCRIPTION
Addresses #13946.

README.md:196 and docs/sub-skill-guide.md linked/presented sub-skill authoring as an open, user-facing workflow, contradicting the 2026-06-09 operator decision (via #11144) that sub-skill authoring is internal-maintainer only. #11400 will remove the guide entirely once the new-arch flip lands, but it's status:pending with no flip linked yet -- not imminent, so patching accuracy in the interim per the issue's suggested option (a).

## Change (docs-only)
- README.md:196 -- Sub-Skill Guide table entry now notes "internal maintainer reference -- not a user-facing workflow"
- docs/sub-skill-guide.md -- added a callout at the top stating the same, with a pointer to #11400 for the eventual retirement

No code change, no CHANGELOG entry (internal doc-accuracy fix, no user-facing behavior change).